### PR TITLE
Removing duplication between main AY article & appendix. (BSC#1104637)

### DIFF
--- a/xml/ay_12_migrate_15.xml
+++ b/xml/ay_12_migrate_15.xml
@@ -31,10 +31,10 @@
    os="sles;sled">&slea;</phrase><phrase os="osuse">Leap</phrase> 15 products,
    &ay; implements a heuristic that selects products automatically. This
    heuristic will be used when the profile does not contain a <tag
-   class="element">product</tag> element. This heuristic is based on the
-   package and pattern selection in the profile. However, whenever possible,
-   avoid using this mechanism and adapt old profiles to use explicit product
-   selection.
+   class="element">product</tag> element. Automatic product selection is based
+   on the package and pattern selection in the profile. However, whenever
+   possible, avoid relying on this mechanism and adapt old profiles to use
+   explicit product selection.
   </para>
   <para>
    For information about explicit product selection, refer to

--- a/xml/ay_12_migrate_15.xml
+++ b/xml/ay_12_migrate_15.xml
@@ -25,25 +25,7 @@
  </info>
  <sect1 os="sles;sled" xml:id="sec.ay_12vs15.product-selection">
   <title>Product Selection</title>
-
-  <para>
-   Starting with &productname; 15, all products are distributed using a single
-   installation medium. Therefore you need to choose which product to install
-   by using the <tag class="element">product</tag> tag. In the following
-   example &sled; is the chosen product:
-  </para>
-
-  <screen><![CDATA[<software>
-  <products config:type="list">
-    <product>SLED</product>
-  </products>
-</software>]]></screen>
-
-  <para>
-   In special cases, the medium may contain only one product. If so there is
-   no need to explicitly select a product as described above. &ay; will select
-   the only available product automatically.
-  </para>
+  
   <para>
    For backward compatibility with profiles created for pre-<phrase
    os="sles;sled">&slea;</phrase><phrase os="osuse">Leap</phrase> 15 products,
@@ -55,7 +37,12 @@
    selection.
   </para>
   <para>
-   If the product selection fails, an error is shown and the installation
+   For information about explicit product selection, refer to
+   <xref linkend="Software.Selections.base_product"/>. 
+  </para>
+  
+  <para>
+   If automatic product selection fails, an error is shown and the installation
    will not be continued.
   </para>
  </sect1>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -5135,7 +5135,7 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
      <term>SLES_SAP</term>
      <listitem>
       <para>
-       &sles4sapa;
+       &sles4sap;
       </para>
      </listitem>
     </varlistentry>
@@ -5170,10 +5170,9 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
       Using &ay; Files from Previous Versions 
      </title>
      <para>
-      There are some special considerations to be aware of if you are using or
-      migrating an &ay; configuration file from an older version of
-      &productname;. Refer to the Appendix, under
-      <xref linkend="sec.ay_12vs15.product-selection"/>. 
+      If you are using or migrating an &ay; configuration file from an older
+      version of &productname;, be aware that there are some special
+      considerations. For details, refer to <xref linkend="sec.ay_12vs15.product-selection"/>. 
      </para>
     </note>
    </sect2>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -5107,12 +5107,52 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
    <sect2 xml:id="Software.Selections.base_product">
     <title>Product Selection</title>
     <para>
-     Starting with &slea; 15, all products are distributed using one medium.
-     You need to choose which product to install. To do so explicitly, use
-     the <tag>product</tag> option.
+     Starting with &productname; 15, all products are distributed using a single
+     installation medium. Therefore you need to choose which product to install
+     by using the <tag class="element">product</tag> tag.
     </para>
+    <para>
+     The available values for the <tag class="element">product</tag> tag are:
+    </para>
+    <variablelist>
+     <varlistentry>
+      <term>SLES</term>
+      <listitem>
+       <para>
+        &sls;
+       </para>
+      </listitem>
+     </varlistentry>
+    <varlistentry>
+     <term>SLE_HPC</term>
+     <listitem>
+      <para>
+       &slehpc;
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>SLES_SAP</term>
+     <listitem>
+      <para>
+       &sles4sapa;
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>SLED</term>
+     <listitem>
+      <para>
+       &sled;
+      </para>
+     </listitem>
+    </varlistentry>
+    </variablelist>
     <example>
      <title>Explicit Product Selection</title>
+     <para>
+      In the following example, &sled; is the chosen product:
+     </para>
 <screen>&lt;software&gt;
   &lt;products config:type="list"&gt;
     &lt;product&gt;SLED&lt;/product&gt;
@@ -5125,15 +5165,17 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
      do not need to select a product explicitly as described above.
      &ay; will select the only available product automatically.
     </para>
-    <para>
-     For backward compatibility with profiles created for pre-&slea; 15
-     products, &ay; implements a heuristic that selects products
-     automatically. This heuristic will be used when the profile does not
-     contain a <tag>product</tag> element.
-     This heuristic is based on the package and pattern selection in the
-     profile. However, whenever possible avoid using this mechanism and adapt
-     old profiles to use explicit product selection.
-    </para>
+    <note>
+     <title>
+      Using &ay; Files from Previous Versions 
+     </title>
+     <para>
+      There are some special considerations to be aware of if you are using or
+      migrating an &ay; configuration file from an older version of
+      &productname;. Refer to the Appendix, under
+      <xref linkend="sec.ay_12vs15.product-selection"/>. 
+     </para>
+    </note>
    </sect2>
 
    <sect2 xml:id="Software.Selections.sles10">

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -5104,7 +5104,7 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
     <remark role="fixme">Add a short description</remark>
    </para>
 
-   <sect2 xml:id="Software.Selections.base_product">
+   <sect2 xml:id="Software.Selections.base_product" os="sles;sled">
     <title>Product Selection</title>
     <para>
      Starting with &productname; 15, all products are distributed using a single


### PR DESCRIPTION
Oxygen complains about links from the appendix back to the main document, but DAPS validates it and it works fine in the HTML version. So I am removing my "work in progress" comment -- I think that this is good to go.

### Description
A few sentences describing the overall goals of this pull request.
If there are relevant Bugzilla or FATE entries, reference them.

### Checks
* Check all items that apply.

*Is a Doc Update section necessary and has it been created?*

- [ ] Minor edit without associated FATE/Bugzilla: no Doc Update required
- [ ] All other edits: Doc Update section has been added, in a separate commit

*Are backports required?*

- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE15SP0
