### PR TITLE
feature/fate317784: Implement a check and warning to make sure we don't start a Service Pack migration with insufficient disk space

### DIFF
--- a/xml/sle_update_upgrading.xml
+++ b/xml/sle_update_upgrading.xml
@@ -27,7 +27,7 @@ Check with Simona, if this is supported or needed.
         12. No new installation is needed. Existing data, such as home
         and data directories and system configuration, is kept intact.
         You can update from a local CD or DVD drive or from a central
-        network installation source. </para>
+        network installation source.</para>
         <para>This chapter explains how to manually upgrade your &sle;
       system, be it by DVD, network, an automated process, or &susemgr;.</para>
       </abstract>
@@ -41,83 +41,7 @@ Check with Simona, if this is supported or needed.
 
     <para>Before starting the update procedure, make sure your system
       is properly prepared. Among others, preparation involves backing
-      up data and checking the release notes. </para>
-
-    <sect2 xml:id="sec.update.prep.disks">
-      <title>Partitioning and Disk Space</title>
-      <para>Before starting your update, make note of the root
-        partition. The command <command>df&nbsp;/</command> lists the
-        device name of the root partition. For example, in <xref
-          linkend="aus.update.df"/>, the root partition to write down is
-        <filename>/dev/sda3</filename> (mounted as
-        <filename>/</filename>). </para>
-      <example xml:id="aus.update.df">
-        <title>List with <command>df -h</command></title>
-        <screen os="sled">Filesystem     Size  Used Avail Use% Mounted on
-/dev/sda3       74G   22G   53G  29% /
-tmpfs          506M     0  506M   0% /dev/shm
-/dev/sda5      116G  5.8G  111G   5% /home
-/dev/sda1       39G  1.6G   37G   4% /windows/C
-/dev/sda2      4.6G  2.6G  2.1G  57% /windows/D</screen>
-        <screen os="sles">Filesystem     Size  Used Avail Use% Mounted on
-/dev/sda3       74G   22G   53G  29% /
-tmpfs          506M     0  506M   0% /dev/shm
-/dev/sda5      116G  5.8G  111G   5% /home
-/dev/sda1       44G    4G   40G   9% /data</screen>
-      </example>
-      <para>Software tends to <quote>grow</quote> from version to
-        version. Therefore, take a look at the available partition space
-        with <command>df</command> before updating. If you suspect you
-        are running short of disk space, secure your data before
-        updating and repartitioning your system. There is no general
-        rule regarding how much space each partition should have. Space
-        requirements depend on your particular partitioning profile and
-        the software selected. </para>
-    </sect2>
-
-    <sect2 xml:id="sec.update.prep.btrfs-on-root">
-      <title>Check Space on Btrfs Root File Systems</title>
-      <para>If you use Btrfs as root file systems on your machine,
-        make sure there is enough free space. Getting disk space can be
-        done with these two commands:
-      </para>
-      <screen>&prompt.root;<command>btrfs</command> filesystem df /
-&prompt.root;<command>df</command> /</screen>
-      <para>The results of the two commands show similar numbers of how
-        much disk space is used. However, the problem with Btrfs and free
-        space is that you do not know what is referenced in a snapshot and what is
-        not; you cannot calculate how much disk space a change would
-        need.</para>
-      <para>In the worst case, an upgrade needs as much disk space
-        as the current root file system (without
-        <filename>/.snapshot</filename>).
-        Besides any Btrfs file systems, check for free space on other
-        file systems as well. The following recommendation has been
-        proven:
-      </para>
-
-      <itemizedlist>
-        <listitem>
-          <para>For all file systems including Btrfs you need enough free
-            disk space to download and install big RPMs.
-            The space of old RPMs are only freed after new RPMs are
-            installed.</para>
-        </listitem>
-        <listitem>
-          <para>For Btrfs with snapshots, you need at minimum as much free
-            space as your current installation takes. It is recommended to
-            have twice as much free space as the current installation.
-          </para>
-          <para>If you do not have enough free space, you can try to
-            delete old snapshots with <command>snapper</command> like this:
-          </para>
-          <screen>&prompt.root;<command>snapper</command> list
-&prompt.root;<command>snapper</command> delete NUMBER</screen>
-          <para>However, this may not help in all cases. Before migration,
-            most snapshots occupy only little space.</para>
-        </listitem>
-      </itemizedlist>
-    </sect2>
+      up data and checking the release notes.</para>
 
     <sect2 xml:id="sec.update.prep.multiversion">
      <title>Temporarily Disable Kernel Multiversion Support</title>
