### PR TITLE
AY Registration - recommend registering the Basesystem module

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -1651,8 +1651,22 @@ echo "Sleeping 10 seconds"
   &lt;reg_code&gt;<replaceable>MY_SECRET_REGCODE</replaceable>&lt;/reg_code&gt;
   &lt;install_updates config:type="boolean"&gt;true&lt;/install_updates&gt;
   &lt;slp_discovery config:type="boolean"&gt;false&lt;/slp_discovery&gt;
+  &lt;--! optionally register some add-ons --&gt;
+  &lt;addons config:type=&quot;list&quot;&gt;
+    &lt;addon&gt;
+      &lt;name&gt;sle-module-basesystem&lt;/name&gt;
+      &lt;version&gt;<replaceable>15.1</replaceable>&lt;/version&gt;
+      &lt;arch&gt;<replaceable>x86_64</replaceable>&lt;/arch&gt;
+    &lt;/addon&gt;
+  &lt;/addons&gt;
 &lt;/suse_register&gt;
  </screen>
+
+   <para>
+    It is recommended to at least register the Basesystem Module to have
+    access to the updates for the base system (the Linux kernel, the system
+    libraries and services).
+   </para>
 
    <para>
     As an alternative to the fully automated registration, &ay; can also


### PR DESCRIPTION

### Description

- Registering the SLES system is not enough to have access to the system updates,
  the updates for `kernel-default` and other system packages are released via the Basesystem module
- So we should recommend to at least register the Basesystem module by default
- Related to https://bugzilla.suse.com/show_bug.cgi?id=1141039

### Checklist

*Are backports required?*

Not necessary.


### Notes

Feel free to adapt to your style guide and improve the wording. :grinning: 