### PR TITLE
Update for maintenance model images (WIP)

### DIFF
--- a/images/src/svg/new-maintenance-model+ltss.svg
+++ b/images/src/svg/new-maintenance-model+ltss.svg
@@ -1,482 +1,649 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="1087"
-   height="395"
-   version="1.1">
+   id="svg191"
+   version="1.1"
+   height="447"
+   width="1153">
+  <metadata
+     id="metadata195">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
   <defs
      id="defs86">
     <linearGradient
        id="linearGradient5393">
       <stop
-         style="stop-color:#ffffff;stop-"
+         id="stop5395"
          offset="0"
-         id="stop5395" />
+         style="stop-color:#ffffff;stop-" />
       <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
+         id="stop5397"
          offset="1"
-         id="stop5397" />
+         style="stop-color:#ffffff;stop-opacity:0;" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient5393"
-       id="linearGradient5399"
-       x1="1109.5564"
-       y1="41.785362"
-       x2="967.62579"
+       gradientTransform="matrix(1,0,0,1.1566265,68,-1.72289)"
+       gradientUnits="userSpaceOnUse"
        y2="41.785362"
-       gradientUnits="userSpaceOnUse" />
+       x2="967.62579"
+       y1="41.785362"
+       x1="1109.5564"
+       id="linearGradient5399"
+       xlink:href="#linearGradient5393" />
   </defs>
+  <path
+     id="rect7"
+     d="M 4.1894531,409 C 2.4225269,409 1,410.338 1,412 v 22 c 0,1.662 1.4225269,3 3.1894531,3 H 1102 l 50,-14 -50,-14 z"
+     style="fill:#71d6e0;stroke-width:1.03108311" />
+  <text
+     id="text11"
+     y="429.6925"
+     x="537.9303"
+     style="font-weight:600;font-size:18.75px;font-family:'Open Sans';fill:#5f5f5f"
+     xml:space="preserve">TIME</text>
   <rect
+     id="rect13"
+     style="fill:#ededed;stroke-width:1.15785813"
+     width="1122"
+     height="192"
+     x="1"
+     y="195"
+     rx="5.795455"
+     ry="5.7831326" />
+  <rect
+     id="rect15"
+     y="265"
+     x="425"
+     height="26"
+     width="190"
+     style="fill:#02d35f" />
+  <rect
+     id="rect17"
+     y="317"
+     x="155"
+     height="26"
+     width="190"
+     style="fill:#02d35f" />
+  <text
+     id="text19"
+     y="232.8459"
+     x="17.084473"
+     style="font-weight:600;font-size:18.75px;font-family:'Open Sans';fill:#00c081"
+     xml:space="preserve">SLES 12</text>
+  <rect
+     id="rect21"
+     y="343"
+     x="20"
+     height="26"
+     width="190"
+     style="fill:#02d35f" />
+  <rect
+     id="rect23"
+     y="317"
+     x="155"
+     height="52"
+     width="55"
+     style="opacity:0.5;fill:#92ecba" />
+  <rect
+     id="rect25"
+     y="291"
+     x="290"
+     height="26"
+     width="190"
+     style="fill:#02d35f" />
+  <rect
+     id="rect27"
+     y="291"
+     x="290"
+     height="52"
+     width="55"
+     style="opacity:0.5;fill:#92ecba" />
+  <rect
+     id="rect29"
+     y="265"
+     x="425"
+     height="52"
+     width="55"
+     style="opacity:0.5;fill:#92ecba" />
+  <rect
+     id="rect31"
+     y="239"
+     x="560"
+     height="26"
+     width="190"
+     style="fill:#02d35f;stroke-width:0.90889329" />
+  <rect
+     id="rect33"
+     y="239"
+     x="560"
+     height="52"
+     width="55"
+     style="opacity:0.5;fill:#92ecba" />
+  <rect
+     id="rect35"
+     y="343"
+     x="210"
+     height="26"
+     width="160"
+     style="fill:#a5efc6" />
+  <rect
+     id="rect37"
+     y="317"
+     x="345"
+     height="26"
+     width="160"
+     style="fill:#a5efc6" />
+  <rect
+     id="rect39"
+     y="291"
+     x="480"
+     height="26"
+     width="160"
+     style="fill:#a5efc6" />
+  <rect
+     id="rect41"
+     y="265"
+     x="615"
+     height="26"
+     width="160"
+     style="fill:#a5efc6" />
+  <rect
+     id="rect43"
+     y="239"
+     x="750"
+     height="26"
+     width="160"
+     style="fill:#a5efc6" />
+  <rect
+     id="rect45"
+     style="fill:#a7a9ac;fill-opacity:0.58823529;stroke-width:0.94733095"
+     width="350"
+     height="2"
+     x="560"
+     y="263" />
+  <rect
+     id="rect47"
+     style="fill:#a7a9ac;fill-opacity:0.58823529"
+     width="350"
+     height="2"
+     x="155"
+     y="341" />
+  <rect
+     id="rect49"
+     style="fill:#a7a9ac;fill-opacity:0.58823529"
+     width="350"
+     height="2"
+     x="20"
+     y="367" />
+  <rect
+     id="rect51"
+     style="fill:#a7a9ac;fill-opacity:0.58823529"
+     width="350"
+     height="2"
+     x="290"
+     y="315" />
+  <rect
+     id="rect53"
+     style="fill:#a7a9ac;fill-opacity:0.58823529"
+     width="350"
+     height="2"
+     x="425"
+     y="289" />
+  <rect
+     id="rect55"
      ry="3"
      rx="3"
-     y="357"
-     x="1"
-     height="28"
-     width="1037.5"
-          style="fill:#71d6e0" />
-  <path
-          d="M 1086,371 1036,357 l 0,28 50,-14 z"
-     style="fill:#71d6e0;" />
-  <text
-     xml:space="preserve"
-     style="font-weight:600;font-size:18.75px;font-family:'Open Sans';fill:#5f5f5f"
-     x="537.9303"
-     y="377.6925"
-     >TIME</text>
-  <rect
-     ry="5"
-     rx="5"
-     y="169"
-     x="1"
-     height="166"
-     width="968"
-          style="fill:#ededed;" />
-  <rect
-     style="fill:#02d35f"
-          width="190"
-     height="26"
-     x="425"
-     y="213" />
-  <rect
-     style="fill:#02d35f"
-          width="190"
-     height="26"
-     x="155"
-     y="265" />
-  <text
-     xml:space="preserve"
-     style="font-weight:600;font-size:18.75px;font-family:'Open Sans';fill:#00c081"
-     x="17.084473"
-     y="206.84555"
-     >SLES 11</text>
-  <rect
-     style="fill:#02d35f"
-          width="190"
-     height="26"
-     x="20"
-     y="291" />
-  <rect
-     style="opacity:0.5;fill:#92ecba"
-          width="55"
-     height="52"
-     x="155"
-     y="265" />
-  <rect
-     style="fill:#02d35f"
-          width="190"
-     height="26"
-     x="290"
-     y="239" />
-  <rect
-     style="opacity:0.5;fill:#92ecba"
-          width="55"
-     height="52"
-     x="290"
-     y="239" />
-  <rect
-     style="opacity:0.5;fill:#92ecba"
-          width="55"
-     height="52"
-     x="425"
-     y="213" />
-  <rect
-     style="fill:#02d35f"
-          width="230"
-     height="26"
-     x="560"
-     y="187" />
-  <rect
-     style="opacity:0.5;fill:#92ecba"
-          width="55"
-     height="52"
-     x="560"
-     y="187" />
-  <rect
-     style="fill:#a5efc6"
-          width="160"
-     height="26"
-     x="210"
-     y="291" />
-  <rect
-     style="fill:#a5efc6"
-          width="160"
-     height="26"
-     x="345"
-     y="265" />
-  <rect
-     style="fill:#a5efc6"
-          width="160"
-     height="26"
-     x="480"
-     y="239" />
-  <rect
-     style="fill:#a5efc6"
-          width="160"
-     height="26"
-     x="615"
-     y="213" />
-  <rect
-     style="fill:#a5efc6"
-          width="160"
-     height="26"
-     x="790"
-     y="187" />
-  <rect
-     y="211"
-     x="560"
-     height="2"
-     width="390"
-          style="fill:#a7a9ac;fill-opacity:0.58823529;" />
-  <rect
-     y="289"
-     x="155"
-     height="2"
-     width="350"
-          style="fill:#a7a9ac;fill-opacity:0.58823529;" />
-  <rect
-     y="315"
-     x="20"
-     height="2"
-     width="350"
-          style="fill:#a7a9ac;fill-opacity:0.58823529;" />
-  <rect
-     y="263"
-     x="290"
-     height="2"
-     width="350"
-          style="fill:#a7a9ac;fill-opacity:0.58823529;" />
-  <rect
-     y="237"
-     x="425"
-     height="2"
-     width="350"
-          style="fill:#a7a9ac;fill-opacity:0.58823529;" />
-  <rect
-     style="fill:#5f5f5f;"
-          width="500"
-     height="36"
+     y="362"
      x="406"
