### PR TITLE
Remove `/connect/` from SMT URL

### DIFF
--- a/xml/rmt_client.xml
+++ b/xml/rmt_client.xml
@@ -65,12 +65,12 @@
    The parameter needs to be entered as
    <literal>regurl=<replaceable>SMT_SERVER_URL</replaceable></literal>. The URL
    needs to be in the following format:
-   <literal>https://<replaceable>FQDN</replaceable>/connect/</literal> with
+   <literal>https://<replaceable>FQDN</replaceable></literal> with
    <replaceable>FQDN</replaceable> being the fully qualified host name of the
    &rmt; server. It must be identical to the FQDN of the server certificate
    used on the &rmt; server. Example:
   </para>
-  <screen>regurl=https://smt.&exampledomain;/connect/</screen>
+  <screen>regurl=https://smt.&exampledomain;</screen>
   <warning>
    <title>Beware of Typing Errors</title>
    <para>


### PR DESCRIPTION
To configure the installer to use a registration proxy, the FQDN of SMT/RMT is enough. There's no need to append `/connect/`, since the SUSEConnect library takes care of that on its own. In fact, SUSEConnect does not handle paths, and even if `fqdn/connect` is given as the regurl, it will only use `fqdn`, and ignore the path. Giving a path can cause a bug when de-registering a system (bsc#954451).