### PR TITLE
hardening guide: reworked the "removing unnecessary packages" section

### DIFF
--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -2145,7 +2145,7 @@ FIXME:
      simplify maintenance efforts when security alerts and patches are
      released. It is a best practice not to install, among others, development
      packages or desktop software packages (for example, an X Server) on
-     production servers. If you do not need them, you should also uninstall,
+     production servers. If you do not need them, you should also not install,
      for example, the Apache Web server or Samba file sharing server.
     </para>
 
@@ -2164,7 +2164,8 @@ FIXME:
      Also, other packages like FTP and Telnet daemons should not be installed
      as well unless there is a justified business reason for it (again,
      <command>ssh</command>, <command>scp</command> or <command>sftp</command>
-     should be used as replacements).
+     should be used as replacements, see
+     <xref linkend="sec.sec_prot.general.remote"/>).
     </para>
 
     <para>
@@ -2193,29 +2194,50 @@ FIXME:
     </tip>
 
     <para>
-     To generate a list of all installed RPMs, use the following command:
+     To generate a list of all installed packages, use the following command:
     </para>
 
-<screen>&prompt.root;rpm -qa</screen>
+<screen>&prompt.root;zypper packages -i</screen>
 
     <para>
-     To retrieve details about a particular RPM (from the RPM itself), run:
+     To retrieve details about a particular package run:
     </para>
 
-<screen>&prompt.root;rpm -qi <replaceable>PACKAGE_NAME</replaceable></screen>
+<screen>&prompt.root;zypper info <replaceable>PACKAGE_NAME</replaceable></screen>
 
     <para>
      To check for and report potential conflicts and dependencies when deleting
-     an RPM, run:
+     a package, run:
     </para>
 
-<screen>&prompt.root;rpm -e --test <replaceable>PACKAGE_NAME</replaceable></screen>
+<screen>&prompt.root;zypper rm -D <replaceable>PACKAGE_NAME</replaceable></screen>
 
     <para>
      This can be very useful, as running the removal command without a test can
-     often yield a mass of complaints and require manual recursive dependency
+     often yield a lot of complaints and require manual recursive dependency
      hunting.
     </para>
+
+    <important>
+     <title>Removal of Essential System Packages</title>
+     <para>
+      When removing packages, be careful not to remove any essential system
+      packages. This could put your system into a broken state in which it can
+      no longer be booted or repaired. If you are uncertain about this, then it
+      is best to do a complete backup of your system before you start to
+      remove any packages.
+     </para>
+    </important>
+
+    <para>
+     For the final removal of one or more packages use the following
+     <command>zypper</command> command with the added <quote>-u</quote>
+     switch, which causes any dependencies that are becoming unused by
+     removing the named packages, to be removed as well:
+    </para>
+
+    <screen>&prompt.root;zypper rm -u <replaceable>PACKAGE_NAME</replaceable></screen>
+
    </sect1>
    <sect1 xml:id="sec.sec_prot.general.patching">
     <title>Patching Linux Systems</title>


### PR DESCRIPTION
- use zypper examples instead of rpm examples. zypper respects
  dependencies and gives a better overview in many cases.
- added a warning about careless removal of packages
- minor grammar changes