-     y="310"
-     rx="3"
-     ry="3" />
-  <text
-     xml:space="preserve"
-     style="font-size:18.75px;font-family:'Open Sans';fill:#00c081"
-     x="425.20929"
-     y="333.1142"
-     >Long Term Service Pack Support (LTSS), up to 3 years</text>
-  <path
-          d="m 419.67562,340 -47.49269,-27.41992 -0.27268,2.15197 -6.91025,-8.03109 10.27663,1.89177 -1.65121,1.35607 47.5502,27.45312 -1.5,2.59808 z"
-     style="fill:#5f5f5f;stroke:none" />
-  <path
-          d="m 427,310 0,-23.83984 -2,0.83984 3.5,-10 3.5,9.84571 -2,-0.75196 L 430,310 Z"
-     style="fill:#5f5f5f;stroke:none" />
-  <rect
-     style="fill:#5f5f5f;"
-          width="499"
      height="36"
-     x="534"
-     y="261"
-     rx="3"
-     ry="3" />
+     width="500"
+     style="fill:#5f5f5f" />
   <text
-     xml:space="preserve"
+     id="text57"
+     y="385.1142"
+     x="425.20929"
      style="font-size:18.75px;font-family:'Open Sans';fill:#00c081"
-     x="547.87531"
-     y="284.07779"
-     >Last Service Pack: General Support until GA + 10 years</text>
+     xml:space="preserve">Long Term Service Pack Support (LTSS), up to 3 years</text>
+  <path
+     id="path59"
+     style="fill:#5f5f5f;stroke:none"
+     d="m 419.67562,392 -47.49269,-27.41992 -0.27268,2.15197 -6.91025,-8.03109 10.27663,1.89177 -1.65121,1.35607 47.5502,27.45312 z" />
+  <path
+     id="path61"
+     style="fill:#5f5f5f;stroke:none"
+     d="M 427,362 V 338.16016 L 425,339 l 3.5,-10 3.5,9.84571 -2,-0.75196 V 362 Z" />
   <rect
-     ry="5"
-     rx="5"
-     y="11"
+     id="rect67"
+     style="fill:#dcddde;stroke-width:1.13738668"
+     width="642"
+     height="192"
      x="510"
-     height="166"
-     width="574"
-          style="fill:#dcddde;" />
+     y="11"
+     rx="5.5923343"
+     ry="5.7831326" />
   <rect
-     style="fill:#02d35f"
-          width="150"
-     height="26"
+     id="rect69"
+     y="81"
      x="934"
-     y="55" />
-  <rect
-     style="fill:#02d35f"
-          width="190"
      height="26"
+     width="190"
+     style="fill:#02d35f;stroke-width:1.12546289" />
+  <rect
+     id="rect71"
+     y="133"
      x="664"
-     y="107" />
+     height="26"
+     width="190"
+     style="fill:#02d35f" />
   <text
-     xml:space="preserve"
-     style="font-weight:600;font-size:18.75px;font-family:'Open Sans';fill:#00c081"
+     id="text73"
+     y="48.727898"
      x="526.08447"
-     y="48.728191"
-     >SLES 12</text>
+     style="font-weight:600;font-size:18.75px;font-family:'Open Sans';fill:#00c081"
+     xml:space="preserve">SLES 15</text>
   <rect
-     style="fill:#02d35f"
-          width="190"
-     height="26"
+     id="rect75"
+     y="159"
      x="529"
-     y="133" />
+     height="26"
+     width="190"
+     style="fill:#02d35f" />
   <rect
-     style="opacity:0.5;fill:#92ecba"
-          width="55"
-     height="52"
+     id="rect77"
+     y="133"
      x="664"
-     y="107" />
+     height="52"
+     width="55"
+     style="opacity:0.5;fill:#92ecba" />
   <rect
-     style="fill:#02d35f"
-          width="190"
+     id="rect79"
+     y="107"
+     x="799"
      height="26"
-     x="799"
-     y="81" />
+     width="190"
+     style="fill:#02d35f" />
   <rect
-     style="opacity:0.5;fill:#92ecba"
-          width="55"
-     height="52"
+     id="rect81"
+     y="107"
      x="799"
-     y="81" />
-  <rect
-     style="opacity:0.5;fill:#92ecba"
-          width="55"
      height="52"
+     width="55"
+     style="opacity:0.5;fill:#92ecba" />
+  <rect
+     id="rect83"
+     y="81"
      x="934"
-     y="55" />
-  <path
-          d="m 331,282 0,-22.83984 -2,0.83984 3.5,-10 3.5,9.84571 -2,-0.75196 0,22.90625 -3,0 z"
-     style="fill:#fd9a2b;stroke:none" />
-  <rect
-     style="opacity:0.5;fill:#92ecba"
-          width="15"
      height="52"
-     x="1069"
-     y="29" />
+     width="55"
+     style="opacity:0.5;fill:#92ecba" />
+  <path
+     id="path85"
+     style="fill:#fd9a2b;stroke:none"
+     d="M 331,334 V 311.16016 L 329,312 l 3.5,-10 3.5,9.84571 -2,-0.75196 V 334 Z" />
   <rect
-     style="fill:#a5efc6"
-          width="160"
-     height="26"
+     id="rect89"
+     y="159"
      x="719"
-     y="133" />
-  <rect
-     style="fill:#a5efc6"
-          width="160"
      height="26"
+     width="160"
+     style="fill:#a5efc6" />
+  <rect
+     id="rect91"
+     y="133"
      x="854"
-     y="107" />
-  <rect
-     style="fill:#a5efc6"
-          width="95"
      height="26"
+     width="160"
+     style="fill:#a5efc6" />
+  <rect
+     transform="scale(1,-1)"
+     id="rect93"
+     y="-133"
      x="989"
-     y="81" />
+     height="26"
+     width="160"
+     style="fill:#a5efc6;stroke-width:1.29777133" />
   <rect
-     y="131"
+     id="rect95"
+     style="fill:#a7a9ac;fill-opacity:0.58823529"
+     width="350"
+     height="2"
      x="664"
-     height="2"
-     width="350"
-          style="fill:#a7a9ac;fill-opacity:0.58823529;" />
+     y="157" />
   <rect
-     y="157"
+     id="rect97"
+     style="fill:#a7a9ac;fill-opacity:0.58823529"
+     width="350"
+     height="2"
      x="529"
-     height="2"
+     y="183" />
+  <rect
+     id="rect99"
+     style="fill:#a7a9ac;fill-opacity:0.58823529;stroke-width:1.10818326"
      width="350"
-          style="fill:#a7a9ac;fill-opacity:0.58823529;" />
-  <rect
-     y="105"
+     height="2"
      x="799"
