### PR TITLE
Update documentation about YaST Firstboot

### DIFF
--- a/xml/deployment_firstboot.xml
+++ b/xml/deployment_firstboot.xml
@@ -353,8 +353,8 @@
   <sect2 id="sec.fb.customize.wf">
    <title>Customizing the Workflow</title>
    <para>
-    By default, a standard firstboot workflow includes the following
-    components:
+    The provided <filename>/etc/YaST2/firstboot.xml</filename> example, defines
+    a standard workflow which includes the following enabled components:
    </para>
    <itemizedlist>
     <listitem>
@@ -375,46 +375,17 @@
     </listitem>
     <listitem>
      <para>
-      Host Name
-     </para>
-    </listitem>
-<!-- some ssh module is here: firstboot_ssh : false -->
-    <listitem>
-     <para>
-      Network
-     </para>
-    </listitem>
-<!-- add Automatic Configuration here: inst_automatic_configuration :
-      false -->
-    <listitem>
-     <para>
       Time and Date
      </para>
     </listitem>
-<!-- NTP Client firstboot_ntp : false -->
     <listitem>
      <para>
-      Desktop
+      Users
      </para>
     </listitem>
     <listitem>
      <para>
-      root Password
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      User Authentication Method
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      User Management
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      Hardware Configuration
+      Root Password
      </para>
     </listitem>
     <listitem>
@@ -424,13 +395,12 @@
     </listitem>
    </itemizedlist>
    <para>
-    This standard layout of a firstboot installation workflow is just
-    a template. You may enable or disable certain components or integrate
-    your own modules into the workflow. To modify the firstboot workflow,
-    manually edit the firstboot configuration file
+    But bear in mind that this workflow is just a template. You may adjust
+    it properly, editing manually the firstboot configuration file
     <filename>/etc/YaST2/firstboot.xml</filename>. This XML file is a subset
     of the standard <filename>control.xml</filename> file that is used by
-    &yast; to control the installation workflow.
+    &yast; to control the installation workflow. See <xref linkend="ex.fb.wf"/>
+    to learn more about how to configure the workflow section.
    </para>
    <para>
     For an overview about proposals, see <xref linkend="ex.fb.proposal"/>.

--- a/xml/deployment_firstboot.xml
+++ b/xml/deployment_firstboot.xml
@@ -107,7 +107,7 @@
 
   <para>
    Customizing the firstboot installation workflow may involve several
-   different components. Customizing them is optional. If you do not make
+   different components. Customizing them is recommended. If you do not make
    any changes, firstboot performs the installation using the default
    settings. The following options are available:
   </para>
@@ -424,8 +424,8 @@
     </listitem>
    </itemizedlist>
    <para>
-    This standard layout of a firstboot installation workflow is not
-    mandatory. You can enable or disable certain components or integrate
+    This standard layout of a firstboot installation workflow is just
+    a template. You may enable or disable certain components or integrate
     your own modules into the workflow. To modify the firstboot workflow,
     manually edit the firstboot configuration file
     <filename>/etc/YaST2/firstboot.xml</filename>. This XML file is a subset
@@ -606,8 +606,7 @@
     <callout arearefs="co.fb.name">
      <para>
       The module name. The module itself must be located under
-      <filename>/usr/share/YaST2/clients</filename> and have the
-      <filename>.ycp</filename> file suffix.
+      <filename>/usr/share/YaST2/clients</filename>.
      </para>
     </callout>
    </calloutlist>
@@ -706,7 +705,7 @@
     <step>
      <para>
       Create your own &yast; module and store the module file
-      <filename><replaceable>module_name</replaceable>.ycp</filename> in
+      <filename><replaceable>module_name</replaceable>.rb</filename> in
       <filename>/usr/share/YaST2/clients</filename>.
      </para>
     </step>
@@ -755,7 +754,7 @@
       <step>
        <para>
         Enter the file name of your module in the <literal>name</literal>
-        element. Omit the full path and the <filename>.ycp</filename>
+        element. Omit the full path and the <filename>.rb</filename>
         suffix.
        </para>
       </step>


### PR DESCRIPTION
### Description

QA has started to test YaST Firstboot without any configuration. They just triggered the module with the example configuration provided at `/etc/YaST2/firstboot.xml`. That _template_ contained two enabled steps asking for the license, which produced a lot of confusion among the testers.

So, apart from [performing the necessary changes to have a more reasonable template](https://github.com/yast/yast-firstboot/pull/67), we would like to adjust a little bit the available documentation to slightly encourage the user to configure the `firstboot.xml` control file before using it. 

In other words, this PR try to clarify that provided `firstboot.xml` is just a template.

#### Relevant Bugzilla entries

* https://bugzilla.suse.com/show_bug.cgi?id=1131301
* https://bugzilla.suse.com/show_bug.cgi?id=1131327

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE15SP0

### Other considerations

#### Changes for SLE12 documentation

Although in the _Contributing_ section of README is stated

>  Always use the develop branch for your edits!

changes of this PR had been done in a branch of top of `maintenance/SLE12` because edited file is no longer available in `develop`.

#### Changes previously sent to suse-bests-practices

By mistake, originally I sent this PR to  https://github.com/SUSE/suse-best-practices (See [PR#25](https://github.com/SUSE/suse-best-practices/pull/25)). Fortunately, @chabowski pointed me out in the right direction after a short chat.

#### A question about the XML comments

In the original PR, I wrote

> I also would like to know if comments like 
> 
> ```xml
> <!-- NTP Client firstboot_ntp : false -->
> ```
> 
> are relevant. I mean, if they are kind of special instruction at the time to build the documentation. I'm asking that because a couple of listed modules  are actually disabled. Shall I include a similar comment?

I still having the same doubt even after read the related sections ([6.2](https://doc.opensuse.org/products/opensuse/Styleguide/opensuse_documentation_styleguide_sd/#sec.xml_comment) and [7](https://doc.opensuse.org/products/opensuse/Styleguide/opensuse_documentation_styleguide_sd/#sec.format_xml)) in the _Documentation Guidelines_.
