### PR TITLE
Fix typos in the self_update_url documentation

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -1028,7 +1028,7 @@ exit 0
   http://example.com/updates/$arch
 &lt;self_update_url/&gt;</screen>
         <para>
-         Alternatively, you can specify the boot paramter
+         Alternatively, you can specify the boot parameter
          <literal>SelfUpdate</literal> on the Kernel command line.
         </para>
         <para>
@@ -1037,8 +1037,8 @@ exit 0
          <literal>x86_64</literal>, <literal>s390x</literal>, etc.
         </para>
         <para>
-         Use the boot paramter <literal>SelfUpdate=0</literal> to
-         disalbe the &yast; self-update.
+         Use the boot parameter <literal>SelfUpdate=0</literal> to
+         disable the &yast; self-update.
         </para>
        </entry>
       </row>


### PR DESCRIPTION
Fixes some typos in the `self_update_url` documentation.

Thanks!