-     height="2"
-     width="285"
-          style="fill:#a7a9ac;fill-opacity:0.58823529;" />
+     y="131" />
   <rect
-     y="79"
-     x="934"
-     height="2"
-     width="150"
-          style="fill:#a7a9ac;fill-opacity:0.58823529;" />
+     id="rect93-2"
+     y="81"
+     x="1124"
+     height="26"
+     width="28"
+     style="fill:#a5efc6;stroke-width:0.54289669" />
   <circle
-     r="18"
-     cy="120"
-     cx="676"
-          style="fill:#00c081" />
-  <text
-          y="126.84781"
-     x="661.95227"
-     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
-     xml:space="preserve">S<tspan
-   style="letter-spacing:-1px"
-   >P</tspan>1</text>
-  <circle
-     r="18"
-     cy="94"
-     cx="811"
-          style="fill:#00c081" />
-  <text
-          y="100.82855"
-     x="795.11841"
-     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
-     xml:space="preserve">S<tspan
-   style="letter-spacing:-0.5px"
-   >P</tspan>2</text>
-  <circle
-     r="18"
-     cy="146"
-     cx="541"
-          style="fill:#02a49c" />
-  <text
-          y="152.86716"
-     x="527.44104"
-     style="font-weight:600;font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
-     xml:space="preserve">GA</text>
-  <circle
-     r="18"
-     cy="68"
-     cx="946"
-          style="fill:#00c081" />
-  <text
-          y="74.809189"
-     x="930.16418"
-     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
-     xml:space="preserve">S<tspan
-   style="letter-spacing:-0.5px"
-   >P</tspan>3</text>
-  <path
+     id="circle103"
      style="fill:#00c081"
-     d="m 1081,24 a 18,18 0 0 0 -18,18 18,18 0 0 0 18,18 18,18 0 0 0 3,-0.253906 l 0,-35.47461 A 18,18 0 0 0 1081,24 Z"
-      />
-  <path
-          d="m 20,53 0,-12.41211 -2,0.83984 3.5,-10 L 25,41.27344 23,40.52148 23,53 20,53 Z"
-     style="fill:#fd9a2b;stroke:none" />
+     cx="676"
+     cy="146"
+     r="18" />
   <text
+     id="text107"
      xml:space="preserve"
-     style="font-size:18.75px;font-family:'Open Sans';text-align:start;text-anchor:start;fill:#000000"
-     x="34.297119"
-     y="48.745605"
-     >Update/upgrade path</text>
-  <path
-          d="m 601,230 0,-22.83984 -2,0.83984 3.5,-10 3.5,9.84571 -2,-0.75196 0,22.90625 -3,0 z"
-     style="fill:#fd9a2b;stroke:none" />
-  <path
-          d="m 466,256 0,-22.83984 -2,0.83984 3.5,-10 3.5,9.84571 -2,-0.75196 0,22.90625 -3,0 z"
-     style="fill:#fd9a2b;stroke:none" />
-  <path
-          d="m 840,124 0,-22.83984 -2,0.83984 3.5,-10 3.5,9.84571 -2,-0.75196 0,22.90625 -3,0 z"
-     style="fill:#fd9a2b;stroke:none" />
-  <path
-          d="m 705,150 0,-22.83984 -2,0.83984 3.5,-10 3.5,9.84571 -2,-0.75196 0,22.90625 -3,0 z"
-     style="fill:#fd9a2b;stroke:none" />
-  <path
-          d="M 975,98 975,75.16016 973,76 976.5,66 980,75.84571 978,75.09375 978,98 l -3,0 z"
-     style="fill:#fd9a2b;stroke:none" />
-  <path
-          d="m 196,308 0,-22.83984 -2,0.83984 3.5,-10 3.5,9.84571 -2,-0.75196 0,22.90625 -3,0 z"
-     style="fill:#fd9a2b;stroke:none" />
-  <path
-     style="fill:url(#linearGradient5399);"
-     d="m 969,11 0,166 110,0 c 2.77,0 5,-2.23 5,-5 l 0,-156 c 0,-2.77 -2.23,-5 -5,-5 z"
-      />
-    <path
-              d="m 993.47461,85 c -2.4242,0 -4.27517,0.639281 -5.55469,1.917969 C 986.64052,88.196657 986,90.03234 986,92.425781 c 0,2.360649 0.64052,4.214321 1.91992,5.558594 1.27952,1.344262 3.13049,2.015625 5.55469,2.015625 2.42431,0 4.27718,-0.671363 5.55664,-2.015625 1.31305,-1.37706 1.96875,-3.230731 1.96875,-5.558594 0,-2.295081 -0.6405,-4.098687 -1.91992,-5.410156 C 997.80056,85.671358 995.93256,85 993.47461,85 Z m 25.99999,0 c -2.4242,0 -4.2752,0.639281 -5.5547,1.917969 -1.2794,1.278688 -1.9199,3.114371 -1.9199,5.507812 0,2.360649 0.6405,4.214321 1.9199,5.558594 1.2795,1.344262 3.1305,2.015625 5.5547,2.015625 2.4243,0 4.2753,-0.671363 5.5547,-2.015625 1.3132,-1.37706 1.9707,-3.230731 1.9707,-5.558594 0,-2.295081 -0.6405,-4.098687 -1.9199,-5.410156 C 1023.8006,85.671358 1021.9326,85 1019.4746,85 Z m 26,0 c -2.4242,0 -4.2752,0.639281 -5.5547,1.917969 -1.2794,1.278688 -1.9199,3.114371 -1.9199,5.507812 0,2.360649 0.6405,4.214321 1.9199,5.558594 1.2795,1.344262 3.1305,2.015625 5.5547,2.015625 2.4243,0 4.2753,-0.671363 5.5547,-2.015625 1.3132,-1.37706 1.9707,-3.230731 1.9707,-5.558594 0,-2.295081 -0.6405,-4.098687 -1.9199,-5.410156 C 1049.8006,85.671358 1047.9325,85 1045.4746,85 Z"
-       style="fill:#5f5f5f;fill-opacity:0.75" />
-  <path
-          d="m 691,204 0,-70.83984 -2,0.83984 3.5,-10 3.5,9.84571 -2,-0.75196 L 694,204 Z"
-     style="fill:#fd9a2b" />
-  <path
-          d="m 540,230 0,-64.83984 -2,0.83984 3.5,-10 3.5,9.84571 -2,-0.75196 0,64.90625 -3,0 z"
-     style="fill:#fd9a2b" />
-  <path
-          d="m 865,150 0,-48.83984 -2,0.83984 3.5,-10 3.5,9.84571 -2,-0.75196 0,48.90625 -3,0 z"
-     style="fill:#fd9a2b" />
-  <path
-          d="m 491,282 0,-48.83984 -2,0.83984 3.5,-10 3.5,9.84571 -2,-0.75196 0,48.90625 -3,0 z"
-     style="fill:#fd9a2b" />
-  <path
-          d="m 626,256 0,-48.83984 -2,0.83984 3.5,-10 3.5,9.84571 -2,-0.75196 0,48.90625 -3,0 z"
-     style="fill:#fd9a2b" />
-  <path
-          d="m 356,308 0,-48.83984 -2,0.83984 3.5,-10 3.5,9.84571 -2,-0.75196 0,48.90625 -3,0 z"
-     style="fill:#fd9a2b" />
+     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
+     x="661.95227"
+     y="152.84781">S<tspan
+   id="tspan105"
+   style="letter-spacing:-1px">P</tspan>1</text>
   <circle
-     r="18"
-     cy="304"
-     cx="32"
-          style="fill:#02a49c" />
+     id="circle109"
+     style="fill:#00c081"
+     cx="811"
+     cy="120"
+     r="18" />
   <text
