### PR TITLE
As in SLE12SP4, move slash from beginning to end of <self_update> clo…

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,3 +14,4 @@ If there are relevant Bugzilla or FATE entries, reference them.
 
 - [ ] To maintenance/SLE12SP3
 - [ ] To maintenance/SLE12SP4
+- [ ] To maintenance/SLE15SP0

--- a/DC-SLED-all
+++ b/DC-SLED-all
@@ -9,7 +9,6 @@ MAIN="MAIN.SLEDS.xml"
 ## Profiling
 PROFOS="sled"
 PROFARCH="x86_64;zseries;power"
-PROFCONDITION="kvm4x86"
 
 ## Provo
 HTMLROOT="sled12"

--- a/DC-SLES-all
+++ b/DC-SLES-all
@@ -9,7 +9,6 @@ MAIN="MAIN.SLEDS.xml"
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
-PROFCONDITION="kvm4x86"
 
 ## Provo
 HTMLROOT="sles12"

--- a/DC-SLES-dockerquick
+++ b/DC-SLES-dockerquick
@@ -10,7 +10,6 @@ ROOTID="book.sles.docker"
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
-PROFCONDITION="kvm4x86"
 
 ## Provo
 HTMLROOT="sles12"

--- a/DC-SLES-virtualization
+++ b/DC-SLES-virtualization
@@ -10,7 +10,6 @@ ROOTID="book.virt"
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
-PROFCONDITION="kvm4x86"
 
 ## Provo
 HTMLROOT="sles12"

--- a/DC-opensuse-virtualization
+++ b/DC-opensuse-virtualization
@@ -10,7 +10,6 @@ ROOTID="book.virt"
 ## Profiling
 PROFOS="osuse"
 PROFARCH="x86_64"
-PROFCONDITION="kvm4x86"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/opensuse2013-ns"

--- a/xml/MAIN.SLEDS.xml
+++ b/xml/MAIN.SLEDS.xml
@@ -44,7 +44,7 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
-          <dm:product>SUSE Linux Enterprise Server 15</dm:product>
+          <dm:product>Beta SUSE Linux Enterprise Server 15 SP1</dm:product>
           <dm:assignee>fs@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
@@ -59,7 +59,7 @@
       <dm:bugtracker>
         <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
         <dm:component>Documentation</dm:component>
-        <dm:product>SUSE Linux Enterprise Desktop 15</dm:product>
+        <dm:product>Beta SUSE Linux Enterprise Desktop 15 SP1</dm:product>
         <dm:assignee>fs@suse.com</dm:assignee>
       </dm:bugtracker>
     </dm:docmanager>

--- a/xml/art_sle_modules_quick.xml
+++ b/xml/art_sle_modules_quick.xml
@@ -975,8 +975,8 @@
    </varlistentry>
   </variablelist>
   <para>
-   The following shows a few examples on how to use <command>zypper
-   search-packages</command>.
+   Below are a few examples on how to use <command>zypper
+    search-packages</command>.
   </para>
   <example xml:id="ex.modules.find.simple">
    <title>Simple Search</title>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2371,7 +2371,7 @@ openssl x509 -noout -fingerprint -sha256
        <row>
         <entry>
          <para>
-          <literal>xen-append</literal>
+          <literal>xen_append</literal>
          </para>
         </entry>
         <entry>
@@ -2379,13 +2379,13 @@ openssl x509 -noout -fingerprint -sha256
           Kernel parameters added at the end of boot entries for &xen;
           guests.
          </para>
-<screen>&lt;append&gt;nomodeset vga=0x317&lt;/append&gt;</screen>
+<screen>&lt;xen_append&gt;nomodeset vga=0x317&lt;/xen_append&gt;</screen>
         </entry>
        </row>
        <row>
         <entry>
          <para>
-          <literal>xen-kernel-append</literal>
+          <literal>xen_kernel_append</literal>
          </para>
         </entry>
         <entry>
