### PR TITLE
Add a Bcache section to the AutoYaST handbook

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -4559,7 +4559,7 @@ openssl x509 -noout -fingerprint -sha256
     <title>Bcache Definition</title>
 <screen>&lt;partitioning config:type="list"&gt;
   &lt;drive&gt;
-    &lt;device&gt;/dev/vda&lt;/device&gt;
+    &lt;device&gt;/dev/sda&lt;/device&gt;
     &lt;type config:type="symbol"&gt;CT_DISK&lt;/type&gt;
     &lt;use&gt;all&lt;/use&gt;
     &lt;enable_snapshots config:type="boolean"&gt;true&lt;/enable_snapshots&gt;
@@ -4570,12 +4570,18 @@ openssl x509 -noout -fingerprint -sha256
         &lt;create config:type="boolean"&gt;true&lt;/create&gt;
         &lt;size&gt;max&lt;/size&gt;
       &lt;/partition&gt;
+      &lt;partition&gt;
+        &lt;filesystem config:type="symbol"&gt;swap&lt;/filesystem&gt;
+        &lt;mount&gt;swap&lt;/mount&gt;
+        &lt;create config:type="boolean"&gt;true&lt;/create&gt;
+        &lt;size&gt;2GiB&lt;/size&gt;
+      &lt;/partition&gt;
     &lt;/partitions&gt;
   &lt;/drive&gt;
 
   &lt;drive&gt;
     &lt;type config:type="symbol"&gt;CT_DISK&lt;/type&gt;
-    &lt;device&gt;/dev/vdb&lt;/device&gt;
+    &lt;device&gt;/dev/sdb&lt;/device&gt;
     &lt;disklabel&gt;msdos&lt;/disklabel&gt;
     &lt;use&gt;all&lt;/use&gt;
     &lt;partitions config:type="list"&gt;
@@ -4591,7 +4597,7 @@ openssl x509 -noout -fingerprint -sha256
 
   &lt;drive&gt;
     &lt;type config:type="symbol"&gt;CT_DISK&lt;/type&gt;
-    &lt;device&gt;/dev/vdc&lt;/device&gt;
+    &lt;device&gt;/dev/sdc&lt;/device&gt;
     &lt;use&gt;all&lt;/use&gt;
     &lt;disklabel&gt;msdos&lt;/disklabel&gt;
     &lt;partitions config:type="list"&gt;

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2617,6 +2617,16 @@ openssl x509 -noout -fingerprint -sha256
             <literal>CT_LVM</literal> for LVM volume groups,
            </para>
           </listitem>
+          <listitem>
+           <para>
+            <literal>CT_RAID</literal> for software RAID devices,
+           </para>
+          </listitem>
+          <listitem>
+           <para>
+            <literal>CT_BCACHE</literal> for software Bcache devices.
+           </para>
+          </listitem>
          </itemizedlist>
 <screen>&lt;type config:type="symbol"&gt;CT_LVM&lt;/type&gt;</screen>
         </entry>
@@ -3370,6 +3380,46 @@ openssl x509 -noout -fingerprint -sha256
        <row>
         <entry>
          <para>
+          bcache_backing_for
+         </para>
+        </entry>
+        <entry>
+         <para>
+          If this device is used as a <emphasis>Bcache backing device</emphasis>, specify the name
+          of the Bcache.
+         </para>
+<screen>&lt;bcache_backing_for&gt;/dev/bcache0&lt;/bcache_backing_for&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          See <xref linkend="ay.partition_bcache"/> for further details.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          bcache_caching_for
+         </para>
+        </entry>
+        <entry>
+         <para>
+          If this device is used as a <emphasis>Bcache caching device</emphasis>, specify the names
+          of the Bcaches.
+         </para>
+<screen>&lt;bcache_caching_for config:type="list"&gt;
+  &lt;listentry&gt;/dev/bcache0&lt;/listentry&gt;
+&lt;/bcache_caching_for&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          See <xref linkend="ay.partition_bcache"/> for further details.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
           <literal>resize</literal>
          </para>
         </entry>
@@ -3380,8 +3430,7 @@ openssl x509 -noout -fingerprint -sha256
           to reuse the device (see <literal>create</literal>) and specify
           a <literal>size</literal>.
          </para>
-<screen>&lt;resize config:type="boolean"
-&gt;false&lt;/resize&gt;</screen>
+<screen>&lt;resize config:type="boolean"&gt;false&lt;/resize&gt;</screen>
         </entry>
         <entry>
          <para>
@@ -4469,6 +4518,160 @@ openssl x509 -noout -fingerprint -sha256
      </tgroup>
     </informaltable>
    </sect3>
