### PR TITLE
Fix bsc#1122029

### DIFF
--- a/xml/docker_building_images.xml
+++ b/xml/docker_building_images.xml
@@ -178,14 +178,27 @@ xml:id="docker.building.images" xml:lang="en">
 
   <para>
    Now you can create a custom &docker; image by using a
-   <literal>Dockerfile</literal>. If you want to create a custom &slea;&nbsp;11 SP4
-   image, please refer to
-   <xref linkend="sec.docker.sle_images.customizing_the_images.sles11sp4"/>. If
-   you want to create a custom &slea;&nbsp;12 &docker; image, please refer to
-   <xref linkend="sec.docker.sle_images.customizing_the_images.sles12"/>. In
-   case you would like to move your application to a &docker; container, please
-   refer to <xref linkend="docker.dockerizing.application"/>.
+   <literal>Dockerfile</literal>. If you want to create a custom image, refer to
   </para>
+
+  <itemizedlist>
+    <listitem>
+      <para>
+        <xref linkend="sec.docker.sle_images.customizing_the_images.sles11sp4"/>
+        for &slea;&nbsp;11 SP4
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        <xref linkend="sec.docker.sle_images.customizing_the_images.sles12"/> for &slea;&nbsp;12
+      </para>
+    </listitem>
+  </itemizedlist>
+
+ <para>
+  In case you would like to move your application to a &docker; container, refer
+  to <xref linkend="docker.dockerizing.application"/>.
+ </para>
 
   <sect2 xml:id="sec.docker.sle_images.customizing_the_images.sles11sp4">
    <title>Creating a Custom &slea;&nbsp;11 SP4 Image</title>

--- a/xml/docker_building_images.xml
+++ b/xml/docker_building_images.xml
@@ -61,10 +61,16 @@ xml:id="docker.building.images" xml:lang="en">
   <title>Obtaining Base &slsa; Images</title>
 
   <para>
-   You can install pre-built images of &slsa; by using Zypper:
+   You can install pre-built images of &slsa; up to &slsa;&nbsp;12 SP2 by using Zypper:
   </para>
 
-<screen>sudo zypper in sles11sp4-docker-image suse-sles12sp4-image</screen>
+  <screen>sudo zypper in sles11sp4-docker-image</screen>
+
+  <para>
+   For newer &slsa; versions, use <literal>docker pull</literal>:
+  </para>
+
+   <screen>docker pull registry.suse.com/suse/sles12sp4</screen>
 
   <para>
    Pre-built images do not have repositories configured. But when the &docker;
@@ -73,21 +79,23 @@ xml:id="docker.building.images" xml:lang="en">
   </para>
 
   <para>
-   After the pre-built images are installed, you need to list them using
+   If you've installed the pre-built images using Zypper, you need to list them using
    <literal>sle2docker</literal> to get a proper image name:
   </para>
 
 <screen>sle2docker list</screen>
 
   <para>
-   Now you need to activate the pre-built images:
+   Furthermore, if Zypper was used for installation, you need to activate the pre-built images:
   </para>
 
 <screen>sle2docker activate <emphasis>PRE-BUILT_IMAGE_NAME</emphasis></screen>
 
   <para>
    After successful activation, <literal>sle2docker</literal> will display the
-   name of the &docker; image. You can customize the docker image as described in
+   name of the &docker; image installed via Zypper.</para>
+
+  <para>You can customize the docker image as described in
    <xref linkend="Customizing_Pre-build_Images"/>.
   </para>
  </sect1>

--- a/xml/docker_building_images.xml
+++ b/xml/docker_building_images.xml
@@ -61,16 +61,23 @@ xml:id="docker.building.images" xml:lang="en">
   <title>Obtaining Base &slsa; Images</title>
 
   <para>
-   You can install pre-built images of &slsa; up to &slsa;&nbsp;12 SP2 by using Zypper:
+   How to obtain a pre-built base image depends on the &productname; version:
   </para>
 
-  <screen>sudo zypper in sles11sp4-docker-image</screen>
-
-  <para>
-   For newer &slsa; versions, use <literal>docker pull</literal>:
-  </para>
-
-   <screen>docker pull registry.suse.com/suse/sles12sp4</screen>
+  <variablelist>
+   <varlistentry>
+    <term>Up to &slsa;&nbsp;12 SP2</term>
+    <listitem>
+     <screen>&prompt.sudo;zypper in sles11sp4-docker-image</screen>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>&slsa;&nbsp;12 SP3 and better</term>
+    <listitem>
+     <screen>docker pull registry.suse.com/suse/sles12sp4</screen>
+    </listitem>
+   </varlistentry>
+  </variablelist>
 
   <para>
    Pre-built images do not have repositories configured. But when the &docker;

--- a/xml/docker_building_images.xml
+++ b/xml/docker_building_images.xml
@@ -160,38 +160,14 @@ xml:id="docker.building.images" xml:lang="en">
 
   <para>
    Now you can create a custom &docker; image by using a
-   <literal>Dockerfile</literal>. If you want to create a custom &slea;&nbsp;12
+   <literal>Dockerfile</literal>. If you want to create a custom &slea;&nbsp;11 SP4
    image, please refer to
