### PR TITLE
Z requires NPIV enabled for automatic LUN scanning, fate#320750

### DIFF
--- a/xml/deployment_docupdates.xml
+++ b/xml/deployment_docupdates.xml
@@ -83,6 +83,11 @@ title="Profiling step"?>
         Added information about the &suse; Package Hub, see <xref linkend="sec.i.yast2.inst_mode.addon.packagehub" />.
        </para>
       </listitem>
+      <listitem>
+       <para>
+        Automatic LUN scanning on &zseries; only works with NPIV enabled, see <xref linkend="sec.i.yast2.s390.part.zfcp" />.
+       </para>
+      </listitem>
      </itemizedlist>
     </listitem>
    </varlistentry>

--- a/xml/inst_yast2.xml
+++ b/xml/inst_yast2.xml
@@ -1675,7 +1675,11 @@
     available <guimenu>Channel Number</guimenu> from the drop-down box.
     <guimenu>Get WWPNs</guimenu> (World Wide Port Number) and <guimenu>Get
     LUNs</guimenu> (Logical Unit Number) return lists with available WWPNs and
-    FCP-LUNs, respectively, to choose from. When completed, exit the zFCP
+    FCP-LUNs, respectively, to choose from. Automatic LUN scanning only works
+    with NPIV enabled.
+   </para>
+   <para>
+    When completed, exit the zFCP
     dialog with <guimenu>Next</guimenu> and the general hard disk configuration
     dialog with <guimenu>Finish</guimenu> to continue with the rest of the
     configuration.


### PR DESCRIPTION
Based on comment #16 of FATE#320750