+  </sect2>
+
+  <sect2 xml:id="ay.partition_bcache">
+   <title>Bcache Configuration</title>
+   <para>
+    Bcache is a caching system which allows using one or more fast drives to speed up the access
+    to one or more slower drives. For instance, you may improve the performance of a big (but
+    slow) drive by using a fast one as a cache.
+   </para>
+
+   <para>
+    In order to set up a Bcache device, AutoYaST needs a profile specifying:
+   </para>
+
+   <itemizedlist>
+    <listitem>
+     <para>
+      The block device will be used as the <emphasis>backing device</emphasis>, which is
+      meant to be the slow drive. Use the <literal>bcache_backing_for</literal> element for that.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      The block device will be used as <emphasis>caching device</emphasis>, which is supposed to
+      be fast. You can use the same device to speed up the access to several drives. Use the
+      <literal>bcache_caching_for</literal> element for that.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      The layout of the Bcache device (i.e., it may contain partitions). Use a
+      <literal>drive</literal> section setting the <literal>type</literal> element to
+      <literal>CT_BCACHE</literal>.
+     </para>
+    </listitem>
+   </itemizedlist>
+
+   <example>
+    <title>Bcache Definition</title>
+<screen>&lt;partitioning config:type="list"&gt;
+  &lt;drive&gt;
+    &lt;device&gt;/dev/vda&lt;/device&gt;
+    &lt;type config:type="symbol"&gt;CT_DISK&lt;/type&gt;
+    &lt;use&gt;all&lt;/use&gt;
+    &lt;enable_snapshots config:type="boolean"&gt;true&lt;/enable_snapshots&gt;
+    &lt;partitions config:type="list"&gt;
+      &lt;partition&gt;
+        &lt;filesystem config:type="symbol"&gt;btrfs&lt;/filesystem&gt;
+        &lt;mount&gt;/&lt;/mount&gt;
+        &lt;create config:type="boolean"&gt;true&lt;/create&gt;
+        &lt;size&gt;max&lt;/size&gt;
+      &lt;/partition&gt;
+    &lt;/partitions&gt;
+  &lt;/drive&gt;
+
+  &lt;drive&gt;
+    &lt;type config:type="symbol"&gt;CT_DISK&lt;/type&gt;
+    &lt;device&gt;/dev/vdb&lt;/device&gt;
+    &lt;disklabel&gt;msdos&lt;/disklabel&gt;
+    &lt;use&gt;all&lt;/use&gt;
+    &lt;partitions config:type="list"&gt;
+      &lt;partition&gt;
+        &lt;!-- It can serve as caching device for several bcaches --&gt;
+        &lt;bcache_caching_for config:type="list"&gt;
+          &lt;listentry&gt;/dev/bcache0&lt;/listentry&gt;
+        &lt;/bcache_caching_for&gt;
+        &lt;size&gt;max&lt;/size&gt;
+      &lt;/partition&gt;
+    &lt;/partitions&gt;
+  &lt;/drive&gt;
+
+  &lt;drive&gt;
+    &lt;type config:type="symbol"&gt;CT_DISK&lt;/type&gt;
+    &lt;device&gt;/dev/vdc&lt;/device&gt;
+    &lt;use&gt;all&lt;/use&gt;
+    &lt;disklabel&gt;msdos&lt;/disklabel&gt;
+    &lt;partitions config:type="list"&gt;
+      &lt;partition&gt;
+        &lt;!-- It can serve as backing device just for one bcache --&gt;
+        &lt;bcache_backing_for&gt;/dev/bcache0&lt;/bcache_backing_for&gt;
+      &lt;/partition&gt;
+    &lt;/partitions&gt;
+  &lt;/drive&gt;
+
+  &lt;drive&gt;
+    &lt;type config:type="symbol"&gt;CT_BCACHE&lt;/type&gt;
+    &lt;device&gt;/dev/bcache0&lt;/device&gt;
+    &lt;bcache_options&gt;
+      &lt;cache_mode&gt;writethrough&lt;/cache_mode&gt;
+    &lt;/bcache_options&gt;
+    &lt;use&gt;all&lt;/use&gt;
+    &lt;partitions config:type="list"&gt;
+      &lt;partition&gt;
+        &lt;mount&gt;/data&lt;/mount&gt;
+        &lt;size&gt;20GiB&lt;/size&gt;
+      &lt;/partition&gt;
+      &lt;partition&gt;
+        &lt;mount&gt;swap&lt;/mount&gt;
+        &lt;filesystem config:type="symbol"&gt;swap&lt;/filesystem&gt;
+        &lt;size&gt;1GiB&lt;/size&gt;
+      &lt;/partition&gt;
+    &lt;/partitions&gt;
+  &lt;/drive&gt;
+&lt;/partitioning&gt;
+</screen>
+</example>
+
+   <para>
+    For the time being, the only supported option in the <literal>bcache_options</literal>
+    section is <literal>cache_mode</literal>, described in the table below.
+   </para>
+
+   <informaltable>
+    <tgroup cols="3">
+     <thead>
+      <row>
+       <entry>
+        <para>
+         Attribute
+        </para>
+       </entry>
+       <entry>
+        <para>
+         Values
+        </para>
+       </entry>
+       <entry>
+        <para>
+         Description
+        </para>
+       </entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>
+        <para>
+         <literal>cache_mode</literal>
+        </para>
+       </entry>
+       <entry>
+        <para/>
+        <screen>&lt;cache_mode&gt;writethrough&lt;/cache_mode&gt;</screen>
+       </entry>
+       <entry>
+        <para>
+         Bcache cache mode. Possible values are <literal>writethrough</literal>,
+         <literal>writeback</literal>, <literal>writearound</literal> and <literal>none</literal>.
+        </para>
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </sect2>
 
    <sect2 xml:id="ay.partition_s390">

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2466,16 +2466,16 @@ openssl x509 -noout -fingerprint -sha256
         </entry>
         <entry>
          <para>
