### PR TITLE
Remove qed as a supported format from our virtualization doc.

### DIFF
--- a/xml/libvirt_configuration.xml
+++ b/xml/libvirt_configuration.xml
@@ -363,8 +363,7 @@
      <title>Supported Storage Formats</title>
      <para>
       &suse; only supports the following storage formats:
-      <literal>raw</literal>, <literal>qcow2</literal>, and
-      <literal>qed</literal>.
+      <literal>raw</literal>, and <literal>qcow2</literal>.
      </para>
     </tip>
    </step>

--- a/xml/libvirt_managing.xml
+++ b/xml/libvirt_managing.xml
@@ -504,12 +504,11 @@
   </warning>
 
   <important>
-   <title>Only for &vmguest;s with Disk Types <literal>raw</literal>, <literal>qcow2</literal>, <literal>qed</literal></title>
+   <title>Only for &vmguest;s with Disk Types <literal>raw</literal>, <literal>qcow2</literal></title>
    <para>
     Saving and restoring &vmguest;s is only possible if the &vmguest; is using
     a virtual disk of the type <literal>raw</literal>
-    (<filename>.img</filename>), <emphasis>qcow2</emphasis>, or
-    <literal>qed</literal>.
+    (<filename>.img</filename>), or <emphasis>qcow2</emphasis>.
    </para>
   </important>
 

--- a/xml/libvirt_storage.xml
+++ b/xml/libvirt_storage.xml
@@ -56,7 +56,7 @@
       <listitem>
        <para>
         A directory for hosting image files. The files can be either one of the
-        supported disk formats (raw, qcow2, or qed), or ISO images.
+        supported disk formats (raw, or qcow2), or ISO images.
        </para>
       </listitem>
      </varlistentry>
@@ -636,8 +636,8 @@ Syncing disks.</screen>
       </para>
       <para>
        Note that &suse; currently only supports <literal>raw</literal>,
-       <literal>qcow2</literal>, or <literal>qed</literal> images. The latter
-       option is not available on LVM group-based pools.
+       or <literal>qcow2</literal> images. The latter option is not available
+       on LVM group-based pools.
       </para>
       <para>
        Next to <guimenu>Max Capacity</guimenu>, specify the amount maximum size
@@ -832,7 +832,7 @@ done</screen>
    <para>
     To add a volume to an existing pool, enter the following command:
    </para>
-<screen>&prompt.user;virsh vol-create-as <replaceable>POOL</replaceable><co xml:id="co.vol-create-as.pool"/><replaceable>NAME</replaceable><co xml:id="co.vol-create-as.name"/> 12G --format<co xml:id="co.vol-create-as.capacity"/><replaceable>raw|qcow2|qed</replaceable><co xml:id="co.vol-create-as.format"/> --allocation 4G<co xml:id="co.vol-create-as.alloc"/></screen>
+<screen>&prompt.user;virsh vol-create-as <replaceable>POOL</replaceable><co xml:id="co.vol-create-as.pool"/><replaceable>NAME</replaceable><co xml:id="co.vol-create-as.name"/> 12G --format<co xml:id="co.vol-create-as.capacity"/><replaceable>raw|qcow2</replaceable><co xml:id="co.vol-create-as.format"/> --allocation 4G<co xml:id="co.vol-create-as.alloc"/></screen>
    <calloutlist>
     <callout arearefs="co.vol-create-as.pool">
      <para>
@@ -853,7 +853,7 @@ done</screen>
     <callout arearefs="co.vol-create-as.format">
      <para>
       Format of the volume. &suse; currently supports <literal>raw</literal>,
-      <literal>qcow2</literal>, and <literal>qed</literal>.
+      and <literal>qcow2</literal>.
      </para>
     </callout>
     <callout arearefs="co.vol-create-as.alloc">

--- a/xml/qemu_guest_installation.xml
+++ b/xml/qemu_guest_installation.xml
@@ -319,8 +319,7 @@
      <callout arearefs="co.qemu_img.create.f">
       <para>
        The format of the target image. Supported formats are
