### PR TITLE
[PoC] Use Docker at Travis

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git/
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,12 @@
+sudo: required
 language: bash
-env:
-      global:
-      - LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
-      - CACHE="$HOME/.cache/entities"
-      - XML_CATALOG_FILES="catalog.xml"
-      - GITHUB_URL="https://raw.githubusercontent.com/openSUSE/doc-ci/master/travis/travis.sh"
+services:
+  - docker
 
-dist: yakkety
-
-cache:
-  directories:
-    - $CACHE
-
-addons:
-  apt:
-    packages:
-    - libxml2-utils
-    - libxml2-dev
-    - libxml2
-
-before_script:
-    - cat /etc/os-release
-    - echo $TRAVIS_COMMIT
-    - sudo apt-get install -y libxml2-utils
-    - xmllint --version
-    - wget $GITHUB_URL && chmod +x travis.sh
+before_install:
+  - docker build -t sle-doc-image .
+  # list the installed packages (just for easier debugging)
+  - docker run --rm -it sle-doc-image rpm -qa | sort
 
 script:
-    - ./travis.sh xml/*.xml
-
-branches:
-    except:
-        - trans/*
-
+  - docker run --rm -it sle-doc-image find . -maxdepth 1 -name 'DC-*' -exec echo "Validating {}..." \; -exec daps -d \{\} validate --remarks \;

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ services:
   - docker
 
 before_install:
-  - docker build -t sle-doc-image .
-  # list the installed packages (just for easier debugging)
-  - docker run --rm -it sle-doc-image rpm -qa | sort
+  - docker pull svenseeberg/doc_ci
 
 script:
-  - docker run --rm -it sle-doc-image find . -maxdepth 1 -name 'DC-*' -exec echo "Validating {}..." \; -exec daps -d \{\} validate --remarks \;
+- docker run --rm -it svenseeberg/doc_ci find . -maxdepth 1 -name 'DC-*-all' -exec echo "Validating {}..." \; -exec daps -d \{\} validate --remarks \;

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM opensuse:tumbleweed
+
+# "zypper dup" synchronizes with the current Tumbleweed (even downgrades if needed),
+# we need to install curl for downloading/installing the GPG key
+# Note: we can keep the metadata cache as this image is only used once at Travis
+RUN zypper --non-interactive dup --no-recommends && \
+  zypper --non-interactive in --no-recommends curl
+
+# import the Documentation:Tools GPG key
+RUN rpm --import https://build.opensuse.org/projects/Documentation:Tools/public_key
+
+RUN zypper ar -f https://download.opensuse.org/repositories/Documentation:/Tools/openSUSE_Tumbleweed/ Documentation:Tools
+
+# Note: unfortunately this pulls in a *lot* of not needed packages like samba, texlive
+# which are not needed for validation, but when we lock them the install command
+# below fails in non-interactive mode :-(
+# RUN zypper addlock texlive-* samba-* ghostscript cups-libs transfig *-fonts mozilla-*
+# saxon6 is required by jing but it's not installed automatically via dependencies
+RUN zypper --non-interactive in --no-recommends daps saxon6
+
+# copy the sources
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+COPY . /usr/src/app


### PR DESCRIPTION
# Proof of Concept

I have noticed  that for Travis builds you use a [travis.sh](https://raw.githubusercontent.com/openSUSE/doc-ci/master/travis/travis.sh) build script. But that

- Does not use `daps` as described in the README
- Uses `docbook-xml-4.5.zip` while the README mentions DocBook 5
- Uses `xmllint` for validation while `daps` uses `jing`
- Uses Ubuntu 14.04, does not use packages from `Documentation:Tools` as suggested in README

I do not know if using simple `xmllint` is just fine for you or if you would like to run full `daps` which to me seems the recommended way.

I have some experience with Travis in YaST as we need to run the YaST tests in openSUSE distribution (Ubuntu is too different for us) so I have prepared this PoC. We run the tests inside a Docker container which contains an openSUSE system.

## Result

- Proposed `Dockerfile` to build the Docker image with the needed tools
  - Is based on openSUSE Tumbleweed (if that's too on the edge for you them switching to e.g. 42.3 is trivial)
  - Uses packages from the Documentation:Tools repository
- Updated `.travis.yml` which runs `daps` in Docker
- See the [example Travis log](https://travis-ci.org/lslezak/doc-sle/builds/296328304#L2541) with used `daps`, you can see the `daps` output there

This is just a proof of concept to collect your opinions about this approach. There are some issues with this approach. The most important one is probably the fact that currently the build takes more than 11 minutes. I do not know how often you change the documentation but this seems quite a lot to me.

## Issues

The very long build time can be split to two parts:

1. Building the Docker image (including `daps`) (takes about 4.5 minutes)
2. Running the tests (takes about 6.5 minutes)

#### The Docker Image

The Docker image can be pre-built, in YaST we build the image in Docker Hub (see e.g. the [yastdevel/ruby](https://hub.docker.com/r/yastdevel/ruby/) image).  Downloading the YaST images takes about 25 seconds in Travis, I think we could get similar numbers for the documentation image as well.

#### Running Tests

The `daps` validation is quite slow and there are almost 40 books, validating all of them takes almost 7 minutes. But we could run the checks in parallel (in separate Travis jobs).  With 3 parallel jobs the test run time could be reduced to about 2 minutes.

Pseudocode:

```
groups = 3
lines = `find . -maxdepth 1 -name 'DC-*' | wc -l`
max_lines = lines / 3
find . -maxdepth 1 -name 'DC-*' | sort | split -l $max_lines -d - TRAVIS_GROUP_
```

This results in `TRAVIS_GROUP_00`, `TRAVIS_GROUP_01` and `TRAVIS_GROUP_02` files which lists the files to process in each Travis job.

See the [.travis.yml](https://github.com/openSUSE/snapper/blob/master/.travis.yml) file in snapper where we build the package for 5 different distributions in parallel.

# Conclusion

I'm interested in your feedback about this approach. If it looks interesting for you and you would like to change the Travis build just let me know, I can help you with that.
