### PR TITLE
Small AutoYaST documentation fixes

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2292,6 +2292,26 @@ exit 0
          </para>
         </entry>
        </row>
+       <row>
+        <entry>
+         <para>
+          <literal>enable_snapshots</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Enable snapshots for Btrfs filesystems. It does not apply to other
+          kind of filesystems.
+         </para>
+<screen>&lt;enable_snapshots config:type="boolean"
+&gt;false&lt;/enable_snapshots&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. The default is <literal>true</literal>.
+         </para>
+        </entry>
+       </row>
       </tbody>
      </tgroup>
     </informaltable>
@@ -2420,7 +2440,7 @@ exit 0
          <para>
           Encryption key
          </para>
-<screen>&lt;crypted_key&gt;xxxxxxxx&lt;/crypt_key&gt;</screen>
+<screen>&lt;crypt_key&gt;xxxxxxxx&lt;/crypt_key&gt;</screen>
         </entry>
         <entry>
          <para>
@@ -3052,13 +3072,14 @@ exit 0
         <entry>
          <para>
           Possible values are: <literal>raid0</literal>,
-          <literal>raid1</literal> and <literal>raid5</literal>.
+          <literal>raid1</literal>, <literal>raid5</literal>,
+          <literal>raid6</literal> and <literal>raid10</literal>.
          </para>
 <screen>&lt;raid_type&gt;raid1&lt;/raid_type&gt;</screen>
         </entry>
         <entry>
          <para>
-          The default is raid1.
+          The default is <literal>raid1</literal>.
          </para>
         </entry>
        </row>


### PR DESCRIPTION
* Add documentation for enable_snapshots.
* Add missing RAID types.
* Fix a typo.