### PR TITLE
Update Quickstart guide for SLE15

### DIFF
--- a/xml/art_sles_rpi_quick.xml
+++ b/xml/art_sles_rpi_quick.xml
@@ -875,10 +875,7 @@ Password:
 
           <para>After successful registration you will be given the option
             to activate <emphasis role="italic">Modules</emphasis> as
-            additional package repositories. For example the <emphasis
-              role="italic">Toolchain Module</emphasis> provides the
-            supported versions of the GNU Compiler Collection for SUSE
-            Linux Enterprise Server for ARM &productnumber;.</para>
+            additional package repositories.</para>
 
         </step>
 
@@ -959,15 +956,6 @@ Device setup complete</screen>
       <para> You can then use <command>hciconfig hci0 up</command> to bring
         the device up and use <command>hcitool scan</command> to scan the
         environment for discoverable devices. </para>
-    </sect2>
-
-    <sect2 xml:id="sec.rpi.gcc">
-      <title>Compiler</title>
-      <para> For compiling software, only the versions of the GNU Compiler
-        Collection provided by the Toolchain Module, which can be selected
-        after registration, are supported. To use the supported version,
-          <command>gcc-7</command> needs to be invoked instead of
-          <command>gcc</command>. </para>
     </sect2>
   </sect1>
 

--- a/xml/art_sles_rpi_quick.xml
+++ b/xml/art_sles_rpi_quick.xml
@@ -1339,7 +1339,7 @@ passwd: password updated successfully
   <sect1 xml:id="sec.rpi.documentation.legal">
     <title>Legal Notice</title>
 
-    <para>Copyright &copy;2006– 2018 SUSE LLC and contributors. All
+    <para>Copyright &copy;2006–2018 SUSE LLC and contributors. All
       rights reserved. </para>
 
     <para>Permission is granted to copy, distribute and/or modify this

--- a/xml/art_sles_rpi_quick.xml
+++ b/xml/art_sles_rpi_quick.xml
@@ -544,10 +544,10 @@
         <title> Writing the Image to the Card using <command>dd</command>
         </title>
         <para>This command decompresses the image
-            <literal>SLE-12-SP3-Server-RaspberryPi3.aarch64-GM.raw.xz</literal>
+            <literal>SLES15-RaspberryPi.aarch64-15.0-GM.raw.xz</literal>
           to the SD card <literal>mmcblk0</literal>. </para>
 
-        <screen>xz -cd SLE-12-SP3-Server-RaspberryPi3.aarch64-GM.raw.xz | dd of=/dev/mmcblk0 bs=4096</screen>
+        <screen>xz -cd SLES15-RaspberryPi.aarch64-15.0-GM.raw.xz | sudo dd of=/dev/mmcblk0 bs=4096</screen>
       </example>
     </sect2>
 
@@ -675,7 +675,7 @@
             is the disk number and imageFile.raw is the name of the
             uncompressed image. </para>
 
-          <screen>&prompt.user;sudo dd bs=4096 if=SLE-12-SP3-Server-RaspberryPi3.aarch64-GM.raw.xz of=/dev/disk4
+          <screen>&prompt.user;sudo dd bs=4096 if=SLES15-RaspberryPi.aarch64-15.0-GM.raw.xz of=/dev/disk4
 Password:
 5550+0 records in
 5550+0 records out

--- a/xml/art_sles_rpi_quick.xml
+++ b/xml/art_sles_rpi_quick.xml
@@ -234,7 +234,7 @@
           <para>Raspberry Pi 3 Model B</para>
         </listitem>
         <listitem>
-          <para>SD card with at least 8&nbsp;GB capacity</para>
+          <para>MicroSD card with at least 8&nbsp;GB capacity</para>
         </listitem>
         <listitem>
           <para>USB keyboard, mouse</para>

--- a/xml/art_sles_rpi_quick.xml
+++ b/xml/art_sles_rpi_quick.xml
@@ -198,7 +198,7 @@
           <listitem>
             <para> A 0.1&nbsp;inch multi-function pin header is also available.
               Note that not all functionality of this header is exposed in
-              &productname; for ARM on the &rpi;. </para>
+              &productname; for ARM &productnumber;. </para>
           </listitem>
         </varlistentry>
       </variablelist>

--- a/xml/art_sles_rpi_quick.xml
+++ b/xml/art_sles_rpi_quick.xml
@@ -73,7 +73,7 @@
 
     <para> To be able to use &productname; for ARM on the &rpi;, an
       Arm compatible &rpi;* is required. &productname; &productnumber; for
-      ARM is tested to work on a &rpi; 3 Model B board. </para>
+      ARM is tested to work on &rpi; 3 Model B and Model B+ boards. </para>
 
     <sect2 xml:id="sec.rpi.platform.system">
       <title>Technical Details of the &rpi; 3 Model B</title>
@@ -120,7 +120,7 @@
       </figure>
 
       <variablelist>
-        <title>Selected Features of the &rpi; 3 Model B</title>
+        <title>Selected Features of the &rpi; 3 Model B/B+</title>
 
         <varlistentry>
           <term>CPU</term>
@@ -153,16 +153,19 @@
           <term>Ethernet</term>
           <listitem>
             <para> A USB Ethernet adapter on the board provides
-              10/100&nbsp;MBit/s Ethernet. </para>
+              10/100&nbsp;MBit/s Ethernet (Model B) or 10/100/1000&nbsp;MBit/s Ethernet with maximum throughput of 300&nbsp;MBit/s (Model B+). </para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
           <term>WLAN</term>
           <listitem>
