### PR TITLE
Rewrite AutoYaST users section

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -8984,64 +8984,818 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
   </sect1>
 
 
-  <sect1 xml:id="Configuration.Security.users">
-   <title>Users</title>
+  <sect1 xml:id="Configuration.Security.users_and_groups">
+   <title>Users and Groups</title>
 
    <para>
-    The &rootuser; and at least one normal user can be added during
-    install using data supplied in the control file. User data and passwords
-    (encrypted or in clear text) are part of the
-    <literal>configure</literal> resource in the control file.
+    AutoYaST supports defining local users, groups, special login settings and even
+    default options for new users. Those settings are defined in the following sections:
    </para>
 
-   <para>
-    At least the &rootuser; should be configured during auto-installation
-    so you can login after the installation is finished. It will also ensure
-    nobody else can login to the system (in case the password is not set).
-   </para>
+   <variablelist>
+    <varlistentry>
+     <term>users</term>
+     <listitem>
+      <para>
+       List of users
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>user_defaults</term>
+     <listitem>
+      <para>
+       Default options for new users
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>groups</term>
+     <listitem>
+      <para>
+       List of groups
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>login_settings</term>
+     <listitem>
+      <para>
+       Special login settings like password-less login or autologin
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
 
-   <para>
-    The two users in the following example are added during system
-    configuration.
-   </para>
+   <note>
+    <title>Users and groups set up during the first stage</title>
+    <para>
+     Starting with &productname; 12 SP1, users and groups are set up during the
+     first stage (in previous versions it happened in the second one). So with a
+     minimal profile, you can set up a usable system running only the first stage.
+    </para>
+   </note>
 
-   <example>
-    <title>User Configuration</title>
-<screen>&lt;users config:type="list"&gt;
+   <sect2 xml:id="Configuration.Security.users">
+    <title>Users</title>
+
+    <para>
+     A list of users can be defined in the <literal>&lt;users&gt;</literal> section.
+     Take into account that at least the &rootuser; users should be set up so you can
+     login after the installation is finished.
+    </para>
+
+    <example>
+     <title>Minimal User Configuration</title>
+     <screen>&lt;users config:type="list"&gt;
   &lt;user&gt;
     &lt;username&gt;root&lt;/username&gt;
     &lt;user_password&gt;password&lt;/user_password&gt;
