### PR TITLE
Feature/docserv2 dc adjustments sle15sp1

### DIFF
--- a/DC-SLED-admin
+++ b/DC-SLED-admin
@@ -11,9 +11,6 @@ ROOTID="book.sle.admin"
 PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sled15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-admin
+++ b/DC-SLED-admin
@@ -9,7 +9,7 @@ ROOTID="book.sle.admin"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86_64;zseries;power"
+PROFARCH="x86_64;zseries;power;aarch64"
 
 ## Provo
 HTMLROOT="sled15"

--- a/DC-SLED-all
+++ b/DC-SLED-all
@@ -10,9 +10,6 @@ MAIN="MAIN.SLEDS.xml"
 PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sled15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-all
+++ b/DC-SLED-all
@@ -8,7 +8,7 @@ MAIN="MAIN.SLEDS.xml"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86_64;zseries;power"
+PROFARCH="x86_64;zseries;power;aarch64"
 
 ## Provo
 HTMLROOT="sled15"

--- a/DC-SLED-deployment
+++ b/DC-SLED-deployment
@@ -11,9 +11,6 @@ ROOTID="book.sle.deployment"
 PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sled15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-deployment
+++ b/DC-SLED-deployment
@@ -9,7 +9,7 @@ ROOTID="book.sle.deployment"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86_64;zseries;power"
+PROFARCH="x86_64;zseries;power;aarch64"
 
 ## Provo
 HTMLROOT="sled15"

--- a/DC-SLED-gnomeuser
+++ b/DC-SLED-gnomeuser
@@ -11,9 +11,6 @@ ROOTID="book.gnomeuser"
 PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sled15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-gnomeuser
+++ b/DC-SLED-gnomeuser
@@ -9,7 +9,7 @@ ROOTID="book.gnomeuser"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86_64;zseries;power"
+PROFARCH="x86_64;zseries;power;aarch64"
 
 ## Provo
 HTMLROOT="sled15"

--- a/DC-SLED-html
+++ b/DC-SLED-html
@@ -8,7 +8,7 @@ MAIN="MAIN.SLEDS.xml"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86_64;zseries;power"
+PROFARCH="x86_64;zseries;power;aarch64"
 
 HTMLROOT="sled15"
 

--- a/DC-SLED-html
+++ b/DC-SLED-html
@@ -10,8 +10,6 @@ MAIN="MAIN.SLEDS.xml"
 PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-HTMLROOT="sled15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-installquick
+++ b/DC-SLED-installquick
@@ -9,7 +9,7 @@ ROOTID="art.sle.installquick"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86_64;zseries;power"
+PROFARCH="x86_64;zseries;power;aarch64"
 
 ## Provo
 HTMLROOT="sled15"

--- a/DC-SLED-installquick
+++ b/DC-SLED-installquick
@@ -11,9 +11,6 @@ ROOTID="art.sle.installquick"
 PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sled15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-modulesquick
+++ b/DC-SLED-modulesquick
@@ -9,7 +9,7 @@ ROOTID="art.modules"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86_64"
+PROFARCH="x86_64;zseries;power;aarch64"
 
 ## Provo
 HTMLROOT="sled-15sp0"

--- a/DC-SLED-modulesquick
+++ b/DC-SLED-modulesquick
@@ -11,9 +11,6 @@ ROOTID="art.modules"
 PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sled-15sp0"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-security
+++ b/DC-SLED-security
@@ -11,9 +11,6 @@ ROOTID="book.security"
 PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sled15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-security
+++ b/DC-SLED-security
@@ -9,7 +9,7 @@ ROOTID="book.security"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86_64;zseries;power"
+PROFARCH="x86_64;zseries;power;aarch64"
 
 ## Provo
 HTMLROOT="sled15"

--- a/DC-SLED-tuning
+++ b/DC-SLED-tuning
@@ -11,9 +11,6 @@ ROOTID="book.sle.tuning"
 PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sled15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-tuning
