### PR TITLE
Fix AutoYaST firewalld full example

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -13889,10 +13889,10 @@ exit 0
   &lt;enable_firewall&gt;true&lt;/enable_firewall&gt;
   &lt;log_denied_packets&gt;all&lt;/log_denied_packets&gt;
   &lt;default_zone&gt;external&lt;/default_zone&gt;
-  &lt;zones&gt;
+  &lt;zones config:type="list"&gt;
     &lt;zone&gt;
       &lt;name&gt;public&lt;/name&gt;
-      &lt;interfaces&gt;
+      &lt;interfaces config:type="list"&gt;
         &lt;interface&gt;eth0&lt;/interface&gt;
       &lt;/interfaces&gt;
       &lt;services config:type="list"&gt;
@@ -13912,7 +13912,7 @@ exit 0
     &lt;/zone&gt;
     &lt;zone&gt;
       &lt;name&gt;dmz&lt;/name&gt;
-      &lt;interfaces&gt;
+      &lt;interfaces config:type="list"&gt;
         &lt;interface&gt;eth1&lt;/interface&gt;
       &lt;/interfaces&gt;
     &lt;/zone&gt;


### PR DESCRIPTION
The firewalld full example is wrong. `<zones>` and `<interfaces>` should be marked as lists.

* Check all items that apply.

*Is a Doc Update section necessary and has it been created?*

- [ ] Minor edit without associated FATE/Bugzilla: no Doc Update required
- [ ] All other edits: Doc Update section has been added, in a separate commit

*Are backports required?*

- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP4