### PR TITLE
Add a multi-device Btrfs section to AutoYaST handbook

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -4712,6 +4712,99 @@ openssl x509 -noout -fingerprint -sha256
    </informaltable>
   </sect2>
 
+  <sect2 xml:id="ay.multidevice_btrfs">
+    <title>Multi-device Btrfs Configuration</title>
+
+    <para>
+      A <emphasis>Btrfs file system</emphasis> can be created on top of many devices, offering similar
+      features to a RAID device. With &ay;, a <emphasis>multi-device Btrfs</emphasis> can be configured
+      by specifying a drive with the <literal>CT_BTRFS</literal> type. The <literal>device</literal>
+      property is used as an arbitrary name to identify each <emphasis>multi-device Btrfs</emphasis>.
+    </para>
+
+    <para>
+      As with RAID, you need to create all block devices first (e.g., partitions, LVM logical volumes,
+      etc.) and assign them to the <emphasis>Btrfs file system</emphasis> you want to create over such
+      block devices.
+    </para>
+
+    <para>
+      The following example shows a simple <emphasis>multi-device Btrfs</emphasis> configuration:
+    </para>
+
+   <example>
+    <title>Multi-device Btrfs configuration</title>
+      <screen>
+        &lt;partitioning config:type="list"&gt;
+          &lt;drive&gt;
+            &lt;device&gt;/dev/sda&lt;/device&gt;
+            &lt;disklabel&gt;none&lt;/disklabel&gt;
+            &lt;partitions&gt;
+              &lt;partition&gt;
+                &lt;btrfs_name&gt;root_fs&lt;/btrfs_name&gt;
+              &lt;/partition&gt;
+            &lt;/partitions&gt;
+            &lt;use&gt;all&lt;/use&gt;
+          &lt;/drive&gt;
+          &lt;drive&gt;
+            &lt;device&gt;/dev/sdb&lt;/device&gt;
+            &lt;disklabel&gt;gpt&lt;/disklabel&gt;
+            &lt;partitions&gt;
+              &lt;partition&gt;
+                &lt;partition_nr&gt;1&lt;/partition_nr&gt;
+                &lt;size&gt;4gb&lt;/size&gt;
+                &lt;filesystem&gt;ext4&lt;/filesystem&gt;
+                &lt;btrfs_name&gt;root_fs&lt;/btrfs_name&gt;
+              &lt;/partition&gt;
+            &lt;/partitions&gt;
+            &lt;use&gt;all&lt;/use&gt;
+          &lt;/drive&gt;
+          &lt;drive&gt;
+            &lt;device&gt;root_fs&lt;/device&gt;
+            &lt;type config:type="symbol"&gt;CT_BTRFS&lt;/type&gt;
+            &lt;partitions&gt;
+              &lt;partition config:type="list&gt;
+                &lt;mount&gt;/&lt;/mount&gt;
+              &lt;/partition&gt;
+            &lt;/partitions&gt;
+            &lt;btrfs_options&gt;
+              &lt;raid_leve&gt;raid1&lt;/raid_level&gt;
+              &lt;metadata_raid_leve&gt;raid1&lt;/metadata_raid_level&gt;
+            &lt;/btrfs_options&gt;
+          &lt;/drive&gt;
+        &lt;/partitioning&gt;
+      </screen>
+    </example>
+
+    <para>
+      The supported data and meta-data RAID levels are: <literal>default</literal>,
+      <literal>single</literal>, <literal>dup</literal>, <literal>raid0</literal>,
+      <literal>raid1</literal>, <literal>raid10</literal>, <literal>raid5</literal> and
+      <literal>raid6</literal>. By default, file system meta-data is mirrored
+      across two devices and data is striped across all of the devices. If only one device is present,
+      meta-data will be duplicated on that one device.
+    </para>
+
+    <para>
+     Keep the following in mind when configuring a <emphasis>multi-device Btrfs</emphasis> file system:
+    </para>
+
+    <itemizedlist mark="bullet" spacing="normal">
+     <listitem>
+      <para>
+        Devices need to indicate the <literal>btrfs_name</literal> property to be included into a
+        <emphasis>multi-device Btrfs</emphasis> file system.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       All Btrfs-specific options are contained in the <literal>btrfs_options</literal> resource of
+       a <literal>CT_BTRFS</literal> drive.
+      </para>
+     </listitem>
+    </itemizedlist>
+  </sect2>
+
   <sect2 xml:id="ay.partition_nfs">
    <title>NFS Configuration</title>
 
@@ -5461,7 +5554,7 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
       </listitem>
      </varlistentry>
     </variablelist>
-  
+
     <example>
      <title>Explicit Product Selection</title>
      <para>


### PR DESCRIPTION
### Description

This PR adds information about how to configure a multi-device Btrfs drive in AutoYaST.

Relevant links:

* https://trello.com/c/FsEzGg70/975-3-multi-device-btrfs-support-in-autoyast
* https://jira.suse.de/browse/SLE-3877

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE15SP0