-          y="310.86716"
-     x="18.44104"
+     id="text113"
+     xml:space="preserve"
+     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
+     x="795.11841"
+     y="126.82855">S<tspan
+   id="tspan111"
+   style="letter-spacing:-0.5px">P</tspan>2</text>
+  <circle
+     id="circle115"
+     style="fill:#02a49c"
+     cx="541"
+     cy="172"
+     r="18" />
+  <text
+     id="text117"
+     xml:space="preserve"
      style="font-weight:600;font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
-     xml:space="preserve">GA</text>
+     x="527.44104"
+     y="178.86716">GA</text>
   <circle
-     r="18"
-     cy="278"
+     id="circle119"
+     style="fill:#00c081"
+     cx="946"
+     cy="94"
+     r="18" />
+  <text
+     id="text123"
+     xml:space="preserve"
+     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
+     x="930.16418"
+     y="100.80919">S<tspan
+   id="tspan121"
+   style="letter-spacing:-0.5px">P</tspan>3</text>
+  <path
+     id="path127"
+     style="fill:#fd9a2b;stroke:none"
+     d="m 20,52.999992 v -12.41211 l -2,0.83984 3.5,-10 3.5,9.84571 -2,-0.75196 v 12.47852 z" />
+  <text
+     id="text129"
+     y="48.745605"
+     x="34.297119"
+     style="font-size:18.75px;font-family:'Open Sans';text-align:start;text-anchor:start;fill:#000000"
+     xml:space="preserve">Update/upgrade path</text>
+  <path
+     id="path131"
+     style="fill:#fd9a2b;stroke:none"
+     d="M 601,282 V 259.16016 L 599,260 l 3.5,-10 3.5,9.84571 -2,-0.75196 V 282 Z" />
+  <path
+     id="path133"
+     style="fill:#fd9a2b;stroke:none"
+     d="M 466,308 V 285.16016 L 464,286 l 3.5,-10 3.5,9.84571 -2,-0.75196 V 308 Z" />
+  <path
+     id="path135"
+     style="fill:#fd9a2b;stroke:none"
+     d="M 840,150 V 127.16016 L 838,128 l 3.5,-10 3.5,9.84571 -2,-0.75196 V 150 Z" />
+  <path
+     id="path137"
+     style="fill:#fd9a2b;stroke:none"
+     d="M 705,176 V 153.16016 L 703,154 l 3.5,-10 3.5,9.84571 -2,-0.75196 V 176 Z" />
+  <path
+     id="path141"
+     style="fill:#fd9a2b;stroke:none"
+     d="M 196,360 V 337.16016 L 194,338 l 3.5,-10 3.5,9.84571 -2,-0.75196 V 360 Z" />
+  <path
+     id="path147"
+     style="fill:#fd9a2b"
+     d="M 685,256 V 161.16016 L 683,162 l 3.5,-10 3.5,9.84571 -2,-0.75196 V 256 Z" />
+  <path
+     id="path149"
+     d="m 593.49478,250 -3.50513,10 2.00293,-0.83984 c 0,26.27434 -9.96383,48.62586 -26.89484,58.66406 C 548.15544,327.86912 524.40738,331 497,331 v 3 c 27.61771,0 51.85768,-3.0654 69.66448,-13.61523 18.74255,-11.10423 28.33259,-34.5554 28.33259,-61.29102 L 597,259.8457 Z"
+     style="fill:#fd9a2b;stroke-width:1.00073278" />
+  <path
+     id="path151"
+     style="fill:#fd9a2b"
+     d="M 865,176 V 127.16016 L 863,128 l 3.5,-10 3.5,9.84571 -2,-0.75196 V 176 Z" />
+  <path
+     id="path153"
+     style="fill:#fd9a2b"
+     d="M 491,334 V 285.16016 L 489,286 l 3.5,-10 3.5,9.84571 -2,-0.75196 V 334 Z" />
+  <path
+     id="path155"
+     style="fill:#fd9a2b"
+     d="M 626,308 V 259.16016 L 624,260 l 3.5,-10 3.5,9.84571 -2,-0.75196 V 308 Z" />
+  <path
+     id="path157"
+     style="fill:#fd9a2b"
+     d="M 356,360 V 311.16016 L 354,312 l 3.5,-10 3.5,9.84571 -2,-0.75196 V 360 Z" />
+  <circle
+     id="circle159"
+     style="fill:#02a49c"
+     cx="32"
+     cy="356"
+     r="18" />
+  <text
+     id="text161"
+     xml:space="preserve"
+     style="font-weight:600;font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
+     x="18.44104"
+     y="362.86716">GA</text>
+  <circle
+     id="circle163"
+     style="fill:#00c081"
      cx="167"
-          style="fill:#00c081" />
+     cy="330"
+     r="18" />
   <text
-          y="284.84781"
+     id="text167"
+     xml:space="preserve"
+     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
      x="152.95227"
-     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
-     xml:space="preserve">S<tspan
-   style="letter-spacing:-1px"
-   >P</tspan>1</text>
+     y="336.84781">S<tspan
+   id="tspan165"
+   style="letter-spacing:-1px">P</tspan>1</text>
   <circle
-     r="18"
-     cy="252"
+     id="circle169"
+     style="fill:#00c081"
      cx="302"
-          style="fill:#00c081" />
+     cy="304"
+     r="18" />
   <text
-          y="258.82855"
+     id="text173"
+     xml:space="preserve"
+     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
      x="286.11841"
-     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
-     xml:space="preserve">S<tspan
-   style="letter-spacing:-0.5px"
-   >P</tspan>2</text>
+     y="310.82855">S<tspan
+   id="tspan171"
+   style="letter-spacing:-0.5px">P</tspan>2</text>
   <circle
-     r="18"
-     cy="200"
+     id="circle175"
+     style="fill:#00c081"
      cx="572"
-          style="fill:#00c081" />
+     cy="252"
+     r="18" />
   <text
-          y="206.80919"
+     id="text179"
+     xml:space="preserve"
+     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
      x="555.80255"
-     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
-     xml:space="preserve">S<tspan
-   style="letter-spacing:-0.5px"
-   >P</tspan>4</text>
+     y="258.8092">S<tspan
+   id="tspan177"
+   style="letter-spacing:-0.5px">P</tspan>4</text>
   <circle
-     r="18"
-     cy="226"
+     id="circle181"
+     style="fill:#00c081"
      cx="437"
-          style="fill:#00c081" />
+     cy="278"
+     r="18" />
   <text
-          y="232.80919"
-     x="421.16418"
+     id="text185"
+     xml:space="preserve"
      style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
-     xml:space="preserve">S<tspan
-   style="letter-spacing:-0.5px"
-   >P</tspan>3</text>
+     x="421.16418"
+     y="284.8092">S<tspan
+   id="tspan183"
+   style="letter-spacing:-0.5px">P</tspan>3</text>
   <path
-          d="m 782,261 0,-52.83984 -2,0.83984 3.5,-10 3.5,9.84571 -2,-0.75196 L 785,261 Z"
-     style="fill:#5f5f5f;stroke:none" />
+     id="path189"
+     style="fill:#fd9a2b;stroke:none"
+     d="M 675,282 V 164.16016 L 673,165 l 3.5,-10 3.5,9.84571 -2,-0.75196 V 282 Z" />
+  <rect
+     id="rect31-6"
+     y="213"
+     x="695"
+     height="26"
+     width="230"
+     style="fill:#02d35f" />
+  <rect
+     id="rect33-2"
+     y="213"
+     x="695"
+     height="52"
+     width="55"
+     style="opacity:0.5;fill:#92ecba" />
+  <rect
+     id="rect43-9"
+     y="213"
+     x="925"
+     height="26"
+     width="160"
+     style="fill:#a5efc6" />
+  <rect
+     id="rect45-1"
+     style="fill:#a7a9ac;fill-opacity:0.58823529"
+     width="390"
+     height="2"
+     x="695"
+     y="237" />
+  <circle
+     id="circle175-2"
+     style="fill:#00c081"
+     cx="707"
+     cy="226"
+     r="18" />
+  <text
+     id="text179-7"
+     xml:space="preserve"
+     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
+     x="690.80255"
+     y="232.8092">S<tspan
+   id="tspan177-0"
+   style="letter-spacing:-0.5px">P5</tspan></text>
+  <rect
+     id="rect69-6"
+     y="55"
+     x="1069"
+     height="26"
+     width="83"
+     style="fill:#02d35f;stroke-width:0.74386382" />
+  <rect
+     id="rect83-1"
+     y="55"
+     x="1069"
+     height="52"
+     width="55"
+     style="opacity:0.5;fill:#92ecba" />
+  <rect
+     id="rect101"
+     style="fill:#a7a9ac;fill-opacity:0.58823529;stroke-width:1.2055428"
+     width="218"
+     height="2"
+     x="934"
+     y="105" />
+  <circle
+     id="circle119-8"
+     style="fill:#00c081"
+     cx="1081"
+     cy="68"
+     r="18" />
   <path
