### PR TITLE
VT best practices: improve description of dom0_mem parameter

### DIFF
--- a/xml/vt_best_practices.xml
+++ b/xml/vt_best_practices.xml
@@ -465,7 +465,9 @@ always madvise [never]</screen>
      </itemizedlist>
      <para>
       For these reasons, it is strongly recommended to disable
-      autoballooning and give Domain-0 a predefined amount of memory.
+      autoballooning and give Domain-0 the memory needed for its workload.
+      Determining Domain-0 memory and vCPU sizing should follow a similar
+      process as any other virtual machine.
      </para>
      <para>
       Autoballooning is controlled by the toolstack used to manage your &xen;
@@ -477,9 +479,14 @@ always madvise [never]</screen>
      </para>
      <para>
       The amount of memory initially allocated to Domain-0 is controlled by
-      the &xen; hypervisor dom0_mem parameter. For example, to set the
-      memory of Domain-0 to 8GB, add <option>dom0_mem=8G</option> to the
-      &xen; hypervisor parameters.
+      the &xen; hypervisor dom0_mem parameter. For example, to set the initial
+      memory allocation of Domain-0 to 8GB, add <option>dom0_mem=8G</option> to
+      the &xen; hypervisor parameters. The dom0_mem parameter can also be used
+      to specify the minimum and maximum memory allocations for Domain-0. For
+      example, to set the initial memory of Domain-0 to 8GB, but allow it to
+      be changed (ballooned) anywhere between 4GB and 16GB, add
+      <option>dom0_mem=8G,min:4G,max:8G</option> to the &xen; hypervisor
+      parameters.
      </para>
      <itemizedlist>
       <listitem>


### PR DESCRIPTION
Add description of setting Domain-0 minimum and maximum memory
allocations using the dom0_mem parameter.