-    &lt;encrypted config:type="boolean"&gt;true&lt;/encrypted&gt;
-    &lt;forename/&gt;
-    &lt;surname/&gt;
+    &lt;encrypted config:type="boolean"&gt;false&lt;/encrypted&gt;
+  &lt;/user&gt;
+    &lt;user&gt;
+    &lt;username&gt;&exampleuser_plain;&lt;/username&gt;
+    &lt;user_password&gt;password&lt;/user_password&gt;
+    &lt;encrypted config:type="boolean"&gt;false&lt;/encrypted&gt;
+  &lt;/user&gt;
+&lt;/users&gt;</screen>
+    </example>
+
+    <informaltable>
+     <tgroup cols="3">
+      <thead>
+       <row>
+        <entry>
+         <para>
+          Attribute
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Values
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Description
+         </para>
+        </entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>
+         <para>
+          <literal>username</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Text
+         </para>
+<screen>&lt;username&gt;lukesw&lt;/username&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Required. It should be a valid username. Check <literal>man 8 useradd</literal>
+          if you're not sure.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>fullname</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Text
+         </para>
+<screen>&lt;fullname&gt;Tux Torvalds&lt;/fullname&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. User's fullname.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>forename</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Text
+         </para>
+<screen>&lt;forname&gt;Tux&lt;/forename&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. User's forename.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>surname</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Text
+         </para>
+<screen>&lt;surname&gt;Skywalkwer&lt;/surname&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. User's surname.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>uid</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Number
+         </para>
+<screen>&lt;uid&gt;1001&lt;/uid&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. User ID. It must be a unique and non-negative number.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>gid</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Number
+         </para>
+<screen>&lt;gid&gt;100&lt;/gid&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. Initial group ID. It must be a unique and non-negative
+          number. Moreover it must refer to an existing group.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>home</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Path
+         </para>
+<screen>&lt;home&gt;/home/luke&lt;/home&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. Absolute path to the user's home directory. By default,
+          <literal>/home/username</literal> will be used (e.g.
+          <literal>alice</literal>'s home directory will be
+          <literal>/home/alice</literal>).
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>shell</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Path
+         </para>
+<screen>&lt;shell&gt;/usr/bin/zsh&lt;/shell&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. <literal>/bin/bash</literal> is the default value. If you
+          choose another one, make sure that it's installed (adding the corresponding
+          package to the <literal>software</literal> section).
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>user_password</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Text
+         </para>
+<screen>&lt;user_password&gt;some-password&lt;/user_password&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. User's password can be written in plain text (not recommended) or in encrypted form.
+          Check the <literal>encrypted</literal> to select the desired behaviour.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>encrypted</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Boolean
+         </para>
+<screen>&lt;encrypted config:type="boolean"&gt;true&lt;/encrypted&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. Considered <literal>false</literal> if not present.
+          Indicates if the user's password in the profile is encrypted or not.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>password_settings</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Password settings
+         </para>
+         <screen>&lt;password_settings&gt;
+  &lt;expire/&gt;
+  &lt;max&gt;60&lt;/max&gt;
+  &lt;warn&gt;7&lt;/warn&gt;
+&lt;/password_settings&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. Some password settings can be customized: <literal>expire</literal>
+          (account expiration date in format <literal>YYYY-MM-DD</literal>), <literal>flag</literal>
+          (<literal>/etc/shadow</literal> flag), <literal>inact</literal> (number of days
+          after password expiration that account is disabled), <literal>max</literal>
+          (maximum number of days a password is valid), <literal>min</literal> (minimum
+          number of days a user can change the password) and <literal>warn</literal>
+          (number of days when the password change reminder starts).
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>authorized_keys</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          List of authorized keys
+         </para>
+         <screen>&lt;authorized_keys config:type="list"&gt;
+  &lt;listentry&gt;ssh-rsa ...&lt;/listentry&gt;
+&lt;/authorized_keys&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          A list of authorized keys to be written to <literal>$HOME/.ssh/authorized_keys</literal>.
+          See example below.
+         </para>
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+
+    <para>
+     The last example shows a more complete example. The data in
+     <filename>/etc/default/useradd</filename> is used to determine the home
+     directory of the user to be created plus other parameters.
+    </para>
+
+    <example>
+     <title>Complex User Configuration</title>
+     <screen>&lt;users config:type="list"&gt;
+  &lt;user&gt;
+    &lt;username&gt;root&lt;/username&gt;
+    &lt;user_password&gt;password&lt;/user_password&gt;
+    &lt;uid&gt;1001&lt;/uid&gt;
+    &lt;gid&gt;100&lt;/gid&gt;
+    &lt;encrypted config:type="boolean"&gt;false&lt;/encrypted&gt;
+    &lt;fullname&gt;Root User&lt;fullname&gt;
+    &lt;authorized_keys config:type="list"&gt;
+      &lt;listentry&gt;command="/opt/login.sh" ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDKLt1vnW2vTJpBp3VK91rFsBvpY97NljsVLdgUrlPbZ/L51FerQQ+djQ/ivDASQjO+567nMGqfYGFA/De1EGMMEoeShza67qjNi14L1HBGgVojaNajMR/NI2d1kDyvsgRy7D7FT5UGGUNT0dlcSD3b85zwgHeYLidgcGIoKeRi7HpVDOOTyhwUv4sq3ubrPCWARgPeOLdVFa9clC8PTZdxSeKp4jpNjIHEyREPin2Un1luCIPWrOYyym7aRJEPopCEqBA9HvfwpbuwBI5F0uIWZgSQLfpwW86599fBo/PvMDa96DpxH1VlzJlAIHQsMkMHbsCazPNC0++Kp5ZVERiH root@example.net&lt;/listentry&gt;
+    &lt;/authorized_keys&gt;
   &lt;/user&gt;
   &lt;user&gt;
     &lt;username&gt;&exampleuser_plain;&lt;/username&gt;
     &lt;user_password&gt;password&lt;/user_password&gt;
