### PR TITLE
Registering an extension with its base product registration code

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -1638,6 +1638,8 @@ openssl x509 -noout -fingerprint -sha256
      <para>
       Some extensions, such as the <literal>sle-ha</literal>
       require a registration code.
+      Depending on your subscription, either use a dedicated registration code
+      for the extension, or restate the code for the base product.
      </para>
     </note>
 


### PR DESCRIPTION
Interactively, it works like this: (bsc#1075551)

>    When registering SLES4SAP, the same registration code as for the base product needs to be re-entered for the HA extension, which is part of the subscription.
>
>    The installer should assure that for these modules registration code is not asked again.
>    The idea is: Try to register non-free extensions with the same product as base system and only ask for those for which registration does not succeed.

But for the autoinstallation, we require to explicitly state the registration code. This docs change clarifies that.

Related:
- https://github.com/yast/yast-registration/pull/352
- https://bugzilla.suse.com/show_bug.cgi?id=1075551