-          The device you want to configure in this &lt;drive&gt;
-          section. You can use persistent device names via id, like
+          The device you want to configure in this section. You can use persistent
+          device names via ID, like
           <filename>/dev/disk/by-id/ata-WDC_WD3200AAKS-75L9A0_WD-WMAV27368122</filename>
-          or <emphasis>by-path</emphasis>,like
+          or <emphasis>by-path</emphasis>, like
           <filename>/dev/disk/by-path/pci-0001:00:03.0-scsi-0:0:0:0</filename>.
          </para>
 <screen>&lt;device&gt;/dev/sda&lt;/device&gt;</screen>
         <para>
           In case of volume groups, software RAID or &bcache; devices, the name in the installed
-          system may be different in order to do not clash with existing devices.
+          system may be different (to avoid clashes with existing devices).
         </para>
         </entry>
         <entry>
@@ -3390,7 +3390,7 @@ openssl x509 -noout -fingerprint -sha256
         <entry>
          <para>
           If this device is used as a <emphasis>&bcache; backing device</emphasis>, specify the name
-          of the &bcache;.
+          of the &bcache; device.
          </para>
 <screen>&lt;bcache_backing_for&gt;/dev/bcache0&lt;/bcache_backing_for&gt;</screen>
         </entry>
@@ -4527,34 +4527,42 @@ openssl x509 -noout -fingerprint -sha256
   <sect2 xml:id="ay.partition_bcache">
    <title>&bcache; Configuration</title>
    <para>
-    &bcache; is a caching system which allows using one or more fast drives to speed up the access
-    to one or more slower drives. For instance, you may improve the performance of a big (but
-    slow) drive by using a fast one as a cache.
+    &bcache; is a caching system which allows using multiple fast drives to speed up the access
+    to one or more slower drives. For example, you can improve the performance
+    of a large (but slow) drive by using a fast one as a cache.
    </para>
 
    <para>
-    In order to set up a &bcache; device, AutoYaST needs a profile specifying:
+    To set up a &bcache; device, &ay; needs a profile which specifies the
+    following:
    </para>
 
    <itemizedlist>
     <listitem>
      <para>
-      The block device will be used as the <emphasis>backing device</emphasis>, which is
-      meant to be the slow drive. Use the <literal>bcache_backing_for</literal> element for that.
+      <remark>taroth 2019-04-05: @Imobach: Your original sentence was not clear
+       to me. I tried to rephrase it in the sense of how I understood the original
+       sentence. Please let me know if I got it right.</remark>
+      To set a (slow) block device as <emphasis>backing device</emphasis>, use
+      the <literal>bcache_backing_for</literal> element.
      </para>
     </listitem>
     <listitem>
      <para>
-      The block device will be used as <emphasis>caching device</emphasis>, which is supposed to
-      be fast. You can use the same device to speed up the access to several drives. Use the
-      <literal>bcache_caching_for</literal> element for that.
+      <remark>taroth 2019-04-05: @Imobach: Your original sentence was not clear
+       to me. I tried to rephrase it in the sense of how I understood the original
+       sentence. Please let me know if I got it right.</remark>
+      To set a (fast) block device as <emphasis>caching device</emphasis>, use
+      the <literal>bcache_caching_for</literal> element. You can use the same
+      device to speed up the access to several drives.
      </para>
     </listitem>
     <listitem>
      <para>
