### PR TITLE
Document a Self-Update temporary repository

### DIFF
--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -356,6 +356,37 @@
      </para>
     </note>
    </sect3>
+
+   <sect3 xml:id="sec.yast_install.self_update.temporary_addon_repo">
+    <title>Temporary Self-Update Addon Repository</title>
+
+    <para>
+     Some packages distributed in the Self-Update repository should not be
+     applied as an update for the installer but should just override the
+     available packages from the installation medium.
+    </para>
+
+    <para>
+     Such packages usualy provide some additional data for the installer,
+     like the installation defaults, system role definitions and similar.
+     These packages are not installed into the target system.
+    </para>
+
+    <para>
+     The installer copies these packages from the Self-Update repository
+     to a local temporary repository and uses them later during installation.
+     This temporary repository is removed at the end of installation and
+     is not saved into the installed system. If there is no such package
+     found in the Self-Update repository this temporary repository is not
+     created.
+    </para>
+
+    <para>
+     This extra repository is not displayed in the list of add-on products,
+     but it still can be visible during installation in the package management
+     as a <literal>SelfUpdate0</literal> repository.
+    </para>
+   </sect3>
   </sect2>
 
   <sect2 xml:id="sec.yast_install.self_update.custom">


### PR DESCRIPTION
- Document a Self-Update temporary repository which might be used in some cases during installation.
- The reason is that in some cases there might be used extra `SelfUpdate0` repository during installation and this might be confusing for the users. Let's make it clear.
- This is related to bug https://bugzilla.suse.com/show_bug.cgi?id=1101016
- This change is valid only for SLE15-SP1/Leap 15.1