### PR TITLE
Added warnings re clash between RMT & Installation server (bsc#1136474)

### DIFF
--- a/xml/deployment_installserver.xml
+++ b/xml/deployment_installserver.xml
@@ -170,6 +170,24 @@
    server module. Then select <guimenu>Add</guimenu> in the overview of existing
    repositories to configure the new repository.
   </para>
+  
+  <warning>
+   <title>&yast; Installation Server Will Conflict with &rmt; Server</title>
+   <para>
+    Configuring a server to be an installation server with &yast; automatically
+    installs and configures the Apache web server, listening on port 80.    
+   </para>
+   <para>
+    However, configuring a machine to be an &rmt; server (&rmtool;)
+    automatically installs the NGINX web server and configures it to listen on
+    port 80.   
+   </para>
+   <para>
+    Do not try to enable both these functions on the same server. It is not
+    possible for a single server to host both simultaneously.
+   </para>
+  </warning>
+      
  </sect1>
  <sect1 xml:id="sec.deployment.instserver.nfs">
   <title>Setting Up an NFS Repository Manually</title>

--- a/xml/rmt_install.xml
+++ b/xml/rmt_install.xml
@@ -16,6 +16,22 @@
   initial configuration.
  </para>
 
+ <warning>
+  <title>&rmt; Server Will Conflict with Installation Server</title>
+  <para>
+   Configuring a server to be an &rmt; server installs and configures the NGINX
+   web server, listening on port 80.    
+  </para>
+  <para>
+   However, configuring a machine to be an Installation Server automatically
+   installs the Apache web server and configures it to listen on port 80.   
+  </para>
+  <para>
+   Do not try to enable both these functions on the same server. It is not
+   possible for a single server to host both simultaneously.
+  </para>
+ </warning>
+
  <sect1 xml:id="sec.rmt_installation.yast">
   <title>Installation During System Installation</title>
   <para>


### PR DESCRIPTION
### Description
Added warnings to the RMT guide and the Installation Server § of the Deployment Guide that these 2 functions clash with one another and a single server cannot host both at once.

In response to https://bugzilla.suse.com/show_bug.cgi?id=1136474

 ****

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE15SP0