-      The layout of the &bcache; device (i.e., it may contain partitions). Use a
-      <literal>drive</literal> section setting the <literal>type</literal> element to
-      <literal>CT_BCACHE</literal>.
+      To specify the layout of the &bcache; device, use a <literal>drive</literal>
+      section and set the <literal>type</literal> element to
+      <literal>CT_BCACHE</literal>. The layout of the &bcache; device may contain
+      partitions.
      </para>
     </listitem>
    </itemizedlist>
@@ -4674,7 +4682,7 @@ openssl x509 -noout -fingerprint -sha256
        </entry>
        <entry>
         <para>
-         &bcache; cache mode. Possible values are <literal>writethrough</literal>,
+         Cache mode for &bcache;. Possible values are <literal>writethrough</literal>,
          <literal>writeback</literal>, <literal>writearound</literal> and <literal>none</literal>.
         </para>
        </entry>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+taroth<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook50-profile.xsl"
  type="text/xml"
  title="Profiling step"?>
@@ -4540,18 +4540,12 @@ openssl x509 -noout -fingerprint -sha256
    <itemizedlist>
     <listitem>
      <para>
-      <remark>taroth 2019-04-05: @Imobach: Your original sentence was not clear
-       to me. I tried to rephrase it in the sense of how I understood the original
-       sentence. Please let me know if I got it right.</remark>
       To set a (slow) block device as <emphasis>backing device</emphasis>, use
       the <literal>bcache_backing_for</literal> element.
      </para>
     </listitem>
     <listitem>
      <para>
-      <remark>taroth 2019-04-05: @Imobach: Your original sentence was not clear
-       to me. I tried to rephrase it in the sense of how I understood the original
-       sentence. Please let me know if I got it right.</remark>
       To set a (fast) block device as <emphasis>caching device</emphasis>, use
       the <literal>bcache_caching_for</literal> element. You can use the same
       device to speed up the access to several drives.

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2473,6 +2473,10 @@ openssl x509 -noout -fingerprint -sha256
           <filename>/dev/disk/by-path/pci-0001:00:03.0-scsi-0:0:0:0</filename>.
          </para>
 <screen>&lt;device&gt;/dev/sda&lt;/device&gt;</screen>
+        <para>
+          In case of volume groups, software RAID or bcache devices, the name in the installed
+          system may be different in order to do not clash with existing devices.
+        </para>
         </entry>
         <entry>
          <para>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -1,4 +1,4 @@
-taroth<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <?xml-stylesheet href="urn:x-suse:xslt:profiling:docbook50-profile.xsl"
  type="text/xml"
  title="Profiling step"?>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2628,7 +2628,7 @@ openssl x509 -noout -fingerprint -sha256
           </listitem>
           <listitem>
            <para>
-            <literal>CT_BCACHE</literal> for software Bcache devices.
+            <literal>CT_BCACHE</literal> for software bcache devices.
            </para>
           </listitem>
          </itemizedlist>
@@ -3389,8 +3389,8 @@ openssl x509 -noout -fingerprint -sha256
         </entry>
         <entry>
          <para>
-          If this device is used as a <emphasis>Bcache backing device</emphasis>, specify the name
-          of the Bcache.
+          If this device is used as a <emphasis>bcache backing device</emphasis>, specify the name
+          of the bcache.
          </para>
 <screen>&lt;bcache_backing_for&gt;/dev/bcache0&lt;/bcache_backing_for&gt;</screen>
         </entry>
@@ -3408,8 +3408,8 @@ openssl x509 -noout -fingerprint -sha256
         </entry>
         <entry>
          <para>
-          If this device is used as a <emphasis>Bcache caching device</emphasis>, specify the names
-          of the Bcaches.
+          If this device is used as a <emphasis>bcache caching device</emphasis>, specify the names
+          of the bcaches.
          </para>
 <screen>&lt;bcache_caching_for config:type="list"&gt;
   &lt;listentry&gt;/dev/bcache0&lt;/listentry&gt;
@@ -4533,7 +4533,7 @@ openssl x509 -noout -fingerprint -sha256
    </para>
 
    <para>
-    In order to set up a Bcache device, AutoYaST needs a profile specifying:
+    In order to set up a bcache device, AutoYaST needs a profile specifying:
    </para>
 
    <itemizedlist>
