### PR TITLE
Clarify configuration location of apache2 instance

### DIFF
--- a/xml/apache2.xml
+++ b/xml/apache2.xml
@@ -2362,11 +2362,11 @@ sudo cp new.cert.key /etc/apache2/ssl.key/server.key</screen>
 <screen>systemctl start apache2@example_web.org</screen>
 
   <para>
-   This instance tries to read its configuration from
-   <filename>/etc/sysconfig/apache2@example_web.org</filename>. If the file
-   is not present or it does not set
-   <systemitem>APACHE_HTTPD_CONF</systemitem>, the instance reads
-   <filename>/etc/apache2@example_web.org/httpd.conf</filename>.
+   By default, the instance uses
+   <filename>/etc/apache2@example_web.org/httpd.conf</filename> as main
+   configuration file, which can be overwritten by setting 
+   <systemitem>APACHE_HTTPD_CONF</systemitem> in
+   <filename>/etc/sysconfig/apache2@example_web.org</filename>.
   </para>
 
   <para>


### PR DESCRIPTION
The first sentence could be understood as if the sysconfig file were the apache configuration before.