### PR TITLE
AutoYaST whole disk and partitioned software RAIDs

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -3464,6 +3464,12 @@ openssl x509 -noout -fingerprint -sha256
     <note os="sles;sled">
      <title>Available in &productname; 15 SP0 via Installer Updates</title>
      <para>
+        Support to use whole disks was included in &productname; 15 
+        as a late feature. To use the feature in this specific version, 
+        the installer self-update must be enabled. See <xref
+       linkend="sec.yast_install.self_update"/> for more information about
+       installer updates.
+   </para>
       Support to use whole disks was included in &productname; 15 SP0 as a
       late feature, so the installer self-update must be enabled in order to
       use it in that specific version. See <xref

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -3481,7 +3481,7 @@ openssl x509 -noout -fingerprint -sha256
     <para>
      &ay; allows to use a whole disk without creating any partition by setting
      the <literal>disklabel</literal> to <literal>none</literal> as described
-     above. In such cases, the configuration in the first
+     as described in <xref linkend="CreateProfile.Partitioning.config"/>. In such cases, the configuration in the first
      <literal>partition</literal> from the <literal>drive</literal> will be
      applied to the whole disk.
     </para>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -3464,12 +3464,14 @@ openssl x509 -noout -fingerprint -sha256
     <note os="sles;sled">
      <title>Available in &productname; 15 SP0 via Installer Updates</title>
      <para>
-        Support to use whole disks was included in &productname; 15 
-        as a late feature. To use the feature in this specific version, 
-        the installer self-update must be enabled. See <xref
+       Support to use whole disks was included in &productname; 15
+       as a late feature. To use the feature in this specific version,
+       the installer self-update must be enabled. See <xref
        linkend="sec.yast_install.self_update"/> for more information about
        installer updates.
-   </para>
+     </para>
+
+     <para>
       Support to use whole disks was included in &productname; 15 SP0 as a
       late feature, so the installer self-update must be enabled in order to
       use it in that specific version. See <xref
@@ -4274,10 +4276,12 @@ openssl x509 -noout -fingerprint -sha256
    <sect3 xml:id="ay.partition_sw_raid_deprecated">
     <title>Using the Deprecated Syntax</title>
     <para>
-     If the installer self-update feature is enabled, it is possible to partition a software RAID 
+     If the installer self-update feature is enabled, it is possible to partition a software RAID
      for &productname; 15. However, that scenario was not supported in previous versions and hence
      the way to define a software RAID was slightly different.
     </para>
+
+    <para>
      Starting on &productname; 15 SP1 (or 15 SP0 if the installer self-update
      feature is enabled), it is possible to partition a software RAID.
      However, that scenario was not supported in previous versions and hence

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -3488,11 +3488,11 @@ openssl x509 -noout -fingerprint -sha256
 
     <para>
      In the example below, we are using the second disk (<literal>/dev/sdb</literal>)
-     as the <literal>/home</literal> filesystem.
+     as the <literal>/home</literal> file system.
     </para>
 
     <example>
-     <title>Using a Whole Disk as a Filesystem</title>
+     <title>Using a Whole Disk as a File System</title>
 <screen>&lt;partitioning config:type="list"&gt;
   &lt;drive&gt;
     &lt;device&gt;/dev/sda&lt;/device&gt;
@@ -4185,15 +4185,15 @@ openssl x509 -noout -fingerprint -sha256
      </listitem>
      <listitem>
       <para>
-       Defining the RAID itself using a dedicated <literal>drive</literal>
+       Defining the RAID itself by using a dedicated <literal>drive</literal>
        section.
       </para>
      </listitem>
     </itemizedlist>
 
     <para>
-     The following example shows a RAID1 configuration using a partition from the first disk
-     and the second disk as RAID members:
+     The following example shows a RAID1 configuration that uses a partition from the first disk
+     and another one from the second disk as RAID members:
     </para>
     <example>
      <title>RAID1 Configuration</title>
@@ -4245,7 +4245,7 @@ openssl x509 -noout -fingerprint -sha256
     </example>
 
     <para>
-     If you do not want to create partitions in the software RAID, just set
+     If you do not want to create partitions in the software RAID, set
      the <literal>disklabel</literal> to <literal>none</literal> as you would
      do for a regular disk. In the example below, only the RAID
      <literal>drive</literal> section is shown for simplicity's sake:
@@ -4285,7 +4285,7 @@ openssl x509 -noout -fingerprint -sha256
     </para>
 
     <para>