-            <para> The BCM43438 chip supports IEEE-802.11b, IEEE-802.11g
+            <para> The BCM43438 chip on Model B supports IEEE-802.11b, IEEE-802.11g
               and IEEE-802.11n in the 2.4&nbsp;GHz band. It also
-              provides Bluetooth 2.0-4.1 (Low Energy). </para>
+              provides Bluetooth 2.0 to 4.1 (Low Energy).
+              The BCM43455 chip on Model B+ supports IEEE-802.11b, IEEE-802.11g,
+              IEEE-802.11n and IEEE-802.11ac in the 2.4&nbsp;GHz and 5&nbsp;GHz bands.
+              It provides Bluetooth 4.2 (Low Energy). </para>
           </listitem>
         </varlistentry>
 
@@ -231,7 +234,7 @@
 
       <itemizedlist>
         <listitem>
-          <para>Raspberry Pi 3 Model B</para>
+          <para>Raspberry Pi 3 Model B or Raspberry Pi 3 Model B+</para>
         </listitem>
         <listitem>
           <para>MicroSD card with at least 8&nbsp;GB capacity</para>
@@ -949,7 +952,7 @@ Password:
         devices. </para>
 
       <para> To enable the Bluetooth* controller for use with
-          <command>bluetoothctl</command> and related applications, run: </para>
+          <command>bluetoothctl</command> and related applications, run on Model B: </para>
 
       <screen>&prompt.root;hciattach /dev/ttyAMA0 bcm43xx 921600
 bcm43xx_init

--- a/xml/art_sles_rpi_quick.xml
+++ b/xml/art_sles_rpi_quick.xml
@@ -128,7 +128,7 @@
             <para> The Broadcom BCM2837 SoC includes a quad-core Arm*
               Cortex*-A53 Application Processor supporting the ARMv8 32-bit
               and 64-bit instruction sets. With the default configuration,
-              it is clocked up to 1.2&#xa0;GHz. </para>
+              it is clocked up to 1.2&nbsp;GHz. </para>
           </listitem>
         </varlistentry>
 
@@ -153,7 +153,7 @@
           <term>Ethernet</term>
           <listitem>
             <para> A USB Ethernet adapter on the board provides
-              10/100&#xa0;MBit/s Ethernet. </para>
+              10/100&nbsp;MBit/s Ethernet. </para>
           </listitem>
         </varlistentry>
 
@@ -161,7 +161,7 @@
           <term>WLAN</term>
           <listitem>
             <para> The BCM43438 chip supports IEEE-802.11b, IEEE-802.11g
-              and IEEE-802.11n in the 2.4&#xa0;GHz band. It also
+              and IEEE-802.11n in the 2.4&nbsp;GHz band. It also
               provides Bluetooth 2.0-4.1 (Low Energy). </para>
           </listitem>
         </varlistentry>
@@ -193,7 +193,7 @@
         <varlistentry>
           <term>Connectors</term>
           <listitem>
-            <para> A 0.1 inch multi-function pin header is also available.
+            <para> A 0.1&nbsp;inch multi-function pin header is also available.
               Note that not all functionality of this header is exposed in
               &productname; for ARM on the &rpi;. </para>
           </listitem>
@@ -234,7 +234,7 @@
           <para>Raspberry Pi 3 Model B</para>
         </listitem>
         <listitem>
-          <para>SD Card with at least 8GB capacity</para>
+          <para>SD card with at least 8&nbsp;GB capacity</para>
         </listitem>
         <listitem>
           <para>USB keyboard, mouse</para>
@@ -243,7 +243,7 @@
           <para>HDMI cable and monitor</para>
         </listitem>
         <listitem>
-          <para>Power supply with at least 2.5A capacity</para>
+          <para>Power supply with at least 2.5&nbsp;A capacity</para>
         </listitem>
       </itemizedlist>
 
@@ -514,8 +514,8 @@
 
     <note>
       <title>SD Card Space Requirements</title>
-      <para> It is recommended to use a card with a capacity of at least 8
-        GB. </para>
+      <para> It is recommended to use a card with a capacity of at least
+        8&nbsp;GB. </para>
       <!--<para>TO DO!!! 8 GB may lead to space issues with btrfs snapshots and
         has not been tested for SP3. Suggestion: Leave as is and revisit
         later.</para>-->

--- a/xml/art_sles_rpi_quick.xml
+++ b/xml/art_sles_rpi_quick.xml
@@ -495,8 +495,8 @@
 
         <para>For other limitations refer to the online version of the
           Release Notes at <link
-            xlink:href="https://www.suse.com/releasenotes/x86_64/SUSE-SLES/12-SP3/"
-            >https://www.suse.com/releasenotes/x86_64/SUSE-SLES/12-SP3/</link>.</para>
+            xlink:href="https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15/"
+            >https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15/</link>.</para>
 
       </sect3>
     </sect2>

--- a/xml/art_sles_rpi_quick.xml
+++ b/xml/art_sles_rpi_quick.xml
@@ -489,10 +489,6 @@
             <listitem>
               <para>&xvendor; hardware acceleration is disabled to
                 improve system stability and reliability.</para>
-              <para>To enable it, comment out the following line in
-                  <filename>/etc/X11/xorg.conf.d/20-kms.conf</filename>:
-                  <literal>Option "AccelMethod" "none"</literal> by
-                prefixing it with <quote>#</quote>.</para>
             </listitem>
           </varlistentry>
         </variablelist>


### PR DESCRIPTION
Reflect SLE15 support of new Model B+ as well as SLE15 having gcc7 now.