### PR TITLE
Add partition_type description

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2652,6 +2652,28 @@ exit 0
        <row>
         <entry>
          <para>
+          <literal>partition_type</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          When using a <literal>msdos</literal> partition table, this element sets the type of the
+          partition, which can be <literal>primary</literal> or <literal>logical</literal>. Bear in
+          mind that this value is just ignored when using a <literal>gpt</literal> partition table
+          because such a distinction does not exist in that case.
+         </para>
+<screen>&lt;partition_type&gt;primary&lt;/partition_type&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. Allowed values are <literal>primary</literal> (default) and
+          <literal>logical</literal>.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
           <literal>mountby</literal>
          </para>
         </entry>


### PR DESCRIPTION
This PR adds the description of the `partition_type` element (see [bsc#1091415](https://bugzilla.suse.com/show_bug.cgi?id=1091415). We should update the documentation for SLE 12 SP2, SLE 12 SP3, SLE 12 SP4 and SLE 15. How to proceed? I can create a new PR for these branches as soon as this PR is reviewed and merged. Is it OK to you?