### PR TITLE
Fix bsc#1069992: add missing CD_DMMULTIPATH

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2575,7 +2575,7 @@ openssl x509 -noout -fingerprint -sha256
          <para>
           Choose between:
          </para>
-         <itemizedlist mark="bullet" spacing="normal">
+         <itemizedlist>
           <listitem>
            <para>
             <literal>CT_DISK</literal> for physical hard disks (default),
@@ -2585,6 +2585,10 @@ openssl x509 -noout -fingerprint -sha256
            <para>
             <literal>CT_LVM</literal> for LVM volume groups,
            </para>
+          </listitem>
+          <listitem>
+           <para>
+            <literal>CT_DMMULTIPATH</literal> for multipath devices. </para>
           </listitem>
          </itemizedlist>
 <screen>&lt;type config:type="symbol"&gt;CT_LVM&lt;/type&gt;</screen>


### PR DESCRIPTION
This PR contains the following changes:

* Add the `CD_DMMULTIPATH` to the type attribute

TODO:

Once confirmed, cherry-picking to
* [ ]  SLE12 SP2
* [ ] SLE 12 SP3
