### PR TITLE
Update Btrfs subvolumes information in AutoYaST

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2655,11 +2655,8 @@ exit 0
         <entry>
          <para>
           List of subvolumes to create for a file system of type Btrfs. This
-          key only makes sense for file systems of type Btrfs. If there is a
-          default subvolume used for the distribution (for example
-          <filename>@</filename> in &productname;) the name of this
-          default subvolume is automatically prefixed to the names in this
-          list.
+          key only makes sense for file systems of type Btrfs. See
+          <xref linkend="ay.btrfs_subvolumes"/> for more information.
          </para>
 <screen>&lt;subvolumes config:type="list"&gt;
   &lt;path&gt;tmp&lt;/path&gt;
@@ -2860,6 +2857,56 @@ exit 0
       </tbody>
      </tgroup>
     </informaltable>
+   </sect2>
+
+   <sect2 xml:id="ay.btrfs_subvolumes">
+     <title>Btrfs subvolumes</title>
+     <para>
+      As mentioned in the <xref linkend="ay.partition_configuration">, it's
+      possible to define a set of subvolumes for each Btrfs filesystem. In
+      its simplest form, is just a list of entries:
+     </para>
+
+<screen>&lt;subvolumes config:type="list"&gt;
+  &lt;path&gt;tmp&lt;/path&gt;
+  &lt;path&gt;opt&lt;/path&gt;
+  &lt;path&gt;srv&lt;/path&gt;
+  &lt;path&gt;var/crash&lt;/path&gt;
+  &lt;path&gt;var/lock&lt;/path&gt;
+  &lt;path&gt;var/run&lt;/path&gt;
+  &lt;path&gt;var/tmp&lt;/path&gt;
+  &lt;path&gt;var/spool&lt;/path&gt;
+&lt;/subvolumes&gt;</screen>
+
+     <para>
+      AutoYaST supports disabling copy-on-write for a given subvolume. In that case,
+      an slightly more complex syntax should be used:
+     </para>
+
+<screen>&lt;subvolumes config:type="list"&gt;
+&lt;listentry&gt;tmp&lt;/listentry&gt;
+&lt;listentry&gt;opt&lt;/listentry&gt;
+&lt;listentry&gt;srv&lt;/listentry&gt;
+&lt;listentry&gt;
+  &lt;path&gt;var/lib/pgsql&lt;/path&gt;
+  &lt;copy_on_write config:type="boolean"&gt;false&lt;copy_on_write&gt;
+&lt;/listentry&gt;
+&lt;/subvolumes&gt;</screen>
+
+     <para os="sles;sled">
+      If there is a default subvolume used for the distribution (for example
+      <filename>@</filename> in &productname;) the name of this default subvolume
+      is automatically prefixed to the names in this list. This behaviour can
+      be disabled setting the <literal>btrfs_set_default_subvolume_name</literal>
+      in the <literal>general/storage</literal> section.
+     </para>
+
+<screen os="sles;sled">&lt;general&gt;
+  &lt;storage&gt;
+    &lt;btrfs_set_default_subvolume_name config:type="boolean"&gt;false&lt;/btrfs_set_default_subvolume_name&gt;
+  &lt;/storage&gt;
+&lt;/general&gt;
+</screen>
    </sect2>
 
    <sect2 xml:id="ay.raid_configuration">


### PR DESCRIPTION
Subvolumes handling in AutoYaST has been improved, as described [in this gist](https://gist.github.com/imobachgs/edb139cd85656dfaaa0ef97c28f51ae2#improved-autoyast-btrfs-subvolumes-handling). This PR adds documentation about those changes.

These changes are not shipped by default in SLE 12 SP2. Is `develop` the right branch to merge those changes?