### PR TITLE
Fix bsc#1119247: localectl & /etc/locale.conf

### DIFF
--- a/xml/suse_l10n.xml
+++ b/xml/suse_l10n.xml
@@ -35,7 +35,8 @@
   <command>locale</command> man page).
  </para>
 
- <variablelist>
+ <variablelist xml:id="vl.suse.l10n.variables">
+  <title>List of Variables</title>
   <varlistentry>
    <term><systemitem>RC_LC_MESSAGES</systemitem>,
     <systemitem>RC_LC_CTYPE</systemitem>,
@@ -79,9 +80,11 @@
    </term>
    <listitem>
     <para>
-     A <literal>yes</literal> or <literal>no</literal> variable. If set to
-     <literal>no</literal>, <systemitem class="username">root</systemitem>
-     always works in the POSIX environment.
+     This variable can be set to <literal>yes</literal> or
+     <literal>ctype</literal> (default). If set to
+     <literal>yes</literal>, <systemitem class="username">root</systemitem>
+      uses language and country-specific settings, otherwise the system administrator
+      always works in a POSIX environment.
     </para>
    </listitem>
   </varlistentry>
@@ -90,15 +93,73 @@
  <para>
   The variables can be set with the &yast; sysconfig editor. The value of such
   a variable contains the language code, country code, encoding and modifier.
-  The individual components are connected by special characters:
+  The individual components are joined by special characters:
  </para>
 
-<screen>
-  LANG=&lt;language&gt;[[_&lt;COUNTRY&gt;].&lt;Encoding&gt;[@&lt;Modifier&gt;]]
-</screen>
+<screen>LANG=&lt;language&gt;[[_&lt;COUNTRY&gt;].&lt;Encoding&gt;[@&lt;Modifier&gt;]]</screen>
+
+ <sect2 xml:id="sec.suse.l10n.settings">
+  <title>System Wide Locale Settings</title>
+  <para>
+   As of &sls; 15, &systemd; reads <filename>/etc/locale.conf</filename>
+   at early boot. The locale settings configured in this file are
+   inherited by every service or user, unless there are individual
+   settings.
+  </para>
+  <para>
+   In earlier versions, &productname; read it's settings from
+   <filename>/etc/sysconfig/language</filename>,
+   <filename>/etc/sysconfig/keyboard</filename>, and
+   <filename>/etc/sysconfig/console</filename>.
+   As of &sls; 15, these files are considered obsolete. &systemd; does not
+   read certain settings from these files anymore. Starting with &sls; 15,
+   &systemd; reads <filename>/etc/locale.conf</filename>.
+
+   All variables defined in <filename>/etc/sysconfig/language</filename>
+   will still be used to override the system-wide locale and to define a
+   different locale settings for users's shells (see <xref
+    linkend="sec.suse.l10n.examples"/>).
+  </para>
+  <para>To set the system-wide locale, you could either:</para>
+
+  <itemizedlist>
+     <listitem>
+      <para>
+       Write your settings in <filename>/etc/locale.conf</filename>.
+       Each line is a environment-like variable assignment (see
+       <command>man 5 locale.conf</command> for a list of variables):
+      </para>
+      <screen>LANG=de_DE.UTF-8</screen>
+      <para>
+       To fine-tune the settings, you can add additional variables,
+       one variable per line.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       Use the command <command>localectl</command>:
+      </para>
+      <screen>&prompt.root;<command
+>localectl</command> set-locale LANG=de_DE.UTF-8</screen>
+      <para>Same here, you can also specify additional variables after the
+      <command>localectl set-locale</command> command.</para>
+     </listitem>
+    </itemizedlist>
+
+  <para>
+   To keep backward compatibility with old systems during the
+   update of the systemd package, all variables mentioned will be migrated
+   from sysconfig to their final destinations if they are not already defined
+   there.
+  </para>
+ </sect2>
 
  <sect2 xml:id="sec.suse.l10n.examples">
   <title>Some Examples</title>
+  <remark>toms 2019-05-21: This section should be restructured as
+  it not completely deals with generating locales.
+  Postponed to a later point.
+  </remark>
   <para>
    You should always set the language and country codes together. Language
    settings follow the standard ISO&nbsp;639 available at
@@ -131,9 +192,7 @@ localedef -i es_ES@euro -f UTF-8 es_ES@euro.UTF-8
 -->
   <remark role="trans">Change the description file in the previous para and the
    following screen to something appropriate for your language.</remark>
-<screen>
-localedef -i en_US -f UTF-8 en_US.UTF-8
-</screen>
+<screen>localedef -i en_US -f UTF-8 en_US.UTF-8</screen>
   <variablelist>
    <varlistentry>
     <term>
@@ -238,8 +297,7 @@ Spanish:  <systemitem>LANG=es_ES@euro</systemitem>
    <literal>LANG</literal> instead of <literal>RC_LANG</literal>:
   </para>
 <screen>LANG=cs_CZ.UTF-8
-LC_COLLATE=C
-</screen>
+LC_COLLATE=C</screen>
  </sect2>
 
  <sect2 xml:id="sec.suse.l10n.fallback">


### PR DESCRIPTION
### Description

This PR contains the following changes to fix bsc#1119247:

* Mention `localectl` & `/etc/locale.conf`
* Migrated some parts from the release notes
* Adjusted two misaligned screens

### Checklist

- [ ] To maintenance/SLE15SP0