+++ b/DC-SLED-tuning
@@ -9,7 +9,7 @@ ROOTID="book.sle.tuning"
 
 ## Profiling
 PROFOS="sled"
-PROFARCH="x86_64;zseries;power"
+PROFARCH="x86_64;zseries;power;aarch64"
 
 ## Provo
 HTMLROOT="sled15"

--- a/DC-SLED-upgrade
+++ b/DC-SLED-upgrade
@@ -11,9 +11,6 @@ ROOTID="book.sle.upgrade"
 PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sles15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-admin
+++ b/DC-SLES-admin
@@ -11,9 +11,6 @@ ROOTID="book.sle.admin"
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sles15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-all
+++ b/DC-SLES-all
@@ -10,9 +10,6 @@ MAIN="MAIN.SLEDS.xml"
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sles15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-autoyast
+++ b/DC-SLES-autoyast
@@ -11,8 +11,6 @@ ROOTID="book.autoyast"
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-HTMLROOT="sles15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-deployment
+++ b/DC-SLES-deployment
@@ -11,9 +11,6 @@ ROOTID="book.sle.deployment"
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sles15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-dockerquick
+++ b/DC-SLES-dockerquick
@@ -11,9 +11,6 @@ ROOTID="book.sles.docker"
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sles15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-gnomeuser
+++ b/DC-SLES-gnomeuser
@@ -11,9 +11,6 @@ ROOTID="book.gnomeuser"
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sled15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-hardening
+++ b/DC-SLES-hardening
@@ -11,9 +11,6 @@ ROOTID="book.hardening"
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sles15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-html
+++ b/DC-SLES-html
@@ -10,9 +10,6 @@ MAIN="MAIN.SLEDS.xml"
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sles15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-installquick
+++ b/DC-SLES-installquick
@@ -11,9 +11,6 @@ ROOTID="art.sle.installquick"
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sles15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-modulesquick
+++ b/DC-SLES-modulesquick
@@ -11,9 +11,6 @@ ROOTID="art.modules"
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sles-15sp0"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-pcidss
+++ b/DC-SLES-pcidss
@@ -11,9 +11,6 @@ ROOTID="art.pcidss"
 PROFOS="article"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sles_pcidss"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-rpi-quick
+++ b/DC-SLES-rpi-quick
@@ -11,9 +11,6 @@ ROOTID="art.rpiquick"
 PROFOS="sles"
 PROFARCH="aarch64"
 
-## Provo
-HTMLROOT="sles15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-security
+++ b/DC-SLES-security
@@ -11,9 +11,6 @@ ROOTID="book.security"
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sles15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-storage
+++ b/DC-SLES-storage
@@ -11,9 +11,6 @@ ROOTID="book.storage"
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sles15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-tuning
+++ b/DC-SLES-tuning
@@ -11,9 +11,6 @@ ROOTID="book.sle.tuning"
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sles15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-upgrade
+++ b/DC-SLES-upgrade
@@ -11,9 +11,6 @@ ROOTID="book.sle.upgrade"
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sles15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-virtualization
+++ b/DC-SLES-virtualization
@@ -11,9 +11,6 @@ ROOTID="book.virt"
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sles15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-vt-best-practices
+++ b/DC-SLES-vt-best-practices
@@ -7,7 +7,6 @@
 MAIN="MAIN.SLEDS.xml"
 ROOTID="article.vt.best.practices"
 
-
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"

--- a/DC-SLES-xen2kvmquick
+++ b/DC-SLES-xen2kvmquick
@@ -11,9 +11,6 @@ ROOTID="art.sles.xen2kvmquick"
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
-## Provo
-HTMLROOT="sles15"
-
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"


### PR DESCRIPTION
This PR has two goals:

-  Making sure the profiling info is the same in all DCs files for which the HTML is build from DC-SLE*-all.

- Cleaning up the DC files (removing parameters that are no longer relevant, e.g. HTMLROOT).

BTW, for SLES, the profiling info was the same across all DCs, no changes required.