-          d="m 675,230 0,-91.83984 -2,0.83984 3.5,-10 3.5,9.84571 -2,-0.75196 L 678,230 Z"
-     style="fill:#fd9a2b;stroke:none" />
+     id="path139"
+     style="fill:#fd9a2b;stroke:none"
+     d="M 975,124 V 101.16016 L 973,102 l 3.5,-10 3.5,9.84571 -2,-0.75196 V 124 Z" />
+  <path
+     id="path187"
+     style="fill:#5f5f5f;stroke:none"
+     d="M 902,287 V 234.16016 L 900,235 l 3.5,-10 3.5,9.84571 -2,-0.75196 V 287 Z" />
+  <path
+     id="path131-9"
+     style="fill:#fd9a2b;stroke:none"
+     d="M 736,256 V 233.16016 L 734,234 l 3.5,-10 3.5,9.84571 -2,-0.75196 V 256 Z" />
+  <path
+     id="path149-0"
+     d="m 728.49478,224 -3.50513,10 2.00293,-0.8398 c 0,26.2743 -9.96383,48.62582 -26.89484,58.66402 C 683.15544,301.86912 659.40738,305 632,305 v 3 c 27.61771,0 51.85768,-3.0654 69.66448,-13.61523 18.74255,-11.10423 28.33259,-34.5554 28.33259,-61.29097 L 732,233.8457 Z"
+     style="fill:#fd9a2b;stroke-width:1.00073278" />
+  <rect
+     id="rect63"
+     ry="4.5"
+     rx="2.0817258"
+     y="285.62891"
+     x="730.36981"
+     height="54"
+     width="346.26041"
+     style="fill:#5f5f5f;stroke-width:1.02022684" />
+  <g
+     transform="translate(1.5258789e-5,-1.5020294)"
+     id="g4289">
+    <text
+       xml:space="preserve"
+       style="font-size:18.75px;font-family:'Open Sans';fill:#00c081"
+       x="751.68268"
+       y="309.46191"
+       id="text65">Last Service Pack: General Support</text>
+    <text
+       xml:space="preserve"
+       style="font-size:18.75px;font-family:'Open Sans';fill:#00c081"
+       x="818.17743"
+       y="328.54117"
+       id="text65-2">up to GA + 10 years</text>
+  </g>
+  <path
+     id="path143"
+     d="m 1037,11 v 192 h 110 c 2.77,0 5,-2.57928 5,-5.78313 V 16.78313 C 1152,13.57928 1149.77,11 1147,11 Z"
+     style="fill:url(#linearGradient5399);stroke-width:1.07546568" />
+  <path
+     id="path145"
+     style="fill:#5f5f5f;fill-opacity:0.75"
+     d="m 1061.4746,99.5 c -2.4242,0 -4.2752,0.63928 -5.5547,1.91797 -1.2794,1.27869 -1.9199,3.11437 -1.9199,5.50781 0,2.36065 0.6405,4.21432 1.9199,5.55859 1.2795,1.34427 3.1305,2.01563 5.5547,2.01563 2.4243,0 4.2772,-0.67136 5.5566,-2.01563 1.3131,-1.37706 1.9688,-3.23073 1.9688,-5.55859 0,-2.29508 -0.6405,-4.09869 -1.9199,-5.41016 -1.2795,-1.34426 -3.1475,-2.01562 -5.6055,-2.01562 z m 26,0 c -2.4242,0 -4.2752,0.63928 -5.5547,1.91797 -1.2794,1.27869 -1.9199,3.11437 -1.9199,5.50781 0,2.36065 0.6405,4.21432 1.9199,5.55859 1.2795,1.34427 3.1305,2.01563 5.5547,2.01563 2.4243,0 4.2753,-0.67136 5.5547,-2.01563 1.3132,-1.37706 1.9707,-3.23073 1.9707,-5.55859 0,-2.29508 -0.6405,-4.09869 -1.9199,-5.41016 -1.2795,-1.34426 -3.1475,-2.01562 -5.6055,-2.01562 z m 26,0 c -2.4242,0 -4.2752,0.63928 -5.5547,1.91797 -1.2794,1.27869 -1.9199,3.11437 -1.9199,5.50781 0,2.36065 0.6405,4.21432 1.9199,5.55859 1.2795,1.34427 3.1305,2.01563 5.5547,2.01563 2.4243,0 4.2753,-0.67136 5.5547,-2.01563 1.3132,-1.37706 1.9707,-3.23073 1.9707,-5.55859 0,-2.29508 -0.6405,-4.09869 -1.9199,-5.41016 -1.2795,-1.34426 -3.1476,-2.01562 -5.6055,-2.01562 z" />
+  <path
+     id="path147-3"
+     style="fill:#fd9a2b"
+     d="M 539,282 V 190.16016 L 537,191 l 3.5,-10 3.5,9.84571 -2,-0.75196 V 282 Z" />
 </svg>

--- a/images/src/svg/new-maintenance-model.svg
+++ b/images/src/svg/new-maintenance-model.svg
@@ -1,368 +1,471 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="1087"
-   height="395"
-   version="1.1">
+   id="svg137"
+   version="1.1"
+   height="447"
+   width="1087">
+  <metadata
+     id="metadata141">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
   <defs
      id="defs86">
     <linearGradient
        id="linearGradient5393">
       <stop
-         style="stop-color:#ffffff;stop-"
+         id="stop5395"
          offset="0"
-         id="stop5395" />
+         style="stop-color:#ffffff;stop-" />
       <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
+         id="stop5397"
          offset="1"
-         id="stop5397" />
+         style="stop-color:#ffffff;stop-opacity:0;" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient5393"
-       id="linearGradient5399"
-       x1="1109.5564"
-       y1="41.785362"
-       x2="967.62579"
+       gradientTransform="matrix(1,0,0,1.1566265,0,-1.722893)"
+       gradientUnits="userSpaceOnUse"
        y2="41.785362"
-       gradientUnits="userSpaceOnUse" />
+       x2="967.62579"
+       y1="41.785362"
+       x1="1109.5564"
+       id="linearGradient5399"
+       xlink:href="#linearGradient5393" />
   </defs>
   <rect
-     ry="3"
-     rx="3"
-     y="357"
-     x="1"
-     height="28"
+     id="rect7"
+     style="fill:#71d6e0"
      width="1037.5"
-          style="fill:#71d6e0" />
-  <path
-          d="M 1086,371 1036,357 l 0,28 50,-14 z"
-     style="fill:#71d6e0;" />
-  <text
-     xml:space="preserve"
-     style="font-weight:600;font-size:18.75px;font-family:'Open Sans';fill:#5f5f5f"
-     x="537.9303"
-     y="377.6925"
-     >TIME</text>
-  <rect
-     ry="5"
-     rx="5"
-     y="169"
+     height="28"
      x="1"
