### PR TITLE
Added article about Amazon EC2 Container Service

### DIFF
--- a/DC-SLES-amazon-ecs
+++ b/DC-SLES-amazon-ecs
@@ -1,0 +1,22 @@
+## ---------------------------- 
+## Doc Config File for SLES/SLED
+## Amazon EC2 Container Service
+## ----------------------------
+##
+## Basics
+MAIN="art_sle_amazon_ecs.xml"
+#ROOTID="art.sle.amazon.ecs"
+
+## Profiling
+PROFOS="sles"
+PROFARCH="x86_64"
+
+## Provo
+HTMLROOT="sles12"
+
+## stylesheet location
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+
+## enable sourcing
+export DOCCONF=$BASH_SOURCE

--- a/xml/art_sle_amazon_ecs.xml
+++ b/xml/art_sle_amazon_ecs.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook50-profile.xsl" 
+ type="text/xml"
+ title="Profiling step"?>
+
+<!DOCTYPE article 
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+  %entities;
+]>
+
+<article xml:id="article.vt.best.practices" xml:lang="en" version="5.0"
+  xmlns="http://docbook.org/ns/docbook" 
+  xmlns:xi="http://www.w3.org/2001/XInclude" 
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+ <?suse-quickstart color="suse"?>
+ <title>SUSE Linux Enterprise in the Public Cloud</title>
+ <subtitle>Amazon EC2 Container Service</subtitle>
+ <info>
+  <productnumber>&productnumber;</productnumber><productname>&productname;</productname><date>
+  <?dbtimestamp format="B d, Y" ?></date>
+ <abstract>
+   <para>
+    Amazon EC2 Container Service (ECS) is a container management service
+    that provides a set of APIs for scheduling container workloads
+    across EC2 clusters.
+   </para>
+   <para>
+    SUSE Linux Enterprise 12 images with the
+    <emphasis role="strong">ecs</emphasis> TLA in the image name are designed
+    to integrate with the Amazon EC2 Container service. The image contains
+    an agent that interacts with Docker to start/stop new containers and
+    gather information about running containers. The agent is fully
+    integrated with SUSE Linux Enterprise.
+   </para>
+ </abstract>
+ </info>
+
+ <sect1 xml:id="cluster-setup">
+    <title>Cluster setup</title>
+    <para>
+      Creating a new ECS cluster in Amazon is accomplished by using the
+      <link xlink:href="https://console.aws.amazon.com/ecs/home#/firstRun">First
+      Run Wizard</link>
+    </para>
+    <para>
+      We recommend retaining the default cluster name
+      <emphasis role="strong">default</emphasis>, because this allows for
+      automatically attaching an ECS instance to the cluster without
+      further configuration of the instance.
+    </para>
+    <para>
+      Renaming the cluster requires additional configuration once an ECS
+      instance is running. When the cluster name is
+      <emphasis role="strong">default</emphasis> the ECS instance will
+      automatically attach itself to the cluster. The additional configuration
+      steps for clusters with a name other than
+      <emphasis role="strong">default</emphasis> are described in the
+      <xref linkend="alternative-cluster-name"/> section below.
+    </para>
+ </sect1>
+ <sect1 xml:id="ecs-instance-role">
+    <title>ECS instance role</title>
+    <para>
+      Use of the Amazon EC2 Container Service requires permissions that
+      are not enabled by default in the Identity and Access Management
+      (IAM) functionality. Therefore it is necessary to create a policy
+      that provides users that are intended to use ECS with the proper
+      permissions. We recommend the following policy:
+    </para>
+    <screen>{
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "ecs:CreateCluster",
+                  "ecs:DeregisterContainerInstance",
+                  "ecs:DiscoverPollEndpoint",
+                  "ecs:Poll",
+                  "ecs:RegisterContainerInstance",
+                  "ecs:Submit*",
+                  "ecs:StartTask",
+                  "ecs:DescribeTasks",
+                  "ecs:StopTask",
+                  "ecs:RegisterTaskDefinition",
+                  "ecs:DescribeTaskDefinition",
+                  "ecs:DescribeContainerInstances",
+                  "ecs:StartTelemetrySession"
+              ],
+              "Resource": [
+                  "*"
+              ]
+          }
+      ]
+    }
+    </screen>
+    <para>
+      For additional information about IAM policies please refer to the
+      Amazon documentation: <link xlink:href="http://docs.aws.amazon.com/AmazonECS/latest/developerguide/IAM_policies.html">IAM Policies</link>
+    </para>
+    <para>
+      Once the policy is created attach it to a role named
+      <emphasis role="strong">ecsInstanceRole</emphasis>. Details about
+      ECS specific policies and roles can be found in the Amazon documentation:
+      <link xlink:href="http://docs.aws.amazon.com/AmazonECS/latest/developerguide/instance_IAM_role.html">IAM Role</link>
+    </para>
+    <para>
+      Note that the policy given above is more permissive than the
+      policy example provided in the Amazon documentation.
+    </para>
+ </sect1>
+ <sect1 xml:id="attach-sles12-ecs-instances-to-the-cluster">
+    <title>Attach SLES12 ECS instances to the cluster</title>
+    <para>
+      Once the cluster is up and running and your AWS account provides a
+      permissive IAM role for ECS, you can continue to run ECS instances
+      as follows:
+    </para>
+    <orderedlist>
+      <listitem>
+        <para>
+          Find the latest SLES12 ECS ami using
+          <link xlink:href="https://www.suse.com/communities/conversations/tag/pint"
+            >pint</link>
+        </para>
+        <screen>$ pint amazon images --active --filter 'name~ecs'</screen>
+      </listitem>
+      <listitem>
+        <para>
+          Run as many instances of the above ami as required for your
+          cluster. Remember to select the ECS role when launching the
+          instance.
+        </para>
+      </listitem>
+    </orderedlist>
+    <sect2 xml:id="alternative-cluster-name">
+      <title>Alternative cluster name</title>
+      <para>
+        If you chose a name other than
+        <emphasis role="strong">default</emphasis> for your cluster it is
+        necessary to configure the instance to attach itself to this
+        cluster. The configuration consists of setting the
+        <emphasis role="strong">ECS_CLUSTER</emphasis>
+        variable as follows:
+      </para>
+      <orderedlist>
+        <listitem>
+          <para>
+            Login to the running ECS instance via ssh.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            Edit the environment file
+            <filename>/etc/ecs/ecs.config</filename>
+            and add an entry of the form:
+          </para>
+          <para>
+            ECS_CLUSTER=name
+          </para>
+          <para>
+            The amazon ECS init launcher will read in the environment
+            file and populate the information into the environment prior
+            to starting the ECS agent. A complete list of configuration
+            options can be found at: <link xlink:href="https://github.com/aws/amazon-ecs-agent#environment-variables">Agent Configuration Variables</link>
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            Restart the service with:
+          </para>
+          <screen>$ sudo systemctl restart amazon-ecs-init</screen>
+          <para>
+            The current instance will be detached from the default
+            cluster and will be re-attached to the configured cluster
+            name.
+          </para>
+          <para>
+            Watching <filename>/var/log/ecs/ecs-agent.log.*</filename>
+            will tell you if the expected cluster is used.
+          </para>
+        </listitem>
+      </orderedlist>
+    </sect2>
+ </sect1>
+</article>
+


### PR DESCRIPTION
This article describes how to use the ECS image provided by the
public cloud development team in Amazon's container service.
Thanks to toms for migrating my db4 sources to db5