### PR TITLE
Docker quickstart: clarify supportability of Docker images

### DIFF
--- a/xml/vt_docker_quick.xml
+++ b/xml/vt_docker_quick.xml
@@ -459,10 +459,9 @@
 
   <para>
    Some users might be confused about which build system to use for what
-   task. The recommended approach is to build the
-   <link xlink:href="http://docs.docker.com/terms/image/#base-image-def">base
-   images</link> using &kiwi; and then use those as foundation blocks inside
-   of the Docker build system. This approach has two advantages:
+   task. The recommended approach is to customize the official &slea; images
+   for Docker using the Docker build system.
+   This approach has two advantages:
   </para>
 
   <itemizedlist mark="bullet" spacing="normal">
@@ -506,8 +505,13 @@
   </itemizedlist>
 
   <para>
-   As you can see, &kiwi; is not intended as a replacement for Docker's
-   build system, it rather complements it.
+   &suse; creates the official
+   <link xlink:href="http://docs.docker.com/terms/image/#base-image-def">base images</link>
+   using &kiwi; and publishes them to allow customers to use
+   those as foundation blocks inside of the Docker build system.
+
+   Only the Docker images built on top of our official ones via the
+   Docker build system are going to be supported.
   </para>
  </sect1>
  <sect1 xml:id="sec.docker.sle_images">


### PR DESCRIPTION
Make it clear we are going to support only the Docker images built via the Docker build system.

Ping @eotchi and @taroth21 