-     height="166"
-     width="968"
-          style="fill:#ededed;" />
-  <rect
-     style="fill:#02d35f"
-          width="190"
-     height="26"
-     x="425"
-     y="213" />
-  <rect
-     style="fill:#02d35f"
-          width="190"
-     height="26"
-     x="155"
-     y="265" />
-  <text
-     xml:space="preserve"
-     style="font-weight:600;font-size:18.75px;font-family:'Open Sans';fill:#00c081"
-     x="17.084473"
-     y="206.84555"
-     >SLES 11</text>
-  <rect
-     style="fill:#02d35f"
-          width="190"
-     height="26"
-     x="20"
-     y="291" />
-  <rect
-     style="opacity:0.5;fill:#92ecba"
-          width="55"
-     height="52"
-     x="155"
-     y="265" />
-  <rect
-     style="fill:#02d35f"
-          width="190"
-     height="26"
-     x="290"
-     y="239" />
-  <rect
-     style="opacity:0.5;fill:#92ecba"
-          width="55"
-     height="52"
-     x="290"
-     y="239" />
-  <rect
-     style="opacity:0.5;fill:#92ecba"
-          width="55"
-     height="52"
-     x="425"
-     y="213" />
-  <rect
-     style="fill:#02d35f"
-          width="230"
-     height="26"
-     x="560"
-     y="187" />
-  <rect
-     style="opacity:0.5;fill:#92ecba"
-          width="55"
-     height="52"
-     x="560"
-     y="187" />
-  <rect
-     y="211"
-     x="560"
-     height="2"
-     width="230"
-          style="fill:#a7a9ac;fill-opacity:0.58823529" />
-  <rect
-     y="289"
-     x="155"
-     height="2"
-     width="190"
-          style="fill:#a7a9ac;fill-opacity:0.58823529" />
-  <rect
-     y="315"
-     x="20"
-     height="2"
-     width="190"
-          style="fill:#a7a9ac;fill-opacity:0.58823529" />
-  <rect
-     y="263"
-     x="290"
-     height="2"
-     width="190"
-          style="fill:#a7a9ac;fill-opacity:0.58823529" />
-  <rect
-     y="237"
-     x="425"
-     height="2"
-     width="190"
-          style="fill:#a7a9ac;fill-opacity:0.58823529" />
-  <rect
-     ry="5"
-     rx="5"
-     y="11"
-     x="510"
-     height="166"
-     width="574"
-          style="fill:#dcddde;" />
-  <rect
-     style="fill:#02d35f"
-          width="150"
-     height="26"
-     x="934"
-     y="55" />
-  <rect
-     style="fill:#02d35f"
-          width="190"
-     height="26"
-     x="664"
-     y="107" />
-  <text
-     xml:space="preserve"
-     style="font-weight:600;font-size:18.75px;font-family:'Open Sans';fill:#00c081"
-     x="526.08447"
-     y="48.728191"
-     >SLES 12</text>
-  <rect
-     style="fill:#02d35f"
-          width="190"
-     height="26"
-     x="529"
-     y="133" />
-  <rect
-     style="opacity:0.5;fill:#92ecba"
-          width="55"
-     height="52"
-     x="664"
-     y="107" />
-  <rect
-     style="fill:#02d35f"
-          width="190"
-     height="26"
-     x="799"
-     y="81" />
-  <rect
-     style="opacity:0.5;fill:#92ecba"
-          width="55"
-     height="52"
-     x="799"
-     y="81" />
-  <rect
-     style="opacity:0.5;fill:#92ecba"
-          width="55"
-     height="52"
-     x="934"
-     y="55" />
-  <rect
-     style="opacity:0.5;fill:#92ecba"
-          width="15"
-     height="52"
-     x="1069"
-     y="29" />
-  <rect
-     y="131"
-     x="664"
-     height="2"
-     width="190"
-          style="fill:#a7a9ac;fill-opacity:0.58823529" />
-  <rect
-     y="157"
-     x="529"
-     height="2"
-     width="190"
-          style="fill:#a7a9ac;fill-opacity:0.58823529" />
-  <rect
-     y="105"
-     x="799"
-     height="2"
-     width="190"
-          style="fill:#a7a9ac;fill-opacity:0.58823529" />
-  <rect
-     y="79"
-     x="934"
-     height="2"
-     width="150"
-          style="fill:#a7a9ac;fill-opacity:0.58823529;" />
-  <circle
-     r="18"
-     cy="120"
-     cx="676"
-          style="fill:#00c081" />
-  <text
-          y="126.84781"
-     x="661.95227"
-     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
-     xml:space="preserve">S<tspan
-   style="letter-spacing:-1px"
-   >P</tspan>1</text>
-  <circle
-     r="18"
-     cy="94"
-     cx="811"
-          style="fill:#00c081" />
-  <text
-          y="100.82855"
-     x="795.11841"
-     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
-     xml:space="preserve">S<tspan
-   style="letter-spacing:-0.5px"
-   >P</tspan>2</text>
-  <circle
-     r="18"
-     cy="146"
-     cx="541"
-          style="fill:#02a49c" />
-  <text
-          y="152.86716"
-     x="527.44104"
-     style="font-weight:600;font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
-     xml:space="preserve">GA</text>
-  <circle
-     r="18"
-     cy="68"
-     cx="946"
-          style="fill:#00c081" />
-  <text
-          y="74.809189"
-     x="930.16418"
-     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
-     xml:space="preserve">S<tspan
-   style="letter-spacing:-0.5px"
-   >P</tspan>3</text>
-  <path
-     style="fill:#00c081"
-     d="m 1081,24 a 18,18 0 0 0 -18,18 18,18 0 0 0 18,18 18,18 0 0 0 3,-0.253906 l 0,-35.47461 A 18,18 0 0 0 1081,24 Z"
-      />
-  <path
-     style="fill:url(#linearGradient5399);"
-     d="m 969,11 0,166 110,0 c 2.77,0 5,-2.23 5,-5 l 0,-156 c 0,-2.77 -2.23,-5 -5,-5 z"
-      />
-    <path
-              d="m 993.47461,85 c -2.4242,0 -4.27517,0.639281 -5.55469,1.917969 C 986.64052,88.196657 986,90.03234 986,92.425781 c 0,2.360649 0.64052,4.214321 1.91992,5.558594 1.27952,1.344262 3.13049,2.015625 5.55469,2.015625 2.42431,0 4.27718,-0.671363 5.55664,-2.015625 1.31305,-1.37706 1.96875,-3.230731 1.96875,-5.558594 0,-2.295081 -0.6405,-4.098687 -1.91992,-5.410156 C 997.80056,85.671358 995.93256,85 993.47461,85 Z m 25.99999,0 c -2.4242,0 -4.2752,0.639281 -5.5547,1.917969 -1.2794,1.278688 -1.9199,3.114371 -1.9199,5.507812 0,2.360649 0.6405,4.214321 1.9199,5.558594 1.2795,1.344262 3.1305,2.015625 5.5547,2.015625 2.4243,0 4.2753,-0.671363 5.5547,-2.015625 1.3132,-1.37706 1.9707,-3.230731 1.9707,-5.558594 0,-2.295081 -0.6405,-4.098687 -1.9199,-5.410156 C 1023.8006,85.671358 1021.9326,85 1019.4746,85 Z m 26,0 c -2.4242,0 -4.2752,0.639281 -5.5547,1.917969 -1.2794,1.278688 -1.9199,3.114371 -1.9199,5.507812 0,2.360649 0.6405,4.214321 1.9199,5.558594 1.2795,1.344262 3.1305,2.015625 5.5547,2.015625 2.4243,0 4.2753,-0.671363 5.5547,-2.015625 1.3132,-1.37706 1.9707,-3.230731 1.9707,-5.558594 0,-2.295081 -0.6405,-4.098687 -1.9199,-5.410156 C 1049.8006,85.671358 1047.9325,85 1045.4746,85 Z"
-       style="fill:#5f5f5f;fill-opacity:0.75" />
-  <circle
-     r="18"
-     cy="304"
-     cx="32"
-          style="fill:#02a49c" />
-  <text
-          y="310.86716"
-     x="18.44104"
-     style="font-weight:600;font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
-     xml:space="preserve">GA</text>
-  <circle
-     r="18"
-     cy="278"
-     cx="167"
-          style="fill:#00c081" />
-  <text
-          y="284.84781"
-     x="152.95227"
-     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
-     xml:space="preserve">S<tspan
-   style="letter-spacing:-1px"
-   >P</tspan>1</text>
-  <circle
-     r="18"
-     cy="252"
-     cx="302"
-          style="fill:#00c081" />
-  <text
-          y="258.82855"
-     x="286.11841"
-     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
-     xml:space="preserve">S<tspan
-   style="letter-spacing:-0.5px"
-   >P</tspan>2</text>
-  <circle
-     r="18"
-     cy="200"
-     cx="572"
-          style="fill:#00c081" />
-  <text
-          y="206.80919"
-     x="555.80255"
-     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
-     xml:space="preserve">S<tspan
-   style="letter-spacing:-0.5px"
-   >P</tspan>4</text>
-  <circle
-     r="18"
-     cy="226"
-     cx="437"
-          style="fill:#00c081" />
-  <text
-          y="232.80919"
-     x="421.16418"
-     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
-     xml:space="preserve">S<tspan
-   style="letter-spacing:-0.5px"
-   >P</tspan>3</text>
-  <rect
-     style="fill:#5f5f5f"
-          width="178.78485"
-     height="36"
-     x="170"
-     y="169"
+     y="409"
      rx="3"
      ry="3" />
