### PR TITLE
Fix bsc#1133376: Migrate from openSUSE -> SLES

### DIFF
--- a/xml/sle_update_online.xml
+++ b/xml/sle_update_online.xml
@@ -704,13 +704,14 @@ Continue? [y/n/? shows all options] (y):</screen>
     <para>Install <package>SUSEConnect</package>.</para>
     <screen>&prompt.root;<command>zypper in SUSEConnect</command></screen>
    </step>
-   <step>
-    <para>
-     Remove packages that produce file conflicts during the migration.
-    </para>
-    <screen>&prompt.root;<command>rpm -e --nodeps yast2-branding-openSUSE</command>
-&prompt.root;<command>rpm -e --nodeps yast2-branding-openSUSE-Oxygen</command></screen>
-   </step>
+   <!-- toms: bsc#1133376
+    According to Ludwig in c#6:
+    "GA is unchanged and needs the extra steps. The issues are only fixed
+    for 15.1->SP1 migration.":
+
+    rpm -e -\-nodeps yast2-branding-openSUSE
+    rpm -e -\-nodeps yast2-branding-openSUSE-Oxygen
+   -->
    <step>
     <para>Register at SCC to get the &productname; repositories.</para>
     <screen>&prompt.root;<command>SUSEConnect -r <replaceable>REGISTRATION_CODE</replaceable> -p SLES/15.0/x86_64</command></screen>

--- a/xml/sle_update_online.xml
+++ b/xml/sle_update_online.xml
@@ -714,7 +714,7 @@ Continue? [y/n/? shows all options] (y):</screen>
    -->
    <step>
     <para>Register at SCC to get the &productname; repositories.</para>
-    <screen>&prompt.root;<command>SUSEConnect -r <replaceable>REGISTRATION_CODE</replaceable> -p SLES/15.0/x86_64</command></screen>
+    <screen>&prompt.root;<command>SUSEConnect -r <replaceable>REGISTRATION_CODE</replaceable> -p SLES/15.1/x86_64</command></screen>
    </step>
    <step>
     <para>
@@ -733,7 +733,7 @@ Continue? [y/n/? shows all options] (y):</screen>
     </para>
 <screen>&prompt.root;<command>SUSEConnect --list-extensions</command>
 [...]
-&prompt.root;<command>SUSEConnect -p sle-module-basesystem/15.0/x86_64</command></screen>
+&prompt.root;<command>SUSEConnect -p sle-module-basesystem/15.1/x86_64</command></screen>
     <para>
      To have replacements for most Leap packages, we recommend to enable
      the Basesystem, Desktop Applications, Server Applications and


### PR DESCRIPTION
### Description
Remove step 3 about to uninstall the packages `yast2-branding-openSUSE` & `yast2-branding-openSUSE-Oxygen`

### Checklist

*Are backports required?* 

maintenance/SLE15SP0 is not needed.
