### PR TITLE
Feature/nvdimm sle15

### DIFF
--- a/xml/admin_docupdates.xml
+++ b/xml/admin_docupdates.xml
@@ -27,13 +27,13 @@
    <title>November 2018</title>
    <variablelist>
     <varlistentry>
-     <term>New sections</term>
+     <term><xref linkend="cha.nvdimm"/></term>
      <listitem>
       <itemizedlist>
        <listitem>
         <para>
-         Added chapter introducing and describing set up of Persistent Memory
-         in <xref linkend="cha.nvdimm"/> (&fate;326330)
+         New chapter introducing and describing set up of Persistent Memory
+         (&fate;326330).
         </para>
        </listitem>
       </itemizedlist>

--- a/xml/admin_docupdates.xml
+++ b/xml/admin_docupdates.xml
@@ -27,6 +27,19 @@
    <title>November 2018</title>
    <variablelist>
     <varlistentry>
+     <term>New sections</term>
+     <listitem>
+      <itemizedlist>
+       <listitem>
+        <para>
+         Added chapter introducing and describing set up of Persistent Memory
+         in <xref linkend="cha.nvdimm"/> (&fate;326330)
+        </para>
+       </listitem>
+      </itemizedlist>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
      <term>Bugfixes</term>
      <listitem>
       <itemizedlist>

--- a/xml/hardware_nvdimm.xml
+++ b/xml/hardware_nvdimm.xml
@@ -120,7 +120,7 @@
     <term>Namespace</term>
     <listitem>
      <para>
-      A single contiguous address range of non-volatile storage, comparable
+      A single contiguously-addressed range of non-volatile storage, comparable
       to NVM Express SSD namespaces, or to SCSI Logical Units (LUNs). Namespaces
       appear in the server's <filename>/dev</filename> directory as separate
       block devices. Depending on the method of access required, namespaces can

--- a/xml/hardware_nvdimm.xml
+++ b/xml/hardware_nvdimm.xml
@@ -48,7 +48,7 @@
 
   <para>
    Different models use different forms of electronic storage medium, such as
-   Intel 3D XPoint, or a combination of NAND flash and DRAM. New forms of
+   Intel 3D XPoint, or a combination of NAND-flash and DRAM. New forms of
    non-volatile RAM are also in development. This means that different vendors
    and models of NVDIMM offer different performance and durability
    characteristics.
@@ -120,7 +120,7 @@
     <term>Namespace</term>
     <listitem>
      <para>
-      A single contiguously-addressed range of non-volatile storage, comparable
+      A single contiguous address range of non-volatile storage, comparable
       to NVM Express SSD namespaces, or to SCSI Logical Units (LUNs). Namespaces
       appear in the server's <filename>/dev</filename> directory as separate
       block devices. Depending on the method of access required, namespaces can
@@ -270,8 +270,8 @@
     <term>Direct Access (DAX)</term>
     <listitem>
      <para>
-      DAX allows persistent memory to be directly mapped into a process' address
-      space, for example using the <literal>mmap</literal> system call.
+      DAX allows persistent memory to be directly mapped into a process's
+      address space, for example using the <literal>mmap</literal> system call.
      </para>
     </listitem>
    </varlistentry>
@@ -317,7 +317,7 @@
    </para>
    <sect3>
     <title>
-     Applications which benefit from large amounts of byte-addressable storage.
+     Applications that benefit from large amounts of byte-addressable storage.
     </title>
     <para>
      If the server will host an application that can directly use large amounts
@@ -327,7 +327,7 @@
     </para>
    </sect3>
    <sect3>
-    <title>Avoiding use of the kernel page cache.</title>
+    <title>Avoiding Use of the Kernel Page Cache</title>
     <para>
      If you wish to conserve the use of RAM for the page cache, and instead
      give it to your applications. For instance, non-volatile memory could be
@@ -346,12 +346,12 @@
    </para>
    <para>
     To applications, such devices just appear as very fast SSDs and can be used
-    like any other storage device - for example, LVM can be layered on top of
-    the non-volatile storage and will work as normal.
+    like any other storage device. For example, LVM can be layered on top of
+    the persistent memory and will work as normal.
    </para>
    <para>
     The advantage of BTT is that sector write atomicity is guaranteed, so even
-    sophisticated applications which depend on data integrity will keep
+    sophisticated applications that depend on data integrity will keep
     working. Media error reporting works through standard error-reporting
     channels.
    </para>
@@ -363,7 +363,7 @@
   <para>
    To manage persistent memory, it is necessary to install the
    <literal>ndctl</literal> package. This also installs the
-   <filename>libndctl</filename> package which provides a set of user-space
+   <filename>libndctl</filename> package, which provides a set of user-space
    libraries to configure NVDIMMs.
   </para>
   
@@ -768,7 +768,7 @@ I/O size (minimum/optimal): 4096 bytes / 4096 bytes</screen>
     </para>
     <para>
      Information about configuring, using and programming systems with
-     non-volatile memory, under Linux and other operating systems. Covers the
+     non-volatile memory under Linux and other operating systems. Covers the
      NVM Library (NVML), which aims to provide useful APIs for programming with
      persistent memory in userspace.
     </para>
@@ -792,7 +792,7 @@ I/O size (minimum/optimal): 4096 bytes / 4096 bytes</screen>
      <link xlink:href="https://github.com/pmem/ndctl">GitHub: pmem/ndctl</link>
     </para>
     <para>
-     Utility library for managing the <command>libnvdimm</command> sub-system
+     Utility library for managing the <command>libnvdimm</command> subsystem
      in the Linux kernel. Also contains userspace libraries, as well as unit
      tests and documentation.
     </para>

--- a/xml/hardware_nvdimm.xml
+++ b/xml/hardware_nvdimm.xml
@@ -8,12 +8,8 @@
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha.nvdimm">
  <title>Non-volatile Main Memory</title>
- <info>
-  <abstract>
-   <para>
-    This chapter contains additional information about using &productname; with
-    non-volatile main memory comprising one or more NVDIMMs.
-   </para>
+ <info><abstract>
+   <para> This chapter contains additional information about using &productname; with non-volatile main memory comprising one or more NVDIMMs. </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker/>
@@ -22,470 +18,250 @@
  </info>
  <sect1 xml:id="sec.nvdimm.intro">
   <title>Introduction</title>
-
-  <para>
-   Non-volatile memory is a new type of computer storage, combining speeds
-   approaching those of dynamic RAM (DRAM) along with RAM's byte-by-byte
-   addressability, plus the permanence of solid-state disks (SSDs).
-  </para>
-
-  <para>
-   Like conventional RAM, it is installed directly into motherboard memory
-   slots. As such, it is supplied in the same physical form factor as RAM - as
-   DIMMs. These are known as NVDIMMs: non-volatile dual inline memory modules.
-  </para>
-
-  <para>
-   Like SSDs, NVDIMMs provide non-volatile storage: their contents are retained
-   when the system is powered off or restarted. Also like SSDs, sector-level
-   access is also possible if that is more suitable for a particular
-   application.
-  </para>
-
-  <para>
-   This new storage subsystem is defined in version 6 of the ACPI standard.
-   However, some types of NVDIMMs already existed before the standard was
-   defined. These can be used in the same way.
-  </para>
-  
-  <para>
-   Different models use different forms of electronic storage medium, such as
-   Intel 3D XPoint, or a combination of NAND flash and DRAM, and in future,
-   memristor storage or other forthcoming types of non-volatile memory.
-  </para>
-
-  <para>
-   This means that different vendors' NVDIMMs offer different performance and
-   durability characteristics. Typically, they are slower than DRAM, but
-   considerably faster than SSDs based on NAND-flash technology.
-  </para>
-
-  <para>
-   Because the storage technologies involved are in an early stage of
-   development, different vendors' hardware may impose different limitations.
-   However, generally, writing data to NVDIMMs is slower than reading from
-   them, and the number of write cycles is generally limited.
-  </para>
-
-  <para>
-   This has two important consequences:
-  </para>
-
+  <para> Non-volatile memory is a new type of computer storage, combining speeds approaching those of dynamic RAM (DRAM) along with RAM's byte-by-byte addressability, plus the permanence of solid-state disks (SSDs). </para>
+  <para> Like conventional RAM, it is installed directly into motherboard memory slots. As such, it is supplied in the same physical form factor as RAM - as DIMMs. These are known as NVDIMMs: non-volatile dual inline memory modules. </para>
+  <para> Like SSDs, NVDIMMs provide non-volatile storage: their contents are retained when the system is powered off or restarted. Also like SSDs, sector-level access is also possible if that is more suitable for a particular application. </para>
+  <para> This new storage subsystem is defined in version 6 of the ACPI standard. However, some types of NVDIMMs already existed before the standard was defined. These can be used in the same way. </para>
+  <para> Different models use different forms of electronic storage medium, such as Intel 3D XPoint, or a combination of NAND flash and DRAM, and in future, memristor storage or other forthcoming types of non-volatile memory. </para>
+  <para> This means that different vendors' NVDIMMs offer different performance and durability characteristics. Typically, they are slower than DRAM, but considerably faster than SSDs based on NAND-flash technology. </para>
+  <para> Because the storage technologies involved are in an early stage of development, different vendors' hardware may impose different limitations. However, generally, writing data to NVDIMMs is slower than reading from them, and the number of write cycles is generally limited. </para>
+  <para> This has two important consequences: </para>
   <itemizedlist>
    <listitem>
-    <para>
-     It is not possible with current technology to run a system with only
-     NVDIMMs and thus achieve completely non-volatile main memory. You must use
-     a mixture of both conventional RAM and NVDIMMs. The operating system and
-     applications will execute in conventional RAM, with the NVDIMMs providing
-     very fast supplementary storage.
-    </para>
+    <para> It is not possible with current technology to run a system with only NVDIMMs and thus achieve completely non-volatile main memory. You must use a mixture of both conventional RAM and NVDIMMs. The operating system and applications will execute in conventional RAM, with the NVDIMMs providing very fast supplementary storage. </para>
    </listitem>
    <listitem>
-    <para>
-     The performance characteristics of different vendors' NVDIMMs mean that it
-     may be necessary for programmers to be aware of the hardware
-     specifications of NVDIMMS in a particular server, including how many and
-     in which memory slots they are fitted. This will obviously impact
-     hypervisor use, migration of software between different host machines, and
-     so on.
-    </para>
+    <para> The performance characteristics of different vendors' NVDIMMs mean that it may be necessary for programmers to be aware of the hardware specifications of NVDIMMS in a particular server, including how many and in which memory slots they are fitted. This will obviously impact hypervisor use, migration of software between different host machines, and so on. </para>
    </listitem>
   </itemizedlist>
  </sect1>
  <sect1 xml:id="sec.nvdimm.terms">
   <title>Terms</title>
-
   <variablelist>
    <varlistentry>
     <term>Region</term>
     <listitem>
-     <para>
-      A <emphasis>region</emphasis> is a block of persistent storage that can
-      be divided up into one or more <emphasis>namespace</emphasis>s. You
-      cannot access the persistent memory of a region without first allocating
-      it to a namespace.
-     </para>
+     <para> A <emphasis>region</emphasis> is a block of persistent storage that can be divided up into one or more <emphasis>namespace</emphasis>s. You cannot access the persistent memory of a region without first allocating it to a namespace. </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>Namespace</term>
     <listitem>
-     <para>
-      A single contiguously-address range of non-volatile storage, comparable to
-      those on NVM Express PCIe SSDs or to a SCSI Logical Unit (LUN). Each
-      NVDIMM usually appears in the server's <filename>/dev</filename> directory
-      as a separate block device. This storage must be assigned to one or more 
-      namespaces for it to be used. Depending on the method of access required,
-      namespaces can either amalgamate storage from separate NVDIMMs into larger
-      volumes, or allow it to be partitioned into smaller volumes, similarly to
-      disk drives.
-     </para>
+     <para> A single contiguously-address range of non-volatile storage, comparable to those on NVM Express PCIe SSDs or to a SCSI Logical Unit (LUN). Each NVDIMM usually appears in the server's <filename>/dev</filename> directory as a separate block device. This storage must be assigned to one or more namespaces for it to be used. Depending on the method of access required, namespaces can either amalgamate storage from separate NVDIMMs into larger volumes, or allow it to be partitioned into smaller volumes, similarly to disk drives. </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>Mode</term>
     <listitem>
-     <para>
-      Each namespace also has a <emphasis>mode</emphasis> that defines which
-      NVDIMM features are enabled for that namespace. Sibling namespaces
-      of the same parent region will always have the same type, but might be
-      configured to have different modes. Namespace modes include:
-     </para>
+     <para> Each namespace also has a <emphasis>mode</emphasis> that defines which NVDIMM features are enabled for that namespace. Sibling namespaces of the same parent region will always have the same type, but might be configured to have different modes. Namespace modes include: </para>
      <variablelist>
       <varlistentry>