-       <literal>qed</literal>, <literal>qcow2</literal>, and
-       <literal>raw</literal>.
+       <literal>raw</literal>, and <literal>qcow2</literal>.
       </para>
      </callout>
      <callout arearefs="co.qemu_img.create.o">
@@ -503,9 +502,9 @@ ERROR: invalid cluster offset=0x34ab0000
     <note>
      <para>
       You can resize the disk image using the formats <literal>raw</literal>,
-      <literal>qcow2</literal> and <literal>qed</literal>. To resize an image
-      in another format, convert it to a supported format with
-      <command>qemu-img convert</command> first.
+      and <literal>qcow2</literal>. To resize an image in another format,
+      convert it to a supported format with <command>qemu-img convert</command>
+      first.
      </para>
     </note>
     <para>

--- a/xml/qemu_running_vms_qemukvm.xml
+++ b/xml/qemu_running_vms_qemukvm.xml
@@ -441,8 +441,7 @@
       <para>
        Specifies the format of the connected disk image. If not specified, the
        format is autodetected. Currently, &suse; supports
-       <literal>qcow2</literal>, <literal>qed</literal> and
-       <literal>raw</literal> formats.
+       <literal>raw</literal>, and <literal>qcow2</literal> formats.
       </para>
      </listitem>
     </varlistentry>

--- a/xml/vt_best_practices.xml
+++ b/xml/vt_best_practices.xml
@@ -1933,12 +1933,12 @@ kernel.numa_balancing_scan_size_mb = 256<co xml:id="co.numa.size"/></screen>
      <listitem>
       <para>
        Use this to have smaller images (useful if your file system does not
-       supports holes, for example on Windows*).
+       supports holes).
       </para>
      </listitem>
      <listitem>
       <para>
-       It has optional AES encryption.
+       It has optional AES encryption (now deprecated).
       </para>
      </listitem>
      <listitem>
@@ -2023,52 +2023,13 @@ kernel.numa_balancing_scan_size_mb = 256<co xml:id="co.numa.size"/></screen>
     </variablelist>
    </sect3>
    <sect3 xml:id="sec.vt.best.img.imageformat.qed">
-    <title>qed format</title>
+    <title>qed Format</title>
     <para>
-     qed is the next-generation qcow (&qemu; Copy On Write). Its
-     characteristics include:
+	    qed is a follow-on qcow (&qemu; Copy On Write) format. Because qcow2 provides all the benefits of qed and more, qed is now deprecated.
     </para>
-    <itemizedlist>
-     <listitem>
-      <para>
-       Strong data integrity because of simple design.
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       Retains sparseness over non-sparse channels (for example HTTP).
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       Supports changing the backing file.
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       Supports consistency checks.
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       Fully asynchronous I/O path.
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       Does not support internal snapshots.
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       Relies on the host file system and cannot be stored on a logical
-       volume directly.
-      </para>
-     </listitem>
-    </itemizedlist>
    </sect3>
    <sect3 xml:id="sec.vt.best.img.imageformat.vmdk">
-    <title>VMDK format</title>
+    <title>VMDK Format</title>
     <para>
      VMware 3, 4, or 6 image format, for exchanging images with that
      product.

--- a/xml/vt_cachemodes.xml
+++ b/xml/vt_cachemodes.xml
@@ -246,11 +246,11 @@
 
   <para>
    The caching of storage data and metadata restricts the configurations
-   that support live migration. Currently, only <literal>raw</literal>,
-   <literal>qcow2</literal> and <literal>qed</literal> image formats can be
-   used for live migration. If a clustered file system is used, all cache
-   modes support live migration. Otherwise the only cache mode that supports
-   live migration on read/write shared storage is <literal>none</literal>.
+   that support live migration. Currently, only <literal>raw</literal>, and
+   <literal>qcow2</literal> image formats can be used for live migration. If a
+   clustered file system is used, all cache modes support live migration.
+   Otherwise the only cache mode that supports live migration on read/write
+   shared storage is <literal>none</literal>.
   </para>
 
   <para>


### PR DESCRIPTION
As per FATE#324200, qed format is no longer formatted. I've updated
the in-package support doc of earlier releases to signal it's
deprecation there, and indicate that it is no longer supported as
of SLE15. Getting the rest of the official documentation in line
here as well.