@@ -2393,7 +2393,7 @@ openssl x509 -noout -fingerprint -sha256
           Kernel parameters added at the end of boot entries for &xen;
           kernels on the &vmhost;.
          </para>
-<screen>&lt;xen-append&gt;dom0_mem=768M&lt;/xen-append&gt;</screen>
+<screen>&lt;xen_kernel_append&gt;dom0_mem=768M&lt;/xen_kernel_append&gt;</screen>
         </entry>
        </row>
       </tbody>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -13889,10 +13889,10 @@ exit 0
   &lt;enable_firewall&gt;true&lt;/enable_firewall&gt;
   &lt;log_denied_packets&gt;all&lt;/log_denied_packets&gt;
   &lt;default_zone&gt;external&lt;/default_zone&gt;
-  &lt;zones&gt;
+  &lt;zones config:type="list"&gt;
     &lt;zone&gt;
       &lt;name&gt;public&lt;/name&gt;
-      &lt;interfaces&gt;
+      &lt;interfaces config:type="list"&gt;
         &lt;interface&gt;eth0&lt;/interface&gt;
       &lt;/interfaces&gt;
       &lt;services config:type="list"&gt;
@@ -13912,7 +13912,7 @@ exit 0
     &lt;/zone&gt;
     &lt;zone&gt;
       &lt;name&gt;dmz&lt;/name&gt;
-      &lt;interfaces&gt;
+      &lt;interfaces config:type="list"&gt;
         &lt;interface&gt;eth1&lt;/interface&gt;
       &lt;/interfaces&gt;
     &lt;/zone&gt;

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -1952,7 +1952,7 @@ openssl x509 -noout -fingerprint -sha256
      (but the SHA256 default is better).
     </para>
     <para>
-     <emphasis>NOTE: </emphasis>This can be used in a trusted network only!
+     <emphasis>Note:</emphasis> This can be used in a trusted network only!
      In a non-trusted network, for example the Internet, you should get the
      fingerprint directly from the server by other means. Fingerprints can
      be fetched via SSH, a saved server configuration and other sources.
@@ -2207,7 +2207,7 @@ openssl x509 -noout -fingerprint -sha256
          <para>
           Write &grub; to the extended partition (important if you want
           to use a generic boot code and the <filename>/boot</filename>
-          partition is logical). NOTE: if the boot partition is logical, you
+          partition is logical). Note: if the boot partition is logical, you
           should use <literal>boot_mbr</literal> (write &grub; to MBR)
           rather than <literal>generic_mbr</literal>.
          </para>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -1097,7 +1097,7 @@ exit 0
        this value is optional. The default is <literal>true</literal>.
       </para>
 <screen><![CDATA[<general>
- <self_update config:type="boolean">true<self_update/>
+ <self_update config:type="boolean">true</self_update>
  ...
 </general>]]></screen>
       <para>

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -358,33 +358,22 @@
    </sect3>
 
    <sect3 xml:id="sec.yast_install.self_update.temporary_addon_repo">
-    <title>Temporary Self-Update Addon Repository</title>
+    <title>Temporary Self-Update Add-on Repository</title>
 
     <para>
-     Some packages distributed in the Self-Update repository should not be
-     applied as an update for the installer but should just override the
-     available packages from the installation medium.
-    </para>
-
-    <para>
-     Such packages usualy provide some additional data for the installer,
-     like the installation defaults, system role definitions and similar.
-     These packages are not installed into the target system.
-    </para>
-
-    <para>
-     The installer copies these packages from the Self-Update repository
-     to a local temporary repository and uses them later during installation.
-     This temporary repository is removed at the end of installation and
-     is not saved into the installed system. If there is no such package
-     found in the Self-Update repository this temporary repository is not
-     created.
+     Some packages distributed in the self-update repository provide additional
+     data for the installer, like the installation defaults, system role definitions
+     and similar. If the installer finds such packages in the self-update repository,
+     a local temporary repository is created, to which those packages are copied.
+     They are used during the installation process, but at the end of the installation,
+     the temporary local repository is removed. Its packages are <emphasis>not</emphasis>
+     installed onto the target system.
     </para>
 
     <para>
      This extra repository is not displayed in the list of add-on products,