-    &lt;encrypted config:type="boolean"&gt;true&lt;/encrypted&gt;
-    &lt;forename&gt;Tux&lt;/forename&gt;
-    &lt;surname&gt;Linux&lt;/surname&gt;
+    &lt;encrypted config:type="boolean"&gt;false&lt;/encrypted&gt;
+    &lt;fullname&gt;Plain User&lt;fullname&gt;
+    &lt;home&gt;/Users/plain&lt;home&gt;
+    &lt;password_settings&gt;
+      &lt;max&gt;120&lt;/max&gt;
+      &lt;inact&gt;5&lt;/inact&gt;
+    &lt;/password_settings&gt;
   &lt;/user&gt;
 &lt;/users&gt;</screen>
-   </example>
+    </example>
 
-   <para>
-    The last example shows the minimal information required for adding
-    users. Additional options are available for a more customized user
-    account management. The data in
-    <filename>/etc/default/useradd</filename> is used to determine the home
-    directory of the user to be created plus other parameters.
-   </para>
-   <note>
-     <title>Users set up during the first stage</title>
+    <note>
+     <title><literal>authorized_keys</literal> file will be overwritten</title>
      <para>
-      Starting with &productname; 12 SP1, users are set up during the first
-      stage (in previous versions it happened in the second one). So with a
-      minimal profile, you can set up a usable system running only the first
-      stage.
+      If the profile defines a set of SSH authorized keys for a user, the content
+      of <literal>$HOME/.ssh/authorized_keys</literal> file will be overwritten
+      when using AutoYaST to perform a system upgrade or configuration.
+     </para>
+     <para>
+      To avoid such behaviour, the <literal>&lt;authorized_keys&gt;</literal> section
+      should be omitted.
+     </para>
+    </note>
+   </sect2>
+
+   <sect2 xml:id="Configuration.Security.user_defaults">
+    <title>User Defaults</title>
+
+    <para>
+     The profile can specify a set of default values for new users like
+     password expiration, initial group, home directory prefix, etc. Besides using them
+     as default values for the users that are defined in the profile, AutoYaST will
+     write those settings to <filename>/etc/default/useradd</filename> to be read for
+     <literal>useradd</literal>.
     </para>