@@ -148,10 +72,10 @@ tmpfs          506M     0  506M   0% /dev/shm
         packages have changed significantly, and which precautions you
         should take in addition to the general recommendations of this
         section. The release notes also provide last-minute information
-        and known issues that could not make it to the manual on time. </para>
+        and known issues that could not make it to the manual on time.</para>
       <para>The current version of the release notes document
         containing the latest information on &productname; can be read
-        online at <link xlink:href="http://www.suse.com/doc/"/>. </para>
+        online at <link xlink:href="http://www.suse.com/doc/"/>.</para>
     </sect2>
 
     <sect2 xml:id="sec.update.prep.backup">
@@ -165,7 +89,7 @@ tmpfs          506M     0  506M   0% /dev/shm
         data in <filename>/home</filename> (the <envar>HOME</envar>
         directories) to a backup medium. Back up this data as
         &rootuser;. Only &rootuser; has read permissions for all local
-        files. </para>
+        files.</para>
       <para>If you have selected <guimenu>Update an Existing
           System</guimenu> as the installation mode in &yast;, you can
         choose to do a (system) backup at a later point in time. You can
@@ -173,7 +97,7 @@ tmpfs          506M     0  506M   0% /dev/shm
           <filename>/etc/sysconfig</filename> directory. However, this
         is not a complete backup, as all the other important directories
         mentioned above are missing. Find the backup in the
-          <filename>/var/adm/backup</filename> directory. </para>
+          <filename>/var/adm/backup</filename> directory.</para>
     </sect2>
 
     <sect2 xml:id="sec.update.prep.mariadb">
@@ -245,7 +169,7 @@ tmpfs          506M     0  506M   0% /dev/shm
         &postgresql; database as a maintenance update. Because of the
         required migration work of the database, there is no automatic
         upgrade process. As such, the switch from one version to another
-        needs to be done manually. </para>
+        needs to be done manually.</para>
       <para>The migration process is conducted by the
           <command>pg_upgrade</command> command which is an alternative
         method of the classic dump and reload. In comparison with the
@@ -297,14 +221,14 @@ tmpfs          506M     0  506M   0% /dev/shm
             <listitem>
               <para>Install the package
                   <package>postgresql94-contrib</package> which contains
-                the command <command>pg_upgrade</command>. </para>
+                the command <command>pg_upgrade</command>.</para>
             </listitem>
             <listitem>
               <para>Make sure you have enough free space in your
                 &postgresql; data area, which is
                   <filename>/var/lib/pgsql/data</filename> by default.
                 If space is tight, try to reduce size with the following
-                SQL command on each database (can take very long!): </para>
+                SQL command on each database (can take very long!):</para>
               <screen>VACUUM FULL</screen>
             </listitem>
           </itemizedlist>
@@ -369,7 +293,102 @@ tmpfs          506M     0  506M   0% /dev/shm
       <para>If your machine serves as a &vmhost; for &kvm; or &xen;,
         make sure to properly shut down all running &vmguest;s prior to
         the update. Otherwise you may not be able to access the guests
