### PR TITLE
Use Travis template from doc-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,15 @@ language: bash
 env:
       global:
       - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
-      - CACHE=$HOME/.cache/entities
+      - CACHE="$HOME/.cache/entities"
       - XML_CATALOG_FILES="catalog.xml"
+      - GITHUB_URL="https://raw.githubusercontent.com/openSUSE/doc-ci/develop/travis/travis.sh"
 
 dist: yakkety
 
 cache:
   directories:
-    - $HOME/.cache/entities
+    - $CACHE
 
 addons:
   apt:
@@ -20,29 +21,9 @@ addons:
 
 before_script:
     - cat /etc/os-release
-    # - ls xml/*.xml
     - echo $TRAVIS_COMMIT
     - xmllint --version
+    - wget $GITHUB_URL && chmod +x travis.sh
 
 script:
-    #- echo -en 'travis_fold:start:catalog_creation\r'
-    - xmlcatalog --noout --create catalog.xml
-    - xmlcatalog --noout --add system "http://www.oasis-open.org/docbook/xml/4.5/dbcentx.mod" "$CACHE/dbcentx.mod" catalog.xml
-    - xmlcatalog catalog.xml "http://www.oasis-open.org/docbook/xml/4.5/dbcentx.mod"
-    #- echo 'XML catalog creation successful.'
-    #- echo -en 'travis_fold:end:catalog_creation\r'
-    # ---------------------
-    #- echo -en 'travis_fold:start:download\r'
-    - test -e $CACHE || ( mkdir -p $CACHE; wget -P $CACHE http://docbook.org/xml/4.5/docbook-xml-4.5.zip; unzip -d $CACHE $CACHE/docbook-xml-4.5.zip )
-    #- echo 'Using DocBook entity cache.'
-    #- echo -en 'travis_fold:end:download\r'
-    # ---------------------
-    #- echo -en 'travis_fold:start:entities\r'
-    - cp -vi $CACHE/*.mod xml/
-    - cp -avi $CACHE/ent xml/
-    #- echo 'Entity copy successful.'
-    #- echo -en 'travis_fold:end:entities\r'
-    # ---------------------
-    # - echo -en 'travis_fold:start:xmlcheck\r'
-    - for file in xml/*.xml; do echo ">>> $file"; xmllint --nonet --noout --noent $file; done
-    # - echo -en 'travis_fold:end:xmlcheck\r'
+    - ./travis.sh xml/*.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
       - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
       - CACHE="$HOME/.cache/entities"
       - XML_CATALOG_FILES="catalog.xml"
-      - GITHUB_URL="https://raw.githubusercontent.com/openSUSE/doc-ci/develop/travis/travis.sh"
+      - GITHUB_URL="https://raw.githubusercontent.com/openSUSE/doc-ci/master/travis/travis.sh"
 
 dist: yakkety
 


### PR DESCRIPTION
@sven15 I improved `.travis.yml` and used a shell script from [doc-c](https://github.com/openSUSE/doc-ci)i repo. Could you review it, please? Thanks!