### PR TITLE
vt-doc: Improve text describing Xen dom0 memory management

### DIFF
--- a/xml/xen_virtualization_vhost.xml
+++ b/xml/xen_virtualization_vhost.xml
@@ -124,40 +124,43 @@
   <title>Managing &dom0; Memory</title>
 
   <para>
-   When the host is set up, a percentage of system memory is reserved for the
-   hypervisor, and all remaining memory is automatically allocated to &dom0;.
+   In a default &xen; installation, a small percentage of system memory is
+   reserved for the hypervisor, and all remaining memory is automatically
+   allocated to &dom0;. Autoballooning of &dom0; is enabled so that
+   memory can be made available when starting &vmguest;s.
   </para>
 
   <para>
-   A better solution is to set a default amount of memory for &dom0;, so the
-   memory can be allocated appropriately to the hypervisor. An adequate amount
-   would be 20 percent of the total system memory up to 4 GiB. A recommended
-   minimum amount would be 512 MiB
+   SUSE recommends disabling autoballooning and configuring &dom0; with
+   adequate memory. Generally 10 percent of the total system memory is
+   sufficient, with a minimum of 1 GiB and a maximum of 64 GiB.
   </para>
 
   <warning>
-   <title>Minimum amount of Memory</title>
+   <title>Insufficient Memory for &dom0;</title>
    <para>
-    The minimum amount of memory heavily depends on how many &vmguest;(s) the
-    host should handle. So be sure you have enough memory to support all your
-    &vmguest;s. If the value is too low, the host system may hang when multiple
-    &vmguest;s use most of the memory.
+    The amount of memory reserved for &dom0; is a function of the number
+    of &vmguest;(s) running on the host since &dom0; provides backend
+    network and disk I/O services for each &vmguest;. Other workloads
+    running in &dom0; should also be considered when calculating &dom0;
+    memory allocation. In general, memory sizing of &dom0; should be
+    determined like any other virtual machine.
    </para>
   </warning>
 
   <sect2 xml:id="sec.xen.vhost.maxmem">
-   <title>Setting a Maximum Amount of Memory</title>
+   <title>Setting &dom0; Memory Allocation</title>
    <procedure>
     <step>
      <para>
-      Determine the amount of memory to set for &dom0;.
+      Determine memory allocation required for &dom0;.
      </para>
     </step>
     <step>
      <para>
       At &dom0;, type <command>xl info</command> to view the amount of memory
-      that is available on the machine. The memory that is currently allocated
-      by &dom0; can be determined with the command <command>xl list</command>.
+      that is available on the machine. &dom0;'s current memory allocation can
+      be determined with the <command>xl list</command> command.
      </para>
     </step>
     <step>
@@ -178,7 +181,7 @@
       <replaceable>MEM_AMOUNT</replaceable> is the maximum amount of memory to
       allocate to &dom0;. Add <command>K</command>, <command>M</command>, or
       <command>G</command>, to specify the size, for example,
-      <command>dom0_mem=768M</command>.
+      <command>dom0_mem=2G</command>.
      </para>
     </step>
     <step>


### PR DESCRIPTION
As noted by one of the SE's, the text regarding Xen dom0 memory
management in section 18.2 is a bit outdated. Update the examples
and improve the content.