### PR TITLE
Add self-update documentation

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -1314,12 +1314,8 @@ exit 0
 &lt;/networking&gt;</screen>
    </tip>
 
-   <table>
-    <title>System Registration: XML Representation</title>
+   <informaltable>
     <tgroup cols="3">
-     <colspec colwidth="1*"/>
-     <colspec colwidth="3*"/>
-     <colspec colwidth="2*"/>
      <thead>
       <row>
        <entry>
@@ -1348,16 +1344,16 @@ exit 0
        </entry>
        <entry>
         <para>
-         Specify whether the system should be registered or not. Can be set
-         to <literal>true</literal> or <literal>false</literal>.
+         Boolean
         </para>
 <screen>&lt;do_registration config:type="boolean"
 &gt;true&lt;/do_registration&gt;</screen>
        </entry>
        <entry>
         <para>
-         If set to <literal>false</literal> all other options are ignored
-         and the system is not registered.
+         Specify whether the system should be registered or not. If set to
+         <literal>false</literal> all other options are ignored and the system
+         is not registered.
         </para>
        </entry>
       </row>
@@ -1369,13 +1365,13 @@ exit 0
        </entry>
        <entry>
         <para>
-         The e-mail address matching the registration code.
+         E-mail address
         </para>
 <screen>&lt;email&gt;&exampleuser_plain;@&exampledomain;&lt;/email&gt;</screen>
        </entry>
        <entry>
         <para>
-         Required value.
+         Optional. The e-mail address matching the registration code.
         </para>
        </entry>
       </row>
@@ -1387,13 +1383,13 @@ exit 0
        </entry>
        <entry>
         <para>
-         The registration code.
+         Text
         </para>
 <screen>&lt;reg_code&gt;<replaceable>SECRET_REGCODE</replaceable>&lt;/reg_code&gt;</screen>
        </entry>
        <entry>
         <para>
-         Required value.
+         Required. Registration code.
         </para>
        </entry>
       </row>
@@ -1405,16 +1401,15 @@ exit 0
        </entry>
        <entry>
         <para>
-         Defines if the update repositories provided by the registration
-         server are used during the installation (<literal>true</literal>)
-         or not (<literal>false</literal>).
+         Boolean
         </para>
 <screen>&lt;install_updates config:type="boolean"
 &gt;true&lt;/install_updates&gt;</screen>
        </entry>
        <entry>
         <para>
-         Optional. The default value is <literal>false</literal>.
+         Optional. Determines if updates from the Updates channels should be
+         installed. The default value is to not install them (<literal>false</literal>).
         </para>
        </entry>
       </row>
@@ -1426,14 +1421,15 @@ exit 0
        </entry>
        <entry>
         <para>
-         Search for the registration server via SLP.
+         Boolean
         </para>
 <screen>&lt;slp_discovery config:type="boolean"
 &gt;true&lt;/slp_discovery&gt;</screen>
        </entry>
        <entry>
         <para>
-         Optional. The default value is <literal>false</literal>.
+         Optional. Search for a registration server via SLP. The default value
+         is <literal>false</literal>.
         </para>
         <para>
          Expects to find a single server. If more than one server is found,
@@ -1442,9 +1438,13 @@ exit 0
          <literal>reg_server</literal>.
         </para>
         <para>
-         Optional, If neither <literal>slp_discovery</literal> or
+         If neither <literal>slp_discovery</literal> nor
          <literal>reg_server</literal> are set, the system is registered
          with the &scc;.
+        </para>
+        <para>
+         This setting also affects self-update feature: if it's disabled, not
+         SLP search will be performed.
         </para>
        </entry>
       </row>
@@ -1456,7 +1456,7 @@ exit 0
        </entry>
        <entry>
         <para>
-         URl to the SMT server
+         URL
         </para>
 <screen>&lt;reg_server&gt;
   https://smt.&exampledomain;
@@ -1464,9 +1464,9 @@ exit 0
        </entry>
        <entry>
         <para>
