### PR TITLE
SLE15 Offline Upgrade

### DIFF
--- a/xml/sle_update_offline.xml
+++ b/xml/sle_update_offline.xml
@@ -375,8 +375,8 @@ initrd (hd0,0)/boot/initrd.upgrade</screen>
    <step>
     <para>
      On the <guimenu>Welcome</guimenu> screen, choose
-     <guimenu>Language</guimenu> and <guimenu>Keyboard</guimenu> and accept the
-     license agreement. Proceed with <guimenu>Next</guimenu>.
+     <guimenu>Language</guimenu> and <guimenu>Keyboard</guimenu>.
+     Proceed with <guimenu>Next</guimenu>.
     </para>
     <para>
      &yast; checks your partitions for already installed &sle; systems.
@@ -387,9 +387,11 @@ initrd (hd0,0)/boot/initrd.upgrade</screen>
      On the <guimenu>Select for Upgrade</guimenu> screen, select the partition
      to upgrade and click <guimenu>Next</guimenu>.
     </para>
+   </step>
+   <step>
     <para>
-     &yast; mounts the selected partition and displays all repositories that
-     have been found on the partition that you want to upgrade.
+     &yast; mounts the selected partition and displays the licence agreement
+     for the upgraded product. To continue accept the license.
     </para>
    </step>
    <step>
@@ -401,49 +403,55 @@ initrd (hd0,0)/boot/initrd.upgrade</screen>
     </para>
    </step>
    <step>
+     <para>
+       The next step depends on whether the upgraded system is registered or not:
+     </para>
+
+     <substeps>
+       <step>
+         <para>
+           If the system is not registered then &yast; displays a popup message
+           suggesting using a second installation medium, the &allmodules; medium.
+         </para>
+         <para>
+           If you do not have that medium then the system can be upgraded only to
+           a minimal &sle; 15 system.
+         </para>
+       </step>
+       <step>
+         <para>
+           If the system is registered then &yast; will show possible migration
+           targets and a summary.
+         </para>
+         <para>
+          Select one migration target from the list and proceed with
+          <guimenu>Next</guimenu>.
+         </para>
+       </step>
+     </substeps>
+   </step>
+   <step>
     <para>
-     On the <guimenu>Registration</guimenu> screen, select whether to register
-     the upgraded system now (by entering your registration data and clicking
-     <guimenu>Next</guimenu>) or if to <guimenu>Skip Registration</guimenu>.
-     For details on registering your system, see
-     <xref linkend="sec.update.registersystem"/>.
+      In the next dialog you can optionally add an additional installation media.
+      If you have additional installation media then activate the
+      <guimenu>I would like to install an additional Add-on Product</guimenu>
+      option and specify the media type.
     </para>
    </step>
    <step>
     <para>
-     Review the <guimenu>Installation Settings</guimenu> for the upgrade,
-     especially the <guimenu>Update Options</guimenu>. Choose between the
-     following options:
+     Review the <guimenu>Installation Settings</guimenu> for the upgrade.
     </para>
-    <itemizedlist>
-     <listitem>
-      <para>
-       <guimenu>Only Update Installed Packages</guimenu>, in which case you
-       might miss new features shipped with the latest &sle; version.
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       <guimenu>Update with Installation of New Software and
-       Features</guimenu>. Click <guimenu>Select Patterns</guimenu> if you want
-       to enable or disable patterns and packages according to your wishes.
-      </para>
-     </listitem>
-    </itemizedlist>
 <!--taroth 2014-11-19: fix for bsc#904188-->
     <note>
      <title>Choice of Desktop</title>
      <para>
-      If you used KDE before upgrading to &sle; 12
+      If you used KDE before upgrading to &sle; 15
       (<varname>DEFAULT_WM</varname> in
       <filename>/etc/sysconfig/windowmanager</filename> was set to
       <literal>kde*</literal>), your desktop environment will automatically be
       replaced with &gnome; after the upgrade. By default, the KDM display
       manager will be replaced with GDM.
-     </para>
-     <para>
-      To change the choice of desktop environment or window manager, adjust the
-      software selection by clicking <guimenu>Select Patterns</guimenu>.
      </para>
     </note>
    </step>
@@ -570,7 +578,7 @@ initrd (hd0,0)/boot/initrd.upgrade</screen>
   <title>Registering Your System</title>
 
   <para>
-   If you skipped the registration step during the installation, you can
+   If the system has not been registered before running the upgrade you can
    register your system at any time using the <guimenu>Product
    Registration</guimenu> module in &yast;.
   </para>
@@ -619,22 +627,15 @@ initrd (hd0,0)/boot/initrd.upgrade</screen>
      of &productname;.
     </para>
    </step>
+   <step>
+     <para>
+      If one or more local registration servers are available on your network,
+      you can choose one of them from a list.
+     </para>
+   </step>
    <step xml:id="step.y2.register.final">
     <para>
-     To start the registration, proceed with <guimenu>Next</guimenu>. If
-     one or more local registration servers are available on your network, you
-     can choose one of them from a list. Alternatively, to ignore the local
-     registration servers and  register with the default &suse; registration server,
-     choose <guimenu>Cancel</guimenu>.
-    </para>
-    <para>
-     During the registration, the online update repositories will be added to
-     your upgrade setup. When finished, you can choose whether to install the
-     latest available package versions from the update repositories. This
-     provides a clean upgrade path for all packages and ensures that
-     &productname; is upgraded with the latest security updates available. If
-     you choose <guimenu>No</guimenu>, all packages will be installed from the
-     installation media. Proceed with <guimenu>Next</guimenu>.
+     To start the registration, proceed with <guimenu>Next</guimenu>.
     </para>
     <para>
      After successful registration, &yast; lists extensions, add-ons, and


### PR DESCRIPTION
This change is mainly related to [fate#323163](https://fate.suse.com/323163) and [fate#323395](https://fate.suse.com/323395).

## Summary

- The license agreement has been moved from the "welcome" screen later
(Background: the SLE15 medium contains several products (SLES, SLED, SLES4SAP), at that point we do not know which product will be upgraded yet. We do not know which license should be displayed. We can know that *after* selecting the partition to upgrade later in the workflow.)
- If the system is registered YaST uses SCC (or SMT) for providing the upgraded packages, the workflow is the same as in the online migration
- If the system is not registered user should use the "Packages" medium as suggested by YaST otherwise the system can be upgraded only to a minimal SLE15 system
- It is not possible to register the system during upgrade
  - If users want to use the packages from SCC they need to boot the original system and register it before running the upgrade
- The update options have been removed from the upgrade summary (see [bug#1071708](https://bugzilla.suse.com/show_bug.cgi?id=1071708) and related [bug#1075077](https://bugzilla.suse.com/show_bug.cgi?id=1075077))
- At the registration step the local registration servers are scanned before filling the registration code, you can select the server already that point

## Notes

- Feel free to reword or improve the text :wink: 
- The offline migration is still WIP, the code has not been submitted to SLE15 yet, thus even the latest build is not able to run the offline migration
- That means there still might be some changes, I'll let you know in that case
- The last item in the summary (scanning the local servers) is changed also in installation and in installed system, you may need to adapt also the other parts of the documentation...