### PR TITLE
Update SMT docs according to new SCC web UI layout

### DIFF
--- a/xml/smt_mirroring.xml
+++ b/xml/smt_mirroring.xml
@@ -41,7 +41,7 @@
    <step>
     <para>
      If you are member of multiple organizations, chose the organization you
-     want to work with from the drop-down box in the top-right corner.
+     want to work with from the sidebar on the left.
     </para>
    </step>
    <step>


### PR DESCRIPTION
There is no org-dropdown on the top-right of SCC anymore. We moved the org-selection to the sidebar on the left quite a while ago :arrow_upper_left: 

I discovered this while looking for something else.

And since I don't have the overview in which other pieces of documentation this step might occur (and since you don't have _Issues_ enabled on this repo ... why, btw?) I open this PR more as a tracking issue to get it fixed in all the places.

Plus, now I'm wondering what else around SCC UI docs might be outdated since we are changing things relativly frequent.

The thing I was actually looking for was, btw, the steps you describe for finding the "Organization (Mirroring) Credentials" in SCC, since I have an open PR (suse/happy-customer#3676) to move them somewhere else and this would need doc-update as-well.

So please excuse that I'm using this PR as a ticket ;) But we need to align my PR with updated docs, if possible, and I'm uncertain what your workflow is.
And we should find a way and the time to check all SCC-related doc pieces and update them if necessary.
And afterwards, I will try to teach myself and my team to always create PRs against the docs pro-activly when we have moved things around :innocent: 

But first things first :)