-         Optional, If neither <literal>slp_discovery</literal> or
-         <literal>reg_server</literal> are set, the system is registered
-         with the &scc;.
+         Optional. &smt; server URL. If neither <literal>slp_discovery</literal>
+         nor <literal>reg_server</literal> are set, the system is registered with
+         the &scc;.
         </para>
        </entry>
       </row>
@@ -1478,8 +1478,7 @@ exit 0
        </entry>
        <entry>
         <para>
-         Fingerprint type. Can either be <literal>SHA1</literal> or
-         <literal>SHA256</literal>.
+         <literal>SHA1</literal> or <literal>SHA256</literal>
         </para>
 <screen>&lt;reg_server_cert_fingerprint_type&gt;
   SHA1
@@ -1487,11 +1486,11 @@ exit 0
        </entry>
        <entry>
         <para>
-         Requires a checksum value provided with
-         <literal>reg_server_cert_fingerprint</literal>. Using the
-         fingerprint is recommended, since it ensures the SSL certificate is
-         verified. The matching certificate will be automatically imported
-         when the SSL communication fails because of a verification error.
+         Optional. Requires a checksum value provided with
+         <literal>reg_server_cert_fingerprint</literal>. Using the fingerprint is
+         recommended, since it ensures the SSL certificate is verified. The matching
+         certificate will be automatically imported when the SSL communication fails
+         because of a verification error.
         </para>
        </entry>
       </row>
@@ -1511,11 +1510,11 @@ exit 0
        </entry>
        <entry>
         <para>
-         Requires a fingerprint type value provided with
-         <literal>reg_server_cert_fingerprint_type</literal>. Using the
-         fingerprint is recommended, since it ensures the SSL certificate is
-         verified. The matching certificate will be automatically imported
-         when the SSL communication fails because of a verification error.
+         Optional. Requires a fingerprint type value provided with
+         <literal>reg_server_cert_fingerprint_type</literal>. Using the fingerprint is
+         recommended, since it ensures the SSL certificate is verified. The matching
+         certificate will be automatically imported when the SSL communication fails
+         because of a verification error.
         </para>
        </entry>
       </row>
@@ -1527,7 +1526,7 @@ exit 0
        </entry>
        <entry>
         <para>
-         Path to the SSL certificate on the server.
+         URL
         </para>
 <screen>&lt;reg_server_cert&gt;
   http://smt.&exampledomain;/smt.crt
@@ -1535,9 +1534,9 @@ exit 0
        </entry>
        <entry>
         <para>
-         Using this option is not recommended, since the certificate that is
-         downloaded is not verified. Use
-         <literal>reg_server_cert_fingerprint</literal> instead.
+         Optional. URL of the SSL certificate on the server. Using this option is
+         not recommended, since the certificate that is downloaded is not verified.
+         Use <literal>reg_server_cert_fingerprint</literal> instead.
         </para>
        </entry>
       </row>
@@ -1549,18 +1548,20 @@ exit 0
        </entry>
        <entry>
         <para>
+         Addons list
+        </para>
+       </entry>
+       <entry>
+        <para>
          Specify an extension from the registration server that should be
          added to the installation repositories. See
          <xref linkend="CreateProfile.Register.Extension"/> for details.
         </para>
        </entry>
-       <entry>
-        <para/>
-       </entry>
       </row>
      </tbody>
     </tgroup>
-   </table>
+   </informaltable>
 
    <sect2 xml:id="CreateProfile.Register.Extension" os="sles;sled">
     <title>Extensions</title>
@@ -4806,315 +4807,6 @@ create_package_descr -x PATH_TO_EXTRA_PROV -d /usr/local/CDs/LATEST/suse</screen
 <screen>&lt;software&gt;
   &lt;do_online_update config:type="boolean"&gt;true&lt;/do_online_update&gt;
 &lt;/software&gt;</screen>