-  </note>
+
+    <informaltable>
+     <tgroup cols="3">
+      <thead>
+       <row>
+        <entry>
+         <para>
+          Attribute
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Values
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Description
+         </para>
+        </entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>
+         <para>
+          <literal>group</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Text
+         </para>
+<screen>&lt;group&gt;100&lt;/group&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. Default initial login group.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>groups</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Text
+         </para>
+<screen>&lt;groups&gt;users&lt;/groups&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. List of additional groups.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>home</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Path
+         </para>
+<screen>&lt;home&gt;/home&lt;/home&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. Users home directories prefix.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>expire</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Date
+         </para>
+<screen>&lt;expire&gt;2017-12-31&lt;/expire&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. Default password expiration date in <literal>YYYY-MM-DD</literal> format.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>inactive</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Number
+         </para>
+<screen>&lt;inactive&gt;3&lt;/inactive&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. Number of days after an expired account is disabled.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>no_group</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Boolean
+         </para>
+<screen>&lt;no_groups config:type="boolean"&gt;true&lt;/no_groups&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. Do not use secondary groups.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>shell</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Path
+         </para>
+<screen>&lt;shell&gt;/usr/bin/fish&lt;/shell&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Default login shell. <literal>/bin/bash</literal> is the default value. If you
+          choose another one, make sure that it's installed (adding the corresponding
+          package to the <literal>software</literal> section).
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>skel</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Path
+         </para>
+<screen>&lt;skel&gt;/etc/skel&lt;/skel&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. Location of the files to be used as skel when adding a new user. You can find more
+          issue in <literal>man 8 useradd</literal>.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>umask</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          File creation mode mask
+         </para>
+<screen>&lt;umask&gt;022&lt;/umask&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Set the file creation mode mask for the home directory. By default
+          <literal>useradd</literal> will use <literal>022</literal>. Check <literal>man 8 useradd</literal>
+          and <literal>man 1 umask</literal> for further information.
+         </para>
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </sect2>
+
+   <sect2 xml:id="Configuration.Security.groups">
+    <title>Groups</title>
+
+    <para>
+     A list of groups can be defined in the <literal>&lt;groups&gt;</literal>
+     as shown in the example.
+    </para>
+
+    <example>
+     <title>Group Configuration</title>
+     <screen>&lt;groups&gt;
+  &lt;group&gt;
+    &lt;gid&gt;100&lt;gid&gt;
+    &lt;groupname&gt;users&lt;/groupname&gt;
+    &lt;userlist&gt;bob,alice&lt;/userlist&gt;
+  &lt;/group&gt;
+&lt;/groups&gt;</screen>
+    </example>
+
+    <informaltable>
+     <tgroup cols="3">
+      <thead>
+       <row>
+        <entry>
+         <para>
+          Attribute
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Values
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Description
+         </para>
+        </entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>
+         <para>
+          <literal>groupname</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Text
+         </para>
+<screen>&lt;groupname&gt;users&lt;/groupname&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Required. It should be a valid groupname. Check <literal>man 8 groupadd</literal>
+          if you're not sure.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>gid</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Number
+<screen>&lt;gid&gt;100&lt;/gid&gt;</screen>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Optional. Group ID. It must be a unique and non-negative number.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>group_password</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Text
+         </para>
+<screen>&lt;group_password&gt;password&lt;/group_password&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. The group's password can be written in plain text (not
+          recommended) or in encrypted form. Check the <literal>encrypted</literal> to
+          select the desired behaviour.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>encrypted</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Boolean
+         </para>
+<screen>&lt;encrypted config:type="boolean"&gt;true&lt;/encrypted&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. Indicates if the group's password in the profile is encrypted or not.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>userlist</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Users list
+         </para>
+<screen>&lt;userlist&gt;bob,alice&lt;/userlist&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. A list of users who belong to the group. Usernames must be separated by commas.
+         </para>
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </sect2>
+   
+   <sect2 xml:id="Configuration.Security.login_settings">
+    <title>Login Settings</title>
+
+    <para>Two special login settings can be enabled through an AutoYaST profile:
+    autologin and password-less login. Both of them are disabled by default.</para>
+
+    <example>
+     <title>Enabling autologin and password-less login</title>
+     <screen>&lt;login_settings&gt;
+  &lt;autologin_user&gt;vagrant&lt;/autologin_user>
+  &lt;password_less_login config:type="boolean"&gt;true&lt;/password_less_login>
+&lt;/login_settings&gt;</screen>
+    </example>
+
+    <informaltable>
+     <tgroup cols="3">
+      <thead>
+       <row>
+        <entry>
+         <para>
+          Attribute
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Values
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Description
+         </para>
+        </entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>
+         <para>
+          <literal>password_less_login</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Boolean
+         </para>
+<screen>&lt;password_less_login config:type="boolean"&gt;true&lt;/password_less_login&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. Enables password-less login. It only affects to graphical login.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>autologin_user</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Text
+         </para>
+<screen>&lt;autologin_user&gt;alice&lt;/autologin_user&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. Enables autologin for the given user.
+         </para>
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </sect2>
+
   </sect1>
+
   <sect1 xml:id="createprofile.scripts">
    <title>Custom User Scripts</title>
 

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -9030,9 +9030,8 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
    <note>
     <title>Users and groups set up during the first stage</title>
     <para>
-     Starting with &productname; 12 SP1, users and groups are set up during the
-     first stage (in previous versions it happened in the second one). So with a
-     minimal profile, you can set up a usable system running only the first stage.
+     Users and groups are set up during the first stage, so you can set up an
+     usable system without running the second stage.
     </para>
    </note>
 


### PR DESCRIPTION
This PR was started to document the new [fate#319471](https://fate.suse.com/319471) feature in AutoYaST. However, I've ended up rewriting the whole users section. Now `<groups>`, `<login_settings>` and `<user_defaults>` elements are documented. Moreover several missing options in the `<users>` group have been added.

You can check the result in [w3.suse.de](https://w3.suse.de/~igonzalezsosa/autoyast/handbook/configuration.html#Configuration.Security.users_and_groups).

But I need the review from some docu-team member, please.