### PR TITLE
Change instructions for firewall setup in yast2-rmt

### DIFF
--- a/xml/rmt_install.xml
+++ b/xml/rmt_install.xml
@@ -103,20 +103,16 @@
    </step>
    <step>
     <para>
-     To view a final summary, select <guimenu>Next</guimenu>. Then
-     select <guimenu>Finish</guimenu> to close &yast;. &yast; then
-     enables and starts all &systemd; services and timers.
+     If firewalld is enabled on this system, enable the checkbox to open the required ports. 
+     Select <guimenu>Next</guimenu>.
     </para>
    </step>
    <step>
     <para>
-     If you have a firewall enabled, allow access to ports 80 and 443.
-     When using the default zone <literal>public</literal>, execute the
-     following commands:
+     To view a final summary, select <guimenu>Next</guimenu>. Then
+     select <guimenu>Finish</guimenu> to close &yast;. &yast; then
+     enables and starts all &systemd; services and timers.
     </para>
-<screen>&prompt.sudo;<command>firewall-cmd --zone=public --add-port=80/tcp --permanent</command>
-&prompt.sudo;<command>firewall-cmd --zone=public --add-port=443/tcp --permanent</command>
-&prompt.sudo;<command>firewall-cmd --reload</command></screen>
    </step>
   </procedure>
  </sect1>


### PR DESCRIPTION
For [this Fate](https://fate.suse.com/326634) we made [some changes](https://github.com/SUSE/yast2-rmt/pull/34) to yast2-rmt, the YaST module for RMT.

As soon as these changes are published as maintenance updates for SLES 15 GA, the documentation needs a small update:

- There is a new wizard page now to allow HTTP and HTTPS services in firewalld.
- Please run the wizard yourself to see the change.
- Basically, if firewalld is installed and enabled on the system, you see a dialog with a checkbox. The wizard checks for the current configuration and prefills the checkbox if all is good already. If not, the checkbox is not enabled and the user is supposed to enable it and proceed by hitting "next".
- It is possible (thanks to yast widget powers) to "See details" and only allow these services (ports) on certain network interfaces. Not sure if this detail needs documentation though.
- If firewalld is not installed or not enabled, the wizard page will tell that to the user. _Next_.
- Also it tells the user, that in case firewalld will be enabled later, these ports have to be opened then. That can be done by running the yast-module again then.
- This new feature makes the last paragraph obsolete. No more manual port opening. Of course that would be still possible, but since the Fate was about a more automated experience, I think we should point the users to the option to just rerun the module instead of hacking it themselves.

I wrote only a pretty minimal sentence. See it more as a placeholder for you to fill out :)