-   </sect2>
-  </sect1>
-
-  <sect1 xml:id="CreateProfile.registration">
-   <title>SUSE Registration</title>
-
-   <para>
-    &ay; also supports the registration of a SUSE Linux Enterprise (SLE) product to the SUSE Customer Center or SMT (Subscription Management Tool).
-    The module is a part of the &slea; product installation or upgrade workflow. So it is not needed for Tumbleweed or Leap.
-    A registered system will receive security updates and the functionality of the system can be extended via online extensions or modules.
-   </para>
-
-   <sect2 xml:id="CreateProfile.registration.general">
-    <title>Registration Section</title>
-    <example>
-     <title>SUSE Registration</title>
-     <screen>&lt;suse_register&gt;
-      &lt;do_registration config:type="boolean"&gt;true&lt;/do_registration&gt;
-      &lt;install_updates config:type="boolean"&gt;true&lt;/install_updates&gt;
-      &lt;email&gt;user@example.com&lt;/email&gt;
-      &lt;reg_code&gt;your_reg_code&lt;/reg_code&gt;
-      &lt;/reg_server&gt;
-      &lt;/reg_server_cert&gt;
-      &lt;slp_discovery config:type="boolean"&gt;false&lt;/slp_discovery&gt;
-      &lt;addons config:type="list"&gt;
-       &lt;addon&gt;
-        &lt;name&gt;sle-sdk&lt;/name&gt;
-        &lt;version&gt;12&lt;/version&gt;
-        &lt;arch&gt;x86_64&lt;/arch&gt;
-        &lt;release_type&gt;nil&lt;/release_type&gt;
-       &lt;/addon&gt;
-      &lt;/addons&gt;
-     &lt;/suse_register&gt;</screen>
-    </example>
-
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          do_registration
-         </para>
-        </entry>
-        <entry>
-         <para>
-          If set to <literal>false</literal> all other options are ignored and the system is not registered.
-         </para>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          reg_server
-         </para>
-        </entry>
-        <entry>
-         <para>
-          If you use SMT specify the server URL here.
-         </para>
-        </entry>
-        <entry>
-         <para>
-         Optional. Default <literal>scc.suse.com</literal>
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          reg_server_cert
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Download the server SSL certificate from the specified URL.
-         </para>
-        </entry>
-        <entry>
-         <para>
-         Optional. Not recommended
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          reg_server_cert_fingerprint_type
-         </para>
-        </entry>
-        <entry>
-         <para>
-         Server SSL certificate fingerprint - the matching certificate will be automatically imported when the SSL communication fails because of verification error. The type can be either <literal>SHA1</literal> or <literal>SHA256</literal>. Write the appropriate checksum value into the <literal>reg_server_cert_fingerprint</literal> tag (this is more secure than using the <literal>reg_server_cert</literal> tag which does not check the authenticity of the downloaded SSL certificate at all).
-         </para>
-        </entry>
-        <entry>
-         <para>
-         Optional
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          reg_server_cert_fingerprint
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Fingerprint value use hexadecimal notation, separate the pairs by
-          double colon (:), comparison is case-insensitive (that is, you can
-          use both <literal>[a-f]</literal> and
-          <literal>[A-F]</literal> characters in hexadecimal numbers).
-         </para>
-        </entry>
-        <entry>
-         <para>
-         Optional
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          email
-         </para>
-        </entry>
-        <entry>
-         <para>
-          E-mail matching the registration code.
-         </para>
-        </entry>
-        <entry>
-         <para>
-         Required
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          reg_code
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Registration code, might be empty when an SMT server is used.
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Required for <literal>scc.suse.com</literal> registration
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          install_updates
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Whether to install the updates from the Update channels.
-         </para>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          slp_discovery
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Obtain the registration server URL from SLP discovery. Exactly one
-          server is expected to be found. If there are more servers found &yast;
-          cannot automatically choose one of them and the installation fails
-          (in that case, use the <literal>reg_server</literal> tag and hardcode the
-          required registration server URL).
-         </para>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          addons
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Register additional extensions or modules
-         </para>
-        </entry>
-        <entry>
-          <para>
-          Described in the next section
-          </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-
-   </sect2>
-
-   <sect2 xml:id="CreateProfile.registration.extensions">
-    <title>Available SCC Extensions</title>
-    <para>
-    Here is a list of currently available extensions for SLES-12-x86_64 which can be used in an &ay; profile.
-    </para>
-    <para>
-     Note: The list is product and architecture dependent, for example only the <literal>sle-sdk</literal> extension is available for SLED, and some SLES extensions are not available for all architectures.
-    </para>
-
-    <para>
-     Extensions <literal>sle-we</literal>, <literal>sle-ha</literal> and <literal>sle-ha-geo</literal> require a registration code.
-    </para>
-
-    <example>
-     <title>SCC Extensions</title>
-     <screen>
-      &lt;addons config:type="list"&gt;
-       &lt;addon&gt;
-        &lt;arch&gt;x86_64&lt;/arch&gt;
-        &lt;name&gt;sle-ha&lt;/name&gt;
-        &lt;reg_code&gt;YOUR_REG_CODE_HERE&lt;/reg_code&gt;
-        &lt;release_type&gt;nil&lt;/release_type&gt;
-        &lt;version&gt;12&lt;/version&gt;
-      &lt;/addon&gt;
-      &lt;addon&gt;
-        &lt;arch&gt;x86_64&lt;/arch&gt;
-        &lt;name&gt;sle-ha-geo&lt;/name&gt;
-        &lt;reg_code&gt;YOUR_REG_CODE_HERE&lt;/reg_code&gt;
-        &lt;release_type&gt;nil&lt;/release_type&gt;
-        &lt;version&gt;12&lt;/version&gt;
-      &lt;/addon&gt;
-      &lt;addon&gt;
-        &lt;arch&gt;x86_64&lt;/arch&gt;
-        &lt;name&gt;sle-module-web-scripting&lt;/name&gt;
-        &lt;reg_code/&gt;
-        &lt;release_type&gt;nil&lt;/release_type&gt;
-        &lt;version&gt;12&lt;/version&gt;
-      &lt;/addon&gt;
-      &lt;addon&gt;
-        &lt;arch&gt;x86_64&lt;/arch&gt;
-        &lt;name&gt;sle-module-adv-systems-management&lt;/name&gt;
-        &lt;reg_code/&gt;
-        &lt;release_type&gt;nil&lt;/release_type&gt;
-        &lt;version&gt;12&lt;/version&gt;
-      &lt;/addon&gt;
-      &lt;addon&gt;
-        &lt;arch&gt;x86_64&lt;/arch&gt;
-        &lt;name&gt;sle-module-legacy&lt;/name&gt;
-        &lt;reg_code/&gt;
-        &lt;release_type&gt;nil&lt;/release_type&gt;
-        &lt;version&gt;12&lt;/version&gt;
-      &lt;/addon&gt;
-      &lt;addon&gt;
-        &lt;arch&gt;x86_64&lt;/arch&gt;
-        &lt;name&gt;sle-we&lt;/name&gt;
-        &lt;reg_code&gt;YOUR_REG_CODE_HERE&lt;/reg_code&gt;
-        &lt;release_type&gt;nil&lt;/release_type&gt;
-        &lt;version&gt;12&lt;/version&gt;
-      &lt;/addon&gt;
-      &lt;addon&gt;
-        &lt;arch&gt;x86_64&lt;/arch&gt;
-        &lt;name&gt;sle-sdk&lt;/name&gt;
-        &lt;reg_code/&gt;
-        &lt;release_type&gt;nil&lt;/release_type&gt;
-        &lt;version&gt;12&lt;/version&gt;
-      &lt;/addon&gt;
-      &lt;addon&gt;
-        &lt;arch&gt;x86_64&lt;/arch&gt;
-        &lt;name&gt;sle-module-public-cloud&lt;/name&gt;
-        &lt;reg_code/&gt;
-        &lt;release_type&gt;nil&lt;/release_type&gt;
-        &lt;version&gt;12&lt;/version&gt;
-      &lt;/addon&gt;
-     </screen>
-    </example>
    </sect2>
   </sect1>
 

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -1034,7 +1034,7 @@ exit 0
        </entry>
        <entry>
         <para>
