### PR TITLE
Add AutoYaST self_update element

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -1029,6 +1029,37 @@ exit 0
       <row>
        <entry>
         <para>
+         <literal>self_update</literal>
+        </para>
+       </entry>
+       <entry>
+        <para>
+         This option allows to enable/disable the self-update.
+         Check out the &deploy; to find further information about this feature.
+         </para>
+        <screen>&lt;self_update config:type="boolean"&gt;
+  false
+&lt;self_update/&gt;</screen>
+        <para>
+         Alternatively, you can specify the boot parameter
+         <literal>self_update</literal> on the Kernel command line.
+        </para>
+        <important>
+         <title>Disabling the self-update</title>
+         <para>
+          Please, note that this feature will be skipped if any option disables
+          it: setting this option to <literal>false</literal> or using the
+          boot parameter <literal>self_update=0</literal>.
+         </para>
+        </important>
+       </entry>
+       <entry>
+        <para>Optional. The default is <literal>true</literal>.</para>
+       </entry>
+      </row>
+      <row>
+       <entry>
+        <para>
          <literal>self_update_url</literal>
         </para>
        </entry>
@@ -1049,10 +1080,6 @@ exit 0
          The URL can contain a variable <envar>$arch</envar> that will be
          replaced by the system's architecture, such as
          <literal>x86_64</literal>, <literal>s390x</literal>, etc.
-        </para>
-        <para>
-         Use the boot parameter <literal>SelfUpdate=0</literal> to
-         disable the &yast; self-update.
         </para>
        </entry>
       </row>


### PR DESCRIPTION
This PR replaces #102. It adds the description of a new AutoYaST element `self_update`. See yast/yast-installation#501 for more details.