-     This section defines how the old-style configuration looks like because
+     This section defines what the old-style configuration looks like because
      it is still supported for backward compatibility.
     </para>
 
@@ -4296,7 +4296,7 @@ openssl x509 -noout -fingerprint -sha256
     <itemizedlist mark="bullet" spacing="normal">
      <listitem>
       <para>
-       The device for raid is always <literal>/dev/md</literal>
+       The device for raid is always <literal>/dev/md</literal>.
       </para>
      </listitem>
      <listitem>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2658,6 +2658,11 @@ openssl x509 -noout -fingerprint -sha256
             <literal>gpt</literal>
            </para>
           </listitem>
+          <listitem>
+           <para>
+            <literal>none</literal>
+           </para>
+          </listitem>
          </itemizedlist>
 <screen>&lt;disklabel&gt;gpt&lt;/disklabel&gt;</screen>
         </entry>
@@ -2666,7 +2671,8 @@ openssl x509 -noout -fingerprint -sha256
           Optional. By default &yast; decides what makes sense. If a partition
           table of a different type already exists, it will be recreated with
           the given type only if it does not include any partition that should
-          be kept or reused.
+          be kept or reused. To use the disk without creating any partition, set
+          this element to <literal>none</literal>.
          </para>
         </entry>
        </row>
@@ -3468,132 +3474,64 @@ openssl x509 -noout -fingerprint -sha256
 <screen>&lt;subvolumes_prefix&gt;&lt;![CDATA[]]&gt;&lt;/subvolumes_prefix&gt;</screen>
    </sect2>
 
-   <sect2 xml:id="ay.raid_configuration">
-    <title>RAID Options</title>
+   <sect2 xml:id="ay.use_whole_disk">
+    <title>Using the Whole Disk</title>
+
+    <note os="sles;sled">
+     <title>Available in &productname; 15 SP0 via Installer Updates</title>
+     <para>
+      Support to use whole disks was included in &productname; 15 SP0 as a
+      late feature, so the installer self-update must be enabled in order to
+      use it in that specific version. See <xref
+       linkend="sec.yast_install.self_update"/> for more information about
+      installer updates.
+     </para>
+    </note>
+
     <para>
-     The following elements must be placed within the following XML
-     structure:
+     &ay; allows to use a whole disk without creating any partition by setting
+     the <literal>disklabel</literal> to <literal>none</literal> as described
+     above. In such cases, the configuration in the first
+     <literal>partition</literal> from the <literal>drive</literal> will be
+     applied to the whole disk.
     </para>
