### PR TITLE
Update the AutoYaST addons documentation (SLE15)

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -1317,7 +1317,7 @@ exit 0
    <para>
     As an alternative to the fully automated registration, &ay; can also
     be configured to start the &yast; registration module during the
-    installation. this offers the possibility to enter the registration data
+    installation. This offers the possibility to enter the registration data
     manually. The following XML code is required:
    </para>
 
@@ -1613,8 +1613,9 @@ openssl x509 -noout -fingerprint -sha256
     <para>
      <emphasis>NOTE: </emphasis>This can be used in a trusted network only!
      In a non-trusted network (or over Internet) you should get the
-     fingerprint directly on the server. Or verify that the downloaded
-     certificate is exactly as on the server.
+     fingerprint directly from the server by other means (e.g. via SSH) or
+     from elsewhere (e.g. saved server configuration). Or verify that the
+     downloaded certificate is exactly the same as on the server.
      </para>
    </tip>
 
@@ -1622,7 +1623,7 @@ openssl x509 -noout -fingerprint -sha256
     <title>Extensions</title>
     <para>
      The &scc; provides several extensions, such as
-     <literal>sle-sdk</literal> (Software Development Kit - SDK) that
+     <literal>sle-module-development-tools</literal> (Development Tools Module) that
      can be included as additional sources during the
      installation. Adding extensions can be done via the
      <literal>addons</literal> property within the
@@ -1633,25 +1634,22 @@ openssl x509 -noout -fingerprint -sha256
     <note>
      <title>Availability of Extensions</title>
      <para>
-      The availability of extensions is product and architecture dependent.
+      The availability of extensions is product and architecture dependent,
+      not all extensions are available on all architectures.
       <!-- All listed extensions are available for &sls; on the x86_64
            architecture. -->
-      Not all extensions are available on other architectures.  The only
-      extension available for &sled; is the <literal>sle-sdk</literal>.
      </para>
      <para>
-      Some extensions, such as the <literal>sle-we</literal>,
-      <literal>sle-ha</literal> and <literal>sle-ha-geo</literal>
+      Some extensions, such as the <literal>sle-ha</literal>
       require a registration code.
      </para>
     </note>
 
     <para>
-     With <command>SUSEConnect --list-extensions</command> (available
-     since &slsa; 12 SP1), you can list all available extensions in a
-     registered system. The result looks like:
+     With <command>SUSEConnect --list-extensions</command> you can list all
+     available extensions in a registered system. The result looks like:
     </para>
-    <screen>Install with: SUSEConnect -p sle-sdk/12.2/x86_64</screen>
+    <screen>Install with: SUSEConnect -p sle-module-development-tools/15/x86_64</screen>
     <para>
      The <option>-p</option> argument displays the
      <replaceable>NAME/VERSION/ARCH</replaceable> values that can be
@@ -1659,20 +1657,40 @@ openssl x509 -noout -fingerprint -sha256
     </para>
     <screen><![CDATA[<addons config:type="list">
  <addon>
-  <!-- SUSE Linux Enterprise Software Development Kit -->
-  <name>sle-sdk</name>
-  <version>12.2</version>
+  <!-- Development Tools Module -->
+  <name>sle-module-development-tools</name>
+  <version>15</version>
   <arch>x86_64</arch>
  </addon>
 </addons>]]></screen>
+
+<note>
+ <title>Extension Dependencies</title>
+ <para>
+   Since &slsa; 15 &ay; automatically reorders the extensions according to their
+   dependencies during registration. That means the order of the extensions
+   in the &ay; profile is not important anymore (in contrast to &slsa; 12).
+ </para>
+ <para>
+   Also &ay; automatically registers the dependant extensions eventhough
+   they are missing in the profile. That means you are not required to fill
+   the extensions list completely.
+ </para>
+ <para>
+   However, if the dependant extension requires a registration key it must be
+   specified in the profile (including the registration key) otherwise the
+   registration would fail.
+ </para>
+</note>
+
     <para>
-     For background information and add-on listings for &slsa; 12,
-     12 SP1, and 12 SP2, see <link
+     For background information and add-on listings for &slsa; see <link
      xlink:href="https://github.com/yast/yast-registration/wiki/Available-SCC-Extensions-for-Use-in-Autoyast"/>.
      The listings will get updated from time to time.
     </para>
    </sect2>
   </sect1>
+
   <sect1 xml:id="CreateProfile.Bootloader">
    <title>The Boot Loader</title>
 


### PR DESCRIPTION
- The extension handling is a bit different in SLE 15:
  - The order is not important anymore, YaST automatically reorders the addons to meet the required registration order. (The SLE15 modular design with a lot of dependencies makes it difficult to write the correct order by hand.)
  - The dependent modules are automatically registered as well even though they are missing in the profile. (Again, to get all the dependencies right might be tricky, this makes the editing the profile by hand much easier. E.g. add just the "Server Applications Module" into the profile and do not care about that 3 dependent modules or much is that...)
  - See https://bugzilla.suse.com/show_bug.cgi?id=1065438 for the details
- Additionally removed/updated some SLE12 references