-   <xref linkend="sec.docker.sle_images.customizing_the_images.sles12"/>. If
-   you want to create a custom &slea;&nbsp;11 SP4 &docker; image, please refer to
-   <xref linkend="sec.docker.sle_images.customizing_the_images.sles11sp4"/>. In
+   <xref linkend="sec.docker.sle_images.customizing_the_images.sles11sp4"/>. If
+   you want to create a custom &slea;&nbsp;12 &docker; image, please refer to
+   <xref linkend="sec.docker.sle_images.customizing_the_images.sles12"/>. In
    case you would like to move your application to a &docker; container, please
    refer to <xref linkend="docker.dockerizing.application"/>.
   </para>
-
-  <sect2 xml:id="sec.docker.sle_images.customizing_the_images.sles12">
-   <title>Creating a Custom &slea;&nbsp;12 Image</title>
-   <para>
-    The following <filename>Dockerfile</filename> creates a simple &docker; image based on
-    &slea;&nbsp;12 SP4:
-   </para>
-<screen>FROM suse/sles12sp4:latest
-
-RUN zypper ref -s
-RUN zypper -n in vim</screen>
-   <para>
-    When the &docker; host machine is registered against an internal &smt;
-    server, the &docker; image requires the SSL certificate used by &smt;:
-   </para>
-<screen>FROM suse/sles12sp4:latest
-
-# Import the crt file of our private SMT server
-ADD http://smt.test.lan/smt.crt /etc/pki/trust/anchors/smt.crt
-RUN update-ca-certificates
-
-RUN zypper ref -s
-RUN zypper -n in vim</screen>
-  </sect2>
 
   <sect2 xml:id="sec.docker.sle_images.customizing_the_images.sles11sp4">
    <title>Creating a Custom &slea;&nbsp;11 SP4 Image</title>
@@ -212,6 +188,30 @@ RUN zypper -n in vim</screen>
 # Import the crt file of our private SMT server
 ADD http://smt.test.lan/smt.crt /etc/ssl/certs/smt.pem
 RUN c_rehash /etc/ssl/certs
+
+RUN zypper ref -s
+RUN zypper -n in vim</screen>
+  </sect2>
+
+  <sect2 xml:id="sec.docker.sle_images.customizing_the_images.sles12">
+   <title>Creating a Custom &slea;&nbsp;12 Image</title>
+   <para>
+    The following <filename>Dockerfile</filename> creates a simple &docker; image based on
+    &slea;&nbsp;12 SP4:
+   </para>
+<screen>FROM suse/sles12sp4:latest
+
+RUN zypper ref -s
+RUN zypper -n in vim</screen>
+   <para>
+    When the &docker; host machine is registered against an internal &smt;
+    server, the &docker; image requires the SSL certificate used by &smt;:
+   </para>
+<screen>FROM suse/sles12sp4:latest
+
+# Import the crt file of our private SMT server
+ADD http://smt.test.lan/smt.crt /etc/pki/trust/anchors/smt.crt
+RUN update-ca-certificates
 
 RUN zypper ref -s
 RUN zypper -n in vim</screen>

--- a/xml/docker_building_images.xml
+++ b/xml/docker_building_images.xml
@@ -86,25 +86,36 @@ xml:id="docker.building.images" xml:lang="en">
   </para>
 
   <para>
-   If you've installed the pre-built images using Zypper, you need to list them using
-   <literal>sle2docker</literal> to get a proper image name:
+   If you have obtained the image with Zypper, you need to activate it. Proceed as follows:
   </para>
 
-<screen>sle2docker list</screen>
+  <procedure>
+   <title>Activating the Base Image for up to &slsa;&nbsp;12 SP2</title>
+   <step>
+    <para>
+     Get the proper image name with <literal>sle2docker</literal> by running
+    </para>
+    <screen>sle2docker list</screen>
+   </step>
+   <step>
+    <para>
+     Activate the image by using the image name from the previous step:
+    </para>
+    <screen>sle2docker activate <emphasis>PRE-BUILT_IMAGE_NAME</emphasis></screen>
+   </step>
+   <step>
+    <para>
+     Check if the image was successfully activated by running
+    </para>
+    <screen>sle2docker</screen>
+   </step>
+  </procedure>
 
   <para>
-   Furthermore, if Zypper was used for installation, you need to activate the pre-built images:
-  </para>
-
-<screen>sle2docker activate <emphasis>PRE-BUILT_IMAGE_NAME</emphasis></screen>
-
-  <para>
-   After successful activation, <literal>sle2docker</literal> will display the
-   name of the &docker; image installed via Zypper.</para>
-
-  <para>You can customize the docker image as described in
+   You can customize the docker image as described in
    <xref linkend="Customizing_Pre-build_Images"/>.
   </para>
+
  </sect1>
  <sect1 xml:id="Customizing_Pre-build_Images">
   <title>Customizing &slsa; &docker; Images</title>

--- a/xml/docker_building_images.xml
+++ b/xml/docker_building_images.xml
@@ -33,7 +33,7 @@ xml:id="docker.building.images" xml:lang="en">
  </para>
 <screen>docker build <replaceable>PATH_TO_BUILD_DIRECTORY</replaceable></screen>
  <para>