-<screen>&lt;partition&gt;
-  &lt;raid_options&gt;
-    ...
-  &lt;/raid_options&gt;
-&lt;/partition&gt;</screen>
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Attribute
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Values
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>chunk_size</literal>
-         </para>
-        </entry>
-        <entry>
-         <para/>
-<screen>&lt;chunk_size&gt;4&lt;/chunk_size&gt;</screen>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>parity_algorithm</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Possible values are:
-         </para>
-         <para>
-          <literal>left_asymmetric</literal>, <literal>left_symmetric,
-          right_asymmetric</literal>, <literal>right_symmetric</literal>.
-         </para>
-         <para>
-          For RAID6 and RAID10 the following values can be used:
-         </para>
-         <para>
-          <literal>parity_first</literal>, <literal>parity_last</literal>,
-          <literal>left_asymmetric_6, left_symmetric_6</literal>,
-          <literal>right_asymmetric_6</literal>,
-          <literal>right_symmetric_6</literal>,
-          <literal>parity_first_6</literal>, <literal>n2</literal>,
-          <literal>o2</literal>, <literal>f2</literal>,
-          <literal>n3</literal>, <literal>o3</literal>,
-          <literal>f3</literal> for RAID6 and RAID10.
-         </para>
-<screen>&lt;parity_algorithm
-&gt;left_asymmetric&lt;/parity_algorithm&gt;</screen>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>raid_type</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Possible values are: <literal>raid0</literal>,
-          <literal>raid1</literal>, <literal>raid5</literal>,
-          <literal>raid6</literal> and <literal>raid10</literal>.
-         </para>
-<screen>&lt;raid_type&gt;raid1&lt;/raid_type&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          The default is <literal>raid1</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>device_order</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          This list contains the optional order of the physical devices:
-         </para>
-<screen>&lt;device_order config:type="list"&gt;
-   &lt;device&gt;/dev/sdb2&lt;/device&gt;
-   &lt;device&gt;/dev/sda1&lt;/device&gt;
-   ...
-&lt;/device_order&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          This is optional and the default is alphabetical order.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+
+    <para>
+     In the example below, we are using the second disk (<literal>/dev/sdb</literal>)
+     as the <literal>/home</literal> filesystem.
+    </para>
+
+    <example>
+     <title>Using a Whole Disk as a Filesystem</title>
+<screen>&lt;partitioning config:type="list"&gt;
+  &lt;drive&gt;
+    &lt;device&gt;/dev/sda&lt;/device&gt;
+    &lt;partitions config:type="list"&gt;
+      &lt;partition&gt;
+        &lt;create config:type="boolean"&gt;true&lt;/create&gt;
+        &lt;format config:type="boolean"&gt;true&lt;/format&gt;
+        &lt;mount&gt;/&lt;/mount&gt;
+        &lt;size&gt;max&lt;/size&gt;
+      &lt;/partition&gt;
+    &lt;/partitions&gt;
+  &lt;/drive&gt;
+  &lt;drive&gt;
+    &lt;device&gt;/dev/sdb&lt;/device&gt;
+    &lt;disklabel&gt;none&lt;/disklabel&gt;
+    &lt;partitions config:type="list"&gt;
+      &lt;partition&gt;
+        &lt;format config:type="boolean"&gt;true&lt;/format&gt;
+        &lt;mount&gt;/home&lt;/mount&gt;
+      &lt;/partition&gt;
+    &lt;/partitions&gt;
+  &lt;/drive&gt;</screen>
+    </example>
+
+    <para>
+     In addition, the whole disk might be used as an LVM physical volume or as a software RAID
+     member. See <xref linkend="ay.partition_lvm"/> and <xref linkend="ay.partition_sw_raid"/>
+     for further details about setting up an LVM or a software RAID.
+    </para>
    </sect2>
 
    <sect2 xml:id="ay.auto_partitioning">

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -4268,6 +4268,10 @@ openssl x509 -noout -fingerprint -sha256
    <sect3 xml:id="ay.partition_sw_raid_deprecated">
     <title>Using the Deprecated Syntax</title>
     <para>
+     If the installer self-update feature is enabled, it is possible to partition a software RAID 
+     for &productname; 15. However, that scenario was not supported in previous versions and hence
+     the way to define a software RAID was slightly different.
+    </para>
      Starting on &productname; 15 SP1 (or 15 SP0 if the installer self-update
      feature is enabled), it is possible to partition a software RAID.
      However, that scenario was not supported in previous versions and hence

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -3405,8 +3405,8 @@ openssl x509 -noout -fingerprint -sha256
         </entry>
         <entry>
          <para>
-          Starting with &productname; 15 resizing works with physical disks and
-          with LVM volumes.
+          Starting with &productname; 15 resizing works with physical disk
+          partitions and with LVM volumes.
          </para>
         </entry>
        </row>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -4087,7 +4087,20 @@ openssl x509 -noout -fingerprint -sha256
    <sect2 xml:id="ay.partition_sw_raid">
     <title>Software RAID</title>
     <note os="sles;sled">
-     <title>Available in &productname; 15 SP0 via Installer Updates</title>
+     <title>Available in &productname; 15 via Installer Updates</title>
+       <para>
+         <remark>taroth 2018-11-05: enable the following sentence as soon as we start to work on SP1 
+            in 'develop': The support for software RAID devices has been greatly improved in
+            &productname; 15 SP1.</remark> Enhanced support for software RAID devices
+            is available for &productname; 15. To use the feature in this specific version, the 
+            installer self-update feature must be enabled.  See  <xref linkend="sec.yast_install.self_update"/>
+            for more information about installer updates.
+     </para>
+     <para>
+      The old way of specifying a software RAID is still supported for backward compatibility. 
+      If needed, see <xref linkend="ay.partition_sw_raid_deprecated"/> for further details
+      about this.
+     </para>
      <para>
       The support for software RAID devices has been greatly improved in
       &productname; 15 SP1. However, these changes are available in

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2485,9 +2485,6 @@ openssl x509 -noout -fingerprint -sha256
           guessing.
          </para>
          <para>
-          A RAID must always have <literal>/dev/md</literal> as device.
-         </para>
-         <para>
           If set to <literal>ask</literal>, &ay; will ask the user which device to use
           during installation.
          </para>
