### PR TITLE
vt doc: Add SLES12 SP4 and SLES15 as supported guests

### DIFF
--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -184,6 +184,40 @@
      <row>
       <entry>
        <para>
+        &slsa; 12 SP4
+       </para>
+      </entry>
+      <entry>
+       <para>
+        Full
+       </para>
+      </entry>
+      <entry>
+       <para>
+        Full
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
+        &slsa; 15
+       </para>
+      </entry>
+      <entry>
+       <para>
+        Full
+       </para>
+      </entry>
+      <entry>
+       <para>
+        Full
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
         &sleda; 12 SP2
        </para>
       </entry>


### PR DESCRIPTION
Section "7.1 Supported VM Guests " is missing recently released
distros.

### Description
Add recently released distros to the list of supported guests in Virtualization Guide.

### Checks
* Check all items that apply.

*Is a Doc Update section necessary and has it been created?*

- [ x] Minor edit without associated FATE/Bugzilla: no Doc Update required
- [ ] All other edits: Doc Update section has been added, in a separate commit

*Are backports required?*

- [ x] To maintenance/SLE12SP3
- [x] To maintenance/SLE12SP4
- [ x] To maintenance/SLE15SP0