-       <term>raw</term>
+       <term>devdax</term>
        <listitem>
-        <para>
-         A memory disk. Does not support DAX. Compatible with other operating
-         systems.
-        </para>
-       </listitem>
-      </varlistentry>
-      <varlistentry>
-       <term>sector</term>
-       <listitem>
-        <para>
-         For legacy filesystems which do not checksum metadata. Suitable for
-         small boot volumes. Compatible with other operating systems.
-        </para>
+        <para> Device-DAX mode. Creates a single-character device file (<filename> /dev/dax<replaceable>X</replaceable>.<replaceable>Y</replaceable>
+         </filename>). Does <emphasis>not</emphasis> require filesystem creation. Suitable to register PMEM for RDMA or for assigning it to virtual machines, or for mapping blocks too large to fit into RAM. </para>
        </listitem>
       </varlistentry>
       <varlistentry>
        <term>fsdax</term>
        <listitem>
-        <para>
-         Filesystem-DAX mode. Default if no other mode is specified. Creates a
-         block device (<filename>/dev/pmem<replaceable>X</replaceable>
-          [.<replaceable>Y</replaceable>]</filename>) which supports DAX for
-         <literal>ext4</literal> or <literal>XFS</literal>.
-        </para>
+        <para> Filesystem-DAX mode. Default if no other mode is specified. Creates a block device (<filename>/dev/pmem<replaceable>X</replaceable> [.<replaceable>Y</replaceable>]</filename>) which supports DAX for <literal>ext4</literal> or <literal>XFS</literal>. </para>
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term>devdax</term>
+       <term>sector</term>
        <listitem>
-        <para>
-         Device-DAX mode. Creates a single-character device file (<filename>
-          /dev/dax<replaceable>X</replaceable>.<replaceable>Y</replaceable>
-         </filename>). Does <emphasis>not</emphasis> require filesystem
-         creation. Suitable to register PMEM for RDMA or for assigning it to
-         virtual machines, or for mapping blocks too large to fit into RAM.
-        </para>
+        <para> For legacy filesystems which do not checksum metadata. Suitable for small boot volumes. Compatible with other operating systems. </para>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term>raw</term>
+       <listitem>
+        <para> A memory disk without a label or metadata. Does not support DAX. Compatible with other operating systems. </para>
+        <note>
+         <para>
+          <literal>raw</literal> mode is not supported by &suse;. It is not possible to mount filesystems on <literal>raw</literal> namespaces. </para>
+        </note>
        </listitem>
       </varlistentry>
      </variablelist>
     </listitem>
    </varlistentry>
-   
    <varlistentry>
     <term>Type</term>
     <listitem>
-     <para>
-      Each namespace and region has a <emphasis>type</emphasis> that defines the
-      way in which the persistent memory associated with that namespace or
-      region can be accessed. A namespace always has the same type as its parent
-      region. There are two different types: Persistent Memory and Block Mode.
-     </para>
+     <para> Each namespace and region has a <emphasis>type</emphasis> that defines the way in which the persistent memory associated with that namespace or region can be accessed. A namespace always has the same type as its parent region. There are two different types: Persistent Memory, which can be configured in two different ways, and the deprecated Block Mode. </para>
      <variablelist>
       <varlistentry>
        <term>Persistent Memory (PMEM)</term>
        <listitem>
-        <para>
-         PMEM storage offers byte-level access, just like RAM. This enables Direct
-         Access (DAX), meaning that accessing the memory bypasses the kernel's
-         page cache and goes direct to the medium. Additionally, using PMEM, a
-         single namespace can include multiple interleaved NVDIMMs, allowing
-         them all to be accessed as a single device.
-        </para>
+        <para> PMEM storage offers byte-level access, just like RAM. Using PMEM, a single namespace can include multiple interleaved NVDIMMs, allowing them all to be used as a single device. </para>
+        <para> There are two ways to configure a PMEM namespace. </para>
+        <variablelist>
+         <varlistentry>
+          <term>PMEM with DAX</term>
+          <listitem>
+           <para> A PMEM namespace configured for Direct Access (DAX) means that accessing the memory bypasses the kernel's page cache and goes direct to the medium. Software can directly read or write every byte of the namespace separately. </para>
+          </listitem>
+         </varlistentry>
+         <varlistentry>
+          <term> PMEM with BTT </term>
+          <listitem>
+           <para> A PMEM namespace configured to operate in BTT mode is accessed on a sector-by-sector basis, like a conventional disk drive, rather than the more RAM-like byte-addressible model. A translation table mechanism batches accesses into sector-sized units. </para>
+           <para> The advantages of BTT are that the storage subsystem ensures that each sector is completely written to the underlying medium, and if a write fails for some reason, it will be unrolled. Thus a given sector cannot be partially written. </para>
+           <para> Additionally, access to BTT namespaces is cached by the kernel. </para>
+           <para> The drawback is that DAX is not possible to BTT namespaces. </para>
+          </listitem>
+         </varlistentry>
+        </variablelist>
        </listitem>
       </varlistentry>
       <varlistentry>
        <term>Block Mode (BLK)</term>
        <listitem>
-        <para>
-         BLK access is in sectors, usually of 512 bytes, through a defined
-         access window, the <emphasis>aperture</emphasis>. This behaviour is
-         more like a traditional disk drive. This also means that both reads and
-         writes are cached by the kernel. With BLK access, each NVDIMM is
-         accessed as a separate namespace.
-        </para>
+        <para> Block mode storage addresses each NVDIMM as a separate device. Its use is deprecated and no longer supported. </para>
        </listitem>
       </varlistentry>
      </variablelist>
-     <para>
-      Some devices support both PMEM and BLK modes. Additionally, some allow
-      the storage to be split into separate namespaces, so that some can be
-      accessed using PMEM and some using BLK.
-     </para>
-     <para>
-      Apart from <literal>devdax</literal> namespaces, all other types must be
-      formatted with a filesystem, just as with a conventional drive.
-      &productname; supports the <literal>ext2</literal>,
-      <literal>ext4</literal> and <literal>XFS</literal> filesystems for this.
-     </para>
+     <para> Apart from <literal>devdax</literal> namespaces, all other types must be formatted with a filesystem, just as with a conventional drive. &productname; supports the <literal>ext2</literal>, <literal>ext4</literal> and <literal>XFS</literal> filesystems for this. </para>
      <note>
       <para>
-       The <literal>ext2</literal> filesystem does not support DAX.
-      </para>
+       &suse; does not support the <literal>ext2</literal> filesystem for use with DAX. </para>
      </note>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>Direct Access (DAX)</term>
     <listitem>
-     <para>
-      Directly <literal>mmap()</literal> NV-RAM into a process' address space.
-     </para>
+     <para> Directly <literal>mmap()</literal> NV-RAM into a process' address space. </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>DIMM Physical Address (DPA)</term>
     <listitem>
-     <para>
-      A memory address as an offset into a single DIMM's memory; that is,
-      starting from zero as the lowest addressable byte on that DIMM.
-     </para>
+     <para> A memory address as an offset into a single DIMM's memory; that is, starting from zero as the lowest addressable byte on that DIMM. </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>Label</term>
     <listitem>
-     <para>
-      Metadata stored on the NVDIMM, such as namespace definitions. This can be
-      accessed using DSMs.
-     </para>
+     <para> Metadata stored on the NVDIMM, such as namespace definitions. This can be accessed using DSMs. </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>Device-specific method (DSM)</term>
     <listitem>
-     <para>
-      ACPI method to access the firmware on an NVDIMM.
-     </para>
+     <para> ACPI method to access the firmware on an NVDIMM. </para>
     </listitem>
    </varlistentry>
   </variablelist>
  </sect1>
- 
  <sect1 xml:id="sec.nvdimm.uses">
   <title>Use Cases</title>
   <sect2 xml:id="sec.nvdimm.uses.pmem">
    <title>PMEM with DAX</title>
-   <para>
-    It is important to note that this form of memory access is
-    <emphasis>not</emphasis> transactional. In the event of a power outage or
-    other system failure, data may not be completely written into storage. PMEM
-    storage is only suitable if the application can handle the situation of
-    partially-written data.
-   </para>
+   <para> It is important to note that this form of memory access is <emphasis>not</emphasis> transactional. In the event of a power outage or other system failure, data may not be completely written into storage. PMEM storage is only suitable if the application can handle the situation of partially-written data. </para>
    <sect3>
-    <title>
-     Applications which benefit from large amounts of byte-addressable storage.
-    </title> 
-    <para>
-     In cases where the server will be hosting an application that can directly
-     access large amounts of storage on a byte-by-byte basis, by 
-     <literal>mmap</literal>ing the storage directly into the application's
-     address space.
-    </para>
+    <title> Applications which benefit from large amounts of byte-addressable storage. </title>
+    <para> In cases where the server will be hosting an application that can directly access large amounts of storage on a byte-by-byte basis, by <literal>mmap</literal>ing the storage directly into the application's address space. </para>
    </sect3>
    <sect3>
     <title>Avoiding use of the kernel page cache.</title>
-    <para>
-     If you wish to conserve the use of RAM for the page cache, and instead
-     give it to your applications. For instance, non-volatile memory could be
-     dedicated to holding virtual machine (VM) images. As these would not be
-     cached, this would reduce the cache usage on the host, allowing more VMs
-     per host.
-    </para>
+    <para> If you wish to conserve the use of RAM for the page cache, and instead give it to your applications. For instance, non-volatile memory could be dedicated to holding virtual machine (VM) images. As these would not be cached, this would reduce the cache usage on the host, allowing more VMs per host. </para>
    </sect3>
   </sect2>
   <sect2>
    <title>PMEM with BTT</title>
-   <para>
-    This is most useful when you just want to use NVDIMMs as very fast storage.
-   </para>
-   <para>
-    To applications, such devices just appear as very fast SSDs and can be used
-    like any other storage device - for example, LVM can be layered on top of
-    the non-volatile storage and will work as normal.
-   </para>
-   <para>
-    The advantage of BTT is that sector write atomicity is guaranteed, so even
-    sophisticated applications which depend on data integrity will keep working.
-    Media error reporting works through standard error-reporting channels.
-   </para>
-  </sect2>
-  <sect2>
-   <title>BLK storage</title>
-   <para>
-    Although it is more robust against single-device failure, this requires
-    additional management, as each NVDIMM appears as a separate device. Thus,
-    PMEM is generally preferred.
-   </para>
-   <para>
-    BLK storage is deprecated and is not supported in later versions of
-    &productname;.
-   </para>
+   <para> This is most useful when you just want to use NVDIMMs as very fast storage. </para>
+   <para> To applications, such devices just appear as very fast SSDs and can be used like any other storage device - for example, LVM can be layered on top of the non-volatile storage and will work as normal. </para>
+   <para> The advantage of BTT is that sector write atomicity is guaranteed, so even sophisticated applications which depend on data integrity will keep working. Media error reporting works through standard error-reporting channels. </para>
   </sect2>
  </sect1>
- 
  <sect1 xml:id="sec.nvdimm.tools">
   <title>Tools for Managing NVDIMM Storage</title>
-
-  <para>
-   To manage NVDIMM storage, it is necessary to install the
-   <literal>ndctl</literal> package. This also installs the
-   <filename>libndctl</filename> package which provides a set of user-space
-   libraries to configure NVDIMMs.
-  </para>
-
-  <para>
-   These tools work via the <filename>libnvdimm</filename> library, which
-   supports three types of NVDIMMs:
-  </para>
-
-  <itemizedlist>
-   <listitem>
-    <para>
-     PMEM
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     BLK
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     Simultaneous PMEM and BLK
-    </para>
-   </listitem>
-  </itemizedlist>
-
-  <para>
-   The <command>ndctl</command> utility has a helpful set of
-   <command>man</command> pages, accessible with the command:
-  </para>
-
-<screen><command>ndctl help <replaceable>subcommand</replaceable></command></screen>
-
-  <para>
-   To see a list of available subcommands, use:
-  </para>
-
-<screen><command>ndctl --list-cmds</command></screen>
-
-  <para>
-   The available subcommands include:
-  </para>
-
+  <para> To manage NVDIMM storage, it is necessary to install the <literal>ndctl</literal> package. This also installs the <filename>libndctl</filename> package which provides a set of user-space libraries to configure NVDIMMs. These tools work via the <filename>libnvdimm</filename> library, which supports multiple types of NVDIMMs. </para>
+  <para> The <command>ndctl</command> utility has a helpful set of <command>man</command> pages, accessible with the command: </para>
+  <screen><command>ndctl help <replaceable>subcommand</replaceable></command></screen>
+  <para> To see a list of available subcommands, use: </para>
+  <screen><command>ndctl --list-cmds</command></screen>
+  <para> The available subcommands include: </para>
   <variablelist>
    <varlistentry>
     <term>version</term>
     <listitem>
-     <para>
-      Displays the current version of the NVDIMM support tools.
-     </para>
+     <para> Displays the current version of the NVDIMM support tools. </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>enable-namespace</term>
     <listitem>