-         YaST is able to update itself during the system installation. This
+         &yast; is able to update itself during the system installation. This
          requires to tell &ay; the location of the respective update
          repository with <literal>self_update_url</literal>:
         </para>
@@ -3961,7 +3961,7 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
          </entry>
          <entry>
           <para>
-           Version of the YaST module. Default: 1.0
+           Version of the &yast; module. Default: 1.0
           </para>
          </entry>
         </row>
@@ -5007,7 +5007,7 @@ create_package_descr -x PATH_TO_EXTRA_PROV -d /usr/local/CDs/LATEST/suse</screen
         <entry>
          <para>
           Obtain the registration server URL from SLP discovery. Exactly one
-          server is expected to be found. If there are more servers found YaST
+          server is expected to be found. If there are more servers found &yast;
           cannot automatically choose one of them and the installation fails
           (in that case, use the <literal>reg_server</literal> tag and hardcode the
           required registration server URL).
@@ -7827,7 +7827,7 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
        <entry>
         <para>
          Each list entry contains the name, type, and additional options.
-         Use the YaST Squid configuration module in order to get an overview
+         Use the &yast; Squid configuration module in order to get an overview
          of possible entries.
         </para>
        </entry>
@@ -7919,7 +7919,7 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
        </entry>
        <entry>
         <para>