-        after the update. </para>
+        after the update.</para>
+    </sect2>
+  </sect1>
+
+  <sect1 xml:id="sec.update.disk">
+    <title>Disk Space</title>
+    <para>
+      Software tends to <quote>grow</quote> from version to
+      version. Therefore, take a look at the available partition space
+      before updating. If you suspect you are running short of disk space,
+      secure your data before increasing the available space
+      by resizing partitions, for example.
+
+      There is no general rule regarding how much space each partition
+      should have. Space requirements depend on your particular partitioning
+      profile and the software selected.
+    </para>
+
+    <note>
+      <title>Automatic Check for enough Space in &yast;</title>
+      <para>
+        During the update procedure, &yast; will check the free disk space
+        and display a warning to the user if the installation may exceed
+        the available amount. In that case, performing the update
+        may lead to an <emphasis>unusable system</emphasis>!
+        Only if you know exactly what you are doing (by testing beforehand),
+        you can skip the warning and continue the update.
+      </para>
+    </note>
+
+    <sect2 xml:id="sec.update.disk.space">
+      <title>Checking Disk Space on Non-Btrfs File Systems</title>
+      <para>
+        Use the <command>df</command> command to list available disk space.
+        For example, in <xref linkend="aus.update.df"/>,
+        the root partition is <filename>/dev/sda3</filename>
+        (mounted as <filename>/</filename>).
+      </para>
+      <example xml:id="aus.update.df">
+        <title>List with <command>df -h</command></title>
+        <screen os="sled">Filesystem     Size  Used Avail Use% Mounted on
+/dev/sda3       74G   22G   53G  29% /
+tmpfs          506M     0  506M   0% /dev/shm
+/dev/sda5      116G  5.8G  111G   5% /home
+/dev/sda1       39G  1.6G   37G   4% /windows/C
+/dev/sda2      4.6G  2.6G  2.1G  57% /windows/D</screen>
+        <screen os="sles">Filesystem     Size  Used Avail Use% Mounted on
+/dev/sda3       74G   22G   53G  29% /
+tmpfs          506M     0  506M   0% /dev/shm
+/dev/sda5      116G  5.8G  111G   5% /home
+/dev/sda1       44G    4G   40G   9% /data</screen>
+      </example>
+    </sect2>
+
+    <sect2 xml:id="sec.update.disk.btrfs-on-root">
+      <title>Checking Disk Space on Btrfs Root File Systems</title>
+      <para>If you use Btrfs as root file systems on your machine,
+        make sure there is enough free space. Getting disk space can be
+        done with these two commands:
+      </para>
+      <screen>&prompt.root;<command>btrfs</command> filesystem df /
+&prompt.root;<command>df</command> /</screen>
+      <para>The results of the two commands show similar numbers of how
+        much disk space is used. However, the problem with Btrfs and free
+        space is that you do not know what is referenced in a snapshot and what is
+        not; you cannot calculate how much disk space a change would
+        need.</para>
+      <para>In the worst case, an upgrade needs as much disk space
+        as the current root file system (without
+        <filename>/.snapshot</filename>).
+        Besides any Btrfs file systems, check for free space on other
+        file systems as well. The following recommendation has been
+        proven:
+      </para>
+
+      <itemizedlist>
+        <listitem>
+          <para>For all file systems including Btrfs you need enough free
+            disk space to download and install big RPMs.
+            The space of old RPMs are only freed after new RPMs are
+            installed.</para>
+        </listitem>
+        <listitem>
+          <para>For Btrfs with snapshots, you need at minimum as much free
+            space as your current installation takes. It is recommended to
+            have twice as much free space as the current installation.
+          </para>
+          <para>If you do not have enough free space, you can try to
+            delete old snapshots with <command>snapper</command> like this:
+          </para>
+          <screen>&prompt.root;<command>snapper</command> list
+&prompt.root;<command>snapper</command> delete NUMBER</screen>
+          <para>However, this may not help in all cases. Before migration,
+            most snapshots occupy only little space.</para>
+        </listitem>
+      </itemizedlist>
     </sect2>
   </sect1>
 
