### PR TITLE
Fix mis-identified parameter for qcow2 images used in

### DIFF
--- a/xml/vt_best_practices.xml
+++ b/xml/vt_best_practices.xml
@@ -1873,7 +1873,7 @@ kernel.numa_balancing_scan_size_mb = 256<co xml:id="co.numa.size"/></screen>
     </itemizedlist>
     <variablelist>
      <varlistentry>
-      <term>12-cache-size</term>
+      <term>l2-cache-size</term>
       <listitem>
        <para>
         qcow2 can provide the same performance for random read/write access as
@@ -1882,7 +1882,7 @@ kernel.numa_balancing_scan_size_mb = 256<co xml:id="co.numa.size"/></screen>
         GB. If you need a bigger disk size, you need to adjust the cache
         size. For a disk size of 64 GB (64*1024 = 65536), you need 65536 /
         8192B = 8 MB of cache (<option>-drive
-        format=qcow2,12-cache-size=8M</option>).
+        format=qcow2,l2-cache-size=8M</option>).
        </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
Virtualization Best Practices doc. 12-cache-size (twelve)
should instead read l2-cache-size (ell two, as in level 2).

Signed-off-by: Bruce Rogers <brogers@suse.com>