### PR TITLE
Update importing ssh keys/configuration attributes

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -12651,7 +12651,7 @@ exit 0
      <title>Importing SSH Keys and Configuration from /dev/sda2</title>
 <screen>&lt;ssh_import&gt;
   &lt;import config:type="boolean"&gt;true&lt;/import&gt;
-  &lt;config config:type="boolean"&gt;true&lt;/config&gt;
+  &lt;copy_config config:type="boolean"&gt;true&lt;/copy_config&gt;
   &lt;device&gt;/dev/sda2&lt;/device&gt;
 &lt;/ssh_import&gt;</screen>
     </example>
@@ -12699,7 +12699,7 @@ exit 0
        <row>
         <entry>
          <para>
-          <literal>config</literal>
+          <literal>copy_config</literal>
          </para>
         </entry>
         <entry>
@@ -12718,7 +12718,7 @@ exit 0
        <row>
         <entry>
          <para>
-          <literal>config</literal>
+          <literal>device</literal>
          </para>
         </entry>
         <entry>


### PR DESCRIPTION
* Adapt 'config' to the new 'copy_config' name.
* Fix 'device'.