### PR TITLE
Stop validating with --remarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,6 @@ before_install:
   - docker run --rm -it sle-doc-image rpm -qa | sort
 
 script:
-  # It is important that we validate with and without remarks. Content between remarks is profiled out and this may
-  - docker run --rm -it sle-doc-image /bin/bash -c 'mkdir -p /root/.config/daps/;mkdir -p /root/.config/daps/; echo DOCBOOK5_RNG_URI="https://github.com/openSUSE/geekodoc/raw/master/geekodoc/rng/geekodoc5-flat.rnc" > /root/.config/daps/dapsrc; for dc_file in `ls DC-*-all`; do echo "Validating $dc_file ..."; daps -vv -d $dc_file validate || exit 1; daps -vv -d $dc_file validate --remarks || exit 1; wait; done'
+  # Validating with remarks is the same as validating without, since remarks are
+  # not profiled away but just ignored by the stylesheets.
+  - docker run --rm -it sle-doc-image /bin/bash -c 'mkdir -p /root/.config/daps/;mkdir -p /root/.config/daps/; echo DOCBOOK5_RNG_URI="https://github.com/openSUSE/geekodoc/raw/master/geekodoc/rng/geekodoc5-flat.rnc" > /root/.config/daps/dapsrc; for dc_file in `ls DC-*-all`; do echo "Validating $dc_file ..."; daps -vv -d $dc_file validate || exit 1; wait; done'


### PR DESCRIPTION
I think, after all, validating with remarks is useless:

* I created a remark in an illegal position and tried to validate with
  and without remarks -> validation failed both times.
* I created a remark in a position where the document would be invalid
  if not for the remark -> it validated both times.

Sorry for arguing for validation with and without --remarks. Doesn't
seem to make any difference. Not even sure what the parameter --remarks
is good for when validating, ultimately.