### PR TITLE
vt-best-practice: Fix cpu-baseline example

### DIFF
--- a/xml/vt_best_practices.xml
+++ b/xml/vt_best_practices.xml
@@ -1477,16 +1477,16 @@ VCPU: CPU Affinity
       should be used. The <command>virsh cpu-baseline</command> command can
       help define a normalized virtual CPU that can be migrated across all
       hosts. The following command, when run on each host in the migration
-      cluster, illustrates collection of all hosts' CPU capabilities in
-      <literal>all-hosts-cpu-caps.xml</literal>.
+      cluster, illustrates collection of all hosts' capabilities in
+      <literal>all-hosts-caps.xml</literal>.
      </para>
-     <screen>&prompt.user;&sudo; virsh capabilities | virsh cpu-baseline /dev/stdin >> all-hosts-cpu-caps.xml</screen>
+     <screen>&prompt.user;&sudo; virsh capabilities >> all-hosts-cpu-caps.xml</screen>
      <para>
-      With the CPU capabilities from each host collected in
-      all-hosts-cpu-caps.xml, use <command>virsh cpu-baseline</command> to
+      With the capabilities from each host collected in
+      all-hosts-caps.xml, use <command>virsh cpu-baseline</command> to
       create a virtual CPU definition that will be compatible across all hosts.
      </para>
-     <screen>&prompt.user;&sudo; virsh cpu-baseline all-hosts-cpu-caps.xml</screen>
+     <screen>&prompt.user;&sudo; virsh cpu-baseline all-hosts-caps.xml</screen>
      <para>
       The resulting virtual CPU definition can be used as the
       <literal>cpu</literal> element in &vmguest; configuration file.


### PR DESCRIPTION
The existing example for creating a baseline virtual CPU across a
cluster of hosts is not quite right. All host capabilties should be
collected and provided to cpu-baseline, not just the <cpu> blocks
from the various hosts.