@@ -3349,23 +3346,7 @@ openssl x509 -noout -fingerprint -sha256
           If this physical volume is part of a RAID, specify the name of the
           RAID.
          </para>
-<screen>&lt;raid_name&gt;/dev/md0&lt;/raid_name&gt;</screen>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>raid_type</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Specify the type of the RAID.
-         </para>
-<screen>&lt;raid_type&gt;raid1&lt;/raid_type&gt;</screen>
+<screen>&lt;raid_name&gt;/dev/md/0&lt;/raid_name&gt;</screen>
         </entry>
         <entry>
          <para/>
@@ -3384,7 +3365,10 @@ openssl x509 -noout -fingerprint -sha256
 <screen>&lt;raid_options&gt;...&lt;/raid_options&gt;</screen>
         </entry>
         <entry>
-         <para/>
+         <para>
+          Setting the RAID options at <literal>partition</literal> level is deprecated.
+          See <xref linkend="ay.partition_sw_raid"/>.
+         </para>
         </entry>
        </row>
        <row>
@@ -4102,6 +4086,22 @@ openssl x509 -noout -fingerprint -sha256
 
    <sect2 xml:id="ay.partition_sw_raid">
     <title>Software RAID</title>
+    <note os="sles;sled">
+     <title>Available in &productname; 15 SP0 via Installer Updates</title>
+     <para>
+      The support for software RAID devices has been greatly improved in
+      &productname; 15 SP1. However, these changes are available in
+      &productname; 15 SP0 too if the installer self-update feature is
+      enabled.  See <xref linkend="sec.yast_install.self_update"/> for more
+      information about installer updates.
+     </para>
+     <para>
+      If needed, see <xref linkend="ay.partition_sw_raid_deprecated"/> to find
+      out further details about the old way of specifying a software RAID
+      which is still supported for backward compatibility.
+     </para>
+    </note>
+
     <para>
      Using &ay;, you can create and assemble software RAID devices. The
      supported RAID levels are the following:
@@ -4152,16 +4152,149 @@ openssl x509 -noout -fingerprint -sha256
      </varlistentry>
     </variablelist>
     <para>
-     As with LVM, you need to create all RAID partitions first and assign
-     them to the RAID device you want to create afterward. Additionally you
-     need to specify whether a partition or a device should be part of the
-     RAID or if it should be a Spare device.
+     Similar to LVM, a software RAID definition in an &ay; profile is composed
+     of two different parts:
     </para>
+
+    <itemizedlist mark="bullet" spacing="normal">
+     <listitem>
+      <para>
+       Determining which disks or partitions are going to be used as RAID
+       members.  In order to do that, you need to set the
+       <literal>raid_name</literal> element in such devices.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       Defining the RAID itself using a dedicated <literal>drive</literal>
+       section.
+      </para>
+     </listitem>
+    </itemizedlist>
+
     <para>
-     The following example shows a simple RAID1 configuration:
+     The following example shows a RAID1 configuration using a partition from the first disk
+     and the second disk as RAID members:
     </para>
     <example>
