### PR TITLE
NVME multipathing is not enabled by default

### DIFF
--- a/xml/storage_nvmeof.xml
+++ b/xml/storage_nvmeof.xml
@@ -32,8 +32,7 @@
    <emphasis>RDMA</emphasis> or <emphasis>&nvme; over Fibre
    Channel</emphasis> (<emphasis>&fcnvme;</emphasis>). The role of
    &nvmeof; is similar to iSCSI. To increase the fault-tolerance,
-   &nvmeof; has a built-in support for multipathing. The &nvmeof;
-   multipathing is not based on the traditional &dmmpio;.
+   &nvmeof; has built-in support for multipathing.
   </para>
   <para>
    The <emphasis>&nvme; host</emphasis> is the machine that connects to
@@ -138,10 +137,10 @@
   <sect2 xml:id="sec.nvmeof.host_configuration.multipathing">
    <title>Multipathing</title>
    <para>
-    &nvme; native multipathing is enabled by default. To
+    &nvme; native multipathing is disabled by default. To
     print the layout of the multipath devices, use the command
-    <command>nvme list-subsys</command>. To disable NVMe native
-    multipathing, add <option>nvme-core.multipath=N</option> as a boot
+    <command>nvme list-subsys</command>. To enable NVMe native
+    multipathing, add <option>nvme-core.multipath=on</option> as a boot
     parameter.
    </para>
   </sect2>


### PR DESCRIPTION
resolves https://bugzilla.suse.com/show_bug.cgi?id=1120512 and https://bugzilla.suse.com/show_bug.cgi?id=1132388
Trello: https://trello.com/c/20lJPLKw/593-bug-sle12sp4-nvme-native-multipathing-is-not-enabled-by-default-on-sle12

### Description
A few sentences describing the overall goals of this pull request.
If there are relevant Bugzilla or FATE entries, reference them.

### Checklist
* Check all items that apply.

*Are backports required?*

- [ x] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE15SP0
