### PR TITLE
Fix bsc#1047650, describe /root/autoupg.xml

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -5023,21 +5023,33 @@ create_package_descr -x PATH_TO_EXTRA_PROV -d /usr/local/CDs/LATEST/suse</screen
      </tgroup>
    </informaltable>
 
-   <note>
-    <title>Starting &ay; in upgrade mode</title>
-    <para>
-     In order to start the &ay; upgrade mode while booting the system you
-     need to select the menu entry <literal>Installation</literal> and use the
-     following boot parameters:
-    </para>
-    <screen>autoupgrade=1 autoyast=http://..</screen>
+   <para>To start the &ay; upgrade mode, you need:</para>
 
-    <remark condition="clarity">
-     2016-07-29 - fs: What about network setup with ifcfg= ?? Otherwise this
-     command line won't work??
-    </remark>
-
-   </note>
+   <procedure xml:id="pro.upgrade.upgrade-mode">
+    <title>Starting &ay; in Upgrade Mode</title>
+    <step>
+     <para>
+      Copy the &ay; profile to <filename>/root/autoupg.xml</filename> into
+     its file system.
+     </para>
+    </step>
+    <step>
+     <para>Boot the system from the installation media.</para>
+    </step>
+    <step>
+     <para>Select the <literal>Installation</literal> menu item.</para>
+    </step>
+    <step>
+     <para>On the command line, set <varname>autoupgrade=1</varname>.</para>
+     <remark condition="clarity">
+      2016-07-29 - fs: What about network setup with ifcfg= ?? Otherwise this
+      command line won't work??
+     </remark>
+    </step>
+    <step>
+     <para>Press <keycap function="enter"/> to start the upgrade process.</para>
+    </step>
+   </procedure>
   </sect1>
 
   <sect1 xml:id="CreateProfile.Services">
@@ -14142,7 +14154,7 @@ echo -n 100
      configuration file, which should be distinguished from the main control
      file in the following places:
     </para>
-    <itemizedlist mark="bullet" spacing="normal">
+    <itemizedlist>
      <listitem>
       <para>
        in the root directory of the initial RAM disk used for booting the
@@ -14186,8 +14198,8 @@ echo -n 100
         </entry>
         <entry>
          <para>
-          Initiate an automatic upgrade using &ay;. Also requires the
-          <literal>autoyast</literal> parameter (see <xref
+          Initiate an automatic upgrade using &ay;, see <xref linkend="CreateProfile.upgrade"/>.
+          For some use cases, you need the <literal>autoyast</literal> parameter (see <xref
           linkend="Commandline.ay"/> for details).
          </para>
         </entry>
@@ -14428,6 +14440,19 @@ echo -n 100
        </row>
       </thead>
       <tbody>
+       <row>
+        <entry>
+         <para>
+          missing
+         </para>
+        </entry>
+        <entry>
+         <para>
+          No <literal>autoyast</literal> variable needed for
+          an automated upgrade, see <xref linkend="pro.upgrade.upgrade-mode"/>.
+         </para>
+        </entry>
+       </row>
        <row>
         <entry>
          <para>


### PR DESCRIPTION
This PR contains:

* a procedure which describes the upgrade process without mentioning the `autoyast` variable
* Add a "missing" line into table.

@imobachgs If there anything else is needed, let me know. Thanks!