### PR TITLE
Add entities for SUMA Retail and SUMA Proxy

### DIFF
--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -166,6 +166,8 @@
 <!ENTITY sdk           "SUSE Software Development Kit">
 <!ENTITY hasi          "High Availability Extension">
 <!ENTITY susemgr       "&suse; Manager">
+<!ENTITY smr           "&susemgr; for Retail">
+<!ENTITY susemgrproxy  "&susemgr; Proxy">
 <!ENTITY scc           "&suse; Customer Center">
 <!ENTITY sccreg        "&suse;&reg; Customer Center">
 <!ENTITY sccurl        "https://scc.suse.com/">

--- a/xml/planning.xml
+++ b/xml/planning.xml
@@ -234,17 +234,17 @@
       <entry>&x86-64;</entry>
      </row>
      <row>
-      <entry>SUSE Manager Server</entry>
+      <entry>&susemgr; Server</entry>
       <entry>SUSE-Manager-Server</entry>
       <entry>&x86-64;; &power;; &zseries;</entry>
      </row>
      <row>
-      <entry>SUSE Manager Proxy</entry>
+      <entry>&susemgrproxy;</entry>
       <entry>SUSE-Manager-Proxy</entry>
       <entry>&x86-64;</entry>
      </row>
      <row>
-      <entry>SUSE Manager Retail Branch Server</entry>
+      <entry>&smr; Branch Server</entry>
       <entry>SUSE-Manager-Retail-Branch-Server</entry>
       <entry>&x86-64;</entry>
      </row>


### PR DESCRIPTION
As per @cjschroder's suggestion
Add entities for the products added in bsc#1123063

### Description
My previous additions of the new products to the lists in the Deployment Guide did not use entities, as this was the first reference to the new products that can be installed from the Unified Installer. Carla suggested "doing it right" and so I have taken the entities used in the SUMA (AsciiDoc) docs.

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE15SP0
