### PR TITLE
Document CDATA; clarify config:type.

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -317,6 +317,14 @@ exit 0
      restriction is specified in the schema files. A configuration component
      with more than one value must either be represented as an embedded list in a property value or as a nested resource.
     </para>
+    <para>
+      An empty element, such as <literal>&lt;foo&gt;&lt;/foo&gt;</literal> or
+      <literal>&lt;bar/&gt;</literal> will be NOT present in the parsed data
+      model. Usually this is interpreted as wanting a sensible default
+      value. In cases where you need an explicit empty string instead, use a
+      CDATA section:
+      <literal>&lt;foo&gt;&lt;![CDATA[]]&gt;&lt;/foo&gt;</literal>.
+    </para>
    </sect2>
 
    <sect2 xml:id="Profile.Format.ressources_nested">
@@ -325,43 +333,14 @@ exit 0
      Nested resource elements allow a tree-like structure of configuration
      components to be built to any level.
     </para>
+    <para>
+     There are two kinds of nested resources: maps and lists. Maps, also
+     known as associative arrays, hashes, or dictionaries, contain mixed
+     contents, identified by their tag names. Lists, or arrays, have all
+     items of the same type.
+    </para>
     <example>
      <title>Nested Resources</title>
-<screen>...
-&lt;drive&gt;
-  &lt;device&gt;/dev/sda&lt;/device&gt;
-  &lt;partitions&gt; &lt;!-- this is wrong, explanation below --&gt;
-    &lt;partition&gt;
-      &lt;size&gt;10G&lt;/size&gt;
-      &lt;mount&gt;/&lt;/mount&gt;
-    &lt;/partition&gt;
-    &lt;partition&gt;
-      &lt;size&gt;1G&lt;/size&gt;
-      &lt;mount&gt;/tmp&lt;/mount&gt;
-    &lt;/partition&gt;
-  &lt;/partitions&gt;
-&lt;/drive&gt;
-....</screen>
-    </example>
-    <para>
-     In the example above the disk resource consists of a device property
-     and a partitions resource. The partitions resource contains multiple
-     instances of the partition resource. Each partition resource contains a
-     size and mount property.
-    </para>
-    <para>
-     The XML schema defines the partitions element as a resource supporting
-     one or multiple partition element children. If only one partition
-     resource is specified, it is important to use the
-     <literal>config:type</literal> attribute of the partitions element to
-     indicate that the content is a resource, in this case a list. Using the
-     partitions element without specifying the type in this case will
-     result in undefined behavior, as &yast; will incorrectly interpret the
-     partitions resource as a property. The example below illustrates this
-     use case.
-    </para>
-    <example>
-     <title>Nested Resources with Type Attributes</title>
 <screen>...
 &lt;drive&gt;
   &lt;device&gt;/dev/sda&lt;/device&gt;
@@ -378,6 +357,18 @@ exit 0
 &lt;/drive&gt;
 ....</screen>
     </example>
+    <para>
+     In the example above the <literal>drive</literal> resource is a map
+     consisting of a <literal>device</literal> property and a
+     <literal>partitions</literal> resource. The partitions resource is a list
+     containing multiple instances of the <literal>partition</literal>
+     resource. Each partition resource is a map containing a
+     <literal>size</literal> and <literal>mount</literal> property.
+    </para>
+    <para>
+     The default type of a nested resource is map. Lists must be marked as
+     such using the <literal>config:type="list"</literal> attribute.
+    </para>
    </sect2>
 
    <sect2 xml:id="Profile.Format.attributes">
@@ -390,23 +381,22 @@ exit 0
      be treated as reserved words in the default namespace.
     </para>
     <para>
-     Global attributes are defined in the configuration namespace and must
-     always be prefixed with <literal>config:</literal> . All attributes are
-     optional. Most can be used with both resource and property elements but
-     some can only be used with one type of element which is specified in
-     the schema files.
+     The <literal>config:type</literal> attribute determines the type of the
+     resource or property in the parsed data model. For resources, lists need
+     a <literal>list</literal> type whereas a map is the default type that
+     does not need an attribute. For properties, <literal>boolean</literal>,
+     <literal>symbol</literal>, and <literal>integer</literal> can be used,
+     the default being a string.
     </para>
     <para>
-     The type of an element is defined using the
-     <literal>config:type</literal> attribute. The type of a resource
-     element is always RESOURCE, although this can also be made explicit
-     with this attribute (to ensure correct identification of an empty
-     element, for example, when there is no schema file to refer to). A
-     resource element cannot be any other type and this restriction is
-     specified in the schema file. The type of a property element determines
-     the interpretation of its literal value. The type of a property element
-     defaults to <literal>STRING</literal>, as specified in the schema file.
-     The full set of permissible types is specified in the schema file.
+     Previously this section stated that all attributes are optional, which is
+     not true. It may appear so because various parts of the schema are not
+     very consistent in their usage of data types. In some places an
+     enumeration is represented by a symbol, elsewhere a string is
+     required. One resource needs <literal>config:type="integer"</literal>,
+     another will parse the number from a string property. Some resources use
+     <literal>config:type="boolean"</literal>, other want "yes" or even
+     "1". If in doubt, consult the schema file.
     </para>
    </sect2>
   </sect1>


### PR DESCRIPTION
Prompted by https://bugzilla.suse.com/show_bug.cgi?id=1083622
YaST Scrum card: https://trello.com/c/esxuIcTv

I wanted to document the CDATA trick to distinguish between a missing element and an empty string.

Then I found out that the docs gets attributes quite wrong so I fixed that.