### PR TITLE
Update product list in AutoYaST docs to match SLE 15.1 product list

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -5394,6 +5394,7 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
     <para>
      The available values for the <tag class="element">product</tag> tag are:
     </para>
+
     <variablelist>
      <varlistentry>
       <term>SLES</term>
@@ -5403,31 +5404,64 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
        </para>
       </listitem>
      </varlistentry>
-    <varlistentry>
-     <term>SLE_HPC</term>
-     <listitem>
-      <para>
-       &slehpc;
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>SLES_SAP</term>
-     <listitem>
-      <para>
-       &sles4sap;
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>SLED</term>
-     <listitem>
-      <para>
-       &sled;
-      </para>
-     </listitem>
-    </varlistentry>
+     <varlistentry>
+      <term>SLE_HPC</term>
+      <listitem>
+       <para>
+        &slehpc;
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>SLE_RT</term>
+      <listitem>
+       <para>
+        &slert;
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>SLES_SAP</term>
+      <listitem>
+       <para>
+        &sles4sap;
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>SLED</term>
+      <listitem>
+       <para>
+        &sled;
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>SUSE-Manager-Server</term>
+      <listitem>
+       <para>
+        SUSE Manager Server
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>SUSE-Manager-Retail-Branch-Server</term>
+      <listitem>
+       <para>
+        SUSE Manager for Retail
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>SUSE-Manager-Proxy</term>
+      <listitem>
+       <para>
+        SUSE Manager Proxy
+       </para>
+      </listitem>
+     </varlistentry>
     </variablelist>
+  
     <example>
      <title>Explicit Product Selection</title>
      <para>


### PR DESCRIPTION
…  from deployment guide

### Description
SLE 15 introduced a Unified Installer that could install SLES, SLED, SLE_HPC and SLES_SAP all from the same media. SLE 15.1 adds 4 more products including 3 SUMA variants. This commit adds the new short product names to the AY docs.
