### PR TITLE
portus: expanded the section on Portus

### DIFF
--- a/xml/docker_docupdates.xml
+++ b/xml/docker_docupdates.xml
@@ -26,6 +26,25 @@
  <sect1 xml:id="sec.docker.docupdates.sle15.sp0">
   <title>&productname; 15 SP0</title>
    <para></para>
+
+   <sect2 xml:id="sec.docker.docupdates.sle15.sp0.sep_2019">
+    <title>January 2019</title>
+    <variablelist>
+     <varlistentry>
+      <term>Bugfixes</term>
+      <listitem>
+       <itemizedlist>
+        <listitem>
+         <para>
+          Improved information on Portus image in <xref
+          linkend="sec.docker.portus"/> (<link xlink:href="&bsc;1109636"/>).
+         </para>
+        </listitem>
+       </itemizedlist>
+      </listitem>
+     </varlistentry>
+    </variablelist>
+   </sect2>
    <sect2 xml:id="sec.docker.docupdates.sle15.sp0.sep_2018">
     <title>September 2018</title>
     <variablelist>
@@ -35,7 +54,7 @@
        <itemizedlist>
         <listitem>
          <para>
-          Fixed version number for the container module <xref
+          Fixed version number for the container module in <xref
           linkend="docker_daemons"/> (<link xlink:href="&bsc;1105498"/>).
          </para>
         </listitem>

--- a/xml/docker_registry.xml
+++ b/xml/docker_registry.xml
@@ -180,11 +180,19 @@
   </para>
 
   <para>
-   Portus is accessible for &slsa; customers as a &docker; image.
+   Portus is accessible for &slsa; customers as a &docker; image. This image can
+   be pulled from the &suse; Container Registry, and customers should use this
+   instead of the community version that can be found on the Docker hub. So, for
+   example, if you want to pull the <literal>2.4.0</literal> tag, you can
+   perform the following command:
   </para>
 
+  <screen>&prompt.user;<command>docker pull registry.suse.com/sles12/portus:2.4.0</command></screen>
+
   <para>
-   For more information and documentation about Portus, see:
+   The image that &slsa; customers will use has the exact same code as the one
+   from the community. Therefore, in order to set it up you may follow the same
+   instructions as explained here:
    <link xlink:href="http://port.us.org/docs/deploy.html"/>.
   </para>
  </sect1>

--- a/xml/docker_registry.xml
+++ b/xml/docker_registry.xml
@@ -180,20 +180,22 @@
   </para>
 
   <para>
-   Portus is accessible for &slsa; customers as a &docker; image. This image can
-   be pulled from the &suse; Container Registry, and customers should use this
-   instead of the community version that can be found on the Docker hub. So, for
-   example, if you want to pull the <literal>2.4.0</literal> tag, you can
-   perform the following command:
+   Portus is available for &slsa; customers as a &docker; image from
+   &suse; Container Registry. For example, to pull the
+   <literal>2.4.0</literal> tag, run the following command:
   </para>
 
   <screen>&prompt.user;<command>docker pull registry.suse.com/sles12/portus:2.4.0</command></screen>
 
   <para>
-   The image that &slsa; customers will use has the exact same code as the one
-   from the community. Therefore, in order to set it up you may follow the same
-   instructions as explained here:
-   <link xlink:href="http://port.us.org/docs/deploy.html"/>.
+   In addition to the official version of the Portus image from
+   &suse; Container Registry, there is a community version that can be found
+   on &dhub;. However, as a &slsa; customer, we strongly suggest you use the
+   official Portus image instead.
+   The Portus image for &slsa; customers has the same code as the one
+   from the community. Therefore, the setup instructions from 
+   <link xlink:href="http://port.us.org/docs/deploy.html"/>
+   apply for both images.
   </para>
  </sect1>
 </chapter>


### PR DESCRIPTION
### Description

In particular, I've added a couple of lines that should address some of
the confusions that our customers have reported.

Fixes SUSE/doc-caasp#115
Bugzilla entry: https://bugzilla.suse.com/show_bug.cgi?id=1109636

### Checks
* Check all items that apply.

*Is a Doc Update section necessary and has it been created?*

- [ ] Minor edit without associated FATE/Bugzilla: no Doc Update required
- [x] All other edits: Doc Update section has been added, in a separate commit

*Are backports required?*

- [x] To maintenance/SLE12SP3
- [x] To maintenance/SLE12SP4
