### PR TITLE
Updates are now referencing SLE12 SP2 instead of SP1, bsc#1016464

### DIFF
--- a/xml/sle_update_upgrading.xml
+++ b/xml/sle_update_upgrading.xml
@@ -738,7 +738,7 @@ tmpfs          506M     0  506M   0% /dev/shm
     <xref linkend="pro.update.sle12.manual.network.pxe-boot" xrefstyle="select:label"/>.
    </para>
    <procedure xml:id="pro.update.sle12.manual.network.boot-from-dvd">
-    <title>Manually Upgrading from &slea;&nbsp;11 SP3 or SP4 to &slea;&nbsp;12 SP1 via Network Installation Source&mdash;Booting from DVD</title>
+    <title>Manually Upgrading from &slea;&nbsp;11 SP3 or SP4 to &slea;&nbsp;12 SP2 via Network Installation Source&mdash;Booting from DVD</title>
     <para>
      This procedure describes booting from a DVD as an example, but you can
      also use another local installation medium like an ISO image on a USB mass
@@ -749,7 +749,7 @@ tmpfs          506M     0  506M   0% /dev/shm
     </para>
     <step>
      <para>
-      Insert DVD 1 of the &sle; 12 SP1 installation media and boot your
+      Insert DVD 1 of the &sle; 12 SP2 installation media and boot your
       machine. A <guimenu>Welcome</guimenu> screen is displayed, followed by
       the boot screen.
      </para>
@@ -772,7 +772,7 @@ tmpfs          506M     0  506M   0% /dev/shm
     </step>
    </procedure>
    <procedure xml:id="pro.update.sle12.manual.network.pxe-boot">
-    <title>Manually Upgrading from &slea;&nbsp;11 SP3 or SP4 to &slea;&nbsp;12 SP1 via Network Installation Source&mdash;Booting via PXE</title>
+    <title>Manually Upgrading from &slea;&nbsp;11 SP3 or SP4 to &slea;&nbsp;12 SP2 via Network Installation Source&mdash;Booting via PXE</title>
     <para>
      To perform an upgrade from a network installation source using PXE Boot,
      proceed as follows:
@@ -787,7 +787,7 @@ tmpfs          506M     0  506M   0% /dev/shm
     <step>
      <para>
       Set up a TFTP server to hold the boot image needed for booting via PXE.
-      Use DVD 1 of your &sle; 12 SP1 installation media for this or follow the
+      Use DVD 1 of your &sle; 12 SP2 installation media for this or follow the
       instructions in <xref linkend="sec.deployment.prep_boot.tftp"/>.
      </para>
     </step>

--- a/xml/sle_update_upgrading.xml
+++ b/xml/sle_update_upgrading.xml
@@ -613,7 +613,7 @@ tmpfs          506M     0  506M   0% /dev/shm
   </para>
  </sect1>
  <sect1 xml:id="sec.update.sle12.manual">
-  <title>Upgrading Manually from &slea;&nbsp;11 SP3 to &slea; 12 SP1, Using an Installation Source</title>
+  <title>Upgrading Manually from &slea;&nbsp;11 SP3 or SP4 to &slea; 12 SP2, Using an Installation Source</title>
 
   <para>
    Before you upgrade your system, read <xref linkend="sec.update.prep"/>
@@ -657,10 +657,10 @@ tmpfs          506M     0  506M   0% /dev/shm
     below.
    </para>
    <procedure xml:id="pro.update.sle12.manual.dvd">
-    <title>Manually Upgrading from &slea;&nbsp;11 SP3 to &slea;&nbsp;12 SP1, Using a DVD</title>
+    <title>Manually Upgrading from &slea;&nbsp;11 SP3 or SP4 to &slea;&nbsp;12 SP2, Using a DVD</title>
     <step>
      <para>
-      Insert DVD 1 of the &sle; 12 SP1 installation medium and boot your
+      Insert DVD 1 of the &sle; 12 SP2 installation medium and boot your
       machine. A <guimenu>Welcome</guimenu> screen is displayed, followed by
       the boot screen.
      </para>

--- a/xml/sle_update_upgrading.xml
+++ b/xml/sle_update_upgrading.xml
@@ -521,7 +521,7 @@ tmpfs          506M     0  506M   0% /dev/shm
     endian are <emphasis>not</emphasis> supported!
    </para>
    <para>
-    Specifically, &slea; 11 on &ppc; (big endian) to &slea; 12 SP1 on &ppc;
+    Specifically, &slea; 11 on &ppc; (big endian) to &slea; 12 SP2 on &ppc;
     (new: little endian!), is <emphasis>not</emphasis> supported.
    </para>
    <para>
@@ -572,7 +572,7 @@ tmpfs          506M     0  506M   0% /dev/shm
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Upgrading from &sle; 12 to SP1</term>
+    <term>Upgrading from &sle; 12 or &sle; 12 SP1 to SP2</term>
     <listitem>
      <para>
       Refer to <xref linkend="cha.update.spmigration"/> for details.
@@ -813,7 +813,7 @@ tmpfs          506M     0  506M   0% /dev/shm
   </sect2>
  </sect1>
  <sect1 xml:id="sec.update.sle12.automated">
-  <title>Migrating Automatically from &slea; 11 SP3 or SP4 to &slea; 12 SP1</title>
+  <title>Migrating Automatically from &slea; 11 SP3 or SP4 to &slea; 12 SP2</title>
 
   <para>
    Before you upgrade your system, read <xref linkend="sec.update.prep"/>
@@ -821,7 +821,7 @@ tmpfs          506M     0  506M   0% /dev/shm
   </para>
 
   <procedure xml:id="pro.update.sle12.automated">
-   <title>Automated Migration from &sle; 11 SP3 to &sle; 12 SP1</title>
+   <title>Automated Migration from &sle; 11 SP3 or SP4 to &sle; 12 SP2</title>
    <remark>toms 2014-03-19: See FATE#315037</remark>
    <remark role="future">toms 2014-03-20: From SLE12 SP1 on, we should probably base
     this example on GRUB2, but not for GA.</remark>


### PR DESCRIPTION
The docu was still "describing" the update to SP1 instead of SP2.
Fix for https://bugzilla.novell.com/show_bug.cgi?id=1016464