### PR TITLE
Fix all the docker build instructions

### DIFF
--- a/xml/docker_building_images.xml
+++ b/xml/docker_building_images.xml
@@ -121,7 +121,7 @@
     </para>
 <screen>FROM suse/sles12:latest
 
-RUN zypper --gpg-auto-import-keys ref -s
+RUN zypper ref -s
 RUN zypper -n in vim</screen>
     <para>
      When the Docker host machine is registered against an internal &smt;
@@ -133,7 +133,7 @@ RUN zypper -n in vim</screen>
 ADD http://smt.test.lan/smt.crt /etc/pki/trust/anchors/smt.crt
 RUN update-ca-certificates
 
-RUN zypper --gpg-auto-import-keys ref -s
+RUN zypper ref -s
 RUN zypper -n in vim</screen>
    </sect2>
    <sect2 xml:id="sec.docker.sle_images.customizing_the_images.sles11sp3">
@@ -144,7 +144,7 @@ RUN zypper -n in vim</screen>
     </para>
 <screen>FROM suse/sles11sp3:latest
 
-RUN zypper --gpg-auto-import-keys ref -s
+RUN zypper ref -s
 RUN zypper -n in vim</screen>
     <para>
      When the Docker host machine is registered against an internal &smt;
@@ -156,7 +156,7 @@ RUN zypper -n in vim</screen>
 ADD http://smt.test.lan/smt.crt /etc/ssl/certs/smt.pem
 RUN c_rehash /etc/ssl/certs
 
-RUN zypper --gpg-auto-import-keys ref -s
+RUN zypper ref -s
 RUN zypper -n in vim</screen>
    </sect2>  
 	</sect1>

--- a/xml/vt_docker_quick.xml
+++ b/xml/vt_docker_quick.xml
@@ -675,7 +675,7 @@
     </para>
 <screen>FROM suse/sles12:latest
 
-RUN zypper --gpg-auto-import-keys ref -s
+RUN zypper ref -s
 RUN zypper -n in vim</screen>
     <para>
      When the Docker host machine is registered against an internal &smt;
@@ -687,7 +687,7 @@ RUN zypper -n in vim</screen>
 ADD http://smt.test.lan/smt.crt /etc/pki/trust/anchors/smt.crt
 RUN update-ca-certificates
 
-RUN zypper --gpg-auto-import-keys ref -s
+RUN zypper ref -s
 RUN zypper -n in vim</screen>
    </sect3>
    <sect3 xml:id="sec.docker.sle_images.customizing_the_images.sles11sp3">
@@ -698,7 +698,7 @@ RUN zypper -n in vim</screen>
     </para>
 <screen>FROM suse/sles11sp3:latest
 
-RUN zypper --gpg-auto-import-keys ref -s
+RUN zypper ref -s
 RUN zypper -n in vim</screen>
     <para>
      When the Docker host machine is registered against an internal &smt;
@@ -710,7 +710,7 @@ RUN zypper -n in vim</screen>
 ADD http://smt.test.lan/smt.crt /etc/ssl/certs/smt.pem
 RUN c_rehash /etc/ssl/certs
 
-RUN zypper --gpg-auto-import-keys ref -s
+RUN zypper ref -s
 RUN zypper -n in vim</screen>
    </sect3>
   </sect2>


### PR DESCRIPTION
Do not use the zypper's `gpg-auto-import-keys` flag when installing software, this is unneeded and causes security issues.

Fixes bsc#1048279

Signed-off-by: Flavio Castelli <fcastelli@suse.com>