### PR TITLE
Fixed "100MB == 1 Gigabyte"

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -3112,7 +3112,7 @@ exit 0
     </para>
     <para>
      <literal>1GB</literal>, <literal>1G</literal>,
-     <literal>100MB</literal>, or <literal>1000M</literal> will all create a
+     <literal>1000MB</literal>, or <literal>1000M</literal> will all create a
      partition of the size 1 Gigabyte.
     </para>
     <example>


### PR DESCRIPTION
- Obviously it's 1000MB instead
- Found by a random scanning through the docs
- See section https://www.suse.com/documentation/sles-12/singlehtml/book_autoyast/book_autoyast.html#ay.auto_partitioning for the previous version