### PR TITLE
Disable memory balloon in guest vm (BSC#1127075)

### DIFF
--- a/xml/libvirt_configuration_virsh.xml
+++ b/xml/libvirt_configuration_virsh.xml
@@ -1433,4 +1433,18 @@ pci_0000_04_11_5</screen>
    </listitem>
   </itemizedlist>
  </sect1>
+<sect1 xml:id="sec.libvirt.config.disable_virtio_mellon">
+  <title>Disabling Memory Balloon Device</title>
+  
+  <para>
+    Memory Balloon is becoming a default option for KVM now, the device will be added
+    to &vmguest; explicitly, and no need to add this element in &vmguest;'s XML configuration.
+    However a <literal>model='none'</literal> will be necessary if thing goes different way.
+    The following example will disable Memory Ballon in &vmguest;:
+  </para>
+  
+  <screen>&lt;devices&gt;
+   &lt;memballoon model='none'/&gt;
+   &lt;/device&gt;</screen>
+  </sect1>
 </chapter>


### PR DESCRIPTION
### Description
A few customers has asked how to disable virtio-balloon for SLES guest VM, and looks we did not dress it anywhere.

### Checklist
* Check all items that apply.

*Are backports required?*

- [Y] To maintenance/SLE12SP3
- [Y] To maintenance/SLE12SP4
- [Y] To maintenance/SLE15SP0
