### PR TITLE
VT best practices: Add section describing aio-max-nr

### DIFF
--- a/xml/vt_best_practices.xml
+++ b/xml/vt_best_practices.xml
@@ -883,6 +883,38 @@ noop deadline [cfq]</screen>
 <screen>w /sys/block/sda/queue/scheduler - - - - deadline
 w /sys/block/sdb/queue/scheduler - - - - noop</screen>
    </sect3>
+   <sect3 xml:id="sec.vt.best.io.async">
+   <title>Asynchronous I/O</title>
+   <para>
+    Many of the virtual disk backends use Linux Asynchronous I/O (aio)
+    in their implementation. By default the maximum number aio contexts
+    is set to 65536, which can be exceeded when running hundreds of
+    &vmguest;s using virtual disks serviced by Linux Asynchronous I/O.
+    When running large numbers of &vmguest;s on a &vmhost;, consider
+    increasing /proc/sys/fs/aio-max-nr.
+   </para>
+   <procedure>
+    <title>Checking and Changing aio-max-nr at Runtime</title>
+    <step>
+     <para>
+      To check your current aio-max-nr setting run:
+     </para>
+     <screen>&prompt.user;cat /proc/sys/fs/aio-max-nr
+65536</screen>
+    </step>
+    <step>
+     <para>
+      You can change aio-max-nr at runtime with the following command:
+     </para>
+     <screen>&prompt.user;&sudo; echo 131072 &gt; /proc/sys/fs/aio-max-nr</screen>
+    </step>
+   </procedure>
+   <para>
+    To permanently set aio-max-nr, add an entry to a local sysctl file. For
+    example append the following to /etc/sysctl.d/99-sysctl.conf
+    <screen>fs.aio-max-nr = 1048576</screen>
+   </para>
+   </sect3>
    <sect3 xml:id="sec.vt.best.io.techniques">
     <title>I/O Virtualization</title>
     <para>


### PR DESCRIPTION
Add a section about tuning the fs.aio-max-nr setting when
running large numbers of virtual machines. For more details see

https://bugzilla.novell.com/show_bug.cgi?id=1067729