### PR TITLE
Reword linuxrc coverage (BSC#1110431)

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -9996,10 +9996,10 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
 
      <para>
       It is possible to specify <literal>rootpassword</literal> in
-      <command>linuxrc</command> and also have a user section for the root user. If this
-      section is missing the password, then the password from <command>linuxrc</command>
-      will be used. Passwords in profiles take precedence over <command>linuxrc</command>
-      passwords.
+      <command>linuxrc</command> and also have a user section for the &rootuser;
+      user. If this section is missing the password, then the password from
+      <command>linuxrc</command> will be used. Passwords in profiles take
+      precedence over <command>linuxrc</command> passwords.
      </para>
     </note>
 
@@ -16208,8 +16208,10 @@ echo -n 100
     </para>
     <para>
      You can pass keywords to <command>linuxrc</command> using the kernel
-     command line, either interactively at boot time, when creating 
-     network-bootable images, or using a specially-configured DHCP server in
+     command line. This can be done in several ways. As is normal for kernel
+     parameters, you can specify them interactively at boot time. You can also
+     insert kernel parameters into custom network-bootable disk images. It is 
+     also possible to configure a DHCP server to pass kernel parameters in
      combination with Etherboot or PXE.
     </para>
     <para>
@@ -17161,23 +17163,25 @@ mv /var/run/zypp.sav /var/run/zypp.pid
   <title>Advanced Linuxrc Options</title>
   <info/>
   <para>
-   <command>Linuxrc</command> is a small program that runs after the kernel loads, but before &ay;
-   or other stages. It prepares the system for installation. It allows the user
-   to load modules, start an installed system or a rescue system, and to guide
-   the operation of &yast;.
+   <command>Linuxrc</command> is a small program that runs after the kernel has
+   loaded, but before &ay; or other stages. It prepares the system for
+   installation. It allows the user to load modules, start an installed system
+   or a rescue system, and to guide the operation of &yast;.
   </para>
   <note>
    <title>Linuxrc Settings Are Not The Same As &ay; Settings</title>
    <para>
     Some <command>linuxrc</command> settings have the same names as settings
-    used by &ay; in the <filename>autoyast.xml</filename> file. Beware that this
-    does not mean that they take the same parameters or function in the same
-    way. For example, &ay; takes a parameter <command>self_update</command>
-    and if this is set, another called <command>self_update_url</command>.
-    Linuxrc also has a <command>self_update</command> parameter, but this takes
-    either <literal>0</literal> or a URL. Attempting to pass &ay; parameters to
-    <command>linuxrc</command> will almost certainly not give the desired 
-    results.
+    used by &ay; in the <filename>autoyast.xml</filename> file. This does not
+    mean that they take the same parameters or function in the same way. For
+    example, &ay; takes a parameter <command>self_update</command>. If this
+    parameter is set, another one, <command>self_update_url</command> will be
+    read and followed. Linuxrc also has a <command>self_update</command> parameter, but this takes
+    either <literal>0</literal> or a URL.
+   </para>
+   <para>
+    Do not pass &ay; parameters to <command>linuxrc</command>, as this will
+    almost certainly not give the desired results.
    </para>
   </note>
   <para>
@@ -17766,7 +17770,7 @@ mv /var/run/zypp.sav /var/run/zypp.pid
     Even if parameters like <literal>hostip</literal>,
     <literal>nameserver</literal>, and <literal>gateway</literal> are passed to
     <command>linuxrc</command>, the network is only started when it is needed
-    (for example, when installing via SSH or VNC). Since <literal>autoyast</literal>
+    (for example, when installing via SSH or VNC). Because <literal>autoyast</literal>
     is not a <command>linuxrc</command> parameter (this parameter is ignored by
     <command>linuxrc</command> and only passed to &yast;), the network will
     <emphasis>not</emphasis> be started automatically when specifying a remote

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -6126,9 +6126,19 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
 
    <para>
     If the following setting is set to <literal>true</literal>, &yast;
-    will keep network settings created during the installation (via <command>linuxrc</command>)
-    and/or merge it with network settings from the &ay; control file (if
-    defined). &ay; settings have higher priority than already present
+    will keep network settings created during the installation (via
+    <command>linuxrc</command>) and/or merge it with network settings from the
+    &ay; control file (if defined).
+   </para>
+   <note>
+    <title>Linuxrc</title>
+    <para>
+     For a detailed description of how linuxrc works and other linuxrc keywords,
+     see <xref linkend="appendix.linuxrc"/>.
+    </para>
+   </note>
+   <para>    
+    &ay; settings have higher priority than already present
     configuration files. &yast; will write ifcfg-* files based on the
     entries in the control file without removing old ones. If there is an
     empty or no dns and routing section, &yast; will keep already
@@ -9923,7 +9933,7 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
     <para>
      A list of users can be defined in the <literal>&lt;users&gt;</literal>
      section. To be able to log in, make sure that either the &rootuser; users are
-     set up or rootpassword is specified as a <command>linuxrc</command> option.
+     set up or rootpassword is specified as a linuxrc option.
     </para>
 
     <example>
@@ -9996,10 +10006,9 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
 
      <para>
       It is possible to specify <literal>rootpassword</literal> in
-      <command>linuxrc</command> and also have a user section for the &rootuser;
-      user. If this section is missing the password, then the password from
-      <command>linuxrc</command> will be used. Passwords in profiles take
-      precedence over <command>linuxrc</command> passwords.
+      linuxrc and also have a user section for the &rootuser; user. If this
+      section is missing the password, then the password from linuxrc will be
+      used. Passwords in profiles take precedence over linuxrc passwords.
      </para>
     </note>
 
@@ -15796,13 +15805,13 @@ echo -n 100
    </sect2>
 
    <sect2 xml:id="Installation.Interface.SerialConsole">
-    <title>Serial console</title>
+    <title>Serial Console</title>
     <para>
      Start installing a system using the serial console by adding the
      keyword <literal>console</literal> (for example
      <literal>console=ttyS0</literal>) to the command line of the kernel.
-     This starts <command>linuxrc</command> in console mode and later &yast; in serial
-     console mode.
+     This starts linuxrc in console mode and later &yast; in serial console
+     mode.
     </para>
    </sect2>
 
@@ -15936,9 +15945,9 @@ echo -n 100
     <title>Command Line Options</title>
     <para>
      Adding the command line variable <literal>autoyast</literal> causes
-     <command>linuxrc</command> to start in automated mode. <command>linuxrc</command> searches for a
-     configuration file, which should be distinguished from the main control
-     file in the following places:
+     linuxrc to start in automated mode. Linuxrc searches for a configuration
+     file, which should be distinguished from the main control file in the
+     following places:
     </para>
     <itemizedlist>
      <listitem>
@@ -15954,12 +15963,12 @@ echo -n 100
      </listitem>
     </itemizedlist>
     <para>
-     The <command>linuxrc</command> configuration file supports multiple keywords.
-     For a detailed description of how <command>linuxrc</command> works and other keywords,
-     see <xref linkend="appendix.linuxrc"/>. Some of the more common ones are:
+     The linuxrc configuration file supports multiple keywords. For a detailed
+     description of how linuxrc works and other keywords, see
+     <xref linkend="appendix.linuxrc"/>. Some of the more common ones are:
     </para>
     <table>
-     <title>Keywords for <command>linuxrc</command></title>
+     <title>Keywords for Linuxrc</title>
      <tgroup cols="2">
       <thead>
        <row>
@@ -16012,11 +16021,12 @@ echo -n 100
         <entry>
          <para>
           Location of the control file for automatic installation.
-          Similar to the <literal>autoyast</literal> option, but <command>linuxrc</command> parses
+          Similar to the <literal>autoyast</literal> option, but linuxrc parses
           the provided value and, for example, tries to configure a network
           when needed. For information about differences between the &ay; and
-          <command>linuxrc</command> URI syntax, see the <command>linuxrc</command> appendix:
-          <xref linkend="appendix.linuxrc"/>. &ay;'s rules and classes are not supported.
+          linuxrc URI syntax, see the linuxrc appendix:
+          <xref linkend="appendix.linuxrc"/>. &ay;'s rules and classes are
+          <emphasis>not</emphasis> supported.
          </para>
         </entry>
        </row>
@@ -16196,10 +16206,10 @@ echo -n 100
      where &yast; can take over with the main control file. Currently,
      the source medium is automatically discovered, which in some cases
      makes it possible to initiate the auto-install process without giving
-     any instructions to <command>linuxrc</command>.
+     any instructions to linuxrc.
     </para>
     <para>
-     The traditional <command>linuxrc</command> configuration file (<filename>info</filename>)
+     The traditional linuxrc configuration file (<filename>info</filename>)
      has the function of giving the client enough information about the
      installation server and the location of the sources. Usually, this file
      is not required, but it is needed in special network environments
@@ -16207,9 +16217,9 @@ echo -n 100
      to be loaded.
     </para>
     <para>
-     You can pass keywords to <command>linuxrc</command> using the kernel
-     command line. This can be done in several ways. As is normal for kernel
-     parameters, you can specify them interactively at boot time. You can also
+     You can pass keywords to linuxrc using the kernel command line. This can be
+     done in several ways. You can specify linurc keywords along with other
+     kernel parameters interactively at boot time, as usual. You can also
      insert kernel parameters into custom network-bootable disk images. It is 
      also possible to configure a DHCP server to pass kernel parameters in
      combination with Etherboot or PXE.
@@ -16528,8 +16538,7 @@ echo -n 100
      <para>
       To disable the network during installations where it is not needed or
       unavailable, for example when auto-installing from DVD-ROMs, use the
-      <command>linuxrc</command> option <literal>netsetup=0</literal> to disable
-      the network setup.
+      linuxrc option <literal>netsetup=0</literal> to disable the network setup.
      </para>
     </note>
     <note>
@@ -16545,13 +16554,13 @@ echo -n 100
       <listitem>
        <para>
         When you use <literal>autoyast=http://...</literal>, you need to
-        provide <command>linuxrc</command> with the network configuration.
+        provide linuxrc with the network configuration.
        </para>
       </listitem>
       <listitem>
        <para>
-        When you use <literal>autoyast2=http://...</literal>, <command>linuxrc</command>
-        tries to configure the network for you.
+        When you use <literal>autoyast2=http://...</literal>, linuxrc tries to
+        configure the network for you.
        </para>
       </listitem>
      </itemizedlist>
@@ -16670,22 +16679,23 @@ default</screen>
    </sect2>
 
    <sect2 xml:id="invoking_autoinst.linuxrc">
-    <title>Combining the linuxrc <filename>info</filename> file with the &ay; control file</title>
+    <title>Combining the Linuxrc <filename>info</filename> File with the &ay; Control File</title>
     <para>
-     If you choose to pass information to <command>linuxrc</command> using the
+     If you choose to pass information to linuxrc using the 
      <filename>info</filename> file, it is possible to integrate the
      keywords in the XML control file. In this case the file needs to be
-     accessible to <command>linuxrc</command> and must be named <filename>info</filename>.
+     accessible to linuxrc and must be named <filename>info</filename>.
     </para>
     <para>
-     <command>Linuxrc</command> will look for a string (<literal>start_linuxrc_conf</literal>
-     in the control file which represents the beginning of the file. If it
-     is found, it will parse the content starting from that string and will
-     finish when the string <literal>end_linuxrc_conf</literal> is found.
-     The options are stored in the control file in the following way:
+     Linuxrc will look for the string <literal>start_linuxrc_conf</literal>
+     in the &ay; control file, which represents the beginning of the embedded
+     linuxrc control file. If the string is found, linuxrc will parse the
+     content starting from that string and will finish when the string
+     <literal>end_linuxrc_conf</literal> is found. The options are stored in the
+     control file in the following way:
     </para>
     <example>
-     <title>Linuxrc options in the control file</title>
+     <title>Linuxrc Options in the &ay; Control File</title>
 <screen>....
   &lt;install&gt;
 ....
@@ -17088,8 +17098,8 @@ mv /var/run/zypp.sav /var/run/zypp.pid
      <para>
       <command>Linuxrc</command> found an unsigned file, such as a driver
       update. To use an unsigned file, you can suppress that message by passing
-      <literal>insecure=1</literal> to the <command>linuxrc</command> parameter
-      list (together with the <literal>autoyast=...</literal> parameter).
+      <literal>insecure=1</literal> to the linuxrc parameter list (together with
+      the <literal>autoyast=...</literal> parameter).
      </para>
     </answer>
    </qandaentry>
@@ -17102,10 +17112,9 @@ mv /var/run/zypp.sav /var/run/zypp.pid
     </question>
     <answer>
      <para>
-      You need to pass <literal>ifcfg</literal> to <command>linuxrc</command>.
-      This is required to set up the network, otherwise &ay; cannot download the
-      profile from the remote host. See <xref linkend="ay.adv_network"/> for
-      more information.
+      You need to pass <literal>ifcfg</literal> to linuxrc. This is required to
+      set up the network, otherwise &ay; cannot download the profile from the
+      remote host. See <xref linkend="ay.adv_network"/> for more information.
      </para>
     </answer>
    </qandaentry>
@@ -17169,15 +17178,16 @@ mv /var/run/zypp.sav /var/run/zypp.pid
    or a rescue system, and to guide the operation of &yast;.
   </para>
   <note>
-   <title>Linuxrc Settings Are Not The Same As &ay; Settings</title>
+   <title>Linuxrc Settings are Not Identical to &ay; Settings</title>
    <para>
-    Some <command>linuxrc</command> settings have the same names as settings
-    used by &ay; in the <filename>autoyast.xml</filename> file. This does not
+    Some linuxrc settings coincidentally have the same names as settings used by
+    &ay; in its <filename>autoyast.xml</filename> file. This does <emphasis>not</emphasis>
     mean that they take the same parameters or function in the same way. For
-    example, &ay; takes a parameter <command>self_update</command>. If this
-    parameter is set, another one, <command>self_update_url</command> will be
-    read and followed. Linuxrc also has a <command>self_update</command> parameter, but this takes
-    either <literal>0</literal> or a URL.
+    example, &ay; takes a <command>self_update</command> setting. If this
+    value is set to <literal>1</literal>, another setting,
+    <command>self_update_url</command> will be read and followed. Linuxrc also
+    has a <command>self_update</command> setting, but the linuxrc settings takes
+    values of either <literal>0</literal> or a URL.
    </para>
    <para>
     Do not pass &ay; parameters to <command>linuxrc</command>, as this will
@@ -17205,7 +17215,7 @@ mv /var/run/zypp.sav /var/run/zypp.pid
    libraries in the initial RAM disk, <filename>initrd</filename>.
   </para>
   <sect1 xml:id="ay.cmd_parameters">
-   <title>Passing parameters to Linuxrc</title>
+   <title>Passing Parameters to Linuxrc</title>
 
    <para>
     Unless <command>linuxrc</command> is in manual mode, it will look for an
@@ -17229,7 +17239,7 @@ mv /var/run/zypp.sav /var/run/zypp.pid
    </para>
   </sect1>
   <sect1 xml:id="info_file_format">
-   <title><filename>info</filename> file format</title>
+   <title><filename>info</filename> File Format</title>
 
    <para>
     Lines starting with <literal>#</literal> are comments. Valid entries are
@@ -17769,15 +17779,14 @@ mv /var/run/zypp.sav /var/run/zypp.pid
    <para>
     Even if parameters like <literal>hostip</literal>,
     <literal>nameserver</literal>, and <literal>gateway</literal> are passed to
-    <command>linuxrc</command>, the network is only started when it is needed
-    (for example, when installing via SSH or VNC). Because <literal>autoyast</literal>
-    is not a <command>linuxrc</command> parameter (this parameter is ignored by
-    <command>linuxrc</command> and only passed to &yast;), the network will
-    <emphasis>not</emphasis> be started automatically when specifying a remote
-    location for the &ay; profile.
+    linuxrc, the network is only started when it is needed (for example, when
+    installing via SSH or VNC). Because <literal>autoyast</literal>
+    is not a linuxrc parameter (this parameter is ignored by linuxrc and is only
+    passed to &yast;), the network will <emphasis>not</emphasis> be started
+    automatically when specifying a remote location for the &ay; profile.
    </para>
    <para>
-    Therefore the network needs to be started explicitly. This used to be done
+    Therefore, the network needs to be started explicitly. This used to be done
     with the <command>linuxrc</command> parameter <literal>netsetup</literal>.
     Starting with &productname; <phrase os="osuse">13.2</phrase><phrase
     os="sles;sled">12</phrase>, the parameter <literal>ifcfg</literal> is

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -17267,27 +17267,6 @@ mv /var/run/zypp.sav /var/run/zypp.pid
    </para>
 
    <table>
-    <title></title>
-    <tgroup cols="2">
-     <colspec colnum="1" colname="1" colwidth="50*"/>
-     <colspec colnum="2" colname="2" colwidth="50*"/>
-     <thead>
-      <row>
-       <entry><para></para></entry>
-       <entry><para></para></entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry><para></para></entry>
-       <entry><para></para></entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </table>
-
-
-   <table>
     <title>Advanced Linuxrc Keywords</title>
     <tgroup cols="2">
      <colspec colnum="1" colname="1" colwidth="30*"/>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -6131,19 +6131,18 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
     &ay; control file (if defined).
    </para>
    <note>
-    <title>Linuxrc</title>
+    <title>The <command>linuxrc</command> program</title>
     <para>
-     For a detailed description of how linuxrc works and other linuxrc keywords,
-     see <xref linkend="appendix.linuxrc"/>.
+     For a detailed description of how <command>linuxrc</command> works and its
+     keywords, see <xref linkend="appendix.linuxrc"/>.
     </para>
    </note>
    <para>    
-    &ay; settings have higher priority than already present
-    configuration files. &yast; will write ifcfg-* files based on the
-    entries in the control file without removing old ones. If there is an
-    empty or no dns and routing section, &yast; will keep already
-    existing values. Otherwise settings from the control file will be
-    applied.
+    &ay; settings have higher priority than any configuration files already
+    present. &yast; will write ifcfg-* files based on the entries in the control
+    file without removing old ones. If there is an empty or absent DNS and
+    routing section, &yast; will keep any pre-existing values. Otherwise,
+    settings from the control file will be applied.
    </para>
 
 <screen>&lt;keep_install_network
@@ -9933,7 +9932,8 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
     <para>
      A list of users can be defined in the <literal>&lt;users&gt;</literal>
      section. To be able to log in, make sure that either the &rootuser; users are
-     set up or <option>rootpassword</option> is specified as a linuxrc option.
+     set up or <option>rootpassword</option> is specified as a <command>linuxrc</command>
+     option.
     </para>
 
     <example>
@@ -10006,9 +10006,10 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
 
      <para>
       It is possible to specify <literal>rootpassword</literal> in
-      linuxrc and also have a user section for the &rootuser; user. If this
-      section is missing the password, then the password from linuxrc will be
-      used. Passwords in profiles take precedence over linuxrc passwords.
+      <command>linuxrc</command> and also have a user section for the &rootuser;
+      user. If this section is missing the password, then the password from 
+      <command>linuxrc</command> will be used. Passwords in profiles take
+      precedence over <command>linuxrc</command> passwords.
      </para>
     </note>
 
@@ -15810,8 +15811,8 @@ echo -n 100
      Start installing a system using the serial console by adding the
      keyword <literal>console</literal> (for example
      <literal>console=ttyS0</literal>) to the command line of the kernel.
-     This starts linuxrc in console mode and later &yast; in serial console
-     mode.
+     This starts <command>linuxrc</command> in console mode and later &yast; in
+     serial console mode.
     </para>
    </sect2>
 
@@ -15945,9 +15946,9 @@ echo -n 100
     <title>Command Line Options</title>
     <para>
      Adding the command line variable <literal>autoyast</literal> causes
-     linuxrc to start in automated mode. Linuxrc searches for a configuration
-     file, which should be distinguished from the main control file in the
-     following places:
+     <command>linuxrc</command> to start in automated mode. The <command>linuxrc</command>
+     program searches for a configuration file, which should be distinguished
+     from the main control file, in the following places:
     </para>
     <itemizedlist>
      <listitem>
@@ -15963,12 +15964,13 @@ echo -n 100
      </listitem>
     </itemizedlist>
     <para>
-     The linuxrc configuration file supports multiple keywords. For a detailed
-     description of how linuxrc works and other keywords, see
-     <xref linkend="appendix.linuxrc"/>. Some of the more common ones are:
+     The <command>linuxrc</command> configuration file supports multiple
+     keywords. For a detailed description of how <command>linuxrc</command>
+     works and other keywords, see <xref linkend="appendix.linuxrc"/>. Some of
+     the more common ones are:
     </para>
     <table>
-     <title>Keywords for Linuxrc</title>
+     <title>Keywords for <command>linuxrc</command></title>
      <tgroup cols="2">
       <thead>
        <row>
@@ -15993,9 +15995,9 @@ echo -n 100
         </entry>
         <entry>
          <para>
-          Initiate an automatic upgrade using &ay;, see <xref linkend="CreateProfile.upgrade"/>.
-          For some use cases, you need the <literal>autoyast</literal> parameter (see <xref
-          linkend="Commandline.ay"/> for details).
+          Initiate an automatic upgrade using &ay;; see <xref linkend="CreateProfile.upgrade"/>.
+          For some use cases, you need the <literal>autoyast</literal> parameter
+          (see <xref linkend="Commandline.ay"/> for details).
          </para>
         </entry>
        </row>
@@ -16007,7 +16009,7 @@ echo -n 100
         </entry>
         <entry>
          <para>
-          Location of the control file for automatic installation,
+          Location of the control file for automatic installation;
           see <xref linkend="Commandline.ay"/> for details.
          </para>
         </entry>
@@ -16021,10 +16023,11 @@ echo -n 100
         <entry>
          <para>
           Location of the control file for automatic installation.
-          Similar to the <literal>autoyast</literal> option, but linuxrc parses
-          the provided value and, for example, tries to configure a network
-          when needed. For information about differences between the &ay; and
-          linuxrc URI syntax, see the linuxrc appendix:
+          Similar to the <literal>autoyast</literal> option, but
+          <command>linuxrc</command> parses the provided value and, for example,
+          tries to configure a network when needed. For information about
+          differences between the &ay; and <command>linuxrc</command> URI
+          syntax, see the <command>linuxrc</command> appendix:
           <xref linkend="appendix.linuxrc"/>. &ay;'s rules and classes are
           <emphasis>not</emphasis> supported.
          </para>
@@ -16206,10 +16209,10 @@ echo -n 100
      where &yast; can take over with the main control file. Currently,
      the source medium is automatically discovered, which in some cases
      makes it possible to initiate the auto-install process without giving
-     any instructions to linuxrc.
+     any instructions to <command>linuxrc</command>.
     </para>
     <para>
-     The traditional linuxrc configuration file (<filename>info</filename>)
+     The traditional <command>linuxrc</command> configuration file (<filename>info</filename>)
      has the function of giving the client enough information about the
      installation server and the location of the sources. Usually, this file
      is not required, but it is needed in special network environments
@@ -16217,12 +16220,13 @@ echo -n 100
      to be loaded.
     </para>
     <para>
-     You can pass keywords to linuxrc using the kernel command line. This can be
-     done in several ways. You can specify linurc keywords along with other
-     kernel parameters interactively at boot time, as usual. You can also
-     insert kernel parameters into custom network-bootable disk images. It is 
-     also possible to configure a DHCP server to pass kernel parameters in
-     combination with Etherboot or PXE.
+     You can pass keywords to <command>linuxrc</command> using the kernel
+     command line. This can be done in several ways. You can specify
+     <command>linurc</command> keywords along with other kernel parameters
+     interactively at boot time, in the usual way. You can also insert kernel
+     parameters into custom network-bootable disk images. It is also possible to
+     configure a DHCP server to pass kernel parameters in combination with
+     Etherboot or PXE.
     </para>
     <para>
      The command line variable <literal>autoyast</literal> can be used in
@@ -16538,7 +16542,8 @@ echo -n 100
      <para>
       To disable the network during installations where it is not needed or
       unavailable, for example when auto-installing from DVD-ROMs, use the
-      linuxrc option <literal>netsetup=0</literal> to disable the network setup.
+      <command>linuxrc</command> option <literal>netsetup=0</literal> to disable
+      the network setup.
      </para>
     </note>
     <note>
@@ -16554,13 +16559,13 @@ echo -n 100
       <listitem>
        <para>
         When you use <literal>autoyast=http://...</literal>, you need to
-        provide linuxrc with the network configuration.
+        provide <command>linuxrc</command> with the network configuration.
        </para>
       </listitem>
       <listitem>
        <para>
-        When you use <literal>autoyast2=http://...</literal>, linuxrc tries to
-        configure the network for you.
+        When you use <literal>autoyast2=http://...</literal>, <command>linuxrc</command>
+        tries to configure the network for you.
        </para>
       </listitem>
      </itemizedlist>
@@ -16679,23 +16684,25 @@ default</screen>
    </sect2>
 
    <sect2 xml:id="invoking_autoinst.linuxrc">
-    <title>Combining the Linuxrc <filename>info</filename> File with the &ay; Control File</title>
+    <title>Combining the <command>linuxrc</command> <filename>info</filename> File with the &ay; Control File</title>
     <para>
-     If you choose to pass information to linuxrc using the 
+     If you choose to pass information to <command>linuxrc</command> using the 
      <filename>info</filename> file, it is possible to integrate the
      keywords in the XML control file. In this case the file needs to be
-     accessible to linuxrc and must be named <filename>info</filename>.
+     accessible to <command>linuxrc</command> and must be named
+     <filename>info</filename>.
     </para>
     <para>
-     Linuxrc will look for the string <literal>start_linuxrc_conf</literal>
-     in the &ay; control file, which represents the beginning of the embedded
-     linuxrc control file. If the string is found, linuxrc will parse the
+     The <command>linuxrc</command> program will look for the string
+     <literal>start_linuxrc_conf</literal> in the &ay; control file, which
+     represents the beginning of the embedded <command>linuxrc</command> control
+     file. If the string is found, <command>linuxrc</command> will parse the
      content starting from that string and will finish when the string
      <literal>end_linuxrc_conf</literal> is found. The options are stored in the
      control file in the following way:
     </para>
     <example>
-     <title>Linuxrc Options in the &ay; Control File</title>
+     <title><command>linuxrc</command> Options in the &ay; Control File</title>
 <screen>....
   &lt;install&gt;
 ....
@@ -17090,16 +17097,16 @@ mv /var/run/zypp.sav /var/run/zypp.pid
    <qandaentry xml:id="qa.ay.insecure">
     <question>
      <para>
-      <command>Linuxrc</command> blocks the installation with <literal>File not
+      <command>linuxrc</command> blocks the installation with <literal>File not
       signed</literal>. I need to manually interact.
      </para>
     </question>
     <answer>
      <para>
-      <command>Linuxrc</command> found an unsigned file, such as a driver
+      <command>linuxrc</command> found an unsigned file, such as a driver
       update. To use an unsigned file, you can suppress that message by passing
-      <literal>insecure=1</literal> to the linuxrc parameter list (together with
-      the <literal>autoyast=...</literal> parameter).
+      <literal>insecure=1</literal> to the <command>linuxrc</command> parameter
+      list (together with the <literal>autoyast=...</literal> parameter).
      </para>
     </answer>
    </qandaentry>
@@ -17112,9 +17119,10 @@ mv /var/run/zypp.sav /var/run/zypp.pid
     </question>
     <answer>
      <para>
-      You need to pass <literal>ifcfg</literal> to linuxrc. This is required to
-      set up the network, otherwise &ay; cannot download the profile from the
-      remote host. See <xref linkend="ay.adv_network"/> for more information.
+      You need to pass <literal>ifcfg</literal> to <command>linuxrc</command>.
+      This is required to set up the network, otherwise &ay; cannot download the
+      profile from the remote host. See <xref linkend="ay.adv_network"/> for
+      more information.
      </para>
     </answer>
    </qandaentry>
@@ -17169,25 +17177,25 @@ mv /var/run/zypp.sav /var/run/zypp.pid
  </appendix>
 
  <appendix xml:id="appendix.linuxrc">
-  <title>Advanced Linuxrc Options</title>
+  <title>Advanced <command>linuxrc</command> Options</title>
   <info/>
   <para>
-   <command>Linuxrc</command> is a small program that runs after the kernel has
+   <command>linuxrc</command> is a small program that runs after the kernel has
    loaded, but before &ay; or other stages. It prepares the system for
    installation. It allows the user to load modules, start an installed system
    or a rescue system, and to guide the operation of &yast;.
   </para>
   <note>
-   <title>Linuxrc Settings are Not Identical to &ay; Settings</title>
+   <title>&ay; and <command>linuxrc</command> Settings Are Not Identical</title>
    <para>
-    Some linuxrc settings coincidentally have the same names as settings used by
-    &ay; in its <filename>autoyast.xml</filename> file. This does <emphasis>not</emphasis>
-    mean that they take the same parameters or function in the same way. For
-    example, &ay; takes a <command>self_update</command> setting. If this
-    value is set to <literal>1</literal>, another setting,
-    <command>self_update_url</command> will be read and followed. Linuxrc also
-    has a <command>self_update</command> setting, but the linuxrc settings takes
-    values of either <literal>0</literal> or a URL.
+    Some <command>linuxrc</command> settings coincidentally have the same names
+    as settings used by &ay; in its <filename>autoyast.xml</filename> file. This
+    does <emphasis>not</emphasis> mean that they take the same parameters or
+    function in the same way. For example, &ay; takes a <command>self_update</command>
+    setting. If this value is set to <literal>1</literal>, another setting,
+    <command>self_update_url</command> will be read and followed. Although <command>linuxrc</command>
+    also has a <command>self_update</command> setting, <command>linuxrc</command>'s
+    setting takes values of either <literal>0</literal> or a URL.
    </para>
    <para>
     Do not pass &ay; parameters to <command>linuxrc</command>, as this will
@@ -17201,7 +17209,7 @@ mv /var/run/zypp.sav /var/run/zypp.pid
    <link xlink:href="https://en.opensuse.org/SDB:Linuxrc"/>
   </para>
   <note>
-   <title>Running Linuxrc on an Installed System</title>
+   <title>Running <command>linuxrc</command> on an Installed System</title>
    <para>
     If you run <command>linuxrc</command> on an installed system, it will work
     slightly differently so as not to destroy your installation. As a
@@ -17215,7 +17223,7 @@ mv /var/run/zypp.sav /var/run/zypp.pid
    libraries in the initial RAM disk, <filename>initrd</filename>.
   </para>
   <sect1 xml:id="ay.cmd_parameters">
-   <title>Passing Parameters to Linuxrc</title>
+   <title>Passing Parameters to <command>linuxrc</command></title>
 
    <para>
     Unless <command>linuxrc</command> is in manual mode, it will look for an
@@ -17231,11 +17239,11 @@ mv /var/run/zypp.sav /var/run/zypp.pid
    </para>
 
    <para>
-    Linuxrc will always look for and parse a file called <filename>/linuxrc.config</filename>.
-    Use this file to change default values if you need to. In general, it is
-    better to use the <filename>info</filename> file instead. Note that
-    <filename>/linuxrc.config</filename> is read before any
-    <filename>info</filename> file, even in manual mode.
+    <command>linuxrc</command> will always look for and parse a file called
+    <filename>/linuxrc.config</filename>. Use this file to change default values
+    if you need to. In general, it is better to use the <filename>info</filename>
+    file instead. Note that <filename>/linuxrc.config</filename> is read before
+    any <filename>info</filename> file, even in manual mode.
    </para>
   </sect1>
   <sect1 xml:id="info_file_format">
@@ -17267,7 +17275,7 @@ mv /var/run/zypp.sav /var/run/zypp.pid
    </para>
 
    <table>
-    <title>Advanced Linuxrc Keywords</title>
+    <title>Advanced <command>linuxrc</command> Keywords</title>
     <tgroup cols="2">
      <colspec colnum="1" colname="1" colwidth="30*"/>
      <colspec colnum="2" colname="2" colwidth="70*"/>
@@ -17756,12 +17764,12 @@ mv /var/run/zypp.sav /var/run/zypp.pid
    <title>Advanced Network Setup</title>
 
    <para>
-    Even if parameters like <literal>hostip</literal>,
-    <literal>nameserver</literal>, and <literal>gateway</literal> are passed to
-    linuxrc, the network is only started when it is needed (for example, when
-    installing via SSH or VNC). Because <literal>autoyast</literal>
-    is not a linuxrc parameter (this parameter is ignored by linuxrc and is only
-    passed to &yast;), the network will <emphasis>not</emphasis> be started
+    Even if parameters like <literal>hostip</literal>, <literal>nameserver</literal>,
+    and <literal>gateway</literal> are passed to <command>linuxrc</command>, the
+    network is only started when it is needed (for example, when installing via
+    SSH or VNC). Because <literal>autoyast</literal> is not a <command>linuxrc</command>
+    parameter (this parameter is ignored by <command>linuxrc</command> and is
+    only passed to &yast;), the network will <emphasis>not</emphasis> be started
     automatically when specifying a remote location for the &ay; profile.
    </para>
    <para>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -9933,7 +9933,7 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
     <para>
      A list of users can be defined in the <literal>&lt;users&gt;</literal>
      section. To be able to log in, make sure that either the &rootuser; users are
-     set up or rootpassword is specified as a linuxrc option.
+     set up or <option>rootpassword</option> is specified as a linuxrc option.
     </para>
 
     <example>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -6126,7 +6126,7 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
 
    <para>
     If the following setting is set to <literal>true</literal>, &yast;
-    will keep network settings created during the installation (via Linuxrc)
+    will keep network settings created during the installation (via <command>linuxrc</command>)
     and/or merge it with network settings from the &ay; control file (if
     defined). &ay; settings have higher priority than already present
     configuration files. &yast; will write ifcfg-* files based on the
@@ -9923,7 +9923,7 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
     <para>
      A list of users can be defined in the <literal>&lt;users&gt;</literal>
      section. To be able to log in, make sure that either the &rootuser; users are
-     set up or rootpassword is specified as a linuxrc option.
+     set up or rootpassword is specified as a <command>linuxrc</command> option.
     </para>
 
     <example>
@@ -9996,9 +9996,9 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
 
      <para>
       It is possible to specify <literal>rootpassword</literal> in
-      linuxrc and also have a user section for the root user. If this
-      section is missing the password, then the password from linuxrc
-      will be used. Passwords in profiles take precedence over linuxrc
+      <command>linuxrc</command> and also have a user section for the root user. If this
+      section is missing the password, then the password from <command>linuxrc</command>
+      will be used. Passwords in profiles take precedence over <command>linuxrc</command>
       passwords.
      </para>
     </note>
@@ -15801,7 +15801,7 @@ echo -n 100
      Start installing a system using the serial console by adding the
      keyword <literal>console</literal> (for example
      <literal>console=ttyS0</literal>) to the command line of the kernel.
-     This starts linuxrc in console mode and later &yast; in serial
+     This starts <command>linuxrc</command> in console mode and later &yast; in serial
      console mode.
     </para>
    </sect2>
@@ -15936,7 +15936,7 @@ echo -n 100
     <title>Command Line Options</title>
     <para>
      Adding the command line variable <literal>autoyast</literal> causes
-     linuxrc to start in automated mode. linuxrc searches for a
+     <command>linuxrc</command> to start in automated mode. <command>linuxrc</command> searches for a
      configuration file, which should be distinguished from the main control
      file in the following places:
     </para>
@@ -15944,22 +15944,22 @@ echo -n 100
      <listitem>
       <para>
        in the root directory of the initial RAM disk used for booting the
-       system,
+       system;
       </para>
      </listitem>
      <listitem>
       <para>
-       in the root directory of the boot medium
+       in the root directory of the boot medium.
       </para>
      </listitem>
     </itemizedlist>
     <para>
-     The configuration file used by linuxrc can have the following keywords
-     (for a detailed description of how linuxrc works and other keywords,
-     see <xref linkend="appendix.linuxrc"/>):
+     The <command>linuxrc</command> configuration file supports multiple keywords.
+     For a detailed description of how <command>linuxrc</command> works and other keywords,
+     see <xref linkend="appendix.linuxrc"/>. Some of the more common ones are:
     </para>
     <table>
-     <title>Keywords for linuxrc</title>
+     <title>Keywords for <command>linuxrc</command></title>
      <tgroup cols="2">
       <thead>
        <row>
@@ -16012,11 +16012,11 @@ echo -n 100
         <entry>
          <para>
           Location of the control file for automatic installation.
-          Similar to <literal>autoyast</literal> option but linuxrc parses
+          Similar to the <literal>autoyast</literal> option, but <command>linuxrc</command> parses
           the provided value and, for example, tries to configure a network
           when needed. For information about differences between the &ay; and
-          linuxrc URI syntax, see the documentation of linuxrc. &ay;'s rules
-          and classes are not supported.
+          <command>linuxrc</command> URI syntax, see the <command>linuxrc</command> appendix:
+          <xref linkend="appendix.linuxrc"/>. &ay;'s rules and classes are not supported.
          </para>
         </entry>
        </row>
@@ -16196,10 +16196,10 @@ echo -n 100
      where &yast; can take over with the main control file. Currently,
      the source medium is automatically discovered, which in some cases
      makes it possible to initiate the auto-install process without giving
-     any instructions to linuxrc.
+     any instructions to <command>linuxrc</command>.
     </para>
     <para>
-     The traditional linuxrc configuration file (<filename>info</filename>)
+     The traditional <command>linuxrc</command> configuration file (<filename>info</filename>)
      has the function of giving the client enough information about the
      installation server and the location of the sources. Usually, this file
      is not required, but it is needed in special network environments
@@ -16207,13 +16207,10 @@ echo -n 100
      to be loaded.
     </para>
     <para>
-     All linuxrc keywords can be passed to linuxrc using the kernel command
-     line. The command line can also be set when creating network bootable
-     images or it can be passed to the kernel using a specially configured
-     DHCP server in combination with Etherboot or PXE.
-     <remark>emap 2011-11-07:Obscure paragraph. What is set in the command
-     line? And what is the 'it' that can be passed to the kernel? Probably not
-     the command line itself.</remark>
+     You can pass keywords to <command>linuxrc</command> using the kernel
+     command line, either interactively at boot time, when creating 
+     network-bootable images, or using a specially-configured DHCP server in
+     combination with Etherboot or PXE.
     </para>
     <para>
      The command line variable <literal>autoyast</literal> can be used in
@@ -16493,13 +16490,12 @@ echo -n 100
       <term>Using a Network Installation Source</term>
       <listitem>
        <para>
-        This option is the most important one because
-        installations of multiple machines are usually done using SLP or NFS
-        servers and other network services like BOOTP and DHCP. The easiest
-        way to make the control file available is to place it in the root
-        directory of the installation source naming it
-        <filename>autoinst.xml</filename>. In this case it will
-        automatically be found and used for the installation. The control
+        This option is the most important one because installations of multiple
+        machines are usually done using SLP or NFS servers and other network
+        services like BOOTP and DHCP. The easiest way to make the control file
+        available is to place it in the root directory of the installation
+        source, naming it <filename>autoinst.xml</filename>. In this case, it
+        will automatically be found and used for the installation. The control
         file can also reside in the following places:
        </para>
        <formalpara>
@@ -16530,8 +16526,8 @@ echo -n 100
      <para>
       To disable the network during installations where it is not needed or
       unavailable, for example when auto-installing from DVD-ROMs, use the
-      linuxrc option <literal>netsetup=0</literal> to disable the network
-      setup.
+      <command>linuxrc</command> option <literal>netsetup=0</literal> to disable
+      the network setup.
      </para>
     </note>
     <note>
@@ -16547,13 +16543,13 @@ echo -n 100
       <listitem>
        <para>
         When you use <literal>autoyast=http://...</literal>, you need to
-        provide linuxrc with the network configuration.
+        provide <command>linuxrc</command> with the network configuration.
        </para>
       </listitem>
       <listitem>
        <para>
-        When you use <literal>autoyast2=http://...</literal>, linuxrc tries
-        to configure the network for you.
+        When you use <literal>autoyast2=http://...</literal>, <command>linuxrc</command>
+        tries to configure the network for you.
        </para>
       </listitem>
      </itemizedlist>
@@ -16674,13 +16670,13 @@ default</screen>
    <sect2 xml:id="invoking_autoinst.linuxrc">
     <title>Combining the linuxrc <filename>info</filename> file with the &ay; control file</title>
     <para>
-     If you choose to pass information to linuxrc using the
+     If you choose to pass information to <command>linuxrc</command> using the
      <filename>info</filename> file, it is possible to integrate the
      keywords in the XML control file. In this case the file needs to be
-     accessible to linuxrc and needs to be named <filename>info</filename>.
+     accessible to <command>linuxrc</command> and must be named <filename>info</filename>.
     </para>
     <para>
-     Linuxrc will look for a string (<literal>start_linuxrc_conf</literal>
+     <command>Linuxrc</command> will look for a string (<literal>start_linuxrc_conf</literal>
      in the control file which represents the beginning of the file. If it
      is found, it will parse the content starting from that string and will
      finish when the string <literal>end_linuxrc_conf</literal> is found.
@@ -17082,16 +17078,16 @@ mv /var/run/zypp.sav /var/run/zypp.pid
    <qandaentry xml:id="qa.ay.insecure">
     <question>
      <para>
-      linuxrc blocks the installation with <literal>File not
+      <command>Linuxrc</command> blocks the installation with <literal>File not
       signed</literal>. I need to manually interact.
      </para>
     </question>
     <answer>
      <para>
-      Linuxrc found some unsigned file (like a driver update). To
-      use an unsigned file, you can suppress that message by passing
-      <literal>insecure=1</literal> to the linuxrc parameter list (together
-      with the <literal>autoyast=...</literal> parameter).
+      <command>Linuxrc</command> found an unsigned file, such as a driver
+      update. To use an unsigned file, you can suppress that message by passing
+      <literal>insecure=1</literal> to the <command>linuxrc</command> parameter
+      list (together with the <literal>autoyast=...</literal> parameter).
      </para>
     </answer>
    </qandaentry>
@@ -17104,24 +17100,24 @@ mv /var/run/zypp.sav /var/run/zypp.pid
     </question>
     <answer>
      <para>
-      You need to pass <literal>ifcfg</literal> to linuxrc. This is required
-      to set up the network, otherwise &ay; cannot download the
-      profile from remote. See <xref linkend="ay.adv_network"/> for more
-      information.
+      You need to pass <literal>ifcfg</literal> to <command>linuxrc</command>.
+      This is required to set up the network, otherwise &ay; cannot download the
+      profile from the remote host. See <xref linkend="ay.adv_network"/> for
+      more information.
      </para>
     </answer>
    </qandaentry>
    <qandaentry xml:id="qa.ay.nfsroot">
     <question>
      <para>
-      Is the installation on an NFS root (<filename>/</filename>) possible?
+      Is installation onto an NFS root (<filename>/</filename>) possible?
      </para>
     </question>
     <answer>
      <para>
-      Yes, but it is a little bit <quote>tricky</quote>. You will need to set
-      up the environment (DHCP, TFTP, etc.) very carefully. The &ay; profile
-      needs to look like the following:
+      Yes, but it is more complex than other methods. The environment (DHCP,
+      TFTP, etc.) must be set up very carefully. The &ay; profile must look
+      like the following:
      </para>
      <screen>&lt;?xml version="1.0"?&gt;
 &lt;!DOCTYPE profile&gt;
@@ -17165,44 +17161,65 @@ mv /var/run/zypp.sav /var/run/zypp.pid
   <title>Advanced Linuxrc Options</title>
   <info/>
   <para>
-   Linuxrc is a program used for setting up the kernel for installation
-   purposes. It allows the user to load modules, start an installed system,
-   a rescue system or an installation via &yast;.
+   <command>Linuxrc</command> is a small program that runs after the kernel loads, but before &ay;
+   or other stages. It prepares the system for installation. It allows the user
+   to load modules, start an installed system or a rescue system, and to guide
+   the operation of &yast;.
   </para>
+  <note>
+   <title>Linuxrc Settings Are Not The Same As &ay; Settings</title>
+   <para>
+    Some <command>linuxrc</command> settings have the same names as settings
+    used by &ay; in the <filename>autoyast.xml</filename> file. Beware that this
+    does not mean that they take the same parameters or function in the same
+    way. For example, &ay; takes a parameter <command>self_update</command>
+    and if this is set, another called <command>self_update_url</command>.
+    Linuxrc also has a <command>self_update</command> parameter, but this takes
+    either <literal>0</literal> or a URL. Attempting to pass &ay; parameters to
+    <command>linuxrc</command> will almost certainly not give the desired 
+    results.
+   </para>
+  </note>
   <para>
-   Linuxrc is designed to be as small as possible. Therefore, all needed
-   programs are linked directly into one binary. So there is no need for
-   shared libraries in the init disk.
+   If <command>linuxrc</command> is installed on a machine, information about it
+   can be found in the folder <filename>/usr/share/doc/packages/linuxrc/</filename>.
+   Alternatively, its documentation can be found online at:
+   <link xlink:href="https://en.opensuse.org/SDB:Linuxrc"/>
   </para>
   <note>
    <title>Running Linuxrc on an Installed System</title>
    <para>
-    If you run Linuxrc on an installed system, it will work slightly
-    differently so as not to destroy your installation. As a consequence you
-    cannot test all features this way.
+    If you run <command>linuxrc</command> on an installed system, it will work
+    slightly differently so as not to destroy your installation. As a
+    consequence, you cannot test all features this way.
    </para>
   </note>
+  <para>
+   To keep the <command>linuxrc</command> binary file as small as possible, all
+   its libraries and other supplemental files are linked directly into the main
+   program binary file. This means that there is no need for any shared
+   libraries in the initial RAM disk, <filename>initrd</filename>.
+  </para>
   <sect1 xml:id="ay.cmd_parameters">
    <title>Passing parameters to Linuxrc</title>
 
    <para>
-    Unless Linuxrc is in manual mode, it will look for an
+    Unless <command>linuxrc</command> is in manual mode, it will look for an
     <filename>info</filename> file in these locations: first
     <filename>/info</filename> on the flash disk and if that does not exist,
-    for <filename>/info</filename> in the initrd. After that it parses the
-    kernel command line for parameters. You may change the
-    <filename>info</filename> file Linuxrc reads by setting the
+    for <filename>/info</filename> in the <filename>initrd</filename>. After
+    that, it parses the kernel command line for parameters. You may change the
+    <filename>info</filename> file <command>linuxrc</command> reads by setting the
     <filename>info</filename> command line parameter. If you do not want
-    Linuxrc to read the kernel command line (for example because you need to
-    specify a kernel parameter that Linuxrc recognizes as well), use
-    <literal>linuxrc=nocmdline</literal>.
+    <command>linuxrc</command> to read the kernel command line (for example, 
+    because you need to specify a kernel parameter that <command>linuxrc</command>
+    recognizes as well), use <literal>linuxrc=nocmdline</literal>.
    </para>
 
    <para>
-    Linuxrc will always look for and parse a file
-    <filename>/linuxrc.config</filename>. Use this file to change default
-    values if you need to. In general, it is better to use the
-    <filename>info</filename> file instead. Note that
+    Linuxrc will always look for and parse a file called <filename>/linuxrc.config</filename>.
+    Use this file to change default values if you need to. In general, it is
+    better to use the <filename>info</filename> file instead. Note that
     <filename>/linuxrc.config</filename> is read before any
     <filename>info</filename> file, even in manual mode.
    </para>
@@ -17211,7 +17228,7 @@ mv /var/run/zypp.sav /var/run/zypp.pid
    <title><filename>info</filename> file format</title>
 
    <para>
-    Lines starting with <literal>#</literal> are comments, valid entries are
+    Lines starting with <literal>#</literal> are comments. Valid entries are
     of the form:
    </para>
 
@@ -17219,19 +17236,19 @@ mv /var/run/zypp.sav /var/run/zypp.pid
 
    <para>
     Note that <literal>value</literal> extends to the end of the line and
-    therefore may contain spaces. <literal>key</literal> is matched
-    case-insensitive.
+    therefore may contain spaces. The matching of <literal>key</literal> is on a
+    case-insensitive basis.
    </para>
 
    <para>
     You can use the same key-value pairs on the kernel command line using
     the syntax <literal>key=value</literal>. Lines that do not have the form
-    described above are ignored.
+    described above will be ignored.
    </para>
 
    <para>
     The table below lists important keys and example values. For a complete
-    list of linuxrc parameters refer to <link
+    list of <command>linuxrc</command> parameters, refer to <link
     xlink:href="https://en.opensuse.org/SDB:Linuxrc"/>.
    </para>
 
@@ -17257,7 +17274,7 @@ mv /var/run/zypp.sav /var/run/zypp.pid
 
 
    <table>
-    <title>Advanced linuxrc keywords</title>
+    <title>Advanced Linuxrc Keywords</title>
     <tgroup cols="2">
      <colspec colnum="1" colname="1" colwidth="30*"/>
      <colspec colnum="2" colname="2" colwidth="70*"/>
@@ -17285,7 +17302,7 @@ mv /var/run/zypp.sav /var/run/zypp.pid
        <entry>
         <para>
          If 0, never ask for swap; if the argument is a positive number
-         <literal>n</literal>, activate the <literal>n</literal>'th swap
+         <literal>n</literal>, activate the <literal>n</literal>th swap
          partition; if the argument is a partition name, activate this swap
          partition.
         </para>
@@ -17748,16 +17765,17 @@ mv /var/run/zypp.sav /var/run/zypp.pid
    <para>
     Even if parameters like <literal>hostip</literal>,
     <literal>nameserver</literal>, and <literal>gateway</literal> are passed to
-    linuxrc, the network is only started when it is needed (for example, when
-    installing via SSH or VNC). Since <literal>autoyast</literal> is not a linuxrc
-    parameter (this parameter is ignored by linuxrc and only passed to &yast;),
-    the network will <emphasis>not</emphasis> be started automatically when
-    specifying a remote location for the &ay; profile.
+    <command>linuxrc</command>, the network is only started when it is needed
+    (for example, when installing via SSH or VNC). Since <literal>autoyast</literal>
+    is not a <command>linuxrc</command> parameter (this parameter is ignored by
+    <command>linuxrc</command> and only passed to &yast;), the network will
+    <emphasis>not</emphasis> be started automatically when specifying a remote
+    location for the &ay; profile.
    </para>
    <para>
     Therefore the network needs to be started explicitly. This used to be done
-    with the linuxrc parameter <literal>netsetup</literal>. Starting with
-    &productname; <phrase os="osuse">13.2</phrase><phrase
+    with the <command>linuxrc</command> parameter <literal>netsetup</literal>.
+    Starting with &productname; <phrase os="osuse">13.2</phrase><phrase
     os="sles;sled">12</phrase>, the parameter <literal>ifcfg</literal> is
     available. It offers more configuration options, for example configuring
     more than one interface. <literal>ifcfg</literal> directly controls the


### PR DESCRIPTION
Purpose is to make it explicit that syntax is not shared with autoyast

I have also formatted the name as a command where it is not capitalised or in a title, and made some minor copy edits, including addressing earlier remarks.

### Description
A few sentences describing the overall goals of this pull request.
If there are relevant Bugzilla or FATE entries, reference them.

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE15SP0