-     <para>
-      Makes the specified namespace available for use.
-     </para>
+     <para> Makes the specified namespace available for use. </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>disable-namespace</term>
     <listitem>
-     <para>
-      Prevents the specified namespace from being used.
-     </para>
+     <para> Prevents the specified namespace from being used. </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>create-namespace</term>
     <listitem>
-     <para>
-      Creates a new namespace from the specified storage devices.
-     </para>
+     <para> Creates a new namespace from the specified storage devices. </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>destroy-namespace</term>
     <listitem>
-     <para>
-      Removes the specified namespace.
-     </para>
+     <para> Removes the specified namespace. </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>enable-region</term>
     <listitem>
-     <para>
-      Makes the specified region available for use.
-     </para>
+     <para> Makes the specified region available for use. </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>disable-region</term>
     <listitem>
-     <para>
-      Prevents the specified region from being used.
-     </para>
+     <para> Prevents the specified region from being used. </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>zero-labels</term>
     <listitem>
-     <para>
-      Erases the metadata from a device.
-     </para>
+     <para> Erases the metadata from a device. </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>read-labels</term>
     <listitem>
-     <para>
-      Retrieves the metadata of the specified device.
-     </para>
+     <para> Retrieves the metadata of the specified device. </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>list</term>
     <listitem>
-     <para>
-      Displays available devices.
-     </para>
+     <para> Displays available devices. </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>help</term>
     <listitem>
-     <para>
-      Displays information about using the tool.
-     </para>
+     <para> Displays information about using the tool. </para>
     </listitem>
    </varlistentry>
   </variablelist>
  </sect1>
  <sect1 xml:id="sec.nvdimm.setup">
   <title>Setting Up NVDIMM Storage</title>
-
   <sect2 xml:id="sec.nvdimm.setup.view">
    <title>Viewing Available NVDIMM Storage</title>
-   <para>
-    The <command>ndctl</command> <literal>list</literal> command can be used to
-    list all available NVDIMMs in a system.
-   </para>
-   <para>
-    In the following example, the system has three NVDIMMs which are in a
-    single, triple-channel interleaved set.
-   </para>
-<screen>&prompt.root;<command>ndctl list --dimms</command>
+   <para> The <command>ndctl</command>
+    <literal>list</literal> command can be used to list all available NVDIMMs in a system. </para>
+   <para> In the following example, the system has three NVDIMMs which are in a single, triple-channel interleaved set. </para>
+   <screen>&prompt.root;<command>ndctl list --dimms</command>
 
 [
  {
@@ -501,20 +277,13 @@
   "id":"8089-00-0000-10325476"
  }
 ]</screen>
-   <para>
-    With a different parameter, <command>ndctl</command>
-    <literal>list</literal> will also list the available regions.
-   </para>
+   <para> With a different parameter, <command>ndctl</command>
+    <literal>list</literal> will also list the available regions. </para>
    <note>
-    <para>
-     Regions may not appear in numerical order.
-    </para>
+    <para> Regions may not appear in numerical order. </para>
    </note>
-   <para>
-    Note that although there are only three NVDIMMs, they appear as four
-    regions.
-   </para>
-<screen>&prompt.root;<command>ndctl list --regions</command>
+   <para> Note that although there are only three NVDIMMs, they appear as four regions. </para>
+   <screen>&prompt.root;<command>ndctl list --regions</command>
 
 [
  {
@@ -543,28 +312,14 @@
    "type":"blk"
   }
 ]</screen>
-   <para>
-    The space is available in two different forms: either as three separate 64
-    GB regions of type BLK, or as one combined 189 GB region of type PMEM which
-    presents all the space on the three interleaved NVDIMMs as a single volume.
-   </para>
-   <para>
-    Note that the displayed value for <literal>available_size</literal> is the
-    same as that for <literal>size</literal>. This means that none of the space
-    has been allocated yet.
-   </para>
+   <para> The space is available in two different forms: either as three separate 64 GB regions of type BLK, or as one combined 189 GB region of type PMEM which presents all the space on the three interleaved NVDIMMs as a single volume. </para>
+   <para> Note that the displayed value for <literal>available_size</literal> is the same as that for <literal>size</literal>. This means that none of the space has been allocated yet. </para>
   </sect2>
-
   <sect2 xml:id="sec.nvdimm.setup.dax">
    <title>Configuring the Storage as a Single PMEM Namespace with DAX</title>
-   <para>
-    For the first example, we will configure our three NVDIMMs into a single
-    PMEM namespace with Direct Access (DAX).
-   </para>
-   <para>
-    The first step is to create a new namespace.
-   </para>
-<screen>&prompt.root;<command>ndctl create-namespace --type=<replaceable>pmem</replaceable> --mode=<replaceable>memory</replaceable></command>
+   <para> For the first example, we will configure our three NVDIMMs into a single PMEM namespace with Direct Access (DAX). </para>
+   <para> The first step is to create a new namespace. </para>
+   <screen>&prompt.root;<command>ndctl create-namespace --type=<replaceable>pmem</replaceable> --mode=<replaceable>memory</replaceable></command>
 {
  "dev":"namespace3.0",
  "mode":"memory",
@@ -572,37 +327,17 @@
  "uuid":"dc8ebb84-c564-4248-9e8d-e18543c39b69",
  "blockdev":"pmem3"
 }</screen>
-   <para>
-    This creates a block device <filename>/dev/pmem3</filename>, which supports
-    DAX. The <literal>3</literal> in the device name is inherited from the
-    parent region number, in this case <filename>region3</filename>.
-   </para>
-   <para>
-    The <option>--mode=memory</option> option sets aside part of the PMEM
-    storage space on the NVDIMMs so that it can be used to allocate internal
-    kernel data structures called <literal>struct pages</literal>. This allows
-    the new PMEM namespace to be used with features such as <literal>O_DIRECT
-    I/O</literal> and <literal>RDMA</literal>.
-   </para>
-   <para>
-    The reservation of some persistent memory for kernel data structures is why
-    the resulting PMEM namespace has a smaller capacity than the parent PMEM
-    Region.
-   </para>
-   <para>
-    Next, we verify that the new block device is available to the operating
-    system:
-   </para>
-<screen>&prompt.root;<command>fdisk -l /dev/<replaceable>pmem3</replaceable></command>
+   <para> This creates a block device <filename>/dev/pmem3</filename>, which supports DAX. The <literal>3</literal> in the device name is inherited from the parent region number, in this case <filename>region3</filename>. </para>
+   <para> The <option>--mode=memory</option> option sets aside part of the PMEM storage space on the NVDIMMs so that it can be used to allocate internal kernel data structures called <literal>struct pages</literal>. This allows the new PMEM namespace to be used with features such as <literal>O_DIRECT I/O</literal> and <literal>RDMA</literal>. </para>
+   <para> The reservation of some persistent memory for kernel data structures is why the resulting PMEM namespace has a smaller capacity than the parent PMEM Region. </para>
+   <para> Next, we verify that the new block device is available to the operating system: </para>
+   <screen>&prompt.root;<command>fdisk -l /dev/<replaceable>pmem3</replaceable></command>
 Disk /dev/pmem3: 186 GiB, 199764213760 bytes, 390164480 sectors
 Units: sectors of 1 * 512 = 512 bytes
 Sector size (logical/physical): 512 bytes / 4096 bytes
 I/O size (minimum/optimal): 4096 bytes / 4096 bytes</screen>
-   <para>
-    Before it can be used, like any other drive, it must be formatted. In this
-    example, we format it with XFS:
-   </para>
-<screen>&prompt.root;<command>mkfs.xfs /dev/<replaceable>pmem3</replaceable></command>
+   <para> Before it can be used, like any other drive, it must be formatted. In this example, we format it with XFS: </para>
+   <screen>&prompt.root;<command>mkfs.xfs /dev/<replaceable>pmem3</replaceable></command>
 meta-data=/dev/pmem3      isize=256    agcount=4, agsize=12192640 blks
          =                sectsz=4096  attr=2, projid32bit=1
          =                crc=0        finobt=0, sparse=0
@@ -612,60 +347,31 @@ naming   =version 2       bsize=4096   ascii-ci=0 ftype=1
 log      =internal log    bsize=4096   blocks=23813, version=2
          =                sectsz=4096  sunit=1 blks, lazy-count=1
 realtime =none            extsz=4096   blocks=0, rtextents=0</screen>
-   <para>
-    Next, we can mount the new drive onto a directory:
-   </para>
-<screen>&prompt.root;<command>mount -o dax /dev/<replaceable>pmem3</replaceable> /mnt/<replaceable>pmem3</replaceable></command></screen>
-   <para>
-    Then we can verify that we now have a DAX-capable device:
-   </para>
-<screen>&prompt.root;<command>mount | grep dax</command>
+   <para> Next, we can mount the new drive onto a directory: </para>
+   <screen>&prompt.root;<command>mount -o dax /dev/<replaceable>pmem3</replaceable> /mnt/<replaceable>pmem3</replaceable></command></screen>
+   <para> Then we can verify that we now have a DAX-capable device: </para>
+   <screen>&prompt.root;<command>mount | grep dax</command>
 /dev/pmem3 on /mnt/pmem3 type xfs (rw,relatime,attr2,dax,inode64,noquota)</screen>
-   <para>
-    The result is that we now have a PMEM namespace formatted with the XFS file
-    system and mounted with DAX.
-   </para>
-   <para>
-    Any <literal>mmap()</literal> calls to files in that file system will
-    return virtual addresses that directly map to the persistent memory on our
-    NVDIMMs, completely bypassing the page cache.
-   </para>
-   <para>
-    Any <literal>fsync</literal> or <literal>msync</literal> calls on files in
-    that file system will still ensure that modified data has been fully
-    written to the NVDIMMs. These calls flush the processor cache lines
-    associated with any pages that have been modified in userspace via
-    <literal>mmap</literal> mappings.
-   </para>
+   <para> The result is that we now have a PMEM namespace formatted with the XFS file system and mounted with DAX. </para>
+   <para> Any <literal>mmap()</literal> calls to files in that file system will return virtual addresses that directly map to the persistent memory on our NVDIMMs, completely bypassing the page cache. </para>
+   <para> Any <literal>fsync</literal> or <literal>msync</literal> calls on files in that file system will still ensure that modified data has been fully written to the NVDIMMs. These calls flush the processor cache lines associated with any pages that have been modified in userspace via <literal>mmap</literal> mappings. </para>
    <sect3 xml:id="sec.nvdimm.setup.deldax">
     <title>Removing a Namespace</title>
-    <para>
-     Before creating any other type of volume that uses the same storage, we
-     must unmount and then remove this PMEM volume.
-    </para>
-    <para>
-     First, unmount it:
-    </para>
-<screen>&prompt.root;<command>umount /mnt/<replaceable>pmem3</replaceable></command></screen>
-    <para>
-     Then disable the namespace:
-    </para>
-<screen>&prompt.root;<command>ndctl disable-namespace <replaceable>namespace3.0</replaceable></command>
+    <para> Before creating any other type of volume that uses the same storage, we must unmount and then remove this PMEM volume. </para>
+    <para> First, unmount it: </para>
+    <screen>&prompt.root;<command>umount /mnt/<replaceable>pmem3</replaceable></command></screen>
+    <para> Then disable the namespace: </para>
+    <screen>&prompt.root;<command>ndctl disable-namespace <replaceable>namespace3.0</replaceable></command>
 disabled 1 namespace</screen>
-    <para>
-     Then delete it:
-    </para>
-<screen>&prompt.root;<command>ndctl destroy-namespace <replaceable>namespace3.0</replaceable></command>
+    <para> Then delete it: </para>
+    <screen>&prompt.root;<command>ndctl destroy-namespace <replaceable>namespace3.0</replaceable></command>
 destroyed 1 namespace</screen>
    </sect3>
   </sect2>
-
   <sect2 xml:id="sec.nvdimm.setup.btt">
    <title>Creating a PMEM Namespace with BTT</title>
-   <para>
-    In the next example, we create a PMEM namespace that uses BTT.
-   </para>
-<screen>&prompt.root;<command>ndctl create-namespace --type=<replaceable>pmem</replaceable> --mode=<replaceable>sector</replaceable></command>
+   <para> In the next example, we create a PMEM namespace that uses BTT. </para>
+   <screen>&prompt.root;<command>ndctl create-namespace --type=<replaceable>pmem</replaceable> --mode=<replaceable>sector</replaceable></command>
 {
  "dev":"namespace3.0",
  "mode":"sector",
@@ -673,205 +379,63 @@ destroyed 1 namespace</screen>
  "sector_size":4096,
  "blockdev":"pmem3s"
 }</screen>