-     <title>RAID1 configuration</title>
+     <title>RAID1 Configuration</title>
+<screen>&lt;partitioning config:type="list"&gt;
+  &lt;drive&gt;
+    &lt;device&gt;/dev/sda&lt;/device&gt;
+    &lt;partitions config:type="list"&gt;
+      &lt;partition&gt;
+        &lt;mount&gt;/&lt;/mount&gt;
+        &lt;size&gt;20G&lt;/size&gt;
+      &lt;/partition&gt;
+      &lt;partition&gt;
+        &lt;raid_name&gt;/dev/md/0&lt;/raid_name&gt;
+        &lt;size&gt;max&lt;/size&gt;
+      &lt;/partition&gt;
+    &lt;/partitions&gt;
+    &lt;use&gt;all&lt;/use&gt;
+  &lt;/drive&gt;
+  &lt;drive&gt;
+    &lt;device&gt;/dev/sdb&lt;/device&gt;
+    &lt;disklabel&gt;none&lt;/disklabel&gt;
+    &lt;partitions config:type="list"&gt;
+      &lt;partition&gt;
+        &lt;raid_name&gt;/dev/md/0&lt;/raid_name&gt;
+      &lt;/partition&gt;
+    &lt;/partitions&gt;
+    &lt;use&gt;all&lt;/use&gt;
+  &lt;/drive&gt;
+  &lt;drive&gt;
+    &lt;device&gt;/dev/md/0&lt;/device&gt;
+    &lt;partitions config:type="list"&gt;
+      &lt;partition&gt;
+        &lt;mount&gt;/home&lt;/mount&gt;
+        &lt;size&gt;40G&lt;/size&gt;
+      &lt;/partition&gt;
+      &lt;partition&gt;
+        &lt;mount&gt;/srv&lt;/mount&gt;
+        &lt;size&gt;10G&lt;/size&gt;
+      &lt;/partition&gt;
+    &lt;/partitions&gt;
+    &lt;raid_options&gt;
+      &lt;chunk_size&gt;4&lt;/chunk_size&gt;
+      &lt;parity_algorithm&gt;left_asymmetric&lt;/parity_algorithm&gt;
+      &lt;raid_type&gt;raid1&lt;/raid_type&gt;
+    &lt;/raid_options&gt;
+    &lt;use&gt;all&lt;/use&gt;
+  &lt;/drive&gt;
+&lt;/partitioning&gt;</screen>
+    </example>
+
+    <para>
+     If you do not want to create partitions in the software RAID, just set
+     the <literal>disklabel</literal> to <literal>none</literal> as you would
+     do for a regular disk. In the example below, only the RAID
+     <literal>drive</literal> section is shown for simplicity's sake:
+    </para>
+
+    <example>
+     <title>RAID1 Without Partitions</title>
+<screen>&lt;drive&gt;
+  &lt;device&gt;/dev/md/0&lt;/device&gt;
+  &lt;disklabel&gt;none&lt;/disklabel&gt;
+  &lt;partitions config:type="list"&gt;
+    &lt;partition&gt;
+      &lt;mount&gt;/home&lt;/mount&gt;
+      &lt;size&gt;40G&lt;/size&gt;
+    &lt;/partition&gt;
+  &lt;/partitions&gt;
+  &lt;raid_options&gt;
+    &lt;chunk_size&gt;4&lt;/chunk_size&gt;
+    &lt;parity_algorithm&gt;left_asymmetric&lt;/parity_algorithm&gt;
+    &lt;raid_type&gt;raid1&lt;/raid_type&gt;
+  &lt;/raid_options&gt;
+  &lt;use&gt;all&lt;/use&gt;
+&lt;/drive&gt;</screen>
+    </example>
+
+   <sect3 xml:id="ay.partition_sw_raid_deprecated">
+    <title>Using the Deprecated Syntax</title>
+    <para>
+     Starting on &productname; 15 SP1 (or 15 SP0 if the installer self-update
+     feature is enabled), it is possible to partition a software RAID.
+     However, that scenario was not supported in previous versions and hence
+     the way to define a software RAID was slightly different.
+    </para>
+
+    <para>
+     This section defines how the old-style configuration looks like because
+     it is still supported for backward compatibility.
+    </para>
+
+    <para>
+     Keep the following in mind when configuring a RAID using this deprecated
+     syntax:
+    </para>
+    <itemizedlist mark="bullet" spacing="normal">
+     <listitem>
+      <para>
+       The device for raid is always <literal>/dev/md</literal>
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       The property <literal>partition_nr</literal> is used to determine the
+       MD device number. If <literal>partition_nr</literal> is equal to 0,
+       then <literal>/dev/md/0</literal> is configured. Adding several
+       <literal>partition</literal> sections means that you want to have
+       multiple software RAIDs (<literal>/dev/md/0</literal>,
+       <literal>/dev/md/1</literal>, etc.).
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       All RAID-specific options are contained in the <literal>raid_options</literal> resource.
+      </para>
+     </listitem>
+    </itemizedlist>
+
+    <example>
+     <title>Old Style RAID1 Configuration</title>
 <screen>&lt;partitioning config:type="list"&gt;
   &lt;drive&gt;
     &lt;device&gt;/dev/sda&lt;/device&gt;
@@ -4187,7 +4320,6 @@ openssl x509 -noout -fingerprint -sha256
         &lt;format config:type="boolean"&gt;false&lt;/format&gt;
         &lt;partition_id config:type="integer"&gt;253&lt;/partition_id&gt;
         &lt;raid_name&gt;/dev/md0&lt;/raid_name&gt;
-        &lt;raid_type&gt;raid&lt;/raid_type&gt;
         &lt;size&gt;4gb&lt;/size&gt;
       &lt;/partition&gt;
     &lt;/partitions&gt;