@@ -381,13 +400,13 @@ tmpfs          506M     0  506M   0% /dev/shm
       <para>Cross-architecture upgrades, such as upgrading from a
         32-bit version of &productname; to the 64-bit version, or
         upgrading from big endian to little endian are
-        <emphasis>not</emphasis> supported! </para>
+        <emphasis>not</emphasis> supported!</para>
       <para>Specifically, &slea; 11 on &ppc; (big endian) to &slea;
         12 SP1 on &ppc; (new: little endian!), is <emphasis>not</emphasis>
-        supported. </para>
+        supported.</para>
       <para>Also, since &sle; 12 is 64-bit only, upgrades from any 32-bit
         &sle; 11 systems to &sle; 12 and later are <emphasis>not</emphasis>
-        supported. </para>
+        supported.</para>
     </important>
 
     <para>Before you perform any migration, read <xref linkend="sec.update.prep"/>.</para>
@@ -397,7 +416,7 @@ tmpfs          506M     0  506M   0% /dev/shm
         <term>Upgrading from &sle; 10 (any Service Pack)</term>
         <listitem>
           <para>There is no supported direct migration path to &sle;
-            12. A fresh installation is recommended instead. </para>
+            12. A fresh installation is recommended instead.</para>
         </listitem>
       </varlistentry>
       <varlistentry>
@@ -408,15 +427,15 @@ tmpfs          506M     0  506M   0% /dev/shm
           <para>If you cannot do a fresh install, you need to first
             update from &slea; 11 GA to SP1, then from &slea; 11 SP1 to SP2,
             and then from &slea; 11 SP2 to SP3. These steps are described in the
-              <link xlink:href="https://www.suse.com/documentation/sles11/">&sle; 11 Deployment Guide</link>. </para>
-          <para>Then proceed with <xref linkend="sec.update.sle12"/>. </para>
+              <link xlink:href="https://www.suse.com/documentation/sles11/">&sle; 11 Deployment Guide</link>.</para>
+          <para>Then proceed with <xref linkend="sec.update.sle12"/>.</para>
         </listitem>
       </varlistentry>
       <varlistentry>
         <term>Upgrading from &sle; 11 SP3 or SP4</term>
         <listitem>
           <para>Refer to <xref linkend="sec.update.sle12"/> for
-            details. </para>
+            details.</para>
         </listitem>
       </varlistentry>
       <varlistentry>
@@ -972,7 +991,7 @@ initrd (hd0,0)/boot/initrd.upgrade</screen>
       more kernel versions, for example, for testing purposes. To enable
       this, &sle; supports the <emphasis>multiversion kernel
         feature</emphasis>. By enabling and configuring this feature the
-      default behavior can be changed and configured to: </para>
+      default behavior can be changed and configured to:</para>
     <itemizedlist>
       <listitem>
         <para>delete an old kernel only after the system has been
@@ -983,13 +1002,13 @@ initrd (hd0,0)/boot/initrd.upgrade</screen>
           fallback</para>
       </listitem>
       <listitem>
-        <para>keep a specific kernel version </para>
+        <para>keep a specific kernel version</para>
       </listitem>
     </itemizedlist>
     <para>After the successful reboot, a script will compare the list
       of installed kernels with the settings in
         <filename>/etc/zypp/zypp.conf</filename> and delete those
-      kernels that are no longer needed. </para>
+      kernels that are no longer needed.</para>
     <sect2 xml:id="sec.update.sle12.multiversion.enable">
       <title>Enabling the Multiversion Kernel Feature</title>
       <para>The default behavior is defined in the configuration file
@@ -1003,7 +1022,7 @@ multiversion.kernels = latest,latest-1,running</screen>
         configure <emphasis>which</emphasis> kernels need to be
         preserved. You need to enable both, otherwise the system will
         keep <emphasis>all</emphasis> kernels and it will fill up your