-  For more <literal>docker build</literal> options please refer to the
+  For more <literal>docker build</literal> options, refer to the
   <link xlink:href="https://docs.docker.com/engine/reference/commandline/build/">official
   Docker documentation</link>.
  </para>
@@ -50,7 +50,7 @@ xml:id="docker.building.images" xml:lang="en">
         <sect1 xml:id="Building_Base_Images_KIWI">
                 <title>Building Base &slsa; Images with KIWI</title>
                 <para>
-                 KIWI is a command line tool that enables you to build images in a variety of formats. You can use the tool to build a base docker image of &slsa;. For more details about KIWI installation and usage, please refer to the <link xlink:href="https://doc.opensuse.org/projects/kiwi/doc/#chap.introduction">KIWI documentation</link>.
+                 KIWI is a command line tool that enables you to build images in a variety of formats. You can use the tool to build a base docker image of &slsa;. For more details about KIWI installation and usage, refer to the <link xlink:href="https://doc.opensuse.org/projects/kiwi/doc/#chap.introduction">KIWI documentation</link>.
                 </para>
                 <para>
                 The procedure of building docker images is given in the <link xlink:href="https://doc.opensuse.org/projects/kiwi/doc/#chap.docker">Docker Images chapter</link>.

--- a/xml/docker_building_images.xml
+++ b/xml/docker_building_images.xml
@@ -199,7 +199,7 @@ RUN zypper -n in vim</screen>
     The following <filename>Dockerfile</filename> creates a simple &docker; image based on
     &slea;&nbsp;12 SP4:
    </para>
-<screen>FROM suse/sles12sp4:latest
+<screen>FROM registry.suse.com/suse/sles12sp4:latest
 
 RUN zypper ref -s
 RUN zypper -n in vim</screen>
@@ -207,7 +207,7 @@ RUN zypper -n in vim</screen>
     When the &docker; host machine is registered against an internal &smt;
     server, the &docker; image requires the SSL certificate used by &smt;:
    </para>
-<screen>FROM suse/sles12sp4:latest
+<screen>FROM registry.suse.com/suse/sles12sp4:latest
 
 # Import the crt file of our private SMT server
 ADD http://smt.test.lan/smt.crt /etc/pki/trust/anchors/smt.crt

--- a/xml/docker_dockerizing_application.xml
+++ b/xml/docker_dockerizing_application.xml
@@ -73,7 +73,7 @@
                 <para>
                 You may face a problem that your application uses a specific version of a package that is different from the package installed on the system that should run your application. You can modify your application to work with another version or you may create a &docker; image with that particular package version. The following example of a <filename>Dockerfile</filename> shows an image based on a current version of  &slsa; but with an older version of the <literal>example</literal> package
                 </para>
-                <screen>FROM suse/sles12sp4:latest
+                <screen>FROM registry.suse.com/suse/sles12sp4:latest
 MAINTAINER Tux
 
 RUN zypper ref &amp;&amp; zypper in -f example-1.0.0-0
@@ -138,7 +138,7 @@ CMD ["-i"]</screen>
                 <para>
                 An example with the <emphasis>example</emphasis> application follows:
                 </para>
-                <screen>FROM suse/sles12sp4:latest
+                <screen>FROM registry.suse.com/suse/sles12sp4:latest
 
 RUN zypper ref &amp;&amp; zypper --non-interactive in example
 
@@ -205,7 +205,7 @@ ENTRYPOINT ["/etc/bin/example"]</screen>
                 <para>
                 Now let's create an example image with a Web server that will read Web content from the host's file system. The <filename>Dockerfile</filename> could look as follows:
                 </para>
-                <screen>FROM suse/sles12sp4:latest
+                <screen>FROM registry.suse.com/suse/sles12sp4:latest
 
 RUN zypper ref &amp;&amp; zypper --non-interactive in apache2
 
@@ -230,7 +230,7 @@ ENTRYPOINT ["apache2ctl"]</screen>
                 </para>
            <example xml:id="ex.docker.dockerfile.apache2">
              <title><filename>Dockerfile</filename> for an Apache2 Web Server</title>
-             <screen>FROM suse/sles12sp4:latest <co xml:id="co.dockerfile.apache2.from"/>
+             <screen>FROM registry.suse.com/suse/sles12sp4:latest <co xml:id="co.dockerfile.apache2.from"/>
 MAINTAINER &exampleuser_plain; <co xml:id="co.dockerfile.apache2.maintainer"/>
 RUN zypper ref -s &amp;&amp; zypper --non-interactive in apache2
 


### PR DESCRIPTION
### Description
Fixed instructions for SLES 12 SP4, see  [bsc#1122029](https://bugzilla.suse.com/show_bug.cgi?id=1122029).

Pre-built Docker images of SLES are only available via Zypper up to `sles12sp2-docker-image` using
`sudo zypper in sles12sp2-docker-image`
For newer versions, `docker pull` is needed:
`docker pull registry.suse.com/suse/sles12sp4`