### PR TITLE
vt doc: add a note about user and group ID requirements

### DIFF
--- a/xml/libvirt_managing.xml
+++ b/xml/libvirt_managing.xml
@@ -984,8 +984,7 @@ Metadata:       yes
     <listitem>
      <para>
       It is recommended that the source and destination systems have the same
-      architecture. However, it is possible to migrate between hosts with AMD*
-      and Intel* architectures.
+      architecture.
      </para>
     </listitem>
     <listitem>
@@ -1021,6 +1020,12 @@ Metadata:       yes
      <para>
       Host and target machine should be in the same subnet on the network,
       otherwise networking will not work after the migration.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      All &vmhost;'s participating in migration must have the same UID for
+      the qemu user and same GIDs for the kvm, qemu, and libvirt groups.
      </para>
     </listitem>
     <listitem>


### PR DESCRIPTION
In a cluster of VM hosts participating in migration, the UID of
qemu user and GID of qemu, kvm, and libvirt groups need to be the
same value. Add a note about the requirement in the "Migration
Requirements" section of the VT doc.

While at it, remove the bogus commment about migrating between Intel
and AMD hosts.

Signed-off-by: Jim Fehlig <jfehlig@suse.com>