### PR TITLE
Remove haspcmcia as it's not used by AutoYaST anymore

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -8402,24 +8402,6 @@ fi;
        <row>
         <entry>
          <para>
-          <literal>haspcmcia</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          System has PCMCIA (i.e Laptops)
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Exact match required, <literal>1</literal> for having PCMCIA or
-          <literal>0</literal> for not having it.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
           <literal>hostid</literal>
          </para>
         </entry>


### PR DESCRIPTION
`haspcmcia` is not used since SLE 12 (including 'SP0'). Should I create a PR also against `develop` branch?

Thanks!