### PR TITLE
VT: fixed guestfs documentation after update

### DIFF
--- a/xml/vt_guestfs.xml
+++ b/xml/vt_guestfs.xml
@@ -162,7 +162,7 @@
     accessing and modifying virtual machine disk images. This functionality
     is provided through a familiar shell interface with built-in safeguards
     which ensure image integrity. Guestfs tools shells expose all
-    capabilities of the guestfs API, and creates an appliance on the fly
+    capabilities of the guestfs API, and create an appliance on the fly
     using the packages installed on the machine and the files found in
     <filename>/usr/lib4/guestfs</filename>.
    </para>
@@ -477,8 +477,8 @@ tmpfs   /run              tmpfs   noauto          0 0
   <sect2 xml:id="sec.guestfs.trouble.btrfs">
    <title>Btrfs-related problems</title>
    <para>
-    When using the guestfs tools on an image with Btrfs root partition as
-    this is the case by default with SLES 12, the following error message
+    When using the guestfs tools on an image with Btrfs root partition (the default
+    with &sls; 12) the following error message
     could be provided:
    </para>
    <screen>&prompt.user; virt-ls -a /path/to/sles12sp2.qcow2 /
@@ -498,8 +498,8 @@ with these tools.  Use the guestfish equivalent commands
 (see the virt tool manual page).
 </screen>
    <para>
-    This usually is due to the presence of snapshots in the guests. In such
-    a case guestfs doesn't know what snapshot to bootstrap. To force the
+    This is usually caused by the presence of snapshots in the guests. In this
+    case guestfs does not know what snapshot to bootstrap. To force the
     use of a snapshot, use the <option>-m</option> parameter as following:
    </para>
    <screen>&prompt.user; virt-ls -m /dev/sda2:/:subvol=@/.snapshots/2/snapshot -a /path/to/sles12sp2.qcow2 /</screen>

--- a/xml/vt_guestfs.xml
+++ b/xml/vt_guestfs.xml
@@ -87,7 +87,7 @@
     modifying &vmguest; disk images and contents. These tools provide
     such capabilities as: viewing and editing files inside guests, scripting
     changes to &vmguest;s, monitoring disk used/free statistics, creating
-    guests, doing V2V migrations, performing backups, cloning &vmguest;s,
+    guests, doing V2V or P2V migrations, performing backups, cloning &vmguest;s,
     formatting disks, and resizing disks.
    </para>
    <warning>
@@ -110,25 +110,36 @@
   <title>Package Installation</title>
 
   <para>
-   libguestfs is shipped through 3 packages:
+   libguestfs is shipped through 4 packages:
   </para>
 
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     libguestfs0: which provides the main C library
+     <systemitem class="resource">libguestfs0</systemitem>: which provides
+     the main C library
     </para>
    </listitem>
    <listitem>
     <para>
-     guestfs-data: which contains the kernel and initrd used when launching
-     images (stored in <filename>/usr/lib64/guestfs</filename>)
+     <systemitem class="resource">guestfs-data</systemitem>: which contains
+     the appliance files used when launching images (stored in
+     <filename>/usr/lib64/guestfs</filename>)
     </para>
    </listitem>
    <listitem>
     <para>
-     guestfs-tools: the core guestfs tools, man pages, and the
-     <filename>/etc/libguestfs-tools.conf</filename> configuration file.
+     <systemitem class="resource">guestfs-tools</systemitem>: the core guestfs
+     tools, man pages, and the <filename>/etc/libguestfs-tools.conf</filename>
+     configuration file.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <systemitem class="resource">guestfs-winsupport</systemitem>: provides
+     support for Windows file guests in the guestfs tools. This package only
+     needs to be installed to handle Windows guests, for example when
+     converting a Windows guest to KVM.
     </para>
    </listitem>
   </itemizedlist>
@@ -151,7 +162,8 @@
     accessing and modifying virtual machine disk images. This functionality
     is provided through a familiar shell interface with built-in safeguards
     which ensure image integrity. Guestfs tools shells expose all
-    capabilities of the guestfs API, and use the kernel and initrd found in
+    capabilities of the guestfs API, and creates an appliance on the fly
+    using the packages installed on the machine and the files found in
     <filename>/usr/lib4/guestfs</filename>.
    </para>
   </sect2>
@@ -174,7 +186,7 @@
     </listitem>
     <listitem>
      <para>
-      Brtfs
+      Btrfs
      </para>
     </listitem>
    </itemizedlist>
@@ -461,6 +473,37 @@ tmpfs   /run              tmpfs   noauto          0 0
   <title>Troubleshooting</title>
 
   <para/>
+
+  <sect2 xml:id="sec.guestfs.trouble.btrfs">
+   <title>Btrfs-related problems</title>
+   <para>
+    When using the guestfs tools on an image with Btrfs root partition as
+    this is the case by default with SLES 12, the following error message
+    could be provided:
+   </para>
+   <screen>&prompt.user; virt-ls -a /path/to/sles12sp2.qcow2 /
+virt-ls: multi-boot operating systems are not supported
+
+If using guestfish '-i' option, remove this option and instead
+use the commands 'run' followed by 'list-filesystems'.
+You can then mount filesystems you want by hand using the
+'mount' or 'mount-ro' command.
+
+If using guestmount '-i', remove this option and choose the
+filesystem(s) you want to see by manually adding '-m' option(s).
+Use 'virt-filesystems' to see what filesystems are available.
+
+If using other virt tools, multi-boot operating systems won't work
+with these tools.  Use the guestfish equivalent commands
+(see the virt tool manual page).
+</screen>
+   <para>
+    This usually is due to the presence of snapshots in the guests. In such
+    a case guestfs doesn't know what snapshot to bootstrap. To force the
+    use of a snapshot, use the <option>-m</option> parameter as following:
+   </para>
+   <screen>&prompt.user; virt-ls -m /dev/sda2:/:subvol=@/.snapshots/2/snapshot -a /path/to/sles12sp2.qcow2 /</screen>
+  </sect2>
 
   <sect2 xml:id="sec.guestfs.trouble.env">
    <title>Environment</title>


### PR DESCRIPTION
Here are a bunch of changes for SLES12 SP2 reflecting the libguestfs upgrade.