### PR TITLE
vt-doc: Add section on using macvtap

### DIFF
--- a/xml/libvirt_configuration.xml
+++ b/xml/libvirt_configuration.xml
@@ -1761,4 +1761,92 @@ virsh net-start passthrough</screen>
    </sect3>
   </sect2>
  </sect1>
+ <sect1 xml:id="sec.libvirt.config.direct">
+  <title>Using macvtap to share &vmhost; network interfaces</title>
+
+  <para>
+   macvtap provides direct attachment of a &vmguest; virtual interface
+   to a host network interface. The macvtap-based interface extends the
+   &vmhost; network interface and has its own MAC address on the same
+   ethernet segment. Typically, this is used to make both the &vmguest;
+   and the &vmhost; show up directly on the switch that the &vmhost; is
+   connected to.
+  </para>
+
+  <note>
+   <title>macvtap cannot be used with a linux bridge</title>
+   <para>
+    macvtap cannot be used with network interfaces already connected
+    to a linux bridge. Remove the interface from the bridge before
+    attempting to create macvtap interface.
+   </para>
+  </note>
+  <note>
+   <title>&vmguest; to &vmhost; communication with macvtap</title>
+   <para>
+    When using macvtap, a &vmguest; is able to communicate with other
+    &vmguest;s, and also with other external hosts on the network, but
+    cannot communicate with the &vmhost; on which the &vmguest; runs.
+    This is the defined behavior of macvtap, due to the way that the
+    &vmhost;'s physical ethernet is attached to the macvtap bridge.
+    Traffic into that bridge from the &vmguest; that is forwarded to
+    the physical interface cannot be bounced back up to the &vmhost;'s
+    IP stack. Simlarly, traffic from the &vmhost;'s IP stack that is
+    sent to the physical interface cannot be bounced back up to the
+    macvtap bridge for forwarding to the &vmguest;.
+   </para>
+  </note>
+
+  <para>
+   Virtual network interfaces based on macvtap are supported by libvirt
+   by specifying an interface type of 'direct'. For example:
+  </para>
+
+  <screen>&lt;interface type='direct'&gt;
+  &lt;mac address='aa:bb:cc:dd:ee:ff'/&gt;
+  &lt;source dev='eth0' mode='bridge'/&gt;
+  &lt;model type='virtio'/&gt;
+  &lt;/interface&gt;</screen>
+
+  <para>
+   The operation mode of a the macvtap device can be controlled with
+   the 'mode' attribute.
+  </para>
+  <itemizedlist mark="bullet" spacing="normal">
+   <listitem>
+    <para>
+     vepa: All &vmguest; packets are sent to an external bridge. Packets
+     whose destination is a &vmguest; on the same &vmhost; as where the
+     packet originates from are sent back to the &vmhost; by the VEPA
+     capable bridge (today's bridges are typically not VEPA capable).
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     bridge: Packets whose destination is on the same &vmhost; as where
+     they originate from are directly delivered to the target macvtap
+     device. Both origin and destination devices need to be in bridge
+     mode for direct delivery. If either one of them is in vepa mode, a
+     VEPA capable bridge is required.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     private: All packets are sent to the external bridge and will only
+     be delivered to a target &vmguest; on the same &vmhost; if they are
+     sent through an external router or gateway and that device sends
+     them back to the &vmhost;. This procedure is followed if either the
+     source or destination device is in private mode.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     passthrough: This feature attaches a virtual function of a SRIOV
+     capable NIC directly to a &vmguest; without losing the migration
+     capability. All packets are sent to the VF/IF of the configured
+     network device.
+    </para>
+   </listitem>
+  </itemizedlist>
+ </sect1>
 </chapter>


### PR DESCRIPTION
Add a section to the libvirt documentation on using macvtap
to share a host network interface.