### PR TITLE
Update firstboot documentation sle12sp1

### DIFF
--- a/xml/deployment_firstboot.xml
+++ b/xml/deployment_firstboot.xml
@@ -115,7 +115,7 @@
 
   <para>
    Customizing the firstboot installation workflow may involve several
-   different components. Customizing them is optional. If you do not make
+   different components. Customizing them is recommended. If you do not make
    any changes, firstboot performs the installation using the default
    settings. The following options are available:
   </para>
@@ -429,8 +429,8 @@
     </listitem>
    </itemizedlist>
    <para>
-    This standard layout of a firstboot installation workflow is not
-    mandatory. You can enable or disable certain components or integrate
+    This standard layout of a firstboot installation workflow is just
+    a template. You may enable or disable certain components or integrate
     your own modules into the workflow. To modify the firstboot workflow,
     manually edit the firstboot configuration file
     <filename>/etc/YaST2/firstboot.xml</filename>. This XML file is a subset
@@ -611,8 +611,7 @@
     <callout arearefs="co.fb.name">
      <para>
       The module name. The module itself must be located under
-      <filename>/usr/share/YaST2/clients</filename> and have the
-      <filename>.ycp</filename> file suffix.
+      <filename>/usr/share/YaST2/clients</filename>.
      </para>
     </callout>
    </calloutlist>
@@ -711,7 +710,7 @@
     <step>
      <para>
       Create your own &yast; module and store the module file
-      <filename><replaceable>module_name</replaceable>.ycp</filename> in
+      <filename><replaceable>module_name</replaceable>.rb</filename> in
       <filename>/usr/share/YaST2/clients</filename>.
      </para>
     </step>
@@ -760,7 +759,7 @@
       <step>
        <para>
         Enter the file name of your module in the <literal>name</literal>
-        element. Omit the full path and the <filename>.ycp</filename>
+        element. Omit the full path and the <filename>.rb</filename>
         suffix.
        </para>
       </step>

--- a/xml/deployment_firstboot.xml
+++ b/xml/deployment_firstboot.xml
@@ -358,7 +358,7 @@
   <sect2 xml:id="sec.fb.customize.wf">
    <title>Customizing the Workflow</title>
    <para>
-    The provided <filename>/etc/YaST2/firstboot.xml</filename> example, defines
+    The provided <filename>/etc/YaST2/firstboot.xml</filename> example defines
     a standard workflow which includes the following enabled components:
    </para>
    <itemizedlist mark="bullet" spacing="normal">

--- a/xml/deployment_firstboot.xml
+++ b/xml/deployment_firstboot.xml
@@ -358,8 +358,8 @@
   <sect2 xml:id="sec.fb.customize.wf">
    <title>Customizing the Workflow</title>
    <para>
-    By default, a standard firstboot workflow includes the following
-    components:
+    The provided <filename>/etc/YaST2/firstboot.xml</filename> example, defines
+    a standard workflow which includes the following enabled components:
    </para>
    <itemizedlist mark="bullet" spacing="normal">
     <listitem>
@@ -380,46 +380,17 @@
     </listitem>
     <listitem>
      <para>
-      Host Name
-     </para>
-    </listitem>
-<!-- some ssh module is here: firstboot_ssh : false -->
-    <listitem>
-     <para>
-      Network
-     </para>
-    </listitem>
-<!-- add Automatic Configuration here: inst_automatic_configuration :
-      false -->
-    <listitem>
-     <para>
       Time and Date
      </para>
     </listitem>
-<!-- NTP Client firstboot_ntp : false -->
     <listitem>
      <para>
-      Desktop
+      Users
      </para>
     </listitem>
     <listitem>
      <para>
-      root Password
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      User Authentication Method
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      User Management
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      Hardware Configuration
+      Root Password
      </para>
     </listitem>
     <listitem>
@@ -429,13 +400,12 @@
     </listitem>
    </itemizedlist>
    <para>
-    This standard layout of a firstboot installation workflow is just
-    a template. You may enable or disable certain components or integrate
-    your own modules into the workflow. To modify the firstboot workflow,
-    manually edit the firstboot configuration file
+    But bear in mind that this workflow is just a template. You may adjust
+    it properly, editing manually the firstboot configuration file
     <filename>/etc/YaST2/firstboot.xml</filename>. This XML file is a subset
     of the standard <filename>control.xml</filename> file that is used by
-    &yast; to control the installation workflow.
+    &yast; to control the installation workflow. See <xref linkend="ex.fb.wf"/>
+    to learn more about how to configure the workflow section.
    </para>
    <para>
     For an overview about proposals, see <xref linkend="ex.fb.proposal"/>.


### PR DESCRIPTION
The same that https://github.com/SUSE/doc-sle/pull/434 for `maintenance/SLE-12-SP1`

> ... adjust a little bit the available documentation to slightly encourage the user to configure the `firstboot.xml` control file before using it.
