### PR TITLE
Small grammar correction

### DIFF
--- a/xml/sle_update_migration.xml
+++ b/xml/sle_update_migration.xml
@@ -22,7 +22,7 @@
 
     <abstract>
       <para>&suse; offers now new tools with some interesting features
-        to system administrators for online service pack migration. This
+        to system administrators for online service pack migration. These
         are simple command line tools, an intuitive graphical user
         interface, support for <quote>rollback</quote> of service packs,
         and some more. This chapter explains how to do a service pack
@@ -149,7 +149,7 @@
       </step>
       <step>
         <para>Start the <guimenu>Online Migration</guimenu> module from
-          the <guimenu>System</guimenu> section in &yast;. </para>
+          the <guimenu>Software</guimenu> section in &yast;. </para>
         <para>&yast; will show possible migration targets and a
           summary.</para>
       </step>


### PR DESCRIPTION
Changed reference from YaST->System to YaST-Software

I just tested the Online Migration module, and it was under Software, not System.