@@ -4552,7 +4552,7 @@ openssl x509 -noout -fingerprint -sha256
     </listitem>
     <listitem>
      <para>
-      The layout of the Bcache device (i.e., it may contain partitions). Use a
+      The layout of the bcache device (i.e., it may contain partitions). Use a
       <literal>drive</literal> section setting the <literal>type</literal> element to
       <literal>CT_BCACHE</literal>.
      </para>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2474,7 +2474,7 @@ openssl x509 -noout -fingerprint -sha256
          </para>
 <screen>&lt;device&gt;/dev/sda&lt;/device&gt;</screen>
         <para>
-          In case of volume groups, software RAID or bcache devices, the name in the installed
+          In case of volume groups, software RAID or &bcache; devices, the name in the installed
           system may be different in order to do not clash with existing devices.
         </para>
         </entry>
@@ -2628,7 +2628,7 @@ openssl x509 -noout -fingerprint -sha256
           </listitem>
           <listitem>
            <para>
-            <literal>CT_BCACHE</literal> for software bcache devices.
+            <literal>CT_BCACHE</literal> for software &bcache; devices.
            </para>
           </listitem>
          </itemizedlist>
@@ -3389,8 +3389,8 @@ openssl x509 -noout -fingerprint -sha256
         </entry>
         <entry>
          <para>
-          If this device is used as a <emphasis>bcache backing device</emphasis>, specify the name
-          of the bcache.
+          If this device is used as a <emphasis>&bcache; backing device</emphasis>, specify the name
+          of the &bcache;.
          </para>
 <screen>&lt;bcache_backing_for&gt;/dev/bcache0&lt;/bcache_backing_for&gt;</screen>
         </entry>
@@ -3408,8 +3408,8 @@ openssl x509 -noout -fingerprint -sha256
         </entry>
         <entry>
          <para>
-          If this device is used as a <emphasis>bcache caching device</emphasis>, specify the names
-          of the bcaches.
+          If this device is used as a <emphasis>&bcache; caching device</emphasis>, specify the names
+          of the &bcache; devices.
          </para>
 <screen>&lt;bcache_caching_for config:type="list"&gt;
   &lt;listentry&gt;/dev/bcache0&lt;/listentry&gt;
@@ -4525,15 +4525,15 @@ openssl x509 -noout -fingerprint -sha256
   </sect2>
 
   <sect2 xml:id="ay.partition_bcache">
-   <title>Bcache Configuration</title>
+   <title>&bcache; Configuration</title>
    <para>
-    Bcache is a caching system which allows using one or more fast drives to speed up the access
+    &bcache; is a caching system which allows using one or more fast drives to speed up the access
     to one or more slower drives. For instance, you may improve the performance of a big (but
     slow) drive by using a fast one as a cache.
    </para>
 
    <para>
-    In order to set up a bcache device, AutoYaST needs a profile specifying:
+    In order to set up a &bcache; device, AutoYaST needs a profile specifying:
    </para>
 
    <itemizedlist>
@@ -4552,7 +4552,7 @@ openssl x509 -noout -fingerprint -sha256
     </listitem>
     <listitem>
      <para>
-      The layout of the bcache device (i.e., it may contain partitions). Use a
+      The layout of the &bcache; device (i.e., it may contain partitions). Use a
       <literal>drive</literal> section setting the <literal>type</literal> element to
       <literal>CT_BCACHE</literal>.
      </para>
@@ -4560,7 +4560,7 @@ openssl x509 -noout -fingerprint -sha256
    </itemizedlist>
 
    <example>
-    <title>Bcache Definition</title>
+    <title>&bcache; Definition</title>
 <screen>&lt;partitioning config:type="list"&gt;
   &lt;drive&gt;
     &lt;device&gt;/dev/sda&lt;/device&gt;
@@ -4674,7 +4674,7 @@ openssl x509 -noout -fingerprint -sha256
        </entry>
        <entry>
         <para>
-         Bcache cache mode. Possible values are <literal>writethrough</literal>,
+         &bcache; cache mode. Possible values are <literal>writethrough</literal>,
          <literal>writeback</literal>, <literal>writearound</literal> and <literal>none</literal>.
         </para>
        </entry>


### PR DESCRIPTION
This PR adds information about setting up a Bcache device using
AutoYaST. It is related to fate#325346.

Relevant PRs:

* https://github.com/yast/yast-storage-ng/pull/867
* https://github.com/yast/yast-autoinstallation/pull/497
* https://github.com/yast/yast-schema/pull/50

* Check all items that apply.

*Are backports required?*

No.

- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE15SP0