### PR TITLE
hardening guide: reworked BIOS section

### DIFF
--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -1044,41 +1044,57 @@ FIXME:
      <title>Secure Boot</title>
      <para>
       This section describes only basic methods to secure the boot process. To
-      find out more about UEFI and the secure boot feature, see
-      <xref linkend="sec.uefi.secboot"/>.
+      find out about more advanced boot protection using UEFI and the
+      secure boot feature, see <xref linkend="sec.uefi.secboot"/>.
      </para>
     </tip>
 
     <para>
      The BIOS (Basic Input/Output System) or its successor UEFI (Unified
      Extensible Firmware Interface) is the lowest level of software/firmware
-     that dictates system configuration and low-level hardware. When this
-     document references the BIOS, it usually means BIOS and/or UEFI. &grub;
-     and other Linux boot loaders access the BIOS to determine how to boot the
-     host. Other hardware types (&ipseries;/&zseries;) that run Linux also have
-     low-level software/firmware. Typically the BIOS can be configured to help
-     prevent attackers from being able to reboot the host and manipulate the
-     system.
+     on PC class systems. Other hardware types (&ipseries;, &zseries;) that run
+     Linux also have low-level firmware that performs similar functions as the
+     PC BIOS. When this document references the BIOS, it usually means BIOS
+     and/or UEFI.
+     The BIOS dictates system configuration, puts the system into a well
+     defined state and provides routines for accessing low-level hardware.
+     The BIOS executes the configured Linux boot loader (like &grub;) to
+     boot the host.
     </para>
 
     <para>
-     Most BIOS varieties allow the setting of a boot password. While this does
-     not provide a high level of security (a BIOS can be reset, removed or
-     modified – assuming case access), it can be another deterrent.
+     Most BIOS implementations can be configured to prevent unauthorized users
+     from manipulating system and boot settings. This is typically done by
+     setting a BIOS admin or boot password. The admin password only needs to
+     be entered for changing the system configuration but the boot password
+     will be required during every normal boot. For most use cases it is
+     enough to set an admin password and restrict booting to the builtin
+     hard disk. This way an attacker will not be able to simply boot a Linux
+     live CD or USB thumb drive, for example. Although this does not provide a
+     high level of security (a BIOS can be reset, removed or modified –
+     assuming case access), it can be another deterrent.
     </para>
 
     <para>
-     Many BIOS capabilities have other various security settings – checking
-     with the system vendor, the system documentation or examine the BIOS
-     during a system boot.
+     Many BIOSs have various other security related settings – check with the
+     system vendor, the system documentation or examine the BIOS during a
+     system boot to find out more.
     </para>
 
     <important>
-     <title>Booting when a BIOS Password is Set</title>
+     <title>Booting when a BIOS Boot Password is Set</title>
      <para>
-      If a system host has been set up with a boot password, the host will not
-      boot up unattended (for example a system reboot, power failure, etc.).
+      If a system has been set up with a boot password, the host will not boot
+      up unattended (for example in case of a system reboot or power failure).
       This is a trade-off.
+     </para>
+    </important>
+    <important>
+     <title>Losing the BIOS Admin Password</title>
+     <para>
+      Once a system is setup the first time, the BIOS admin password will not
+      be required often. Don't forget the password or you will need to clear
+      the BIOS memory via hardware manipulation to get access again.
      </para>
     </important>
    </sect1>


### PR DESCRIPTION
- an attempt to make some statements more precise
- grub does not really access the BIOS to determine how to boot the
  host, it's rather the other way around
- introduced a differentation between admin and boot passwords
- hint about boot device limitation, which is often the more interesting
  approach than a general boot password