### PR TITLE
AMD SEV article: remove virtio-blk limitation

### DIFF
--- a/xml/art_amd-sev.xml
+++ b/xml/art_amd-sev.xml
@@ -105,12 +105,11 @@
    </para>
   </note>
   <para>
-   Currently <literal>virtio-blk</literal> disks are not supported. SATA and <literal>virtio-scsi</literal>
-   disks are supported and work as expected. All <literal>virtio</literal>
-   devices need to be configured with the <tag class="attribute">iommu='on'</tag>
-   attribute in their <tag class="starttag">driver</tag> configuration. In
-   addition, all memory regions used by the VM must be locked for Direct Memory
-   Access (DMA) and to prevent swapping.
+   All <literal>virtio</literal> devices need to be configured with the
+   <tag class="attribute">iommu='on'</tag> attribute in their
+   <tag class="starttag">driver</tag> configuration. In addition, all memory
+   regions used by the VM must be locked for Direct Memory Access (DMA) and to
+   prevent swapping.
   </para>
  </sect1>
  <sect1 xml:id="sec.amd-sev.config">
@@ -141,13 +140,10 @@
     &lt;/memtune&gt;
     &lt;devices&gt;
     &lt;disk type='file' device='disk'&gt;
-    &lt;driver name='qemu' type='raw'/&gt;
-    &lt;target dev='sda' bus='scsi'/&gt;
+    &lt;driver iommu='on' name='qemu' type='raw'/&gt;
+    &lt;target dev='vda' bus='virtio'/&gt;
     &lt;source file='/vmimages/sev-guest-disk.raw'/&gt;
     &lt;/disk&gt;
-    &lt;controller type='scsi' model='virtio-scsi'&gt;
-    &lt;driver iommu='on'/&gt;
-    &lt;/controller&gt;
     &lt;rng model='virtio'&gt;
     &lt;driver iommu='on'/&gt;
     ...
@@ -401,12 +397,6 @@
     <para>
      SEV-encrypted VMs cannot contain directly-accessible host devices (that is,
      PCI passthrough).
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     <literal>virtio-blk</literal> disks are not supported. <literal>virtio-scsi</literal>
-     and SATA disks are supported and work as expected.
     </para>
    </listitem>
   </itemizedlist>


### PR DESCRIPTION
On the distros where we support AMD SEV, the kernel has been fixed and
virtio-blk disks are now usable with SEV guests. See bsc#1120008 for
more details. Remove the limitation from the AMD SEV article.

### Description
A few sentences describing the overall goals of this pull request.
If there are relevant Bugzilla or FATE entries, reference them.

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE15SP0