-         Use the YaST Squid configuration module in order to get an overview
+         Use the &yast; Squid configuration module in order to get an overview
          about possible entries.
         </para>
        </entry>
@@ -9121,7 +9121,7 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
      <para>
       If you want to call <emphasis>zypper</emphasis> in the pre-install
       script you will need to set the environment variable <emphasis>ZYPP_LOCKFILE_ROOT="/var/run/autoyast"</emphasis>
-      in order to prevent conflicts with the running YaST process.
+      in order to prevent conflicts with the running &yast; process.
      </para>
     </note>
     <para>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -1034,16 +1034,15 @@ exit 0
        </entry>
        <entry>
         <para>
-         &yast; is able to update itself during the system installation. This
-         requires to tell &ay; the location of the respective update
-         repository with <literal>self_update_url</literal>:
+         Location of the update repository to use during &yast; self-update.
+         Check out the &deploy; to find further information about this feature.
         </para>
         <screen>&lt;self_update_url&gt;
   http://example.com/updates/$arch
 &lt;self_update_url/&gt;</screen>
         <para>
          Alternatively, you can specify the boot parameter
-         <literal>SelfUpdate</literal> on the Kernel command line.
+         <literal>self_update</literal> on the Kernel command line.
         </para>
         <para>
          The URL can contain a variable <envar>$arch</envar> that will be
@@ -1051,7 +1050,7 @@ exit 0
          <literal>x86_64</literal>, <literal>s390x</literal>, etc.
         </para>
         <para>
-         Use the boot parameter <literal>SelfUpdate=0</literal> to
+         Use the boot parameter <literal>self_update=0</literal> to
          disable the &yast; self-update.
         </para>
        </entry>
@@ -1467,6 +1466,11 @@ exit 0
          Optional. &smt; server URL. If neither <literal>slp_discovery</literal>
          nor <literal>reg_server</literal> are set, the system is registered with
          the &scc;.
+        </para>
+        <para>
+         This URL can be used if needed while trying to determine the
+         self-update update repository. Check out the &deploy; to find further
+         information about this feature.
         </para>
        </entry>
       </row>

--- a/xml/inst_yast2.xml
+++ b/xml/inst_yast2.xml
@@ -1145,6 +1145,23 @@
     </para>
 <screen>security=selinux selinux=1</screen>
    </sect3>
+   <sect3 xml:id="sec.i.yast.start.parameters.self_update">
+    <title>Disabling the Installer Self-Update</title>
+    <para>
+     During installation and upgrade, &yast; will try to update itself as
+     described <xref linkend="sec.i.yast2.self_update"/> in order to solve
+     potential bugs discovered after release. The <literal>self_update</literal>
+     parameter can be used to modify the behaviour of this feature.
+    </para>
+    <para>
+     To disable the installer self-update set the parameter to <literal>0</literal>.
+    </para>
+<screen>self_update=0</screen>
+    <para>
+     To use a user-defined repository, just specify the URL:
+    </para>
+<screen>self_update=https://updates.example.com/</screen>
+   </sect3>
   </sect2>
  </sect1>
  <sect1 xml:id="sec.i.yast2.steps">