-   <para>
-    Next, verify that the new device is present:
-   </para>
-<screen>&prompt.root;<command>fdisk -l /dev/<replaceable>pmem3s</replaceable></command>
+   <para> Next, verify that the new device is present: </para>
+   <screen>&prompt.root;<command>fdisk -l /dev/<replaceable>pmem3s</replaceable></command>
 Disk /dev/pmem3s: 188.8 GiB, 202738135040 bytes, 49496615 sectors
 Units: sectors of 1 * 4096 = 4096 bytes
 Sector size (logical/physical): 4096 bytes / 4096 bytes
 I/O size (minimum/optimal): 4096 bytes / 4096 bytes</screen>
-   <para>
-    Like the DAX-capable PMEM namespace we previously configured, this
-    BTT-capable PMEM namespace consumes all the available storage on the
-    NVDIMMs.
-   </para>
+   <para> Like the DAX-capable PMEM namespace we previously configured, this BTT-capable PMEM namespace consumes all the available storage on the NVDIMMs. </para>
    <note>
-    <para>
-     The trailing <literal>s</literal> in the device name
-     (<filename>/dev/<replaceable>pmem3s</replaceable></filename>) stands for
-     <literal>sector</literal> and can be used to easily distinguish PMEM and
-     BLK namespaces that are configured to use the BTT.
-    </para>
+    <para> The trailing <literal>s</literal> in the device name (<filename>/dev/<replaceable>pmem3s</replaceable></filename>) stands for <literal>sector</literal> and can be used to easily distinguish PMEM and BLK namespaces that are configured to use the BTT. </para>
    </note>
-   <para>
-    The volume can be formatted and mounted as in the previous example.
-   </para>
-   <para>
-    The PMEM namespace shown here cannot use DAX. Instead it uses the BTT to
-    provide <emphasis>sector write atomicity</emphasis>. On each sector write
-    through the PMEM block driver, the BTT will allocate a new sector to
-    receive the new data. The BTT atomically updates its internal mapping
-    structures after the new data is fully written so the newly written data
-    will be available to applications. If the power fails at any point during
-    this process, the write will be completely lost and the application will
-    have access to its old data, still intact. This prevents the condition
-    known as "torn sectors".
-   </para>
-   <para>
-    This BTT-enabled PMEM namespace can be formatted and used with a filesystem
-    just like any other standard block device. It cannot be used with DAX.
-    However, <literal>mmap</literal> mappings for files on this block device
-    will use the page cache.
-   </para>
+   <para> The volume can be formatted and mounted as in the previous example. </para>
+   <para> The PMEM namespace shown here cannot use DAX. Instead it uses the BTT to provide <emphasis>sector write atomicity</emphasis>. On each sector write through the PMEM block driver, the BTT will allocate a new sector to receive the new data. The BTT atomically updates its internal mapping structures after the new data is fully written so the newly written data will be available to applications. If the power fails at any point during this process, the write will be completely lost and the application will have access to its old data, still intact. This prevents the condition known as "torn sectors". </para>
+   <para> This BTT-enabled PMEM namespace can be formatted and used with a filesystem just like any other standard block device. It cannot be used with DAX. However, <literal>mmap</literal> mappings for files on this block device will use the page cache. </para>
    <note>
-    <para>
-     In both these examples, space from all the NVDIMMs is combined into a
-     single volume. Just as with a non-redundant disk array, this means that if
-     any individual NVDIMM suffers an error, the contents of the entire volume
-     could be lost. The more NVDIMMs are included in the volume, the higher the
-     chance of such an error.
-    </para>
+    <para> In both these examples, space from all the NVDIMMs is combined into a single volume. Just as with a non-redundant disk array, this means that if any individual NVDIMM suffers an error, the contents of the entire volume could be lost. The more NVDIMMs are included in the volume, the higher the chance of such an error. </para>
    </note>
    <sect3 xml:id="sec.nvdimm.setup.delbtt">
     <title>Removing the PMEM Volume</title>
-    <para>
-     As in the previous example, before re-allocating the space, we must first
-     remove the volume and the namespace:
-    </para>
-<screen>&prompt.root;<command>ndctl disable-namespace <replaceable>namespace3.0</replaceable></command>
+    <para> As in the previous example, before re-allocating the space, we must first remove the volume and the namespace: </para>
+    <screen>&prompt.root;<command>ndctl disable-namespace <replaceable>namespace3.0</replaceable></command>
 disabled 1 namespace
 
 &prompt.root;<command>ndctl destroy-namespace <replaceable>namespace3.0</replaceable></command>
 destroyed 1 namespace</screen>
    </sect3>
   </sect2>
-
-  <sect2 xml:id="sec.nvdimm.setup.blk">
-   <title>Creating BLK Namespaces</title>
-   <para>
-    In this example, we will create 3 separate BLK devices, one per NVDIMM.
-   </para>
-   <para>
-    One advantage of this approach is that if any individual NVDIMM fails, the
-    other volumes will be unaffected.
-   </para>
-   <note>
-    <para>
-     The commands must be repeated for each namespace.
-    </para>
-   </note>
-<screen>&prompt.root;<command>ndctl create-namespace --type=<replaceable>blk</replaceable> --mode=<replaceable>sector</replaceable></command>
-{
- "dev":"namespace1.0",
- "mode":"sector",
- "uuid":"fed466bd-90f6-460b-ac81-ad1f08716602",
- "sector_size":4096,
- "blockdev":"ndblk1.0s"
-}
-   
-&prompt.root;ndctl create-namespace --type=blk --mode=sector
-{
- "dev":"namespace0.0",
- "mode":"sector",
- "uuid":"12a29b6f-b951-4d08-8dbc-8dea1a2bb32d",
- "sector_size":4096,
- "blockdev":"ndblk0.0s"
-}
-    
-&prompt.root;<command>ndctl create-namespace --type=<replaceable>blk</replaceable> --mode=<replaceable>sector</replaceable></command>
-{
- "dev":"namespace2.0",
- "mode":"sector",
- "uuid":"7c84dab5-cc08-452a-b18d-53e430bf8833",
- "sector_size":4096,
- "blockdev":"ndblk2.0s"
-}
-   </screen>
-   <para>
-    Next, we can verify that the new devices exist:
-   </para>
-<screen>&prompt.root;fdisk -l /dev/<replaceable>ndblk*</replaceable>
-Disk /dev/ndblk0.0s: 63.4 GiB, 68115001344 bytes, 16629639 sectors
-Units: sectors of 1 * 4096 = 4096 bytes
-Sector size (logical/physical): 4096 bytes / 4096 bytes
-I/O size (minimum/optimal): 4096 bytes / 4096 bytes
-
-Disk /dev/ndblk1.0s: 63.4 GiB, 68115001344 bytes, 16629639 sectors
-Units: sectors of 1 * 4096 = 4096 bytes
-Sector size (logical/physical): 4096 bytes / 4096 bytes
-I/O size (minimum/optimal): 4096 bytes / 4096 bytes
-
-Disk /dev/ndblk2.0s: 63.4 GiB, 68115001344 bytes, 16629639 sectors
-Units: sectors of 1 * 4096 = 4096 bytes
-Sector size (logical/physical): 4096 bytes / 4096 bytes
-I/O size (minimum/optimal): 4096 bytes / 4096 bytes</screen>
-   <para>
-    The block devices generated for BLK namespaces are named
-    <filename>/dev/ndblk<replaceable>X</replaceable>.<replaceable>Y</replaceable></filename>
-    where <replaceable>X</replaceable> is the parent region number and
-    <replaceable>Y</replaceable> is a unique namespace number within that
-    region. So, <filename>/dev/ndblk2.0s</filename> is child namespace number 0
-    of region 2.
-   </para>
-   <para>
-    As in the previous example, the trailing <literal>s</literal> means that
-    this namespace is configured to use the BTT - in other words, for
-    sector-based access. Because they are accessed via a <literal>block
-    window</literal>, programs cannot use DAX, but accesses will be cached.
-   </para>
-   <para>
-    As ever, these devices must all be formatted and mounted before they can be
-    used.
-   </para>
-  </sect2>
  </sect1>
  <sect1 xml:id="sec.nvdimm.moreinfo">
   <title>For More Information</title>
-
-  <para>
-   More about this topic can be found in the following list:
-  </para>
-
+  <para> More about this topic can be found in the following list: </para>
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
      <link xlink:href="https://nvdimm.wiki.kernel.org/"
-      >Persistent
-     Memory Wiki</link>
+      >Persistent Memory Wiki</link>
     </para>
-    <para>
-     Contains instructions for configuring NVDIMM systems, information about
-     testing, and links to specifications related to NVDIMM enabling. This site
-     is developing as NVDIMM support in Linux is developing.
-    </para>
+    <para> Contains instructions for configuring NVDIMM systems, information about testing, and links to specifications related to NVDIMM enabling. This site is developing as NVDIMM support in Linux is developing. </para>
    </listitem>
    <listitem>
     <para>
      <link xlink:href="http://pmem.io/">Persistent Memory Programming</link>
     </para>
-    <para>
-     Information about configuring, using and programming systems with
-     non-volatile memory, under Linux and other operating systems. Covers the
-     NVM Library (NVML), which aims to provide useful APIs for programming with
-     persistent memory in userspace.
-    </para>
+    <para> Information about configuring, using and programming systems with non-volatile memory, under Linux and other operating systems. Covers the NVM Library (NVML), which aims to provide useful APIs for programming with persistent memory in userspace. </para>
    </listitem>
    <listitem>
     <para>
      <link
       xlink:href="https://www.kernel.org/doc/Documentation/nvdimm/nvdimm.txt"
-      >
-     LIBNVDIMM: Non-Volatile Devices</link>
+      > LIBNVDIMM: Non-Volatile Devices</link>
     </para>
-    <para>
-     Aimed at kernel developers, this is part of the Documentation folder in
-     the current Linux kernel tree. It talks about the different kernel modules
-     involved in NVDIMM enablement, lays out some technical details of the
-     kernel implementation, and talks about the
-     <filename>sysfs</filename>interface to the kernel that is used by the
-     <command>ndctl</command> tool.
-    </para>
+    <para> Aimed at kernel developers, this is part of the Documentation folder in the current Linux kernel tree. It talks about the different kernel modules involved in NVDIMM enablement, lays out some technical details of the kernel implementation, and talks about the <filename>sysfs</filename>interface to the kernel that is used by the <command>ndctl</command> tool. </para>
    </listitem>
    <listitem>
     <para>
      <link xlink:href="https://github.com/pmem/ndctl">GitHub: pmem/ndctl</link>
     </para>
-    <para>
-     Utility library for managing the <command>libnvdimm</command> sub-system
-     in the Linux kernel. Also contains userspace libraries, as well as unit
-     tests and documentation.
-    </para>
+    <para> Utility library for managing the <command>libnvdimm</command> sub-system in the Linux kernel. Also contains userspace libraries, as well as unit tests and documentation. </para>
    </listitem>
   </itemizedlist>
  </sect1>

--- a/xml/hardware_nvdimm.xml
+++ b/xml/hardware_nvdimm.xml
@@ -7,12 +7,13 @@
 <chapter xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha.nvdimm">
- <title>Non-volatile Main Memory</title>
+ <title>Persistent Memory</title>
  <info>
   <abstract>
    <para>
     This chapter contains additional information about using &productname; with
-    non-volatile main memory comprising one or more NVDIMMs.
+    non-volatile main memory, also known as <emphasis>Persistent Memory</emphasis>,
+    comprising one or more NVDIMMs.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -24,46 +25,49 @@
   <title>Introduction</title>
 
   <para>
-   Non-volatile memory is a new type of computer storage, combining speeds
+   Persistent memory is a new type of computer storage, combining speeds
    approaching those of dynamic RAM (DRAM) along with RAM's byte-by-byte
    addressability, plus the permanence of solid-state disks (SSDs).
   </para>
 
   <para>
    Like conventional RAM, it is installed directly into motherboard memory
-   slots. As such, it is supplied in the same physical form factor as RAM - as
+   slots. As such, it is supplied in the same physical form factor as RAM&mdash;as
    DIMMs. These are known as NVDIMMs: non-volatile dual inline memory modules.
   </para>
 
   <para>
-   Like SSDs, NVDIMMs provide non-volatile storage: their contents are retained
-   when the system is powered off or restarted. Also like SSDs, sector-level
-   access is also possible if that is more suitable for a particular
-   application.
-  </para>
-
-  <para>
-   This new storage subsystem is defined in version 6 of the ACPI standard.
-   However, some types of NVDIMMs already existed before the standard was
-   defined. These can be used in the same way.
+   Unlike RAM, though, persistent memory is also similar to flash-based SSDs in
+   several ways. Both are based on forms of solid-state memory circuitry, but 
+   despite this, both provide non-volatile storage: their contents are retained
+   when the system is powered off or restarted. For both forms of medium,
+   writing data is slower than reading it, and both support a limited number of
+   rewrite cycles. Finally, also like SSDs, sector-level access to persistent
+   memory is possible if that is more suitable for a particular application.
   </para>
 
   <para>
    Different models use different forms of electronic storage medium, such as
    Intel 3D XPoint, or a combination of NAND flash and DRAM. New forms of
