### PR TITLE
Re-implement fix for BSC #1119551,

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -1083,7 +1083,7 @@ exit 0
     During the installation, &yast; can update itself to solve bugs in the
     installer that were discovered after the release. Refer to the &deploy;
     for further information about this feature. Use the following tags to
-    configure &yast; self-update:
+    configure the &yast; self-update:
    </para>
 
    <variablelist>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -1077,7 +1077,7 @@ exit 0
   </sect2>
 
   <sect2 xml:id="CreateProfile.General.self_update">
-   <title>The Self Update Section</title>
+   <title>The Self-Update Section</title>
 
    <para>
     During the installation, &yast; can update itself to solve bugs in the
@@ -1111,7 +1111,7 @@ exit 0
      </term>
      <listitem>
       <para>
-       Location of the update repository to use during &yast; self-update.
+       Location of the update repository to use during the &yast; self-update.
        For more information, refer to the &deploy;.
       </para>
       <important>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -1093,11 +1093,11 @@ exit 0
      <listitem>
       <para>
        This option allows to enable (set to <literal>true</literal>) or
-       disable (set to <literal>false</literal> the self-update. Setting
-       this value is optional. The default is <literal>true</literal>.
+       disable (set to <literal>false</literal>) &yast; from self-updating.
+       Setting this value is optional. The default is <literal>true</literal>.
       </para>
 <screen><![CDATA[<general>
- <self_update config:type="boolean">true<self_update/>
+ <self_update config:type="boolean">true</self_update>
  ...
 </general>]]></screen>
       <para>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -1080,10 +1080,10 @@ exit 0
    <title>The Self Update Section</title>
 
    <para>
-    During the installation, &yast; is able to update itself to solve bugs in
-    the installer that were discovered after the release. Refer to the &deploy;
-    for further information about
-    this feature. Use the following tags to configure the self update:
+    During the installation, &yast; can update itself to solve bugs in the
+    installer that were discovered after the release. Refer to the &deploy;
+    for further information about this feature. Use the following tags to
+    configure &yast; self-update:
    </para>
 
    <variablelist>
@@ -1092,9 +1092,9 @@ exit 0
      </term>
      <listitem>
       <para>
-       This option allows to enable (set to <literal>true</literal>) or
-       disable (set to <literal>false</literal>) &yast; from self-updating.
-       Setting this value is optional. The default is <literal>true</literal>.
+       This option enables (set to <literal>true</literal>) or disables (set to
+       <literal>false</literal>) the &yast; self-update feature. Setting this
+       value is optional. The default is <literal>true</literal>.
       </para>
 <screen><![CDATA[<general>
  <self_update config:type="boolean">true</self_update>
@@ -1112,8 +1112,7 @@ exit 0
      <listitem>
       <para>
        Location of the update repository to use during &yast; self-update.
-       Check out the &deploy; to find
-       further information about this feature.
+       For more information, refer to the &deploy;.
       </para>
       <important>
        <title>Installer Self-Update Repository Only</title>


### PR DESCRIPTION
Working against develop for easier back-porting (I did it against SLE12 SP4 last time, and messed it up.) 

I also noticed a missing parenthesis in the preceding paragraph, and fixed that and the wording around it.

### Description
Move the slash in the closing <self_update> tag into the correct position. As per:
https://bugzilla.suse.com/show_bug.cgi?id=1119551

### Checks

*Is a Doc Update section necessary and has it been created?*

- [ ] Minor edit without associated FATE/Bugzilla: no Doc Update required
- [ ] All other edits: Doc Update section has been added, in a separate commit

*Are backports required?*

- [x] To maintenance/SLE12SP3
- [x] To maintenance/SLE12SP4
- [x] To maintenance/SLE15SP0