-        hard disk. </para>
+        hard disk.</para>
       <para>The <literal>multiversion.kernels</literal> line can contain
         several keywords in different combinations and order:</para>
       <variablelist>
@@ -1054,7 +1073,7 @@ multiversion.kernels = latest,latest-1,running</screen>
       <title>Use Case: Deleting an Old Kernel After Reboot Only</title>
       <para>You want to make sure that an old kernel will only be
         deleted after the system has rebooted successfully of the new
-        kernel. </para>
+        kernel.</para>
       <para>Change the following line in
           <filename>/etc/zypp/zypp.conf</filename>:</para>
       <screen>multiversion.kernels = latest,running</screen>
@@ -1079,7 +1098,7 @@ multiversion.kernels = latest,latest-1,running</screen>
         <literal>latest,running</literal>), the previous kernel version
         of the new kernel (configured as <literal>latest-1</literal>), and
         the predecessor of the previous kernel version (configured as
-          <literal>latest-2</literal>). </para>
+          <literal>latest-2</literal>).</para>
     </sect2>
 
     <sect2 xml:id="sec.update.sle12.multiversion.specificversion">

--- a/xml/sle_update_upgrading.xml
+++ b/xml/sle_update_upgrading.xml
@@ -22,7 +22,7 @@ Check with Simona, if this is supported or needed.
   <title>Upgrading &sle;</title>
   <info>
     <abstract>
-      <para> &slereg; (&slea;) allows to update an existing system to
+      <para>&slereg; (&slea;) allows to update an existing system to
         the new version, for example, going from &slea; 11 SP4 to &slea;
         12. No new installation is needed. Existing data, such as home
         and data directories and system configuration, is kept intact.
@@ -39,13 +39,13 @@ Check with Simona, if this is supported or needed.
   <sect1 xml:id="sec.update.prep">
     <title>General Preparations</title>
 
-    <para> Before starting the update procedure, make sure your system
+    <para>Before starting the update procedure, make sure your system
       is properly prepared. Among others, preparation involves backing
       up data and checking the release notes. </para>
 
     <sect2 xml:id="sec.update.prep.disks">
       <title>Partitioning and Disk Space</title>
-      <para> Before starting your update, make note of the root
+      <para>Before starting your update, make note of the root
         partition. The command <command>df&nbsp;/</command> lists the
         device name of the root partition. For example, in <xref
           linkend="aus.update.df"/>, the root partition to write down is
@@ -65,7 +65,7 @@ tmpfs          506M     0  506M   0% /dev/shm
 /dev/sda5      116G  5.8G  111G   5% /home
 /dev/sda1       44G    4G   40G   9% /data</screen>
       </example>
-      <para> Software tends to <quote>grow</quote> from version to
+      <para>Software tends to <quote>grow</quote> from version to
         version. Therefore, take a look at the available partition space
         with <command>df</command> before updating. If you suspect you
         are running short of disk space, secure your data before
@@ -141,7 +141,7 @@ tmpfs          506M     0  506M   0% /dev/shm
 
     <sect2 xml:id="sec.update.prep.relnotes">
       <title>Check the Release Notes</title>
-      <para> In the release notes you can find additional information on
+      <para>In the release notes you can find additional information on
         what has changed since the previous release of &sle;.
         Verify there if your specific hardware or set up needs special
         considerations, which of your favorite specific software
@@ -149,14 +149,14 @@ tmpfs          506M     0  506M   0% /dev/shm
         should take in addition to the general recommendations of this
         section. The release notes also provide last-minute information
         and known issues that could not make it to the manual on time. </para>
-      <para> The current version of the release notes document
+      <para>The current version of the release notes document
         containing the latest information on &productname; can be read
         online at <link xlink:href="http://www.suse.com/doc/"/>. </para>
     </sect2>
 
     <sect2 xml:id="sec.update.prep.backup">
       <title>Make a Backup</title>
