### PR TITLE
Fix typo in autoyast system registration section

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -1285,10 +1285,10 @@ exit 0
    <title>System Registration and Extension Selection</title>
 
    <para>
-    Registering the system with the can be configured within the
-    <literal>suse_register</literal> resource. The following example registers
-    the system with the &scc;. In case your organization provides its own
-    registration server, you need to specify the required data with the
+    Registering the system with the registration server can be configured
+    within the <literal>suse_register</literal> resource. The following example
+    registers the system with the &scc;. In case your organization provides its
+    own registration server, you need to specify the required data with the
     <literal>reg_server*</literal> properties. Refer to the table below for
     details.
    </para>


### PR DESCRIPTION
This small PR adds some missing words in the AutoYaST Registration Server section.