### PR TITLE
Warn about missing boot partitions

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2957,13 +2957,16 @@ openssl x509 -noout -fingerprint -sha256
     </informaltable>
 
     <important>
-     <title>Boot Partition Might not Be Created</title>
+     <title>Creating Boot Partitions Automatically</title>
      <para>
-      If <literal>size</literal> is set to <literal>auto</literal> for the
-      <literal>boot</literal> partition, &ay; will not create it unless is
-      strictly required in order to boot. If you want to force the creation of
-      a boot partition, you should specify the size using a number or a
-      percentage.
+      When &ay; determines that a boot partition might be required in order
+      to boot properly, it will automatically add one even if it is not specified
+      in the profile.
+     </para>
+     <para>
+      However, if for any reason the boot partition does not fit in the current
+      partitioning layout, &ay; will just display a warning, allowing the
+      installation to proceed.
      </para>
     </important>
    </sect2>


### PR DESCRIPTION
AutoYaST behaves in a more predictable (and sane) way when it comes to handling missing boot partitions.