-      <para> Before updating, copy existing configuration files to a
+      <para>Before updating, copy existing configuration files to a
         separate medium (such as tape device, removable hard disk, etc.)
         to back up the data. This primarily applies to files stored in
           <filename>/etc</filename> and some directories
@@ -166,7 +166,7 @@ tmpfs          506M     0  506M   0% /dev/shm
         directories) to a backup medium. Back up this data as
         &rootuser;. Only &rootuser; has read permissions for all local
         files. </para>
-      <para> If you have selected <guimenu>Update an Existing
+      <para>If you have selected <guimenu>Update an Existing
           System</guimenu> as the installation mode in &yast;, you can
         choose to do a (system) backup at a later point in time. You can
         choose to include all modified files and files from the
@@ -366,7 +366,7 @@ tmpfs          506M     0  506M   0% /dev/shm
 
     <sect2 xml:id="sec.update.prep.vms">
       <title>Shut Down Virtual Machine Guests</title>
-      <para> If your machine serves as a &vmhost; for &kvm; or &xen;,
+      <para>If your machine serves as a &vmhost; for &kvm; or &xen;,
         make sure to properly shut down all running &vmguest;s prior to
         the update. Otherwise you may not be able to access the guests
         after the update. </para>
@@ -378,14 +378,14 @@ tmpfs          506M     0  506M   0% /dev/shm
 
     <important>
       <title>Cross-architecture Upgrades Are Not Supported</title>
-      <para> Cross-architecture upgrades, such as upgrading from a
+      <para>Cross-architecture upgrades, such as upgrading from a
         32-bit version of &productname; to the 64-bit version, or
         upgrading from big endian to little endian are
         <emphasis>not</emphasis> supported! </para>
-      <para> Specifically, &slea; 11 on &ppc; (big endian) to &slea;
+      <para>Specifically, &slea; 11 on &ppc; (big endian) to &slea;
         12 SP1 on &ppc; (new: little endian!), is <emphasis>not</emphasis>
         supported. </para>
-      <para> Also, since &sle; 12 is 64-bit only, upgrades from any 32-bit
+      <para>Also, since &sle; 12 is 64-bit only, upgrades from any 32-bit
         &sle; 11 systems to &sle; 12 and later are <emphasis>not</emphasis>
         supported. </para>
     </important>
@@ -396,7 +396,7 @@ tmpfs          506M     0  506M   0% /dev/shm
       <varlistentry>
         <term>Upgrading from &sle; 10 (any Service Pack)</term>
         <listitem>
-          <para> There is no supported direct migration path to &sle;
+          <para>There is no supported direct migration path to &sle;
             12. A fresh installation is recommended instead. </para>
         </listitem>
       </varlistentry>
@@ -409,13 +409,13 @@ tmpfs          506M     0  506M   0% /dev/shm
             update from &slea; 11 GA to SP1, then from &slea; 11 SP1 to SP2,
             and then from &slea; 11 SP2 to SP3. These steps are described in the
               <link xlink:href="https://www.suse.com/documentation/sles11/">&sle; 11 Deployment Guide</link>. </para>
-          <para> Then proceed with <xref linkend="sec.update.sle12"/>. </para>
+          <para>Then proceed with <xref linkend="sec.update.sle12"/>. </para>
         </listitem>
       </varlistentry>
       <varlistentry>
         <term>Upgrading from &sle; 11 SP3 or SP4</term>
         <listitem>
-          <para> Refer to <xref linkend="sec.update.sle12"/> for
+          <para>Refer to <xref linkend="sec.update.sle12"/> for
             details. </para>
         </listitem>
       </varlistentry>


### PR DESCRIPTION
This adds a note about the new check for free space in YaST during SP installation and also removes some whitespace.

The reorganization of the "General Preparations" section caused some id changes. Is that ok?