### PR TITLE
More details for the AutoYaST "product_dir"

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -5606,8 +5606,8 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
           This entry is mandatory.
          </para>
          <para>
-          If you use a multi product medium like the &sle; Packages DVD
-          then the URL path should point to the root of the multi product
+          If you use a multi-product medium such as the &sle; Packages DVD,
+          then the URL path should point to the root directory of the multi-product
           medium. The specific product directory is selected using
           the <literal>product_dir</literal> value (see below).
          </para>
@@ -5647,7 +5647,7 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
         </entry>
         <entry>
          <para>
-          Optional subpath, should be used only for the multi product media like the
+          Optional subpath. This should only be used for multi-product media such as the
           &sle; Packages DVD.
          </para>
         </entry>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -5605,6 +5605,12 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
           <literal>http://</literal>, <literal>ftp://</literal>, etc.
           This entry is mandatory.
          </para>
+         <para>
+          If you use a multi product medium like the &sle; Packages DVD
+          then the URL path should point to the root of the multi product
+          medium. The specific product directory is selected using
+          the <literal>product_dir</literal> value (see below).
+         </para>
         </entry>
        </row>
        <row>
@@ -5641,7 +5647,8 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
         </entry>
         <entry>
          <para>
-          Additional subpath.
+          Optional subpath, should be used only for the multi product media like the
+          &sle; Packages DVD.
          </para>
         </entry>
        </row>


### PR DESCRIPTION
### Description

- Setting the AutoYaST `product_dir` is a bit complicated for multi product media (like the Package DVD), added more details
- Related to https://bugzilla.suse.com/show_bug.cgi?id=1133406#c7

### Checklist

- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE15SP0

(No backport required, IMHO SLE15-SP1 or SP2 is enough.)