### PR TITLE
zSystem requires Upgrade=1 parameter for upgrade

### DIFF
--- a/xml/deployment_prep_zseries.xml
+++ b/xml/deployment_prep_zseries.xml
@@ -116,6 +116,16 @@
       </para>
      </listitem>
     </varlistentry>
+    <varlistentry>
+     <term><command>Upgrade=&lt;0|1&gt;</command></term>
+     <listitem>
+      <para>If you want to upgrade your &sle;, specify
+       <command>Upgrade=1</command>. Therefore, a custom parmfile is
+       required for upgrading an existing installation of &sle;. Without
+       this parameter, the installation provides no upgrade option.
+      </para>
+     </listitem>
+    </varlistentry>
    </variablelist>
    <tip>
     <title>Creating a File with Autoinstallation Information</title>

--- a/xml/deployment_prep_zseries.xml
+++ b/xml/deployment_prep_zseries.xml
@@ -119,10 +119,10 @@
     <varlistentry>
      <term><command>Upgrade=&lt;0|1&gt;</command></term>
      <listitem>
-      <para>If you want to upgrade your &sle;, specify
-       <command>Upgrade=1</command>. Therefore, a custom parmfile is
-       required for upgrading an existing installation of &sle;. Without
-       this parameter, the installation provides no upgrade option.
+      <para>To upgrade your &sle;, specify <command>Upgrade=1</command>.
+       Therefore, a custom parmfile is required for upgrading an
+       existing installation of &sle;. Without this parameter, the
+       installation provides no upgrade option.
       </para>
      </listitem>
     </varlistentry>

--- a/xml/sle_update_upgrading.xml
+++ b/xml/sle_update_upgrading.xml
@@ -605,6 +605,13 @@ tmpfs          506M     0  506M   0% /dev/shm
    </listitem>
   </itemizedlist>
  </sect1>
+  <sect1 xml:id="sec.update.sle12zseries">
+  <title>Upgrading on IBM &zseries;</title>
+  <para>Upgrading a &sle; installation on &zseries; requires the
+   <command>Upgrade=1</command> kernel parameter, for example via the
+   parmfile. See <xref linkend="sec.appdendix.parm" xrefstyle="HeadingOnPage"/>
+  </para>
+ </sect1>
  <sect1 xml:id="sec.update.sle12.manual">
   <title>Upgrading Manually from &slea;&nbsp;11 SP3 to &slea; 12 SP1, Using an Installation Source</title>
 

--- a/xml/sle_update_upgrading.xml
+++ b/xml/sle_update_upgrading.xml
@@ -609,7 +609,7 @@ tmpfs          506M     0  506M   0% /dev/shm
   <title>Upgrading on IBM &zseries;</title>
   <para>Upgrading a &sle; installation on &zseries; requires the
    <command>Upgrade=1</command> kernel parameter, for example via the
-   parmfile. See <xref linkend="sec.appdendix.parm" xrefstyle="HeadingOnPage"/>
+   parmfile. See <xref linkend="sec.appdendix.parm" xrefstyle="HeadingOnPage"/>.
   </para>
  </sect1>
  <sect1 xml:id="sec.update.sle12.manual">


### PR DESCRIPTION
All update paths for zSystems require a special kernel parameter. Added a note in the "Upgrading SUSE Linux Enterprise" chapter and added the parameter in the parmfile section.

https://bugzilla.suse.com/show_bug.cgi?id=1010771&GoAheadAndLogIn=1