-   non-volatile RAM are also in development. This means that different vendors'
-   NVDIMMs offer different performance and durability characteristics.
-   Typically, they are slower than DRAM, but considerably faster than SSDs based
-   on NAND-flash technology.
+   non-volatile RAM are also in development. This means that different vendors
+   and models of NVDIMM offer different performance and durability
+   characteristics.
   </para>
 
   <para>
    Because the storage technologies involved are in an early stage of
    development, different vendors' hardware may impose different limitations.
-   However, generally, writing data to NVDIMMs is slower than reading from
-   them, and the number of write cycles is generally limited.
+   Thus, the following statements are generalizations.
   </para>
-
+  
+  <para>
+   Persistent memory is up to ten times slower than DRAM, but around a thousand
+   times faster than flash storage. It can be rewritten on a byte-by-byte basis
+   rather than flash memory's whole-sector erase-and-rewrite process. Finally, 
+   while rewrite cycles are limited, most forms of persistent memory can handle
+   millions of rewrites, compared to the thousands of cycles of flash storage.
+  </para>
+  
   <para>
    This has two important consequences:
   </para>
@@ -72,23 +76,30 @@
    <listitem>
     <para>
      It is not possible with current technology to run a system with only
-     NVDIMMs and thus achieve completely non-volatile main memory. You must use
-     a mixture of both conventional RAM and NVDIMMs. The operating system and
-     applications will execute in conventional RAM, with the NVDIMMs providing
-     very fast supplementary storage.
+     persistent memory and thus achieve completely non-volatile main memory. You
+     must use a mixture of both conventional RAM and NVDIMMs. The operating
+     system and applications will execute in conventional RAM, with the NVDIMMs
+     providing very fast supplementary storage.
     </para>
    </listitem>
    <listitem>
     <para>
-     The performance characteristics of different vendors' NVDIMMs mean that it
-     may be necessary for programmers to be aware of the hardware
-     specifications of NVDIMMS in a particular server, including how many and
-     in which memory slots they are fitted. This will obviously impact
-     hypervisor use, migration of software between different host machines, and
-     so on.
+     The performance characteristics of different vendors' persistent memory
+     mean that it may be necessary for programmers to be aware of the hardware
+     specifications of the NVDIMMs in a particular server, including how many
+     NVDIMMs there are and in which memory slots they are fitted. This will
+     obviously impact hypervisor use, migration of software between different
+     host machines, and so on.
     </para>
    </listitem>
   </itemizedlist>
+
+  <para>
+   This new storage subsystem is defined in version 6 of the ACPI standard.
+   However, <filename>libnvdimm</filename> supports pre-standard NVDIMMs and
+   they can be used in the same way.
+  </para>
+  
  </sect1>
  <sect1 xml:id="sec.nvdimm.terms">
   <title>Terms</title>
@@ -98,7 +109,7 @@
     <term>Region</term>
     <listitem>
      <para>
-      A <emphasis>region</emphasis> is a block of persistent storage that can
+      A <emphasis>region</emphasis> is a block of persistent memory that can
       be divided up into one or more <emphasis>namespace</emphasis>s. You
       cannot access the persistent memory of a region without first allocating
       it to a namespace.
@@ -109,14 +120,12 @@
     <term>Namespace</term>
     <listitem>
      <para>
-      A single contiguously-address range of non-volatile storage, comparable
-      to those on NVM Express SSDs or to a SCSI Logical Unit (LUN). Each NVDIMM
-      usually appears in the server's <filename>/dev</filename> directory as a
-      separate block device. This storage must be assigned to one or more
-      namespaces for it to be used. Depending on the method of access required,
-      namespaces can either amalgamate storage from separate NVDIMMs into larger
-      volumes, or allow it to be partitioned into smaller volumes, similarly to
-      disk drives.
+      A single contiguously-addressed range of non-volatile storage, comparable
+      to NVM Express SSD namespaces, or to SCSI Logical Units (LUNs). Namespaces
+      appear in the server's <filename>/dev</filename> directory as separate
+      block devices. Depending on the method of access required, namespaces can
+      either amalgamate storage from multiple NVDIMMs into larger volumes, or
+      allow it to be partitioned into smaller volumes.
      </para>
     </listitem>
    </varlistentry>
@@ -135,10 +144,9 @@
        <listitem>
         <para>
          Device-DAX mode. Creates a single-character device file (<filename>
-         /dev/dax<replaceable>X</replaceable>.<replaceable>Y</replaceable>
-         </filename>). Does <emphasis>not</emphasis> require filesystem
-         creation. Suitable to register PMEM for RDMA or for assigning it to
-         virtual machines, or for mapping blocks too large to fit into RAM.
+          /dev/dax<replaceable>X</replaceable>.<replaceable>Y</replaceable>
+         </filename>). Does <emphasis>not</emphasis> require file system
+         creation.
         </para>
        </listitem>
       </varlistentry>
@@ -146,9 +154,9 @@
        <term>fsdax</term>
        <listitem>
         <para>
-         Filesystem-DAX mode. Default if no other mode is specified. Creates a
+         File system-DAX mode. Default if no other mode is specified. Creates a
          block device (<filename>/dev/pmem<replaceable>X</replaceable>
-         [.<replaceable>Y</replaceable>]</filename>) which supports DAX for
+          [.<replaceable>Y</replaceable>]</filename>) which supports DAX for
          <literal>ext4</literal> or <literal>XFS</literal>.
         </para>
        </listitem>
@@ -157,7 +165,7 @@
        <term>sector</term>
        <listitem>
         <para>
-         For legacy filesystems which do not checksum metadata. Suitable for
+         For legacy file systems which do not checksum metadata. Suitable for
          small boot volumes. Compatible with other operating systems.
         </para>
        </listitem>
@@ -172,7 +180,7 @@
         <note>
          <para>
           <literal>raw</literal> mode is not supported by &suse;. It is not
-          possible to mount filesystems on <literal>raw</literal> namespaces.
+          possible to mount file systems on <literal>raw</literal> namespaces.
          </para>
         </note>
        </listitem>
@@ -252,23 +260,18 @@
      </variablelist>
      <para>
       Apart from <literal>devdax</literal> namespaces, all other types must be
-      formatted with a filesystem, just as with a conventional drive.
+      formatted with a file system, just as with a conventional drive.
       &productname; supports the <literal>ext2</literal>,
-      <literal>ext4</literal> and <literal>XFS</literal> filesystems for this.
+      <literal>ext4</literal> and <literal>XFS</literal> file systems for this.
      </para>
-     <note>
-      <para>
-       &suse; does not support the <literal>ext2</literal> filesystem for use
-       with DAX.
-      </para>
-     </note>
-    </listitem>
+   </listitem>
    </varlistentry>
    <varlistentry>
     <term>Direct Access (DAX)</term>
     <listitem>
      <para>
-      Directly <literal>mmap()</literal> NV-RAM into a process' address space.
+      Directly <literal>mmap()</literal> persistent memory into a process'
+      address space.
      </para>
     </listitem>
    </varlistentry>
@@ -313,12 +316,14 @@
     partially-written data.
    </para>
    <sect3>
-    <title>Applications which benefit from large amounts of byte-addressable storage.</title>
+    <title>
+     Applications which benefit from large amounts of byte-addressable storage.
+    </title>
     <para>
-     In cases where the server will be hosting an application that can directly
-     access large amounts of storage on a byte-by-byte basis, by
-     <literal>mmap</literal>ing the storage directly into the application's
-     address space.
+     If the server will host an application that can directly use large amounts
+     of fast storage on a byte-by-byte basis, the programmer can use the <literal>mmap</literal>
+     system call to place blocks of persistent memory directly into the
+     application's address space, without using any additional system RAM.
     </para>
    </sect3>
    <sect3>
@@ -336,7 +341,8 @@
   <sect2>
    <title>PMEM with BTT</title>
    <para>
-    This is most useful when you just want to use NVDIMMs as very fast storage.
+    This is useful when you want to use the persistent memory on a set of
+    NVDIMMs as a disk-like pool of very fast storage.
    </para>
    <para>
     To applications, such devices just appear as very fast SSDs and can be used
@@ -352,16 +358,37 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec.nvdimm.tools">
-  <title>Tools for Managing NVDIMM Storage</title>
+  <title>Tools for Managing Persistent Memory</title>
 
   <para>
-   To manage NVDIMM storage, it is necessary to install the
+   To manage persistent memory, it is necessary to install the
    <literal>ndctl</literal> package. This also installs the
    <filename>libndctl</filename> package which provides a set of user-space
-   libraries to configure NVDIMMs. These tools work via the
-   <filename>libnvdimm</filename> library, which supports multiple types of
-   NVDIMMs.
+   libraries to configure NVDIMMs.
   </para>
+  
+  <para>
+   These tools work via the <filename>libnvdimm</filename> library, which
+   supports three types of NVDIMMs:
+  </para>
+  
+  <itemizedlist>
+   <listitem>
+    <para>
+     PMEM
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     BLK
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Simultaneous PMEM and BLK.
+    </para>
+   </listitem>
+  </itemizedlist>
 
   <para>
    The <command>ndctl</command> utility has a helpful set of
@@ -472,7 +499,7 @@
   </variablelist>
  </sect1>
  <sect1 xml:id="sec.nvdimm.setup">
-  <title>Setting Up NVDIMM Storage</title>
+  <title>Setting Up Persistent Memory</title>
 
   <sect2 xml:id="sec.nvdimm.setup.view">
    <title>Viewing Available NVDIMM Storage</title>
@@ -555,7 +582,7 @@
   </sect2>
 
   <sect2 xml:id="sec.nvdimm.setup.dax">
-   <title>Configuring the Storage as a PMEM Namespace with DAX</title>
+   <title>Configuring the Storage as a Single PMEM Namespace with DAX</title>
    <para>
     For the first example, we will configure our three NVDIMMs into a single
     PMEM namespace with Direct Access (DAX).
@@ -586,7 +613,7 @@
    <para>
     The reservation of some persistent memory for kernel data structures is why
     the resulting PMEM namespace has a smaller capacity than the parent PMEM
-    Region.
+    region.
    </para>
    <para>
     Next, we verify that the new block device is available to the operating
@@ -708,7 +735,7 @@ I/O size (minimum/optimal): 4096 bytes / 4096 bytes</screen>
     known as "torn sectors".
    </para>
    <para>
-    This BTT-enabled PMEM namespace can be formatted and used with a filesystem
+    This BTT-enabled PMEM namespace can be formatted and used with a file system
     just like any other standard block device. It cannot be used with DAX.
     However, <literal>mmap</literal> mappings for files on this block device
     will use the page cache.

--- a/xml/hardware_nvdimm.xml
+++ b/xml/hardware_nvdimm.xml
@@ -8,8 +8,12 @@
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha.nvdimm">
  <title>Non-volatile Main Memory</title>
- <info><abstract>
-   <para> This chapter contains additional information about using &productname; with non-volatile main memory comprising one or more NVDIMMs. </para>
+ <info>
+  <abstract>
+   <para>
+    This chapter contains additional information about using &productname; with
+    non-volatile main memory comprising one or more NVDIMMs.
+   </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker/>
@@ -18,69 +22,158 @@
  </info>
  <sect1 xml:id="sec.nvdimm.intro">
   <title>Introduction</title>
-  <para> Non-volatile memory is a new type of computer storage, combining speeds approaching those of dynamic RAM (DRAM) along with RAM's byte-by-byte addressability, plus the permanence of solid-state disks (SSDs). </para>
-  <para> Like conventional RAM, it is installed directly into motherboard memory slots. As such, it is supplied in the same physical form factor as RAM - as DIMMs. These are known as NVDIMMs: non-volatile dual inline memory modules. </para>
-  <para> Like SSDs, NVDIMMs provide non-volatile storage: their contents are retained when the system is powered off or restarted. Also like SSDs, sector-level access is also possible if that is more suitable for a particular application. </para>
-  <para> This new storage subsystem is defined in version 6 of the ACPI standard. However, some types of NVDIMMs already existed before the standard was defined. These can be used in the same way. </para>
-  <para> Different models use different forms of electronic storage medium, such as Intel 3D XPoint, or a combination of NAND flash and DRAM, and in future, memristor storage or other forthcoming types of non-volatile memory. </para>
-  <para> This means that different vendors' NVDIMMs offer different performance and durability characteristics. Typically, they are slower than DRAM, but considerably faster than SSDs based on NAND-flash technology. </para>
-  <para> Because the storage technologies involved are in an early stage of development, different vendors' hardware may impose different limitations. However, generally, writing data to NVDIMMs is slower than reading from them, and the number of write cycles is generally limited. </para>
-  <para> This has two important consequences: </para>
+
+  <para>
+   Non-volatile memory is a new type of computer storage, combining speeds
+   approaching those of dynamic RAM (DRAM) along with RAM's byte-by-byte
+   addressability, plus the permanence of solid-state disks (SSDs).
+  </para>
+
+  <para>
+   Like conventional RAM, it is installed directly into motherboard memory
+   slots. As such, it is supplied in the same physical form factor as RAM - as
+   DIMMs. These are known as NVDIMMs: non-volatile dual inline memory modules.
+  </para>
+
+  <para>
+   Like SSDs, NVDIMMs provide non-volatile storage: their contents are retained
+   when the system is powered off or restarted. Also like SSDs, sector-level
+   access is also possible if that is more suitable for a particular
+   application.
+  </para>
+
+  <para>
+   This new storage subsystem is defined in version 6 of the ACPI standard.
+   However, some types of NVDIMMs already existed before the standard was
+   defined. These can be used in the same way.
+  </para>
+
+  <para>
+   Different models use different forms of electronic storage medium, such as
+   Intel 3D XPoint, or a combination of NAND flash and DRAM. New forms of
+   non-volatile RAM are also in development. This means that different vendors'
+   NVDIMMs offer different performance and durability characteristics.
+   Typically, they are slower than DRAM, but considerably faster than SSDs based
+   on NAND-flash technology.
+  </para>
+
+  <para>
+   Because the storage technologies involved are in an early stage of
+   development, different vendors' hardware may impose different limitations.
+   However, generally, writing data to NVDIMMs is slower than reading from
+   them, and the number of write cycles is generally limited.
+  </para>
+
+  <para>
+   This has two important consequences:
+  </para>
+
   <itemizedlist>
    <listitem>