-     but it still can be visible during installation in the package management
-     as a <literal>SelfUpdate0</literal> repository.
+     but during installation it still can be visible as
+     <literal>SelfUpdate0</literal> repository in the package management.
     </para>
    </sect3>
   </sect2>

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -356,6 +356,37 @@
      </para>
     </note>
    </sect3>
+
+   <sect3 xml:id="sec.yast_install.self_update.temporary_addon_repo">
+    <title>Temporary Self-Update Addon Repository</title>
+
+    <para>
+     Some packages distributed in the Self-Update repository should not be
+     applied as an update for the installer but should just override the
+     available packages from the installation medium.
+    </para>
+
+    <para>
+     Such packages usualy provide some additional data for the installer,
+     like the installation defaults, system role definitions and similar.
+     These packages are not installed into the target system.
+    </para>
+
+    <para>
+     The installer copies these packages from the Self-Update repository
+     to a local temporary repository and uses them later during installation.
+     This temporary repository is removed at the end of installation and
+     is not saved into the installed system. If there is no such package
+     found in the Self-Update repository this temporary repository is not
+     created.
+    </para>
+
+    <para>
+     This extra repository is not displayed in the list of add-on products,
+     but it still can be visible during installation in the package management
+     as a <literal>SelfUpdate0</literal> repository.
+    </para>
+   </sect3>
   </sect2>
 
   <sect2 xml:id="sec.yast_install.self_update.custom">

--- a/xml/docker_building_images.xml
+++ b/xml/docker_building_images.xml
@@ -154,9 +154,9 @@
    <title>Creating a Custom &slea;&nbsp;12 Image</title>
    <para>
     The following <filename>Dockerfile</filename> creates a simple &docker; image based on
-    &slea;&nbsp;12 SP3:
+    &slea;&nbsp;12 SP4:
    </para>
-<screen>FROM registry.suse.com/suse/sles12sp3
+<screen>FROM registry.suse.com/suse/sles12sp4
 
 RUN zypper ref -s
 RUN zypper -n in vim</screen>
@@ -168,7 +168,7 @@ RUN zypper -n in vim</screen>
     SMT has been replaced by RMT (Repository Mirroring Tool) meanwhile - @DEV:
     please check</remark>
    </para>
-<screen>FROM registry.suse.com/suse/sles12sp3
+<screen>FROM registry.suse.com/suse/sles12sp4
 
 # Import the crt file of our private SMT server
 ADD http://smt.test.lan/smt.crt /etc/pki/trust/anchors/smt.crt

--- a/xml/docker_containers.xml
+++ b/xml/docker_containers.xml
@@ -62,13 +62,13 @@
   <para>
    First, create a container to link to:
   </para>
-  <screen>&prompt.user;docker run -d --name sles sles12sp3 /bin/bash</screen>
+  <screen>&prompt.user;docker run -d --name sles sles12sp4 /bin/bash</screen>
 
   <para>
    Then create a container that will link to the <emphasis>sles</emphasis>
    container:
   </para>
-  <screen>&prompt.user;docker run --link sles:sles sles12sp3 /bin/bash</screen>
+  <screen>&prompt.user;docker run --link sles:sles sles12sp4 /bin/bash</screen>
 
   <para>
    The container that links to <emphasis>sles</emphasis> has defined

--- a/xml/docker_dockerizing_application.xml
+++ b/xml/docker_dockerizing_application.xml
@@ -99,7 +99,7 @@
    version of the <literal>example</literal> package
   </para>
 
-<screen>FROM registry.suse.com/suse/sles12sp3
+<screen>FROM registry.suse.com/suse/sles12sp4
 MAINTAINER Tux
 
 RUN zypper ref &amp;&amp; zypper in -f example-1.0.0-0
@@ -182,7 +182,7 @@ CMD ["-i"]</screen>
    An example with the <emphasis>example</emphasis> application follows:
   </para>
 
