### PR TITLE
Updated the Docker quickstart to improve the Portus section

### DIFF
--- a/xml/vt_docker_quick.xml
+++ b/xml/vt_docker_quick.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook50-profile.xsl"
-                 type="text/xml" 
+                 type="text/xml"
                  title="Profiling step"?>
 <!DOCTYPE article
 [
@@ -823,9 +823,65 @@ RUN zypper -n in vim</screen>
   </para>
 
   <para>
+    Portus is accessible for &slea;&nbsp;12 customers through the Containers
+    module. To install Portus, use the following command:
+  </para>
+
+  <screen>sudo zypper in Portus</screen>
+
+  <para>
+    In order to configure Portus properly, follow these steps:
+  </para>
+
+  <procedure>
+    <step>
+      <para>
+        First of all, you should install Portus' dependencies if you haven't
+        already. This is thoroughly documented here:
+        <link xlink:href="http://port.us.org/docs/setups/1_rpm_packages.html#portus-dependencies"/>.
+        This document will help you to get through the installation process, and
+        it will also warn you about some of the common pitfalls.
+      </para>
+    </step>
+
+    <step>
+      <para>
+        After installing Portus and its dependencies, you need to configure
+        your instance. The initial setup of Portus is explained here:
+        <link xlink:href="http://port.us.org/docs/setups/1_rpm_packages.html#initial-setup"/>.
+        When you are done with portusctl, you should modify some configurable
+        values before using Portus. This is thoroughly explained in this
+        documentation page:
+        <link xlink:href="http://port.us.org/docs/Configuring-Portus.html"/>.
+      </para>
+    </step>
+
+    <step>
+      <para>
+        To apply the configuration changes, restart Apache (this is required
+        after each configuration change).
+      </para>
+    </step>
+
+    <step>
+      <para>
+        Finally, when entering Portus for the first time, you will be required
+        to enter some information about your installed registry. For details, see:
+        <link xlink:href="http://port.us.org/docs/setups/1_rpm_packages#the-default-installation.html"/>.
+      </para>
+    </step>
+
+    <step>
+      <para>
+        The Portus setup is now complete and you can start using Portus.
+      </para>
+    </step>
+  </procedure>
+
+  <para>
    Currently, Portus is part of &suse;'s Docker offer as a technology
    preview. For more information and documentation about Portus, see:
-   <link xlink:href="http://suse.github.io/Portus/"/>.
+   <link xlink:href="http://port.us.org/"/>.
   </para>
  </sect1>
 </article>


### PR DESCRIPTION
The Portus section has been improved in order to contain all the latest
documentation. This way, customers will be able to have Portus up and ready for
usage.

Ping @eotchi, @taroth21, @flavio and @jordimassaguerpla

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>