### PR TITLE
vt best practices: Clarify note about qemu binary

### DIFF
--- a/xml/vt_best_practices.xml
+++ b/xml/vt_best_practices.xml
@@ -185,9 +185,15 @@
     supports &vmguest;s running a 32-bit or a 64-bit operating system. Because
     <command>qemu-system-x86_64</command> usually also provides better
     performance for 32-bit guests, &suse; generally recommends using
-    <command>qemu-system-x86_64</command>. Scenarios where
-    <command>qemu-system-i386</command> is known to perform better are not
-    supported by &suse;.
+    <command>qemu-system-x86_64</command> for both 32-bit and 64-bit &vmguests;s
+    on KVM. Scenarios where <command>qemu-system-i386</command> is known to
+    perform better are not supported by &suse;.
+   </para>
+   <para>
+    Xen also uses binaries from the qemu package but prefers
+    <command>qemu-system-i386</command>, which can be used for both 32-bit and
+    64bit Xen &vmguest;s. To maintain compatibility with upstream Xen Community,
+    SUSE encourages using <command>qemu-system-i386</command> for Xen &vmguest;s.
    </para>
   </sect2>
  </sect1>


### PR DESCRIPTION
Section 3.2 recommends using qemu-system-x86_64 over qemu-system-i386.
This is a fine recommendation for KVM, but the opposite is true for
Xen. Clarify the section by adding notes about the preferred qemu
binary for both KVM and Xen.

Note: This change is the result of user comment in bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1037985#c4