-    <para> It is not possible with current technology to run a system with only NVDIMMs and thus achieve completely non-volatile main memory. You must use a mixture of both conventional RAM and NVDIMMs. The operating system and applications will execute in conventional RAM, with the NVDIMMs providing very fast supplementary storage. </para>
+    <para>
+     It is not possible with current technology to run a system with only
+     NVDIMMs and thus achieve completely non-volatile main memory. You must use
+     a mixture of both conventional RAM and NVDIMMs. The operating system and
+     applications will execute in conventional RAM, with the NVDIMMs providing
+     very fast supplementary storage.
+    </para>
    </listitem>
    <listitem>
-    <para> The performance characteristics of different vendors' NVDIMMs mean that it may be necessary for programmers to be aware of the hardware specifications of NVDIMMS in a particular server, including how many and in which memory slots they are fitted. This will obviously impact hypervisor use, migration of software between different host machines, and so on. </para>
+    <para>
+     The performance characteristics of different vendors' NVDIMMs mean that it
+     may be necessary for programmers to be aware of the hardware
+     specifications of NVDIMMS in a particular server, including how many and
+     in which memory slots they are fitted. This will obviously impact
+     hypervisor use, migration of software between different host machines, and
+     so on.
+    </para>
    </listitem>
   </itemizedlist>
  </sect1>
  <sect1 xml:id="sec.nvdimm.terms">
   <title>Terms</title>
+
   <variablelist>
    <varlistentry>
     <term>Region</term>
     <listitem>
-     <para> A <emphasis>region</emphasis> is a block of persistent storage that can be divided up into one or more <emphasis>namespace</emphasis>s. You cannot access the persistent memory of a region without first allocating it to a namespace. </para>
+     <para>
+      A <emphasis>region</emphasis> is a block of persistent storage that can
+      be divided up into one or more <emphasis>namespace</emphasis>s. You
+      cannot access the persistent memory of a region without first allocating
+      it to a namespace.
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>Namespace</term>
     <listitem>
-     <para> A single contiguously-address range of non-volatile storage, comparable to those on NVM Express PCIe SSDs or to a SCSI Logical Unit (LUN). Each NVDIMM usually appears in the server's <filename>/dev</filename> directory as a separate block device. This storage must be assigned to one or more namespaces for it to be used. Depending on the method of access required, namespaces can either amalgamate storage from separate NVDIMMs into larger volumes, or allow it to be partitioned into smaller volumes, similarly to disk drives. </para>
+     <para>
+      A single contiguously-address range of non-volatile storage, comparable
+      to those on NVM Express SSDs or to a SCSI Logical Unit (LUN). Each NVDIMM
+      usually appears in the server's <filename>/dev</filename> directory as a
+      separate block device. This storage must be assigned to one or more
+      namespaces for it to be used. Depending on the method of access required,
+      namespaces can either amalgamate storage from separate NVDIMMs into larger
+      volumes, or allow it to be partitioned into smaller volumes, similarly to
+      disk drives.
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>Mode</term>
     <listitem>
-     <para> Each namespace also has a <emphasis>mode</emphasis> that defines which NVDIMM features are enabled for that namespace. Sibling namespaces of the same parent region will always have the same type, but might be configured to have different modes. Namespace modes include: </para>
+     <para>
+      Each namespace also has a <emphasis>mode</emphasis> that defines which
+      NVDIMM features are enabled for that namespace. Sibling namespaces of the
+      same parent region will always have the same type, but might be
+      configured to have different modes. Namespace modes include:
+     </para>
      <variablelist>
       <varlistentry>
        <term>devdax</term>
        <listitem>
-        <para> Device-DAX mode. Creates a single-character device file (<filename> /dev/dax<replaceable>X</replaceable>.<replaceable>Y</replaceable>
-         </filename>). Does <emphasis>not</emphasis> require filesystem creation. Suitable to register PMEM for RDMA or for assigning it to virtual machines, or for mapping blocks too large to fit into RAM. </para>
+        <para>
+         Device-DAX mode. Creates a single-character device file (<filename>
+         /dev/dax<replaceable>X</replaceable>.<replaceable>Y</replaceable>
+         </filename>). Does <emphasis>not</emphasis> require filesystem
+         creation. Suitable to register PMEM for RDMA or for assigning it to
+         virtual machines, or for mapping blocks too large to fit into RAM.
+        </para>
        </listitem>
       </varlistentry>
       <varlistentry>
        <term>fsdax</term>
        <listitem>
-        <para> Filesystem-DAX mode. Default if no other mode is specified. Creates a block device (<filename>/dev/pmem<replaceable>X</replaceable> [.<replaceable>Y</replaceable>]</filename>) which supports DAX for <literal>ext4</literal> or <literal>XFS</literal>. </para>
+        <para>
+         Filesystem-DAX mode. Default if no other mode is specified. Creates a
+         block device (<filename>/dev/pmem<replaceable>X</replaceable>
+         [.<replaceable>Y</replaceable>]</filename>) which supports DAX for
+         <literal>ext4</literal> or <literal>XFS</literal>.
+        </para>
        </listitem>
       </varlistentry>
       <varlistentry>
        <term>sector</term>
        <listitem>
-        <para> For legacy filesystems which do not checksum metadata. Suitable for small boot volumes. Compatible with other operating systems. </para>
+        <para>
+         For legacy filesystems which do not checksum metadata. Suitable for
+         small boot volumes. Compatible with other operating systems.
+        </para>
        </listitem>
       </varlistentry>
       <varlistentry>
        <term>raw</term>
        <listitem>
-        <para> A memory disk without a label or metadata. Does not support DAX. Compatible with other operating systems. </para>
+        <para>
+         A memory disk without a label or metadata. Does not support DAX.
+         Compatible with other operating systems.
+        </para>
         <note>
          <para>
-          <literal>raw</literal> mode is not supported by &suse;. It is not possible to mount filesystems on <literal>raw</literal> namespaces. </para>
+          <literal>raw</literal> mode is not supported by &suse;. It is not
+          possible to mount filesystems on <literal>raw</literal> namespaces.
+         </para>
         </note>
        </listitem>
       </varlistentry>
@@ -90,27 +183,58 @@
    <varlistentry>
     <term>Type</term>
     <listitem>
-     <para> Each namespace and region has a <emphasis>type</emphasis> that defines the way in which the persistent memory associated with that namespace or region can be accessed. A namespace always has the same type as its parent region. There are two different types: Persistent Memory, which can be configured in two different ways, and the deprecated Block Mode. </para>
+     <para>
+      Each namespace and region has a <emphasis>type</emphasis> that defines
+      the way in which the persistent memory associated with that namespace or
+      region can be accessed. A namespace always has the same type as its
+      parent region. There are two different types: Persistent Memory, which
+      can be configured in two different ways, and the deprecated Block Mode.
+     </para>
      <variablelist>
       <varlistentry>
        <term>Persistent Memory (PMEM)</term>
        <listitem>
-        <para> PMEM storage offers byte-level access, just like RAM. Using PMEM, a single namespace can include multiple interleaved NVDIMMs, allowing them all to be used as a single device. </para>
-        <para> There are two ways to configure a PMEM namespace. </para>
+        <para>
+         PMEM storage offers byte-level access, just like RAM. Using PMEM, a
+         single namespace can include multiple interleaved NVDIMMs, allowing
+         them all to be used as a single device.
+        </para>
+        <para>
+         There are two ways to configure a PMEM namespace.
+        </para>
         <variablelist>
          <varlistentry>
           <term>PMEM with DAX</term>
           <listitem>
-           <para> A PMEM namespace configured for Direct Access (DAX) means that accessing the memory bypasses the kernel's page cache and goes direct to the medium. Software can directly read or write every byte of the namespace separately. </para>
+           <para>
+            A PMEM namespace configured for Direct Access (DAX) means that
+            accessing the memory bypasses the kernel's page cache and goes
+            direct to the medium. Software can directly read or write every
+            byte of the namespace separately.
+           </para>
           </listitem>
          </varlistentry>
          <varlistentry>
-          <term> PMEM with BTT </term>
+          <term>PMEM with BTT</term>
           <listitem>
-           <para> A PMEM namespace configured to operate in BTT mode is accessed on a sector-by-sector basis, like a conventional disk drive, rather than the more RAM-like byte-addressible model. A translation table mechanism batches accesses into sector-sized units. </para>
-           <para> The advantages of BTT are that the storage subsystem ensures that each sector is completely written to the underlying medium, and if a write fails for some reason, it will be unrolled. Thus a given sector cannot be partially written. </para>
-           <para> Additionally, access to BTT namespaces is cached by the kernel. </para>
-           <para> The drawback is that DAX is not possible to BTT namespaces. </para>
+           <para>
+            A PMEM namespace configured to operate in BTT mode is accessed on a
+            sector-by-sector basis, like a conventional disk drive, rather than
+            the more RAM-like byte-addressible model. A translation table
+            mechanism batches accesses into sector-sized units.
+           </para>
+           <para>
+            The advantages of BTT are that the storage subsystem ensures that
+            each sector is completely written to the underlying medium, and if
+            a write fails for some reason, it will be unrolled. Thus a given
+            sector cannot be partially written.
+           </para>
+           <para>
+            Additionally, access to BTT namespaces is cached by the kernel.
+           </para>
+           <para>
+            The drawback is that DAX is not possible to BTT namespaces.
+           </para>
           </listitem>
          </varlistentry>
         </variablelist>
@@ -119,149 +243,248 @@
       <varlistentry>
        <term>Block Mode (BLK)</term>
        <listitem>
-        <para> Block mode storage addresses each NVDIMM as a separate device. Its use is deprecated and no longer supported. </para>
+        <para>
+         Block mode storage addresses each NVDIMM as a separate device. Its use
+         is deprecated and no longer supported.
+        </para>
        </listitem>
       </varlistentry>
      </variablelist>
-     <para> Apart from <literal>devdax</literal> namespaces, all other types must be formatted with a filesystem, just as with a conventional drive. &productname; supports the <literal>ext2</literal>, <literal>ext4</literal> and <literal>XFS</literal> filesystems for this. </para>
+     <para>
+      Apart from <literal>devdax</literal> namespaces, all other types must be
+      formatted with a filesystem, just as with a conventional drive.
+      &productname; supports the <literal>ext2</literal>,
+      <literal>ext4</literal> and <literal>XFS</literal> filesystems for this.
+     </para>
      <note>
       <para>
-       &suse; does not support the <literal>ext2</literal> filesystem for use with DAX. </para>
+       &suse; does not support the <literal>ext2</literal> filesystem for use
+       with DAX.
+      </para>
      </note>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>Direct Access (DAX)</term>
     <listitem>
-     <para> Directly <literal>mmap()</literal> NV-RAM into a process' address space. </para>
+     <para>
+      Directly <literal>mmap()</literal> NV-RAM into a process' address space.
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>DIMM Physical Address (DPA)</term>
     <listitem>
-     <para> A memory address as an offset into a single DIMM's memory; that is, starting from zero as the lowest addressable byte on that DIMM. </para>
+     <para>
+      A memory address as an offset into a single DIMM's memory; that is,
+      starting from zero as the lowest addressable byte on that DIMM.
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>Label</term>
     <listitem>
-     <para> Metadata stored on the NVDIMM, such as namespace definitions. This can be accessed using DSMs. </para>
+     <para>
+      Metadata stored on the NVDIMM, such as namespace definitions. This can be
+      accessed using DSMs.
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>Device-specific method (DSM)</term>
     <listitem>
