### PR TITLE
libvirt: clarify description of xendomains and libvirtd conflict

### DIFF
--- a/xml/libvirt_overview.xml
+++ b/xml/libvirt_overview.xml
@@ -70,8 +70,10 @@ active</screen>
 &prompt.user;sudo systemctl start libvirtd</screen>
   <para>
    <systemitem class="daemon">xendomains</systemitem> and <systemitem
-   class="daemon">libvirtd</systemitem> use different methods for communicating
-   with the domUs and therefore cannot be used in parallel.
+   class="daemon">libvirtd</systemitem> provide the same service and when used
+   in parallel may interfere with one another. As an example, <systemitem
+   class="daemon">xendomains</systemitem> may attempt to start a domU already
+   started by <systemitem class="daemon">libvirtd</systemitem>.
   </para>
  </important>
 


### PR DESCRIPTION
Provide a more accurate description of why xendomains and libvirtd
conflict, including a simple example.