### PR TITLE
stated that self_update is a boot parameter

### DIFF
--- a/xml/inst_yast2.xml
+++ b/xml/inst_yast2.xml
@@ -1301,8 +1301,8 @@
   <para>
    During the installation and upgrade process, &yast; is able to update itself
    to solve bugs in the installer that were discovered after the release.
-   This functionality is disabled by default, to enable it, set the parameter
-   <option>self_update</option> to <literal>1</literal>.
+   This functionality is disabled by default, to enable it, set the 
+   boot parameter <option>self_update</option> to <literal>1</literal>.
    For more information, see
    <xref linkend="sec.i.yast.start.parameters.self_update"/>.
   </para>


### PR DESCRIPTION
Made it clear that self_update for YaST is a boot parameter. The link for further details does not make that fact clear immediately.