-     <para> ACPI method to access the firmware on an NVDIMM. </para>
+     <para>
+      ACPI method to access the firmware on an NVDIMM.
+     </para>
     </listitem>
    </varlistentry>
   </variablelist>
  </sect1>
  <sect1 xml:id="sec.nvdimm.uses">
   <title>Use Cases</title>
+
   <sect2 xml:id="sec.nvdimm.uses.pmem">
    <title>PMEM with DAX</title>
-   <para> It is important to note that this form of memory access is <emphasis>not</emphasis> transactional. In the event of a power outage or other system failure, data may not be completely written into storage. PMEM storage is only suitable if the application can handle the situation of partially-written data. </para>
+   <para>
+    It is important to note that this form of memory access is
+    <emphasis>not</emphasis> transactional. In the event of a power outage or
+    other system failure, data may not be completely written into storage. PMEM
+    storage is only suitable if the application can handle the situation of
+    partially-written data.
+   </para>
    <sect3>
-    <title> Applications which benefit from large amounts of byte-addressable storage. </title>
-    <para> In cases where the server will be hosting an application that can directly access large amounts of storage on a byte-by-byte basis, by <literal>mmap</literal>ing the storage directly into the application's address space. </para>
+    <title>Applications which benefit from large amounts of byte-addressable storage.</title>
+    <para>
+     In cases where the server will be hosting an application that can directly
+     access large amounts of storage on a byte-by-byte basis, by
+     <literal>mmap</literal>ing the storage directly into the application's
+     address space.
+    </para>
    </sect3>
    <sect3>
     <title>Avoiding use of the kernel page cache.</title>
-    <para> If you wish to conserve the use of RAM for the page cache, and instead give it to your applications. For instance, non-volatile memory could be dedicated to holding virtual machine (VM) images. As these would not be cached, this would reduce the cache usage on the host, allowing more VMs per host. </para>
+    <para>
+     If you wish to conserve the use of RAM for the page cache, and instead
+     give it to your applications. For instance, non-volatile memory could be
+     dedicated to holding virtual machine (VM) images. As these would not be
+     cached, this would reduce the cache usage on the host, allowing more VMs
+     per host.
+    </para>
    </sect3>
   </sect2>
+
   <sect2>
    <title>PMEM with BTT</title>
-   <para> This is most useful when you just want to use NVDIMMs as very fast storage. </para>
-   <para> To applications, such devices just appear as very fast SSDs and can be used like any other storage device - for example, LVM can be layered on top of the non-volatile storage and will work as normal. </para>
-   <para> The advantage of BTT is that sector write atomicity is guaranteed, so even sophisticated applications which depend on data integrity will keep working. Media error reporting works through standard error-reporting channels. </para>
+   <para>
+    This is most useful when you just want to use NVDIMMs as very fast storage.
+   </para>
+   <para>
+    To applications, such devices just appear as very fast SSDs and can be used
+    like any other storage device - for example, LVM can be layered on top of
+    the non-volatile storage and will work as normal.
+   </para>
+   <para>
+    The advantage of BTT is that sector write atomicity is guaranteed, so even
+    sophisticated applications which depend on data integrity will keep
+    working. Media error reporting works through standard error-reporting
+    channels.
+   </para>
   </sect2>
  </sect1>
  <sect1 xml:id="sec.nvdimm.tools">
   <title>Tools for Managing NVDIMM Storage</title>
-  <para> To manage NVDIMM storage, it is necessary to install the <literal>ndctl</literal> package. This also installs the <filename>libndctl</filename> package which provides a set of user-space libraries to configure NVDIMMs. These tools work via the <filename>libnvdimm</filename> library, which supports multiple types of NVDIMMs. </para>
-  <para> The <command>ndctl</command> utility has a helpful set of <command>man</command> pages, accessible with the command: </para>
-  <screen><command>ndctl help <replaceable>subcommand</replaceable></command></screen>
-  <para> To see a list of available subcommands, use: </para>
-  <screen><command>ndctl --list-cmds</command></screen>
-  <para> The available subcommands include: </para>
+
+  <para>
+   To manage NVDIMM storage, it is necessary to install the
+   <literal>ndctl</literal> package. This also installs the
+   <filename>libndctl</filename> package which provides a set of user-space
+   libraries to configure NVDIMMs. These tools work via the
+   <filename>libnvdimm</filename> library, which supports multiple types of
+   NVDIMMs.
+  </para>
+
+  <para>
+   The <command>ndctl</command> utility has a helpful set of
+   <command>man</command> pages, accessible with the command:
+  </para>
+
+<screen><command>ndctl help <replaceable>subcommand</replaceable></command></screen>
+
+  <para>
+   To see a list of available subcommands, use:
+  </para>
+
+<screen><command>ndctl --list-cmds</command></screen>
+
+  <para>
+   The available subcommands include:
+  </para>
+
   <variablelist>
    <varlistentry>
     <term>version</term>
     <listitem>
-     <para> Displays the current version of the NVDIMM support tools. </para>
+     <para>
+      Displays the current version of the NVDIMM support tools.
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>enable-namespace</term>
     <listitem>
-     <para> Makes the specified namespace available for use. </para>
+     <para>
+      Makes the specified namespace available for use.
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>disable-namespace</term>
     <listitem>
-     <para> Prevents the specified namespace from being used. </para>
+     <para>
+      Prevents the specified namespace from being used.
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>create-namespace</term>
     <listitem>
-     <para> Creates a new namespace from the specified storage devices. </para>
+     <para>
+      Creates a new namespace from the specified storage devices.
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>destroy-namespace</term>
     <listitem>
-     <para> Removes the specified namespace. </para>
+     <para>
+      Removes the specified namespace.
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>enable-region</term>
     <listitem>
-     <para> Makes the specified region available for use. </para>
+     <para>
+      Makes the specified region available for use.
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>disable-region</term>
     <listitem>
-     <para> Prevents the specified region from being used. </para>
+     <para>
+      Prevents the specified region from being used.
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>zero-labels</term>
     <listitem>
-     <para> Erases the metadata from a device. </para>
+     <para>
+      Erases the metadata from a device.
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>read-labels</term>
     <listitem>
-     <para> Retrieves the metadata of the specified device. </para>
+     <para>
+      Retrieves the metadata of the specified device.
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>list</term>
     <listitem>
-     <para> Displays available devices. </para>
+     <para>
+      Displays available devices.
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>help</term>
     <listitem>
-     <para> Displays information about using the tool. </para>
+     <para>
+      Displays information about using the tool.
+     </para>
     </listitem>
    </varlistentry>
   </variablelist>
  </sect1>
  <sect1 xml:id="sec.nvdimm.setup">
   <title>Setting Up NVDIMM Storage</title>
+
   <sect2 xml:id="sec.nvdimm.setup.view">
    <title>Viewing Available NVDIMM Storage</title>
-   <para> The <command>ndctl</command>
-    <literal>list</literal> command can be used to list all available NVDIMMs in a system. </para>
-   <para> In the following example, the system has three NVDIMMs which are in a single, triple-channel interleaved set. </para>
-   <screen>&prompt.root;<command>ndctl list --dimms</command>
+   <para>
+    The <command>ndctl</command> <literal>list</literal> command can be used to
+    list all available NVDIMMs in a system.
+   </para>
+   <para>
+    In the following example, the system has three NVDIMMs which are in a
+    single, triple-channel interleaved set.
+   </para>
+<screen>&prompt.root;<command>ndctl list --dimms</command>
 
 [
  {
@@ -277,13 +500,20 @@
   "id":"8089-00-0000-10325476"
  }
 ]</screen>
-   <para> With a different parameter, <command>ndctl</command>
-    <literal>list</literal> will also list the available regions. </para>
+   <para>
+    With a different parameter, <command>ndctl</command>
+    <literal>list</literal> will also list the available regions.
+   </para>
    <note>
-    <para> Regions may not appear in numerical order. </para>
+    <para>
+     Regions may not appear in numerical order.
+    </para>
    </note>
-   <para> Note that although there are only three NVDIMMs, they appear as four regions. </para>
-   <screen>&prompt.root;<command>ndctl list --regions</command>
+   <para>
+    Note that although there are only three NVDIMMs, they appear as four
+    regions.
+   </para>
+<screen>&prompt.root;<command>ndctl list --regions</command>
 
 [
  {
@@ -312,14 +542,28 @@
    "type":"blk"
   }
 ]</screen>
-   <para> The space is available in two different forms: either as three separate 64 GB regions of type BLK, or as one combined 189 GB region of type PMEM which presents all the space on the three interleaved NVDIMMs as a single volume. </para>
-   <para> Note that the displayed value for <literal>available_size</literal> is the same as that for <literal>size</literal>. This means that none of the space has been allocated yet. </para>
+   <para>
+    The space is available in two different forms: either as three separate 64
+    GB regions of type BLK, or as one combined 189 GB region of type PMEM which
+    presents all the space on the three interleaved NVDIMMs as a single volume.
+   </para>
+   <para>
+    Note that the displayed value for <literal>available_size</literal> is the
+    same as that for <literal>size</literal>. This means that none of the space
+    has been allocated yet.
+   </para>
   </sect2>
+
   <sect2 xml:id="sec.nvdimm.setup.dax">
-   <title>Configuring the Storage as a Single PMEM Namespace with DAX</title>
-   <para> For the first example, we will configure our three NVDIMMs into a single PMEM namespace with Direct Access (DAX). </para>
-   <para> The first step is to create a new namespace. </para>
-   <screen>&prompt.root;<command>ndctl create-namespace --type=<replaceable>pmem</replaceable> --mode=<replaceable>memory</replaceable></command>
+   <title>Configuring the Storage as a PMEM Namespace with DAX</title>
+   <para>
+    For the first example, we will configure our three NVDIMMs into a single
+    PMEM namespace with Direct Access (DAX).
+   </para>
+   <para>
+    The first step is to create a new namespace.
+   </para>
+<screen>&prompt.root;<command>ndctl create-namespace --type=<replaceable>pmem</replaceable> --mode=<replaceable>fsdax</replaceable> --map=<replaceable>memory</replaceable></command>
 {
  "dev":"namespace3.0",
  "mode":"memory",
@@ -327,17 +571,37 @@
  "uuid":"dc8ebb84-c564-4248-9e8d-e18543c39b69",
  "blockdev":"pmem3"
 }</screen>
-   <para> This creates a block device <filename>/dev/pmem3</filename>, which supports DAX. The <literal>3</literal> in the device name is inherited from the parent region number, in this case <filename>region3</filename>. </para>
-   <para> The <option>--mode=memory</option> option sets aside part of the PMEM storage space on the NVDIMMs so that it can be used to allocate internal kernel data structures called <literal>struct pages</literal>. This allows the new PMEM namespace to be used with features such as <literal>O_DIRECT I/O</literal> and <literal>RDMA</literal>. </para>
-   <para> The reservation of some persistent memory for kernel data structures is why the resulting PMEM namespace has a smaller capacity than the parent PMEM Region. </para>
-   <para> Next, we verify that the new block device is available to the operating system: </para>
-   <screen>&prompt.root;<command>fdisk -l /dev/<replaceable>pmem3</replaceable></command>
+   <para>
+    This creates a block device <filename>/dev/pmem3</filename>, which supports
+    DAX. The <literal>3</literal> in the device name is inherited from the
+    parent region number, in this case <filename>region3</filename>.
+   </para>
+   <para>
+    The <option>--map=memory</option> option sets aside part of the PMEM
+    storage space on the NVDIMMs so that it can be used to allocate internal
+    kernel data structures called <literal>struct pages</literal>. This allows
+    the new PMEM namespace to be used with features such as <literal>O_DIRECT
+    I/O</literal> and <literal>RDMA</literal>.
+   </para>
+   <para>
+    The reservation of some persistent memory for kernel data structures is why
+    the resulting PMEM namespace has a smaller capacity than the parent PMEM
+    Region.
+   </para>
+   <para>
+    Next, we verify that the new block device is available to the operating
+    system:
+   </para>
+<screen>&prompt.root;<command>fdisk -l /dev/<replaceable>pmem3</replaceable></command>
 Disk /dev/pmem3: 186 GiB, 199764213760 bytes, 390164480 sectors
 Units: sectors of 1 * 512 = 512 bytes
 Sector size (logical/physical): 512 bytes / 4096 bytes
 I/O size (minimum/optimal): 4096 bytes / 4096 bytes</screen>
-   <para> Before it can be used, like any other drive, it must be formatted. In this example, we format it with XFS: </para>
-   <screen>&prompt.root;<command>mkfs.xfs /dev/<replaceable>pmem3</replaceable></command>
+   <para>
+    Before it can be used, like any other drive, it must be formatted. In this
+    example, we format it with XFS:
+   </para>
+<screen>&prompt.root;<command>mkfs.xfs /dev/<replaceable>pmem3</replaceable></command>
 meta-data=/dev/pmem3      isize=256    agcount=4, agsize=12192640 blks
          =                sectsz=4096  attr=2, projid32bit=1
          =                crc=0        finobt=0, sparse=0