-<screen>FROM registry.suse.com/suse/sles12sp3
+<screen>FROM registry.suse.com/suse/sles12sp4
 RUN zypper ref &amp;&amp; zypper --non-interactive in example
 
 ENV BACKUP=/backup
@@ -265,7 +265,7 @@ ENTRYPOINT ["/etc/bin/example"]</screen>
    container by using the <literal>-v</literal> option:
   </para>
 
-  <screen>&prompt.user;docker run -it --name testing -v /home/tux/data:/data sles12sp3:latest /bin/bash</screen>
+  <screen>&prompt.user;docker run -it --name testing -v /home/tux/data:/data sles12sp4:latest /bin/bash</screen>
 
   <note>
    <para>
@@ -281,7 +281,7 @@ ENTRYPOINT ["/etc/bin/example"]</screen>
    could look as follows:
   </para>
 
-<screen>FROM registry.suse.com/suse/sles12sp3
+<screen>FROM registry.suse.com/suse/sles12sp4
 RUN zypper ref &amp;&amp; zypper --non-interactive in apache2
 COPY apache2 /etc/sysconfig/
 RUN chown -R admin /data

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -156,7 +156,7 @@
 <!ENTITY productnameshort "<phrase xmlns='http://docbook.org/ns/docbook' role='productname'><phrase os='osuse'>&opensuse; Leap</phrase><phrase os='sles'>&slsa;</phrase><phrase os='sled'>&sleda;</phrase></phrase>">
 <!ENTITY product-ga    "15">
 <!ENTITY product-sp    "SP1">
-<!ENTITY productnumber "<phrase xmlns='http://docbook.org/ns/docbook' role='productnumber'><phrase os='osuse'>15.0</phrase><phrase os='sles;sled'>&product-ga;</phrase></phrase>">
+<!ENTITY productnumber "<phrase xmlns='http://docbook.org/ns/docbook' role='productnumber'><phrase os='osuse'>15.0</phrase><phrase os='sles;sled'>&product-ga; &product-sp;</phrase></phrase>">
 <!ENTITY prodrpi       "&productname; for the &rpi;*">
 <!ENTITY sdk           "SUSE Software Development Kit">
 <!ENTITY hasi          "High Availability Extension">

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -155,7 +155,7 @@
 <!ENTITY productnamereg "<phrase xmlns='http://docbook.org/ns/docbook' role='productname'><phrase os='osuse'>&opensusereg; Leap</phrase><phrase os='sles'>&slsreg;</phrase><phrase os='sled'>&sledreg;</phrase></phrase>">
 <!ENTITY productnameshort "<phrase xmlns='http://docbook.org/ns/docbook' role='productname'><phrase os='osuse'>&opensuse; Leap</phrase><phrase os='sles'>&slsa;</phrase><phrase os='sled'>&sleda;</phrase></phrase>">
 <!ENTITY product-ga    "15">
-<!ENTITY product-sp    "GA">
+<!ENTITY product-sp    "SP1">
 <!ENTITY productnumber "<phrase xmlns='http://docbook.org/ns/docbook' role='productnumber'><phrase os='osuse'>15.0</phrase><phrase os='sles;sled'>&product-ga;</phrase></phrase>">
 <!ENTITY prodrpi       "&productname; for the &rpi;*">
 <!ENTITY sdk           "SUSE Software Development Kit">

--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -1464,7 +1464,7 @@
         4-pass DoD 5220.22-M section 8-306 procedure (d) for sanitizing
         removable and non-removable rigid disks which requires overwriting all
         addressable locations with a character, its complement, a random
-        character, then verify. NOTE: scrub performs the random pass first to
+        character, then verify. Note: scrub performs the random pass first to
         make verification easier: random, 0x00, 0xff, verify.
        </para>
       </listitem>

--- a/xml/kvm_appendix.xml
+++ b/xml/kvm_appendix.xml
@@ -14,7 +14,7 @@
       </dm:docmanager>
     </info>
     <para/>