+  <path
+     id="path9"
+     style="fill:#71d6e0"
+     d="m 1086,423 -50,-14 v 28 z" />
   <text
+     id="text11"
+     y="429.6925"
+     x="537.9303"
+     style="font-weight:600;font-size:18.75px;font-family:'Open Sans';fill:#5f5f5f"
+     xml:space="preserve">TIME</text>
+  <rect
+     id="rect13"
+     style="fill:#ededed;stroke-width:1.07546568"
+     width="968"
+     height="192"
+     x="1"
+     y="195"
+     rx="5"
+     ry="5.7831326" />
+  <rect
+     id="rect15"
+     y="265"
+     x="425"
+     height="26"
+     width="190"
+     style="fill:#02d35f" />
+  <rect
+     id="rect17"
+     y="317"
+     x="155"
+     height="26"
+     width="190"
+     style="fill:#02d35f" />
+  <text
+     id="text19"
+     y="232.8459"
+     x="17.084473"
+     style="font-weight:600;font-size:18.75px;font-family:'Open Sans';fill:#00c081"
+     xml:space="preserve">SLES 12</text>
+  <rect
+     id="rect21"
+     y="343"
+     x="20"
+     height="26"
+     width="190"
+     style="fill:#02d35f" />
+  <rect
+     id="rect23"
+     y="317"
+     x="155"
+     height="52"
+     width="55"
+     style="opacity:0.5;fill:#92ecba" />
+  <rect
+     id="rect25"
+     y="291"
+     x="290"
+     height="26"
+     width="190"
+     style="fill:#02d35f" />
+  <rect
+     id="rect27"
+     y="291"
+     x="290"
+     height="52"
+     width="55"
+     style="opacity:0.5;fill:#92ecba" />
+  <rect
+     id="rect29"
+     y="265"
+     x="425"
+     height="52"
+     width="55"
+     style="opacity:0.5;fill:#92ecba" />
+  <rect
+     id="rect31"
+     y="239"
+     x="560"
+     height="26"
+     width="230"
+     style="fill:#02d35f" />
+  <rect
+     id="rect33"
+     y="239"
+     x="560"
+     height="52"
+     width="55"
+     style="opacity:0.5;fill:#92ecba" />
+  <rect
+     id="rect37"
+     style="fill:#a7a9ac;fill-opacity:0.58823529"
+     width="190"
+     height="2"
+     x="155"
+     y="341" />
+  <rect
+     id="rect39"
+     style="fill:#a7a9ac;fill-opacity:0.58823529"
+     width="190"
+     height="2"
+     x="20"
+     y="367" />
+  <rect
+     id="rect41"
+     style="fill:#a7a9ac;fill-opacity:0.58823529"
+     width="190"
+     height="2"
+     x="290"
+     y="315" />
+  <rect
+     id="rect43"
+     style="fill:#a7a9ac;fill-opacity:0.58823529"
+     width="190"
+     height="2"
+     x="425"
+     y="289" />
+  <rect
+     id="rect45"
+     style="fill:#dcddde;stroke-width:1.07546568"
+     width="574"
+     height="192"
+     x="510"
+     y="11"
+     rx="5"
+     ry="5.7831326" />
+  <rect
+     id="rect47"
+     y="81"
+     x="934"
+     height="26"
+     width="150"
+     style="fill:#02d35f" />
+  <rect
+     id="rect49"
+     y="133"
+     x="664"
+     height="26"
+     width="190"
+     style="fill:#02d35f" />
+  <text
+     id="text51"
+     y="48.727894"
+     x="526.08447"
+     style="font-weight:600;font-size:18.75px;font-family:'Open Sans';fill:#00c081"
+     xml:space="preserve">SLES 15</text>
+  <rect
+     id="rect53"
+     y="159"
+     x="529"
+     height="26"
+     width="190"
+     style="fill:#02d35f" />
+  <rect
+     id="rect55"
+     y="133"
+     x="664"
+     height="52"
+     width="55"
+     style="opacity:0.5;fill:#92ecba" />
+  <rect
+     id="rect57"
+     y="107"
+     x="799"
+     height="26"
+     width="190"
+     style="fill:#02d35f" />
+  <rect
+     id="rect59"
+     y="107"
+     x="799"
+     height="52"
+     width="55"
+     style="opacity:0.5;fill:#92ecba" />
+  <rect
+     id="rect61"
+     y="81"
+     x="934"
+     height="52"
+     width="55"
+     style="opacity:0.5;fill:#92ecba" />
+  <rect
+     id="rect63"
+     y="55"
+     x="1069"
+     height="52"
+     width="15"
+     style="opacity:0.5;fill:#92ecba" />
+  <rect
+     id="rect65"
+     style="fill:#a7a9ac;fill-opacity:0.58823529"
+     width="190"
+     height="2"
+     x="664"
+     y="157" />
+  <rect
+     id="rect67"
+     style="fill:#a7a9ac;fill-opacity:0.58823529"
+     width="190"
+     height="2"
+     x="529"
+     y="183" />
+  <rect
+     id="rect69"
+     style="fill:#a7a9ac;fill-opacity:0.58823529"
+     width="190"
+     height="2"
+     x="799"
+     y="131" />
+  <rect
+     id="rect71"
+     style="fill:#a7a9ac;fill-opacity:0.58823529"
+     width="150"
+     height="2"
+     x="934"
+     y="105" />
+  <circle
+     id="circle73"
+     style="fill:#00c081"
+     cx="676"
+     cy="146"
+     r="18" />
+  <text
+     id="text77"
      xml:space="preserve"
