### PR TITLE
Support for on-demand activated services

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -5455,9 +5455,9 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
    <title>Services and Targets</title>
 
    <para>
-    With the <literal>services-manager</literal> resource you can set the
-    default systemd target and specify in detail which system services you
-    want to start or deactivate.
+    With the <literal>services-manager</literal> resource you can set
+    the default systemd target and specify in detail which system
+    services you want to start or deactivate and how to start them.
    </para>
 
    <para>
@@ -5468,8 +5468,24 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
    </para>
 
    <para>
-    The &lt;enable config:type="list"&gt; and &lt;disable
-    config:type="list"&gt; let you explicitly enable or disable services.
+    To specify the set of services that should be started on boot, use
+    the <literal>enable</literal> and <literal>disable</literal> lists.
+    To start a service, add its name to the <literal>enable</literal>
+    list. To make sure that the service is not started on boot, add it
+    to the <literal>disable</literal> list.
+   </para>
+
+   <para>
+    If a service is not listed as enabled or disabled, a default
+    setting setting is used. The default setting can equally be
+    disabled or enabled.
+   </para>
+
+   <para>
+    Finally, some services like <literal>cups</literal> support on-demand
+    activation (socket activated services). If you want to take advantage of
+    such a feature, list the names of those services under the
+    <literal>on_demand</literal> list instead of <literal>enable</literal>.
    </para>
 
    <example>
@@ -5478,11 +5494,14 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
   &lt;default_target&gt;multi-user&lt;/default_target&gt;
   &lt;services&gt;
     &lt;disable config:type="list"&gt;
-      &lt;service&gt;cups&lt;/service&gt;
+      &lt;service&gt;libvirtd&lt;/service&gt;
     &lt;/disable&gt;
     &lt;enable config:type="list"&gt;
       &lt;service&gt;sshd&lt;/service&gt;
     &lt;/enable&gt;
+    &lt;on_demand config:type="list"&gt;
+      &lt;service&gt;cups&lt;/service&gt;
+    &lt;/on_demand&gt;
   &lt;/services&gt;
 &lt;/services-manager&gt;</screen>
    </example>


### PR DESCRIPTION
Extend services manager documentation regarding [socket based
activated](https://github.com/yast/yast-services-manager/pull/165) services.