- <sect1 xml:id="app.kvm.virtio_install" condition="kvm4x86" os="sles;sled">
+ <sect1 xml:id="app.kvm.virtio_install" os="sles;sled">
   <title>Installing Paravirtualized Drivers</title>
 
   <para/>

--- a/xml/kvm_virtualization_basics.xml
+++ b/xml/kvm_virtualization_basics.xml
@@ -43,9 +43,9 @@
   <itemizedlist>
    <listitem>
     <para>
-     A set of kernel modules<phrase condition="kvm4x86">
+     A set of kernel modules
      (<systemitem>kvm.ko</systemitem>, <systemitem>kvm-intel.ko</systemitem>,
-     and <systemitem>kvm-amd.ko</systemitem>)</phrase> that provides the core
+     and <systemitem>kvm-amd.ko</systemitem>) that provides the core
      virtualization infrastructure and processor-specific drivers.
     </para>
    </listitem>

--- a/xml/libvirt_configuration.xml
+++ b/xml/libvirt_configuration.xml
@@ -605,7 +605,7 @@
    </step>
   </procedure>
  </sect1>
- <sect1 xml:id="sec.libvirt.config.cdrom" condition="kvm4x86">
+ <sect1 xml:id="sec.libvirt.config.cdrom">
   <title>Adding a CD/DVD-ROM Device with &vmm;</title>
 
   <para>
@@ -677,13 +677,13 @@
    <step>
     <para>
      Reboot the &vmguest; to make the new device
-     available.<phrase condition="kvm4x86"> For more information, see
-     <xref linkend="sec.libvirt.config.cdrom.media_change"/>.</phrase>
+     available. For more information, see
+     <xref linkend="sec.libvirt.config.cdrom.media_change"/>.
     </para>
    </step>
   </procedure>
  </sect1>
- <sect1 xml:id="sec.libvirt.config.floppy" condition="kvm4x86">
+ <sect1 xml:id="sec.libvirt.config.floppy">
   <title>Adding a Floppy Device with &vmm;</title>
 
   <para>
@@ -755,13 +755,13 @@
    <step>
     <para>
      Reboot the &vmguest; to make the new device
-     available.<phrase condition="kvm4x86"> For more information, see
-     <xref linkend="sec.libvirt.config.cdrom.media_change"/>.</phrase>
+     available. For more information, see
+     <xref linkend="sec.libvirt.config.cdrom.media_change"/>.
     </para>
    </step>
   </procedure>
  </sect1>
- <sect1 xml:id="sec.libvirt.config.cdrom.media_change" condition="kvm4x86">
+ <sect1 xml:id="sec.libvirt.config.cdrom.media_change">
   <title>Ejecting and Changing Floppy or CD/DVD-ROM Media with &vmm;</title>
 
   <para>

--- a/xml/libvirt_managing.xml
+++ b/xml/libvirt_managing.xml
@@ -992,7 +992,7 @@ Metadata:       yes
       NFS or iSCSI) and must be configured as a storage pool on both machines.
       For more information, see <xref linkend="cha.libvirt.storage"/>.
      </para>
-     <para condition="kvm4x86">
+     <para>
       This is also true for CD-ROM or floppy images that are connected during
       the move. However, you can disconnect them prior to the move as described
       in <xref linkend="sec.libvirt.config.cdrom.media_change"/>.
@@ -1609,7 +1609,7 @@ CPU: 6.1%  Mem: 3072 MB (3072 MB by guests)
    <para>
     <command>kvm_stat</command> can be used in three different modes:
    </para>
-<screen condition="kvm4x86">kvm_stat                    # update in 1 second intervals
+<screen>kvm_stat                    # update in 1 second intervals
 kvm_stat -1                 # 1 second snapshot
 kvm_stat -l &gt; kvmstats.log  # update in 1 second intervals in log format
                             # can be imported to a spreadsheet</screen>
