### PR TITLE
new tag in add-on section ... add_on_others

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -5621,8 +5621,12 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
      products can be added from almost every other location during an &ay;
      installation.
     </para>
+    <para>
+      Even repositories which do not have any product, module,... information
+      can be added while the installation. We call it <literal>other add-ons</literal>.
+    </para>
     <example>
-     <title>Adding the SDK Extension</title>
+     <title>Adding the SDK Extension and an User Defined Repository</title>
 <screen>&lt;add-on&gt;
   &lt;add_on_products config:type="list"&gt;
     &lt;listentry&gt;
@@ -5636,8 +5640,20 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
       &lt;name&gt;SUSE Linux Enterprise Software Development Kit&lt;/name&gt;
     &lt;/listentry&gt;
   &lt;/add_on_products&gt;
+  &lt;add_on_others config:type="list"&gt;
+    &lt;listentry&gt;
+      &lt;media_url&gt;https://download.opensuse.org/repositories/YaST:/Head/openSUSE_Leap_15.1/&lt;/media_url&gt;
+      &lt;alias&gt;yast2_head&lt;/alias&gt;
+      &lt;priority config:type="integer"&gt;30&lt;/priority&gt;
+      &lt;name&gt;Latest YaST2 packages from OBS&lt;/name&gt;
+    &lt;/listentry&gt;
+  &lt;/add_on_others&gt;
 &lt;/add-on&gt;</screen>
     </example>
+    <para>
+      The sections <literal>add_on_others</literal> and <literal>add_on_products</literal> are supporting
+      the same values:
+    </para>
     <informaltable>
      <tgroup cols="2">
       <thead>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -5622,11 +5622,11 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
      installation.
     </para>
     <para>
-      Even repositories which do not have any product, module,... information
-      can be added while the installation. We call it <literal>other add-ons</literal>.
+      Even repositories which do not have any product or module information
+      can be added during the installation. These are called <literal>other add-ons</literal>.
     </para>
     <example>
-     <title>Adding the SDK Extension and an User Defined Repository</title>
+     <title>Adding the SDK Extension and a User Defined Repository</title>
 <screen>&lt;add-on&gt;
   &lt;add_on_products config:type="list"&gt;
     &lt;listentry&gt;
@@ -5651,7 +5651,7 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
 &lt;/add-on&gt;</screen>
     </example>
     <para>
-      The sections <literal>add_on_others</literal> and <literal>add_on_products</literal> are supporting
+      The <literal>add_on_others</literal> and <literal>add_on_products</literal> sections support
       the same values:
     </para>
     <informaltable>


### PR DESCRIPTION
### Description
With the new add_on_others section in add-ons the user can defined manually any repo which
will be added while the installation.


### Checklist
* Check all items that apply.

*Are backports required?*
no. Only Head.


