### PR TITLE
group tag needs to be of type list

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -10273,8 +10273,8 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
 
     <example>
      <title>Group Configuration</title>
-     <screen>&lt;groups&gt;
-  &lt;group config:type="list"&gt;
+     <screen>&lt;groups config:type="list"&gt;
+  &lt;group&gt;
     &lt;gid&gt;100&lt;gid&gt;
     &lt;groupname&gt;users&lt;/groupname&gt;
     &lt;userlist&gt;bob,alice&lt;/userlist&gt;

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -10274,7 +10274,7 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
     <example>
      <title>Group Configuration</title>
      <screen>&lt;groups&gt;
-  &lt;group&gt;
+  &lt;group config:type="list"&gt;
     &lt;gid&gt;100&lt;gid&gt;
     &lt;groupname&gt;users&lt;/groupname&gt;
     &lt;userlist&gt;bob,alice&lt;/userlist&gt;


### PR DESCRIPTION
    File Name: ay_bigfile.xml
    ID: Configuration.Security.groups
XML Example didn't create groups.

### Description
Example 4.47: Group Configuration the group tag needs to be of type list. 
Otherwise no groups are created.

### Checks
Check all items that apply.

- [ ] Minor edit (does not require Doc Update)
- [ ] Doc Update section has been added in separate commits
- [x] Backport to maintenance/SLE12SP3 required
- [x] Backport to maintenance/SLE12SP4 required