@@ -1183,6 +1200,12 @@
   </tip>
 
   <orderedlist spacing="normal">
+   <listitem>
+    <para>
+     <!-- Installer Self-Update -->
+     <xref linkend="sec.i.yast2.self_update" xrefstyle="HeadingOnPage"/>
+    </para>
+   </listitem>
    <listitem>
     <para>
 <!-- Language, Keyboard and License Agreement -->
@@ -1275,6 +1298,220 @@
    </listitem>
   </orderedlist>
  </sect1>
+
+ <sect1 xml:id="sec.i.yast2.self_update">
+  <title>Installer Self-Update</title>
+
+  <para>
+   During the installation or upgrade process, &yast; is able to update itself
+   in order to solve bugs in the installer that were discovered after the release.
+   The self-update is performed automatically but it can be disabled if desired.
+   Check out <xref linkend="sec.i.yast.start.parameters.self_update"/> for further
+   information.
+  </para>
+
+  <para>
+   Although this feature was designed to run without user intervention, it is worth
+   to know how it works. If you're not interested, you can jump directly into
+   <xref linkend="sec.i.yast2.welcome"/> and skip the rest of this section.
+  </para>
+
+  <tip>
+   <title>Language Selection</title>
+   <para>
+    The installer self-update is executed before the language selection step.
+    That means that progress and errors which happens during this process are by default
+    displayed in English.
+   </para>
+   <para>
+    To use another language for this part of the installer, press
+    <keycap>F2</keycap> in the DVD boot menu and select the language from the list.
+    Or just use the <literal>language</literal> boot parameter (e.g.
+    <literal>language=de_DE</literal>).
+   </para>
+  </tip>
+
+  <sect2 xml:id="sec.i.yast2.self_update.process">
+   <title>Self-Update Process</title>
+
+   <para>
+    The process can be broken down into two different parts:
+   </para>
+
+   <orderedlist spacing="normal">
+    <listitem>
+     <para>
+      Determine updates repository URL.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Download and apply the updates to the installation system.
+     </para>
+    </listitem>
+   </orderedlist>
+
+   <sect3 xml:id="sec.i.yast2.self_update.determine_repo">
+    <title>Determining the Updates Repository URL</title>
+
+    <para>
+     Updates are distributed as regular RPM packages through a dedicated
+     repository, so the first step is to find out the repository URL. &yast; will try
+     the following sources of information:
+    </para>
+
+    <orderedlist spacing="normal">
+     <listitem>
+      <para>
+       <literal>self_update</literal> boot parameter (check <xref
+       linkend="sec.i.yast.start.parameters.self_update"/> for more details). If
+       you specified some URL, it will take precedence over any other method.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       <literal>/general/self_update_url</literal> profile element in case you're using &ay;.
+      </para>
+     </listitem>
+     <listitem os="sles;sled">
+      <para>
+       Registration server. &yast; will ask to a registration server for the
+       URL. The server to use is determined in the following order:
+      </para>
+      <orderedlist spacing="normal">
+       <listitem>
+        <para>
+         The &smt; specified through the <literal>regurl</literal> boot parameter
+         (<xref linkend="sec.i.yast2.start.parameters.smt"/>).
+        </para>
+       </listitem>
+     <listitem>
+      <para>
+       <literal>/suse_register/reg_server</literal> profile element in case you're using &ay;.
+      </para>
+     </listitem>
+       <listitem>
+        <para>
+         Performing a SLP lookup. If a SLP server is found, &yast; will ask the
+         user if it should be used because there's no authentication involved and
+         everybody on the local network could announce a registration server.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         As a last resort, the &scc; will be used.
+        </para>
+       </listitem>
+      </orderedlist>
+     </listitem>
+     <listitem>
+      <para>
+       A fallback URL defined in the installation media.
+       If none of the previous attempts worked, the fallback URL (defined in the
+       installation media) will be used.
+      </para>
+     </listitem>
+    </orderedlist>
+   </sect3>
+
+   <sect3 xml:id="sec.i.yast2.self_update.apply_updates">
+    <title>Downloading and applying the updates</title>
+
+    <para>
+     Once the updates repository is determined, &yast; will check whether an update
+     is available. In that case, all the updates will be downloaded and applied to
+     the installation system.
+    </para>
+
+    <para>
+     Finally, &yast; will be restarted to load the new version and the
+     welcome screen will be shown. If no updates were available, the installation
+     will continue without restarting &yast;
+    </para>
+
+    <note>
+     <title>Updates Integrity</title>
+     <para>
+      Updates signatures will be checked to ensure its integrity and authorship.
+      If some signature is not correct (or is missing), the user will be asked whether
+      she/he wants to apply the update.
+     </para>
+    </note>
+   </sect3>
+  </sect2>
+
+  <sect2 xml:id="sec.i.yast2.self_update.networking">
+   <title>Networking During Self-Update</title>
+
+   <para>
+    Obviously, for downloading the installer updates &yast; needs network. By
+    default it tries using DHCP on all network interfaces. If there is a DHCP server
+    in the network, then it will work automatically.
+   </para>
+
+   <para>
+    If you need a static IP setup, then you can use the <literal>ifcfg</literal>
+    boot argument. The syntax is
+    <literal>ifcfg=&lt;interface&gt;=&lt;ip address&gt;,&lt;gateway&gt;,&lt;nameserver&gt;</literal>.
+    Check out linuxrc documentation for more details.
+   </para>
+
+   <example>
+    <title>Specifying Network Configuration At Boot</title>
+    <screen>ifcfg=eth0=192.168.1.101/24,192.168.1.1,192.168.1.2</screen>
+   </example>
+  </sect2>
+
+  <sect2 xml:id="sec.i.yast2.self_update.custom">
+   <title>Custom self-update repositories</title>
+
+   <para>
+    &yast; can use a user-defined repository instead of the official one specifying
+    an URL through the <literal>self_update</literal> boot option.
+    However, the following points should be considered:
+   </para>
+
+   <itemizedlist mark="bullet" spacing="normal">
+    <listitem>
+     <para>
+      Only HTTP/HTTPS and FTP repositories are supported.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Only RPM-MD repositories are supported (required by &smt;).
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Packages are not installed in the usual way: they're just uncompressed and no
+      scripts are executed.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      No dependency checks are performed. Packages are installed in alfabetical order.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Files from the packages override those files from the original
+      installation media. That means that the update packages might not need to
+      contain all files, just the changed ones. The unchanged files can be omitted to
+      save memory and download bandwith.
+     </para>
+    </listitem>
+   </itemizedlist>
+
+   <note>
+    <title>Only One Repository</title>
+    <para>
+     Currently, it's not possible to use more than one repository as source of updates.
+    </para>
+   </note>
+  </sect2>
+ </sect1>
+
  <sect1 xml:id="sec.i.yast2.welcome">
   <title>Language, Keyboard and License Agreement</title>
 


### PR DESCRIPTION
Changes included in this PR:

* Add installer self-update information to the deployment guide
* Remove a duplicated section regarding SUSE registration in the AutoYaST guide.
* Update self-update information in AutoYaST guide.

You can check the final result here:

* [AutoYaST guide](https://w3.suse.de/~igonzalezsosa/doc-sle/autoyast-self-update/)
* [Deployment guide](https://w3.suse.de/~igonzalezsosa/doc-sle/book.sle.deployment/cha.inst.html#sec.i.yast2.self_update): [self_update boot parameter](https://w3.suse.de/~igonzalezsosa/doc-sle/book.sle.deployment/cha.inst.html#sec.i.yast.start.parameters.self_update) and [the process](https://w3.suse.de/~igonzalezsosa/doc-sle/book.sle.deployment/cha.inst.html#sec.i.yast2.self_update).

## For the blog

YaST documentation has been updated to include information about the installer self-update feature, which will debut in SUSE Linux Enterprise 12 SP3 and openSUSE Leap 42.2. On the AutoYaST side, some additional improvements were made, including cleaning-up some duplicated information about SUSE registration.