### PR TITLE
VT: add a note to disable USB auto-redirection

### DIFF
--- a/xml/vt_tools.xml
+++ b/xml/vt_tools.xml
@@ -133,6 +133,15 @@ virsh # hostname
       To start the &vmm;, enter <command>virt-manager</command> at the command
       prompt.
      </para>
+     <note>
+      <para>
+       To disable automatic USB device redirection for &vmguest; using spice,
+       either launch <command>virt-manager</command> with the
+       <option>--spice-disable-auto-usbredir</option> parameter or run the
+       following command to persistently change the default behavior:
+      </para>
+      <screen>&prompt.user; dconf write /org/virt-manager/virt-manager/console/auto-redirect false</screen>
+     </note>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -159,6 +168,13 @@ virsh # hostname
        </imageobject>
       </mediaobject>
      </informalfigure>
+     <note>
+      <para>
+       To disable automatic USB device redirection for &vmguest; using spice,
+       add an empty filter using the
+       <option>--spice-usbredir-auto-redirect-filter=''</option> parameter.
+      </para>
+     </note>
     </listitem>
    </varlistentry>
    <varlistentry>


### PR DESCRIPTION
Since SLES 12SP2, USB devices can be automatically redirected by
virt-manager or virt-viewer. Add notes on how to disable this feature
on these tools.