### PR TITLE
Adjusted `Language` option

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -4139,7 +4139,7 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
      <screen>
        &lt;language&gt;
          &lt;language&gt;en_GB&lt;/language&gt;
-         &lt;languages&gt;de_DE,en_GB&lt;/languages&gt;
+         &lt;languages&gt;de_DE,en_US&lt;/languages&gt;
        &lt;/language&gt;
      </screen>
    </example>
@@ -4169,7 +4169,7 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
         <row>
          <entry>
           <para>
-           language
+           languages
           </para>
          </entry>
          <entry>
@@ -4193,6 +4193,11 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
        </tbody>
       </tgroup>
    </informaltable>
+
+   <para>
+   If a primary language is unknown, it will be automatically changed into
+   the default one, which is <literal>en_US</literal>.
+   </para>
 
    <example>
      <title>Timezone</title>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -4195,8 +4195,8 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
    </informaltable>
 
    <para>
-   If a primary language is unknown, it will be automatically changed into
-   the default one, which is <literal>en_US</literal>.
+    If the configured value for the primary language is unknown, it will be reset
+    to the default, <literal>en_US</literal>.
    </para>
 
    <example>


### PR DESCRIPTION
## Changes
- fixed language -> languages (secondary languages)
- adjusted example for languages (it did not make sense to have en_GB for both pripary and secondary language)
- added note about fixing unknown language by replacing with the default one en_US (bsc#991001)

The profile still validates using `daps`.