@@ -347,31 +611,60 @@ naming   =version 2       bsize=4096   ascii-ci=0 ftype=1
 log      =internal log    bsize=4096   blocks=23813, version=2
          =                sectsz=4096  sunit=1 blks, lazy-count=1
 realtime =none            extsz=4096   blocks=0, rtextents=0</screen>
-   <para> Next, we can mount the new drive onto a directory: </para>
-   <screen>&prompt.root;<command>mount -o dax /dev/<replaceable>pmem3</replaceable> /mnt/<replaceable>pmem3</replaceable></command></screen>
-   <para> Then we can verify that we now have a DAX-capable device: </para>
-   <screen>&prompt.root;<command>mount | grep dax</command>
+   <para>
+    Next, we can mount the new drive onto a directory:
+   </para>
+<screen>&prompt.root;<command>mount -o dax /dev/<replaceable>pmem3</replaceable> /mnt/<replaceable>pmem3</replaceable></command></screen>
+   <para>
+    Then we can verify that we now have a DAX-capable device:
+   </para>
+<screen>&prompt.root;<command>mount | grep dax</command>
 /dev/pmem3 on /mnt/pmem3 type xfs (rw,relatime,attr2,dax,inode64,noquota)</screen>
-   <para> The result is that we now have a PMEM namespace formatted with the XFS file system and mounted with DAX. </para>
-   <para> Any <literal>mmap()</literal> calls to files in that file system will return virtual addresses that directly map to the persistent memory on our NVDIMMs, completely bypassing the page cache. </para>
-   <para> Any <literal>fsync</literal> or <literal>msync</literal> calls on files in that file system will still ensure that modified data has been fully written to the NVDIMMs. These calls flush the processor cache lines associated with any pages that have been modified in userspace via <literal>mmap</literal> mappings. </para>
+   <para>
+    The result is that we now have a PMEM namespace formatted with the XFS file
+    system and mounted with DAX.
+   </para>
+   <para>
+    Any <literal>mmap()</literal> calls to files in that file system will
+    return virtual addresses that directly map to the persistent memory on our
+    NVDIMMs, completely bypassing the page cache.
+   </para>
+   <para>
+    Any <literal>fsync</literal> or <literal>msync</literal> calls on files in
+    that file system will still ensure that modified data has been fully
+    written to the NVDIMMs. These calls flush the processor cache lines
+    associated with any pages that have been modified in userspace via
+    <literal>mmap</literal> mappings.
+   </para>
    <sect3 xml:id="sec.nvdimm.setup.deldax">
     <title>Removing a Namespace</title>
-    <para> Before creating any other type of volume that uses the same storage, we must unmount and then remove this PMEM volume. </para>
-    <para> First, unmount it: </para>
-    <screen>&prompt.root;<command>umount /mnt/<replaceable>pmem3</replaceable></command></screen>
-    <para> Then disable the namespace: </para>
-    <screen>&prompt.root;<command>ndctl disable-namespace <replaceable>namespace3.0</replaceable></command>
+    <para>
+     Before creating any other type of volume that uses the same storage, we
+     must unmount and then remove this PMEM volume.
+    </para>
+    <para>
+     First, unmount it:
+    </para>
+<screen>&prompt.root;<command>umount /mnt/<replaceable>pmem3</replaceable></command></screen>
+    <para>
+     Then disable the namespace:
+    </para>
+<screen>&prompt.root;<command>ndctl disable-namespace <replaceable>namespace3.0</replaceable></command>
 disabled 1 namespace</screen>
-    <para> Then delete it: </para>
-    <screen>&prompt.root;<command>ndctl destroy-namespace <replaceable>namespace3.0</replaceable></command>
+    <para>
+     Then delete it:
+    </para>
+<screen>&prompt.root;<command>ndctl destroy-namespace <replaceable>namespace3.0</replaceable></command>
 destroyed 1 namespace</screen>
    </sect3>
   </sect2>
+
   <sect2 xml:id="sec.nvdimm.setup.btt">
    <title>Creating a PMEM Namespace with BTT</title>
-   <para> In the next example, we create a PMEM namespace that uses BTT. </para>
-   <screen>&prompt.root;<command>ndctl create-namespace --type=<replaceable>pmem</replaceable> --mode=<replaceable>sector</replaceable></command>
+   <para>
+    In the next example, we create a PMEM namespace that uses BTT.
+   </para>
+<screen>&prompt.root;<command>ndctl create-namespace --type=<replaceable>pmem</replaceable> --mode=<replaceable>sector</replaceable></command>
 {
  "dev":"namespace3.0",
  "mode":"sector",
@@ -379,63 +672,103 @@ destroyed 1 namespace</screen>
  "sector_size":4096,
  "blockdev":"pmem3s"
 }</screen>
-   <para> Next, verify that the new device is present: </para>
-   <screen>&prompt.root;<command>fdisk -l /dev/<replaceable>pmem3s</replaceable></command>
+   <para>
+    Next, verify that the new device is present:
+   </para>
+<screen>&prompt.root;<command>fdisk -l /dev/<replaceable>pmem3s</replaceable></command>
 Disk /dev/pmem3s: 188.8 GiB, 202738135040 bytes, 49496615 sectors
 Units: sectors of 1 * 4096 = 4096 bytes
 Sector size (logical/physical): 4096 bytes / 4096 bytes
 I/O size (minimum/optimal): 4096 bytes / 4096 bytes</screen>
-   <para> Like the DAX-capable PMEM namespace we previously configured, this BTT-capable PMEM namespace consumes all the available storage on the NVDIMMs. </para>
+   <para>
+    Like the DAX-capable PMEM namespace we previously configured, this
+    BTT-capable PMEM namespace consumes all the available storage on the
+    NVDIMMs.
+   </para>
    <note>
-    <para> The trailing <literal>s</literal> in the device name (<filename>/dev/<replaceable>pmem3s</replaceable></filename>) stands for <literal>sector</literal> and can be used to easily distinguish PMEM and BLK namespaces that are configured to use the BTT. </para>
+    <para>
+     The trailing <literal>s</literal> in the device name
+     (<filename>/dev/<replaceable>pmem3s</replaceable></filename>) stands for
+     <literal>sector</literal> and can be used to easily distinguish namespaces
+     that are configured to use the BTT.
+    </para>
    </note>
-   <para> The volume can be formatted and mounted as in the previous example. </para>
-   <para> The PMEM namespace shown here cannot use DAX. Instead it uses the BTT to provide <emphasis>sector write atomicity</emphasis>. On each sector write through the PMEM block driver, the BTT will allocate a new sector to receive the new data. The BTT atomically updates its internal mapping structures after the new data is fully written so the newly written data will be available to applications. If the power fails at any point during this process, the write will be completely lost and the application will have access to its old data, still intact. This prevents the condition known as "torn sectors". </para>
-   <para> This BTT-enabled PMEM namespace can be formatted and used with a filesystem just like any other standard block device. It cannot be used with DAX. However, <literal>mmap</literal> mappings for files on this block device will use the page cache. </para>
-   <note>
-    <para> In both these examples, space from all the NVDIMMs is combined into a single volume. Just as with a non-redundant disk array, this means that if any individual NVDIMM suffers an error, the contents of the entire volume could be lost. The more NVDIMMs are included in the volume, the higher the chance of such an error. </para>
-   </note>
-   <sect3 xml:id="sec.nvdimm.setup.delbtt">
-    <title>Removing the PMEM Volume</title>
-    <para> As in the previous example, before re-allocating the space, we must first remove the volume and the namespace: </para>
-    <screen>&prompt.root;<command>ndctl disable-namespace <replaceable>namespace3.0</replaceable></command>
-disabled 1 namespace
+   <para>
+    The volume can be formatted and mounted as in the previous example.
+   </para>
+   <para>
+    The PMEM namespace shown here cannot use DAX. Instead it uses the BTT to
+    provide <emphasis>sector write atomicity</emphasis>. On each sector write
+    through the PMEM block driver, the BTT will allocate a new sector to
+    receive the new data. The BTT atomically updates its internal mapping
+    structures after the new data is fully written so the newly written data
+    will be available to applications. If the power fails at any point during
+    this process, the write will be completely lost and the application will
+    have access to its old data, still intact. This prevents the condition
+    known as "torn sectors".
+   </para>
+   <para>
+    This BTT-enabled PMEM namespace can be formatted and used with a filesystem
+    just like any other standard block device. It cannot be used with DAX.
+    However, <literal>mmap</literal> mappings for files on this block device
+    will use the page cache.
+   </para>
 
-&prompt.root;<command>ndctl destroy-namespace <replaceable>namespace3.0</replaceable></command>
-destroyed 1 namespace</screen>
-   </sect3>
   </sect2>
  </sect1>
  <sect1 xml:id="sec.nvdimm.moreinfo">
   <title>For More Information</title>
-  <para> More about this topic can be found in the following list: </para>
+
+  <para>
+   More about this topic can be found in the following list:
+  </para>
+
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     <link xlink:href="https://nvdimm.wiki.kernel.org/"
-      >Persistent Memory Wiki</link>
+     <link xlink:href="https://nvdimm.wiki.kernel.org/">
+      Persistent Memory Wiki</link>
     </para>
-    <para> Contains instructions for configuring NVDIMM systems, information about testing, and links to specifications related to NVDIMM enabling. This site is developing as NVDIMM support in Linux is developing. </para>
+    <para>
+     Contains instructions for configuring NVDIMM systems, information about
+     testing, and links to specifications related to NVDIMM enabling. This site
+     is developing as NVDIMM support in Linux is developing.
+    </para>
    </listitem>
    <listitem>
     <para>
      <link xlink:href="http://pmem.io/">Persistent Memory Programming</link>
     </para>
-    <para> Information about configuring, using and programming systems with non-volatile memory, under Linux and other operating systems. Covers the NVM Library (NVML), which aims to provide useful APIs for programming with persistent memory in userspace. </para>
+    <para>
+     Information about configuring, using and programming systems with
+     non-volatile memory, under Linux and other operating systems. Covers the
+     NVM Library (NVML), which aims to provide useful APIs for programming with
+     persistent memory in userspace.
+    </para>
    </listitem>
    <listitem>
     <para>
-     <link
-      xlink:href="https://www.kernel.org/doc/Documentation/nvdimm/nvdimm.txt"
-      > LIBNVDIMM: Non-Volatile Devices</link>
+     <link xlink:href="https://www.kernel.org/doc/Documentation/nvdimm/nvdimm.txt">
+      LIBNVDIMM: Non-Volatile Devices</link>
     </para>
-    <para> Aimed at kernel developers, this is part of the Documentation folder in the current Linux kernel tree. It talks about the different kernel modules involved in NVDIMM enablement, lays out some technical details of the kernel implementation, and talks about the <filename>sysfs</filename>interface to the kernel that is used by the <command>ndctl</command> tool. </para>
+    <para>
+     Aimed at kernel developers, this is part of the Documentation folder in
+     the current Linux kernel tree. It talks about the different kernel modules
+     involved in NVDIMM enablement, lays out some technical details of the
+     kernel implementation, and talks about the
+     <filename>sysfs</filename>interface to the kernel that is used by the
+     <command>ndctl</command> tool.
+    </para>
    </listitem>
    <listitem>
     <para>
      <link xlink:href="https://github.com/pmem/ndctl">GitHub: pmem/ndctl</link>
     </para>
-    <para> Utility library for managing the <command>libnvdimm</command> sub-system in the Linux kernel. Also contains userspace libraries, as well as unit tests and documentation. </para>
+    <para>
+     Utility library for managing the <command>libnvdimm</command> sub-system
+     in the Linux kernel. Also contains userspace libraries, as well as unit
+     tests and documentation.
+    </para>
    </listitem>
   </itemizedlist>
  </sect1>

--- a/xml/hardware_nvdimm.xml
+++ b/xml/hardware_nvdimm.xml
@@ -270,8 +270,8 @@
     <term>Direct Access (DAX)</term>
     <listitem>
      <para>
-      Directly <literal>mmap()</literal> persistent memory into a process'
-      address space.
+      DAX allows persistent memory to be directly mapped into a process' address
+      space, for example using the <literal>mmap</literal> system call.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
### Description
Copying the new NVDIMM section of the SLE12 SP4 Admin guide into the SLE15 docs. Drops examples using BLK format storage as this is deprecated.

### Checks
Check items that apply.

- [ ] Minor edit (does not required Doc Update)
- [ ] Doc Update section has been added in separate commit
- [ ] Backport required for maintenance/SLE12
- [ ] Backport required for maintenance/SLE12SP1
- [ ] Backport required for maintenance/SLE12SP2
- [ ] Backport required for maintenance/SLE12SP3
- [ ] Backport required for maintenance/SLE12SP4