@@ -1649,7 +1649,6 @@ kvm_stat -l &gt; kvmstats.log  # update in 1 second intervals in log format
  request_irq                  0       0
  signal_exits                 0       0
  tlb_flush               394182     148</screen>
-<screen condition="kvm4zSseries">?????</screen>
    </example>
    <para>
     See

--- a/xml/qemu_running_vms_qemukvm.xml
+++ b/xml/qemu_running_vms_qemukvm.xml
@@ -351,10 +351,10 @@
   <para>
    &qemu; virtual machines emulate all devices needed to run a &vmguest;.
    &qemu; supports, for example, several types of network cards, block devices
-   (hard and removable drives), <phrase condition="kvm4x86">USB devices,
-   </phrase>character devices (serial and parallel
-   ports)<phrase condition="kvm4x86">, or multimedia devices (graphic and sound
-   cards)</phrase>. This section introduces options to configure various types
+   (hard and removable drives), USB devices,
+   character devices (serial and parallel
+   ports), or multimedia devices (graphic and sound
+   cards). This section introduces options to configure various types
    of supported devices.
   </para>
 
@@ -900,7 +900,7 @@ QEMU 2.3.1 monitor - type 'help' for more information
    </sect3>
   </sect2>
 
-  <sect2 xml:id="cha.qemu.running.devices.usb" condition="kvm4x86">
+  <sect2 xml:id="cha.qemu.running.devices.usb">
    <title>USB Devices</title>
    <para>
     There are two ways to create USB devices usable by the &vmguest; in &kvm;:

--- a/xml/sle_update_preparation.xml
+++ b/xml/sle_update_preparation.xml
@@ -215,7 +215,7 @@
       Store your dump file, the configuration file
       <filename>/etc/my.cnf</filename>, and the directory
       <filename>/etc/mysql/</filename> for later investigation
-      (<emphasis>NOT</emphasis> installation!) in a safe place.
+      (<emphasis>not</emphasis> installation!) in a safe place.
      </para>
     </step>
     <step>
@@ -228,7 +228,7 @@
     <step>
      <para>
       Configure your MariaDB database to your needs. Do
-      <emphasis>NOT</emphasis> use the former configuration file and directory,
+      <emphasis>not</emphasis> use the former configuration file and directory,
       but use it as a reminder and adapt it.
      </para>
     </step>

--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -515,7 +515,7 @@
    </member>
   </simplelist>
 
-  <sect2 xml:id="sec.kvm.requires.guests.virt_drivers" condition="kvm4x86">
+  <sect2 xml:id="sec.kvm.requires.guests.virt_drivers">
    <title>Availability of Paravirtualized Drivers</title>
    <para>
     To improve the performance of the guest operating system,
@@ -716,7 +716,7 @@
   </note>
  </sect1>
 <!-- Start X86_64 only -->
- <sect1 xml:id="sec.kvm.requires.hardware" condition="kvm4x86">
+ <sect1 xml:id="sec.kvm.requires.hardware">
   <title>&kvm; Hardware Requirements</title>
 
   <para>

--- a/xml/vt_tools.xml
+++ b/xml/vt_tools.xml
@@ -172,7 +172,7 @@ virsh # hostname
      <informalfigure os="osuse">
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="virt_virt-viewer.png_osuse" width="80%" format="PNG"/>
+        <imagedata fileref="virt_virt-viewer_osuse.png" width="80%" format="PNG"/>
        </imageobject>
        <imageobject role="html">
         <imagedata fileref="virt_virt-viewer_osuse.png" width="80%" format="PNG"/>


### PR DESCRIPTION
…sing tag (BSC#1119551)

### Description
This is the same fix as in the SLE12SP4 maintenance branch. It implements the change requested in
https://bugzilla.suse.com/show_bug.cgi?id=1119551

### Checks
* Check all items that apply.

*Is a Doc Update section necessary and has it been created?*

- [ ] Minor edit without associated FATE/Bugzilla: no Doc Update required
- [ ] All other edits: Doc Update section has been added, in a separate commit

*Are backports required?*

- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE15SP0
