### PR TITLE
vt-best-practices: Add a section describing Xen autoballooning

### DIFF
--- a/xml/vt_best_practices.xml
+++ b/xml/vt_best_practices.xml
@@ -536,18 +536,76 @@ always madvise [never]</screen>
     </para>
    </sect3>
    <sect3>
-    <title>xenstore in tmpfs</title>
-    <para>
-     When using Xen, it is recommended to place the xenstore database
-     on tmpfs. xenstore is used as a control plane by the xm/xend and
-     xl/libxl toolstacks and the frontend and backend drivers servicing
-     domain I/O devices. The load on xenstore increases linearly as the
-     number of running domains increase. If you anticipate hosting many
-     &vmguest; on a Xen host, move the xenstore database onto tmpfs to
-     improve overall performance of the control plane.
-     Mount the <filename>/var/lib/xenstored</filename> directory on tmpfs:
+    <title>Xen-specific Memory Notes</title>
+    <sect4>
+     <title>Managing Domain-0 Memory</title>
+     <para>
+      When using the Xen hypervisor, by default a small percentage of system
+      memory is reserved for the hypervisor, with all remaining memory
+      automatically allocated to Domain-0. When virtual machines are created,
+      memory is ballooned out of Domain-0 to provide memory for the virtual
+      machine. This process is referred to as "autoballooning".
+     </para>
+     <para>
+      Autoballooning has several drawbacks:
+     </para>
+     <itemizedlist>
+      <listitem><para>Reduced performance while dom0 is ballooning down to free memory for the new domain.</para></listitem>
+      <listitem><para>Memory freed by ballooning is not confined to a specific NUMA node. This can result in performance problems in the new domain due to using a non-optimal NUMA configuration.</para></listitem>
+      <listitem><para>Failure to start large domains due to delays while ballooning large amounts of memory from dom0.</para></listitem>
+     </itemizedlist>
+     <para>
+      For these reasons, it is strongly recommended to disable autoballooning
+      and give Domain-0 a pre-defined amount of memory.
+     </para>
+     <para>
+      Autoballooning is controlled by the toolstack used to manage your Xen
+      installation. For the xl/libxl toolstack, autoballooning is controlled
+      by the <option>autoballoon</option> setting in
+      <filename>/etc/xen/xl.conf</filename>. For the libvirt+libxl toolstack,
+      autoballooning is controlled by the <option>autoballoon</option> setting
+      in <filename>/etc/libvirt/libxl.conf</filename>.
+     </para>
+     <para>
+      The amount of memory initially allocated to Domain-0 is controlled by
+      the Xen hypervisor dom0_mem parameter. E.g. to set Domain-0's memory
+      to 8GB, add <option>dom0_mem=8G</option> to the Xen hypervisor
+      parameters.
+     </para>
+     <para>
+      To set dom0_mem on SLE11 products, modify <filename>/boot/grub/menu.lst</filename>,
+      adding <option>dom0_mem=XX</option> to the Xen hypervisor (xen.gz)
+      parameters. The change will be applied at next reboot.
     </para>
-    <screen># mount -t tmpfs tmpfs /var/lib/xenstored/</screen>
+    <para>
+     To set dom0_mem on SLE12 products, modify <filename>/etc/default/grub</filename>,
+     adding <option>dom0_mem-XX</option> to <option>GRUB_CMDLINE_XEN_DEFAULT</option>.
+     Changes to <filename>/etc/default/grub</filename> require rebuilding the
+     grub configuration with <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>.
+     and rebooting the host.
+    </para>
+     <para>
+      Autoballooning is enabled by default since it is extremely difficult
+      to determine a pre-defined amount of memory required by Domain-0.
+      Memory needed by Domain-0 is heavily dependent on the number of hosted
+      virtual machines and their configuration. Users must ensure Domain-0 has
+      sufficient memory resources to accommodate virtual machine workloads.
+     </para>
+    </sect4>
+    <sect4>
+     <title>xenstore in tmpfs</title>
+     <para>
+      When using Xen, it is recommended to place the xenstore database
+      on tmpfs. xenstore is used as a control plane by the xm/xend and
+      xl/libxl toolstacks and the frontend and backend drivers servicing
+      domain I/O devices. The load on xenstore increases linearly as the
+      number of running domains increase. If you anticipate hosting many
+      &vmguest; on a Xen host, move the xenstore database onto tmpfs to
+      improve overall performance of the control plane.
+      Mount the <filename>/var/lib/xenstored</filename> directory on tmpfs:
+     </para>
+     <screen># mount -t tmpfs tmpfs /var/lib/xenstored/</screen>
+    </sect4>
    </sect3>
   </sect2>
 


### PR DESCRIPTION
Add a sub-section about autoballooning and setting Domain-0 memory
to the Memory and Pages section.