### PR TITLE
hardening guide: reworked banner section

### DIFF
--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -3589,47 +3589,64 @@ EOF</screen>
 
     <para>
      It is often necessary to place a banner on login screens on all servers
-     for legal/audit policy reasons and to deter intruders, etc.
+     for legal/audit policy reasons or to give security instructions to
+     users.
     </para>
 
     <para>
-     If you want to print a legal banner after a user logs in using SSH, local
-     console, etc., you can leverage the <filename>/etc/motd</filename> (motd =
-     message of the day) file. The file exists on &suse;, however it is empty.
-     Simply add content to the file that is applicable/required by the
+     If you want to print a login banner <emphasis>after</emphasis> a user
+     logs in on a text based terminal for example using SSH or on a local
+     console, you can leverage the file <filename>/etc/motd</filename> (motd =
+     message of the day). The file exists by default on &suse;, however it is
+     empty. Simply add content to the file that is applicable/required by the
      organization.
     </para>
 
     <note>
      <title>Banner Length</title>
      <para>
-      Try to keep the content to a single page (or less), as it will scroll the
-      screen if it does not fit.
+      Try to keep the login banner content to a single terminal page (or
+      less), as it will scroll the screen if it does not fit, making it more
+      difficult to read.
      </para>
     </note>
 
     <para>
-     For SSH you can edit the <quote>Banner</quote> parameter in the
+     You can also have a login banner printed <emphasis>before</emphasis> a
+     user logs in on a text based terminal. For local console
+     logins you can edit the <filename>/etc/issue</filename> file which will
+     cause the banner to the displayed before the login prompt. For logins via
+     SSH you can edit the <quote>Banner</quote> parameter in the
      <filename>/etc/ssh/sshd_config</filename> file which will then
-     appropriately display the banner text before the login prompt. For local
-     console logins you can edit the <filename>/etc/issue</filename> file which
-     will display the banner before the login prompt. For GDM, you could make
-     the following changes to require a user to acknowledge the legal banner by
-     selecting <guimenu>Yes</guimenu> or <guimenu>No</guimenu>. Edit the
-     <filename>/etc/gdm/PreSession/Default</filename> file and add the
-     following lines at the beginning of the script:
+     appropriately display the banner text before the SSH login prompt.
     </para>
-
-<screen>if ! gdialog --yesno '\n<replaceable>This system is classified...</replaceable>\n' 10 10; then
-    sleep 10
-    exit 1;
-fi</screen>
 
     <para>
-     The <replaceable>This system is classified...</replaceable> test should be
-     replaced with the valid text. It is important to note that this dialog
-     will not prevent a login from progressing.
+     For graphical logins via GDM, you can follow
+     <link xlink:href="https://help.gnome.org/admin/system-admin-guide/stable/login-banner.html.en">
+     the GNOME admin guide</link> to setup a login banner. Furthermore
+     you can make the following changes to require a user to acknowledge the
+     legal banner by selecting <guimenu>Yes</guimenu> or <guimenu>No</guimenu>.
+     Edit the <filename>/etc/gdm/Xsession</filename> file and add the
+     following lines at the <emphasis>beginning</emphasis> of the script:
     </para>
+
+    <screen>
+if ! /usr/bin/gdialog --yesno '\n<replaceable>This system is classified...</replaceable>\n' 10 10; then
+    /usr/bin/gdialog --infobox 'Aborting login'
+    exit 1;
+fi
+   </screen>
+
+    <para>
+     The text <replaceable>This system is classified...</replaceable> needs to
+     be replaced with the desired banner text. It is important to note that
+     this dialog will not prevent a login from progressing. For more
+     information about GDM scripting, refer to the
+     <link xlink:href="https://help.gnome.org/admin/gdm/stable/configuration.html.en#scripting">
+     GDM Admin Manual</link>.
+    </para>
+
    </sect1>
    <sect1 xml:id="sec.sec_prot.misc">
     <title>Miscellaneous</title>


### PR DESCRIPTION
- completely overhauled the paragraphs, better separating the "before
  login", "after login" and terminal/graphical banner topics.
- adjusted the GDM example to match the SLE15 situation
- added references to the upstream manuals