### PR TITLE
Add a NFS section to AutoYaST handbook

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -4705,15 +4705,20 @@ openssl x509 -noout -fingerprint -sha256
    <title>NFS Configuration</title>
 
    <para>
-    &ay; allows to install over a Network Filesystem (NFS). For that, you only have to create a drive with CT_NFS type and give the NFS share name (server:path) as device name. The information relative to the mount point is included as part of its first partition section. Note that for an NFS drive, only the first partition is taken into account.
+    &ay; allows to install over a <emphasis>Network File System</emphasis>
+    (NFS). For that, you have to create a drive with the
+    <literal>CT_NFS</literal> type and provide the NFS share name
+    (<replaceable>SERVER:PATH</replaceable>) as device name. The information relative
+     to the mount point is included as part of its first partition section. Note
+     that for an NFS drive, only the first partition is taken into account.
    </para>
 
    <example>
-    <title>NFS Definition</title>
+    <title>NFS Share Definition</title>
       <screen>
         &lt;partitioning config:type="list"&gt;
           &lt;drive&gt;
-            &lt;device&gt;10.1.1.2:/exports/root_fs&lt;/device&gt;
+            &lt;device&gt;192.168.1.1:/exports/root_fs&lt;/device&gt;
             &lt;type config:type="symbol"&gt;CT_NFS&lt;/type&gt;
             &lt;use&gt;all&lt;/use&gt;
             &lt;partitions config:type="list"&gt;

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -4705,12 +4705,14 @@ openssl x509 -noout -fingerprint -sha256
    <title>NFS Configuration</title>
 
    <para>
-    &ay; allows to install over a <emphasis>Network File System</emphasis>
-    (NFS). For that, you have to create a drive with the
+    &ay; allows to install onto a <emphasis>Network File System</emphasis>
+    (NFS) share. For that, you have to create a drive with the
     <literal>CT_NFS</literal> type and provide the NFS share name
     (<replaceable>SERVER:PATH</replaceable>) as device name. The information relative
      to the mount point is included as part of its first partition section. Note
-     that for an NFS drive, only the first partition is taken into account.
+     that for an NFS drive, only the first partition is taken into account. Refer to
+     <xref linkend="ay.nfs"/> for additional information about how to configure a NFS
+     client and server once the system has been installed.
    </para>
 
    <example>
@@ -7849,7 +7851,7 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
    <title>NFS Client and Server</title>
 
    <para>
-    Configuring a system as an NFS client or an NFS server is can be done
+    Configuring a system as an NFS client or an NFS server can be done
     using the configuration system. The following examples show how both NFS
     client and server can be configured.
    </para>
@@ -7863,6 +7865,11 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
     structure is not compatible with the new one and the control files with
     an NFS section created on older releases will not work with newer
     products.
+   </para>
+
+   <para>
+    Also refer to <xref linkend="ay.partition_nfs"/> for additional information about how
+    to install the system onto a NFS share.
    </para>
 
    <example>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -4701,6 +4701,33 @@ openssl x509 -noout -fingerprint -sha256
    </informaltable>
   </sect2>
 
+  <sect2 xml:id="ay.partition_nfs">
+   <title>NFS Configuration</title>
+
+   <para>
+    &ay; allows to install over a Network Filesystem (NFS). For that, you only have to create a drive with CT_NFS type and give the NFS share name (server:path) as device name. The information relative to the mount point is included as part of its first partition section. Note that for an NFS drive, only the first partition is taken into account.
+   </para>
+
+   <example>
+    <title>NFS Definition</title>
+      <screen>
+        &lt;partitioning config:type="list"&gt;
+          &lt;drive&gt;
+            &lt;device&gt;10.1.1.2:/exports/root_fs&lt;/device&gt;
+            &lt;type config:type="symbol"&gt;CT_NFS&lt;/type&gt;
+            &lt;use&gt;all&lt;/use&gt;
+            &lt;partitions config:type="list"&gt;
+              &lt;partition&gt;
+                &lt;mount&gt;/&lt;/mount&gt;
+                &lt;fstopt&gt;nolock&lt;/fstopt&gt;
+              &lt;/partition&gt;
+            &lt;/partitions&gt;
+          &lt;/drive&gt;
+        &lt;/partitioning&gt;
+      </screen>
+    </example>
+  </sect2>
+
    <sect2 xml:id="ay.partition_s390">
     <title>&zseries; Specific Configuration</title>
     <para/>


### PR DESCRIPTION
### Description

This PR adds information about setting up a NFS drive for AutoYaST installation.

Relevant links:

* https://github.com/yast/yast-storage-ng/pull/896
* https://bugzilla.suse.com/show_bug.cgi?id=1130256

### Checklist
*Check all items that apply.*

*Are backports required?*

- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP4
- [x] To maintenance/SLE15SP0
