### PR TITLE
vt-doc: fix PCI address in hostdev passthrough example

### DIFF
--- a/xml/libvirt_configuration.xml
+++ b/xml/libvirt_configuration.xml
@@ -1056,7 +1056,7 @@ Product Name: Standard PC (Q35 + ICH9, 2009)</screen>
      </para>
 <screen>&lt;hostdev mode='subsystem' type='pci' managed='yes'&gt;
   &lt;source&gt;
-    &lt;address domain='0x0000' bus='0x03' slot='0x07' function='0x00'/&gt;
+    &lt;address domain='0x0000' bus='0x03' slot='0x07' function='0x0'/&gt;
   &lt;/source&gt;
 &lt;/hostdev&gt;</screen>
      <tip xml:id="tip.libvirt.config.pci.virsh.managed">


### PR DESCRIPTION
Section "14.10.2 Adding a PCI Device with virsh" of the VT doc
contains example XML for host device passthrough that is not
quite right. The 'function' part of a PCI address is restricted
to one digit with a range of 0-7. The libvirt RNG defines a
pciFunc type as

  <define name="pciFunc">
    <choice>
      <data type="string">
        <param name="pattern">(0x)?[0-7]</param>
      </data>
      <data type="int">
        <param name="minInclusive">0</param>
        <param name="maxInclusive">7</param>
      </data>
    </choice>
  </define>

In the example XML the function part of the address contains
the value '0x00', which does not validate against the above
schema. This simple patch fixes the example by changing the
value to '0x0'.