### PR TITLE
vt-doc: replace obsolete data-plane with IOThreads

### DIFF
--- a/xml/kvm_support_status.xml
+++ b/xml/kvm_support_status.xml
@@ -314,17 +314,6 @@
     </listitem>
    </varlistentry>
    <varlistentry condition="kvm4x86">
-    <term>Virtio-data-block - data-plane</term>
-    <listitem>
-     <para>
-      An experimental block I/O back-end is available using the,
-      <option>x-data-plane=on</option> parameter to <option>-device
-      virtio-blk-pci</option>. This interface allows higher I/O rates. This
-      is not yet supported.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry condition="kvm4x86">
     <term>Q35 Machine</term>
     <listitem>
      <para>

--- a/xml/libvirt_managing.xml
+++ b/xml/libvirt_managing.xml
@@ -1028,12 +1028,6 @@ Metadata:       yes
     </listitem>
     <listitem>
      <para>
-      <xref linkend="kvm.virtio_data_plane"/> is not supported for
-      migration.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
       No physical devices can be passed from host to guest. Live migration
       is currently not supported when using devices with PCI pass-through or
       <xref linkend="vt.io.sriov"/>. If live migration needs to be

--- a/xml/qemu_running_vms_qemukvm.xml
+++ b/xml/qemu_running_vms_qemukvm.xml
@@ -540,65 +540,40 @@
      </para>
     </important>
    </sect3>
-   <sect3 xml:id="kvm.virtio_data_plane">
-    <title>virtio-blk-data-plane</title>
+   <sect3 xml:id="kvm.iothreads">
+    <title>IOThreads</title>
     <para>
-     The <emphasis>virtio-blk-data-plane</emphasis> is a new feature for &kvm;.
-     It enables a high-performance code path for I/O requests coming from
-     &vmguest;s. More specifically, this feature introduces dedicated threads
-     (one per virtual block device) to process I/O requests going through the
-     <emphasis>virtio-blk</emphasis> driver. It uses the Linux AIO
-     (asynchronous I/O) interface of the &vmhost; kernel directly&mdash;without
-     the need to go through the &qemu; block layer. Therefore, it can sustain
-     very high I/O rates on storage setups.
+      IOThreads are dedicated event loop threads for virtio devices to perform
+      I/O requests in order to improve scalability, especially on an SMP
+      &vhmost; with SMP &vmguest;s using many disk devices. Instead of using
+      &qemu;'s main event loop for I/O processing, IOThreads allow spreading
+      I/O work across multiple CPUs and can improve latency when properly
+      configured.
     </para>
     <para>
-     The virtio-blk-data-plane feature can be enabled or disabled by the
-     <option>x-data-plane=on|off</option> option on the <command>qemu</command>
-     command line when starting the &vmguest;:
+      IOThreads are enabled by defining IOThread objects. virtio devices can
+      then use the objects for their I/0 event loops. Many virtio devices can
+      use a single IOThread object, or virtio devices and IOThread objects
+      can be configured in a 1:1 mapping. The following example creates a
+      single IOThread with ID <literal>iothread0</literal> which is then used
+      as the event loop for two virtio-blk devices.
     </para>
-<screen>&prompt.user;qemu-system-x86_64 [...] -drive if=none,id=drive0,cache=none,aio=native,\
+<screen>&prompt.user;qemu-system-x86_64 [...] -object iothread,id=iothread0\
+-drive if=none,id=drive0,cache=none,aio=native,\
 format=raw,file=filename -device virtio-blk-pci,drive=drive0,scsi=off,\
-config-wce=off,x-data-plane=on [...]</screen>
+iothread=iothread0 -drive if=none,id=drive1,cache=none,aio=native,\
+format=raw,file=filename -device virtio-blk-pci,drive=drive1,scsi=off,\
+iothread=iothread0 [...]</screen>
     <para>
-     Currently, virtio-blk-data-plane has the following limitations:
+      The following qemu command line example illustrates a 1:1 virtio device
+      to IOThread mapping:
     </para>
-    <itemizedlist mark="bullet" spacing="normal">
-     <listitem>
-      <para>
-       Only the raw image format is supported.
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       No support for live migration.
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       Block jobs and hot unplug operations fail with
-       <literal>-EBUSY</literal>.
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       I/O throttling limits are ignored.
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       Only Linux &vmhost;s are supported because of the Linux AIO usage, but
-       non-Linux &vmguest;s are supported.
-      </para>
-     </listitem>
-    </itemizedlist>
-    <important>
-     <title>Support Status</title>
-     <para>
-      The virtio-blk-data-plane feature is not yet supported in &productname;.
-      It is released as a technology preview only.
-     </para>
-    </important>
+<screen>&prompt.user;qemu-system-x86_64 [...] -object iothread,id=iothread0\
+-object iothread,id=iothread1 -drive if=none,id=drive0,cache=none,aio=native,\
+format=raw,file=filename -device virtio-blk-pci,drive=drive0,scsi=off,\
+iothread=iothread0 -drive if=none,id=drive1,cache=none,aio=native,\
+format=raw,file=filename -device virtio-blk-pci,drive=drive1,scsi=off,\
+    iothread=iothread1 [...]</screen>
    </sect3>
    <sect3 xml:id="kvm.virtio_blk.use_bio">
     <title>Bio-Based I/O Path for virtio-blk</title>


### PR DESCRIPTION
The experimental x-data-plane option was removed in qemu 2.5
and replaced with the more generic IOThreads. The option no
longer works with SLES12 >= SP2 and should be removed from the
virtualization docs. Replace it with information on configuring
its successor, IOThreads.