### PR TITLE
Mount Points with FCoE or iSCSI

### DIFF
--- a/xml/storage_fcoe.xml
+++ b/xml/storage_fcoe.xml
@@ -106,6 +106,17 @@
     </imageobject>
    </mediaobject>
   </informalfigure>
+  <note>
+   <title>Mount Point Support</title>
+   <para>FCoE devices will appear asynchronously during the
+    boot process. While the initrd guarantees that those devices are
+    setup correctly for the root file system, there are no such
+    guarantees for any other file systems or mount points like 
+    <filename>/usr</filename>. Hence any system mount points like 
+    <filename>/usr</filename> or <filename>/var</filename> are not 
+    supported. If you want to use those devices, ensure correct
+    synchronisation with the respective services and devices.</para>
+  </note>
  </sect1>
  <sect1 xml:id="sec.fcoe.install">
   <title>Installing FCoE and the &yast; FCoE Client</title>

--- a/xml/storage_fcoe.xml
+++ b/xml/storage_fcoe.xml
@@ -110,12 +110,12 @@
    <title>Mount Point Support</title>
    <para>FCoE devices will appear asynchronously during the
     boot process. While the initrd guarantees that those devices are
-    setup correctly for the root file system, there are no such
+    set up correctly for the root file system, there are no such
     guarantees for any other file systems or mount points like 
     <filename>/usr</filename>. Hence any system mount points like 
     <filename>/usr</filename> or <filename>/var</filename> are not 
     supported. If you want to use those devices, ensure correct
-    synchronisation with the respective services and devices.</para>
+    synchronisation of the respective services and devices.</para>
   </note>
  </sect1>
  <sect1 xml:id="sec.fcoe.install">

--- a/xml/storage_iscsi.xml
+++ b/xml/storage_iscsi.xml
@@ -1218,6 +1218,18 @@ node.session.iscsi.ImmediateData = Yes
    to attach iSCSI disks to the system and use them in the installation
    process.
   </para>
+  
+  <note>
+   <title>Mount Point Support</title>
+   <para>iSCSI devices will appear asynchronously during the
+    boot process. While the initrd guarantees that those devices are
+    setup correctly for the root file system, there are no such
+    guarantees for any other file systems or mount points like 
+    <filename>/usr</filename>. Hence any system mount points like 
+    <filename>/usr</filename> or <filename>/var</filename> are not 
+    supported. If you want to use those devices, ensure correct
+    synchronisation with the respective services and devices.</para>
+  </note>
  </sect1>
  <sect1 xml:id="sec.iscsi.trouble">
   <title>Troubleshooting iSCSI</title>

--- a/xml/storage_iscsi.xml
+++ b/xml/storage_iscsi.xml
@@ -1223,12 +1223,12 @@ node.session.iscsi.ImmediateData = Yes
    <title>Mount Point Support</title>
    <para>iSCSI devices will appear asynchronously during the
     boot process. While the initrd guarantees that those devices are
-    setup correctly for the root file system, there are no such
+    set up correctly for the root file system, there are no such
     guarantees for any other file systems or mount points like 
     <filename>/usr</filename>. Hence any system mount points like 
     <filename>/usr</filename> or <filename>/var</filename> are not 
     supported. If you want to use those devices, ensure correct
-    synchronisation with the respective services and devices.</para>
+    synchronisation of the respective services and devices.</para>
   </note>
  </sect1>
  <sect1 xml:id="sec.iscsi.trouble">


### PR DESCRIPTION
/usr and /var are not supported mount points for iSCSI and FCoE

https://bugzilla.suse.com/show_bug.cgi?id=1010297
uses text from https://bugzilla.suse.com/show_bug.cgi?id=1012335#c28