### PR TITLE
AutoYaST: minor fix to old style RAID1 example

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -4299,7 +4299,7 @@ openssl x509 -noout -fingerprint -sha256
         &lt;partition_id config:type="integer"&gt;253&lt;/partition_id&gt;
         &lt;format config:type="boolean"&gt;false&lt;/format&gt;
         &lt;raid_name&gt;/dev/md0&lt;/raid_name&gt;
-        &lt;raid_type&gt;raid&lt;/raid_type&gt;
+        &lt;raid_type&gt;raid1&lt;/raid_type&gt;
         &lt;size&gt;4G&lt;/size&gt;
       &lt;/partition&gt;
 


### PR DESCRIPTION
Minor fix to old style RAID1 example.

* Check all items that apply.

*Is a Doc Update section necessary and has it been created?*

- [X] Minor edit without associated FATE/Bugzilla: no Doc Update required
- [ ] All other edits: Doc Update section has been added, in a separate commit

*Are backports required?*

- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE15SP0