@@ -4204,8 +4336,7 @@ openssl x509 -noout -fingerprint -sha256
         &lt;partition_nr config:type="integer"&gt;0&lt;/partition_nr&gt;
         &lt;raid_options&gt;
           &lt;chunk_size&gt;4&lt;/chunk_size&gt;
-          &lt;parity_algorithm&gt;left-asymmetric&lt;/parity_algorithm&gt;
-          &lt;raid_type&gt;raid1&lt;/raid_type&gt;
+          &lt;parity_algorithm&gt;left_asymmetric&lt;/parity_algorithm&gt;
         &lt;/raid_options&gt;
       &lt;/partition&gt;
     &lt;/partitions&gt;
@@ -4213,30 +4344,136 @@ openssl x509 -noout -fingerprint -sha256
   &lt;/drive&gt;
 &lt;/partitioning&gt;</screen>
     </example>
+   </sect3>
+
+   <sect3 xml:id="ay.raid_configuration">
+    <title>RAID Options</title>
     <para>
-     Keep the following in mind when configuring a RAID:
+     The following elements must be placed within the following XML
+     structure:
     </para>
-    <itemizedlist mark="bullet" spacing="normal">
-     <listitem>
-      <para>
-       The device for raid is always <literal>/dev/md</literal>
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       The property <literal>partition_nr</literal> is used to determine the
-       MD device number. If <literal>partition_nr</literal> is equal to 0,
-       then <literal>/dev/md0</literal> is configured.
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       All RAID-specific options are contained in the
-       <literal>raid_options</literal> resource.
-      </para>
-     </listitem>
-    </itemizedlist>
-   </sect2>
+    <screen>&lt;partition&gt;
+     &lt;raid_options&gt;
+     ...
+     &lt;/raid_options&gt;
+     &lt;/partition&gt;</screen>
+    <informaltable>
+     <tgroup cols="3">
+      <thead>
+       <row>
+        <entry>
+         <para>
+          Attribute
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Values
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Description
+         </para>
+        </entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>
+         <para>
+          <literal>chunk_size</literal>
+         </para>
+        </entry>
+        <entry>
+         <para/>
+         <screen>&lt;chunk_size&gt;4&lt;/chunk_size&gt;</screen>
+        </entry>
+        <entry>
+         <para/>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>parity_algorithm</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Possible values are:
+         </para>
+         <para>
+          <literal>left_asymmetric</literal>, <literal>left_symmetric,
+           right_asymmetric</literal>, <literal>right_symmetric</literal>.
+         </para>
+         <para>
+          For RAID6 and RAID10 the following values can be used:
+         </para>
+         <para>
+          <literal>parity_first</literal>, <literal>parity_last</literal>,
+          <literal>left_asymmetric_6, left_symmetric_6</literal>,
+          <literal>right_asymmetric_6</literal>,
+          <literal>right_symmetric_6</literal>,
+          <literal>parity_first_6</literal>, <literal>n2</literal>,
+          <literal>o2</literal>, <literal>f2</literal>,
+          <literal>n3</literal>, <literal>o3</literal>,
+          <literal>f3</literal> for RAID6 and RAID10.
+         </para>
+         <screen>&lt;parity_algorithm
+          &gt;left_asymmetric&lt;/parity_algorithm&gt;</screen>
+        </entry>
+        <entry>
+         <para/>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>raid_type</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Possible values are: <literal>raid0</literal>,
+          <literal>raid1</literal>, <literal>raid5</literal>,
+          <literal>raid6</literal> and <literal>raid10</literal>.
+         </para>
+         <screen>&lt;raid_type&gt;raid1&lt;/raid_type&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          The default is <literal>raid1</literal>.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>device_order</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          This list contains the optional order of the physical devices:
+         </para>
+         <screen>&lt;device_order config:type="list"&gt;
+          &lt;device&gt;/dev/sdb2&lt;/device&gt;
+          &lt;device&gt;/dev/sda1&lt;/device&gt;
+          ...
+          &lt;/device_order&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          This is optional and the default is alphabetical order.
+         </para>
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </sect3>
+  </sect2>
 
    <sect2 xml:id="ay.partition_s390">
     <title>&zseries; Specific Configuration</title>


### PR DESCRIPTION
For SLE 15 SP1 it will possible to use a whole disk as a filesystem or as part of a LVM or a software RAID. Additionally, we have introduced support for partitioned RAIDs.

However, these features will be available for SLE 15 SP0 using the installer self-update functionality and I am not sure about how to reflect that in the documentation. Please, have a look when you have time. Feedback is welcome.