-     style="font-size:18.75px;font-family:'Open Sans';fill:#00c081"
+     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
+     x="661.95227"
+     y="152.84781">S<tspan
+   id="tspan75"
+   style="letter-spacing:-1px">P</tspan>1</text>
+  <circle
+     id="circle79"
+     style="fill:#00c081"
+     cx="811"
+     cy="120"
+     r="18" />
+  <text
+     id="text83"
+     xml:space="preserve"
+     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
+     x="795.11841"
+     y="126.82855">S<tspan
+   id="tspan81"
+   style="letter-spacing:-0.5px">P</tspan>2</text>
+  <circle
+     id="circle85"
+     style="fill:#02a49c"
+     cx="541"
+     cy="172"
+     r="18" />
+  <text
+     id="text87"
+     xml:space="preserve"
+     style="font-weight:600;font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
+     x="527.44104"
+     y="178.86716">GA</text>
+  <circle
+     id="circle89"
+     style="fill:#00c081"
+     cx="946"
+     cy="94"
+     r="18" />
+  <text
+     id="text93"
+     xml:space="preserve"
+     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
+     x="930.16418"
+     y="100.80919">S<tspan
+   id="tspan91"
+   style="letter-spacing:-0.5px">P</tspan>3</text>
+  <path
+     id="path95"
+     d="m 1081,50 a 18,18 0 0 0 -18,18 18,18 0 0 0 18,18 18,18 0 0 0 3,-0.253906 V 50.271484 A 18,18 0 0 0 1081,50 Z"
+     style="fill:#00c081" />
+  <path
+     id="path97"
+     d="m 969,11 v 192 h 110 c 2.77,0 5,-2.57927 5,-5.78313 V 16.783135 C 1084,13.579276 1081.77,11 1079,11 Z"
+     style="fill:url(#linearGradient5399);stroke-width:1.07546568" />
+  <path
+     id="path99"
+     style="fill:#5f5f5f;fill-opacity:0.75"
+     d="m 993.47461,111 c -2.4242,0 -4.27517,0.63928 -5.55469,1.91797 -1.2794,1.27869 -1.91992,3.11437 -1.91992,5.50781 0,2.36065 0.64052,4.21432 1.91992,5.5586 1.27952,1.34426 3.13049,2.01562 5.55469,2.01562 2.42431,0 4.27718,-0.67136 5.55664,-2.01562 1.31305,-1.37706 1.96875,-3.23074 1.96875,-5.5586 0,-2.29508 -0.6405,-4.09869 -1.91992,-5.41015 C 997.80056,111.67136 995.93256,111 993.47461,111 Z m 25.99999,0 c -2.4242,0 -4.2752,0.63928 -5.5547,1.91797 -1.2794,1.27869 -1.9199,3.11437 -1.9199,5.50781 0,2.36065 0.6405,4.21432 1.9199,5.5586 1.2795,1.34426 3.1305,2.01562 5.5547,2.01562 2.4243,0 4.2753,-0.67136 5.5547,-2.01562 1.3132,-1.37706 1.9707,-3.23074 1.9707,-5.5586 0,-2.29508 -0.6405,-4.09869 -1.9199,-5.41015 C 1023.8006,111.67136 1021.9326,111 1019.4746,111 Z m 26,0 c -2.4242,0 -4.2752,0.63928 -5.5547,1.91797 -1.2794,1.27869 -1.9199,3.11437 -1.9199,5.50781 0,2.36065 0.6405,4.21432 1.9199,5.5586 1.2795,1.34426 3.1305,2.01562 5.5547,2.01562 2.4243,0 4.2753,-0.67136 5.5547,-2.01562 1.3132,-1.37706 1.9707,-3.23074 1.9707,-5.5586 0,-2.29508 -0.6405,-4.09869 -1.9199,-5.41015 C 1049.8006,111.67136 1047.9325,111 1045.4746,111 Z" />
+  <circle
+     id="circle101"
+     style="fill:#02a49c"
+     cx="32"
+     cy="356"
+     r="18" />
+  <text
+     id="text103"
+     xml:space="preserve"
+     style="font-weight:600;font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
+     x="18.44104"
+     y="362.86716">GA</text>
+  <circle
+     id="circle105"
+     style="fill:#00c081"
+     cx="167"
+     cy="330"
+     r="18" />
+  <text
+     id="text109"
+     xml:space="preserve"
+     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
+     x="152.95227"
+     y="336.84781">S<tspan
+   id="tspan107"
+   style="letter-spacing:-1px">P</tspan>1</text>
+  <circle
+     id="circle111"
+     style="fill:#00c081"
+     cx="302"
+     cy="304"
+     r="18" />
+  <text
+     id="text115"
+     xml:space="preserve"
+     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
+     x="286.11841"
+     y="310.82855">S<tspan
+   id="tspan113"
+   style="letter-spacing:-0.5px">P</tspan>2</text>
+  <circle
+     id="circle123"
+     style="fill:#00c081"
+     cx="437"
+     cy="278"
+     r="18" />
+  <text
+     id="text127"
+     xml:space="preserve"
+     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
+     x="421.16418"
+     y="284.8092">S<tspan
+   id="tspan125"
+   style="letter-spacing:-0.5px">P</tspan>3</text>
+  <rect
+     id="rect129"
+     ry="3"
+     rx="3"
+     y="221"
+     x="170"
+     height="36"
+     width="178.78485"
+     style="fill:#5f5f5f" />
+  <text
+     id="text131"
+     y="243.94266"
      x="184.86394"
-     y="191.94266"
-     >6 month overlap</text>
+     style="font-size:18.75px;font-family:'Open Sans';fill:#00c081"
+     xml:space="preserve">6 month overlap</text>
   <path
-     style="fill:#5f5f5f"
-     d="m 190.39243,205 0,54.83984 -2,-0.83984 3.5,10 3.5,-9.8457 -2,0.75195 0,-54.90625 -3,0 z"
-      />
+     id="path133"
+     d="m 190.39243,257 v 54.83984 l -2,-0.83984 3.5,10 3.5,-9.8457 -2,0.75195 V 257 Z"
+     style="fill:#5f5f5f" />
   <path
-     style="fill:#5f5f5f"
-     d="m 325.39244,205 0,28.83984 -2,-0.83984 3.5,10 3.5,-9.8457 -2,0.75195 0,-28.90625 -3,0 z"
-      />
+     id="path135"
+     d="m 325.39244,257 v 28.83984 l -2,-0.83984 3.5,10 3.5,-9.8457 -2,0.75195 V 257 Z"
+     style="fill:#5f5f5f" />
+  <rect
+     id="rect31-5"
+     y="213"
+     x="735"
+     height="26"
+     width="230"
+     style="fill:#02d35f" />
+  <rect
+     id="rect35-2"
+     style="fill:#a7a9ac;fill-opacity:0.58823529"
+     width="230"
+     height="2"
+     x="735"
+     y="237" />
+  <rect
+     id="rect33-6"
+     y="213"
+     x="735"
+     height="52"
+     width="55"
+     style="opacity:0.5;fill:#92ecba" />
+  <rect
+     id="rect35"
+     style="fill:#a7a9ac;fill-opacity:0.58823529"
+     width="230"
+     height="2"
+     x="560"
+     y="263" />
+  <circle
+     id="circle117"
+     style="fill:#00c081"
+     cx="572"
+     cy="252"
+     r="18" />
+  <text
+     id="text121"
+     xml:space="preserve"
+     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
+     x="555.80255"
+     y="258.8092">S<tspan
+   id="tspan119"
+   style="letter-spacing:-0.5px">P</tspan>4</text>
+  <circle
+     id="circle117-9"
+     style="fill:#00c081"
+     cx="747"
+     cy="226"
+     r="18" />
+  <text
+     id="text121-1"
+     xml:space="preserve"
+     style="font-size:18.75px;font-family:'Open Sans';fill:#ffffff"
+     x="730.80249"
+     y="232.80919">S<tspan
+   id="tspan119-2"
+   style="letter-spacing:-0.5px">P5</tspan></text>
 </svg>


### PR DESCRIPTION
### Description
These images still referenced the 11/12 transition, 12/15 seems more appropriate

This image may need its upgrade paths corrected still, please review:

![maintmodel](https://user-images.githubusercontent.com/5476547/57065603-3f239180-6cca-11e9-871a-cbd59d7c25bc.png)


### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP4
- [x] To maintenance/SLE15SP0
