### PR TITLE
Remove redundant info about boot media in x86-64 & ARM sections

### DIFF
--- a/xml/deployment_prep_x86_workflow.xml
+++ b/xml/deployment_prep_x86_workflow.xml
@@ -26,9 +26,9 @@
   <step>
    <para>
     Set the boot parameters required for your installation method. An overview of
-    the different methods is provided in <xref linkend="sec.x86.prep.installation_methods"/>.
-    A list of boot parameters is available in
-    <xref linkend="cha.boot_parameters"/>.
+    the different methods is provided in <xref
+    linkend="sec.x86.prep.installation_methods"/>.  A list of boot parameters
+    is available in <xref linkend="cha.boot_parameters"/>.
    </para>
   </step>
   <xi:include xpointer="element(/1/3/3/4)" href="deployment_xpointer.xml"/>

--- a/xml/deployment_xpointer.xml
+++ b/xml/deployment_xpointer.xml
@@ -102,9 +102,11 @@
    </listitem>
    <listitem>
     <para>
+     <phrase os="sles">
      When using very recent hardware, it can be necessary to boot the
      installation with a newer kernel. For details, refer to
      <xref linkend="cha.kiso"/>.
+      </phrase>
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/deployment_xpointer.xml
+++ b/xml/deployment_xpointer.xml
@@ -6,9 +6,9 @@
 ]>
 
 <!--
-  IMPORTANT: The content of this file is included into the AArch64 section
-  via xpointers. Make sure to add xpointers if needed or update the section
-  accordingly.
+  IMPORTANT: The content of this file is included into the x86_64 & AArch64
+  sections via xpointers. Make sure to add xpointers if needed or update the
+  section accordingly.
 -->
 
 <sect1 version="5.0" xml:id="sec.deployment.xpointer.source"
@@ -96,22 +96,15 @@
    <listitem>
     <para>
      Unlike previous &slea; products, the entire &slea; &productnumber;
-     product line can be installed using the same ISO image:
-     The &slea; &productnumber; Installer DVD 1. If you want to install without
-     network access, additionally download the other two DVD images: &slea;
-     &productnumber; Installer DVD 2 and &slea; &productnumber; Installer DVD 3. 
+     product line can be installed from the same media with the new Unified
+     Installer; see <xref linkend="sec.planning.leanos"/>. 
     </para>
    </listitem>
    <listitem>
     <para>
-     When installing the system, the media for booting and for installing the
-     system may be different. All combinations of supported media for booting and
-     installing may be used.
-     <phrase os="sles">
-      When using very recent hardware, it can be necessary to boot the
-      installation with a newer kernel. For details, refer to
-      <xref linkend="cha.kiso"/>.
-     </phrase>
+     When using very recent hardware, it can be necessary to boot the
+     installation with a newer kernel. For details, refer to
+     <xref linkend="cha.kiso"/>.
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/deployment_xpointer.xml
+++ b/xml/deployment_xpointer.xml
@@ -95,9 +95,11 @@
   <itemizedlist>
    <listitem>
     <para>
-     Unlike previous &slea; products, the entire &slea; &productnumber;
-     product line can be installed from the same media with the new &leanos;;
-     see <xref linkend="sec.planning.leanos"/>.  
+     <phrase os="sles">
+      Unlike previous &slea; products, the entire &slea; &productnumber;
+      product line can be installed from the same media with the new &leanos;;
+      see <xref linkend="sec.planning.leanos"/>.
+     </phrase>
     </para>
    </listitem>
    <listitem>

--- a/xml/deployment_xpointer.xml
+++ b/xml/deployment_xpointer.xml
@@ -96,8 +96,8 @@
    <listitem>
     <para>
      Unlike previous &slea; products, the entire &slea; &productnumber;
-     product line can be installed from the same media with the new Unified
-     Installer; see <xref linkend="sec.planning.leanos"/>. 
+     product line can be installed from the same media with the new &leanos;;
+     see <xref linkend="sec.planning.leanos"/>. 
     </para>
    </listitem>
    <listitem>

--- a/xml/deployment_xpointer.xml
+++ b/xml/deployment_xpointer.xml
@@ -103,10 +103,10 @@
    <listitem>
     <para>
      <phrase os="sles">
-     When using very recent hardware, it can be necessary to boot the
-     installation with a newer kernel. For details, refer to
-     <xref linkend="cha.kiso"/>.
-      </phrase>
+      When using very recent hardware, it can be necessary to boot the
+      installation with a newer kernel. For details, refer to
+      <xref linkend="cha.kiso"/>.
+     </phrase>
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/deployment_xpointer.xml
+++ b/xml/deployment_xpointer.xml
@@ -96,17 +96,12 @@
    <listitem>
     <para>
      Unlike previous &slea; products, the entire &slea; &productnumber;
-     product line can be installed using the same ISO image:
-     The &slea; &productnumber; Installer DVD 1. If you want to install without
-     network access, additionally download the other two DVD images: &slea;
-     &productnumber; Installer DVD 2 and &slea; &productnumber; Installer DVD 3. 
+     product line can be installed from the same media with the new &leanos;;
+     see <xref linkend="sec.planning.leanos"/>.  
     </para>
    </listitem>
    <listitem>
     <para>
-     When installing the system, the media for booting and for installing the
-     system may be different. All combinations of supported media for booting and
-     installing may be used.
      <phrase os="sles">
       When using very recent hardware, it can be necessary to boot the
       installation with a newer kernel. For details, refer to

--- a/xml/deployment_xpointer.xml
+++ b/xml/deployment_xpointer.xml
@@ -6,9 +6,9 @@
 ]>
 
 <!--
-  IMPORTANT: The content of this file is included into the x86_64 & AArch64
-  sections via xpointers. Make sure to add xpointers if needed or update the
-  section accordingly.
+  IMPORTANT: The content of this file is included into the AArch64 section
+  via xpointers. Make sure to add xpointers if needed or update the section
+  accordingly.
 -->
 
 <sect1 version="5.0" xml:id="sec.deployment.xpointer.source"
@@ -96,12 +96,17 @@
    <listitem>
     <para>
      Unlike previous &slea; products, the entire &slea; &productnumber;
-     product line can be installed from the same media with the new &leanos;;
-     see <xref linkend="sec.planning.leanos"/>. 
+     product line can be installed using the same ISO image:
+     The &slea; &productnumber; Installer DVD 1. If you want to install without
+     network access, additionally download the other two DVD images: &slea;
+     &productnumber; Installer DVD 2 and &slea; &productnumber; Installer DVD 3. 
     </para>
    </listitem>
    <listitem>
     <para>
+     When installing the system, the media for booting and for installing the
+     system may be different. All combinations of supported media for booting and
+     installing may be used.
      <phrase os="sles">
       When using very recent hardware, it can be necessary to boot the
       installation with a newer kernel. For details, refer to

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -131,7 +131,7 @@
 
 <!ENTITY opensuse      "openSUSE">
 <!ENTITY opensusereg   "openSUSE&reg;">
-<!ENTITY leanos        "Installer">
+<!ENTITY leanos        "Unified Installer">
 <!ENTITY allmodules    "SLE-&product-ga;-SP&product-sp;-Packages">
 <!ENTITY sle           "SUSE Linux Enterprise">
 <!ENTITY slea          "SLE">

--- a/xml/planning.xml
+++ b/xml/planning.xml
@@ -98,9 +98,7 @@
 
   <para>
    &sls; provides you with a broad variety of services. Find an overview of the
-   documentation in this book in <xref
-    linkend="pre.sle"
-   />. Most of the
+   documentation in this book in <xref linkend="pre.sle"/>. Most of the
    needed configurations can be made with &yast;, the &suse; configuration
    utility. In addition, many manual configurations are described in the
    corresponding chapters.
@@ -183,7 +181,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec.planning.leanos">
-  <title>Changes in Installation from &sls; Version &product-ga;</title>
+  <title>Changes in Installation in &sls; Version &product-ga;</title>
 
   <para>
    Starting with &productname; 15, all &sle;-based products on each

--- a/xml/planning.xml
+++ b/xml/planning.xml
@@ -185,7 +185,7 @@
 
   <para>
    Starting with &productname; 15, all &sle;-based products on each
-   supported architecture are installed using a Unified Installer from a single
+   supported architecture are installed using a &leanos; from a single
    set of installation media and a supplementary Packages medium. 
   </para>
 


### PR DESCRIPTION
(relevant to BSC#1122035)

### Description
Removed the description of installation media from both ARM and X86 sections; added pointer to description of Unified Installer in Planning section.

Removed description of different boot and install volumes; added pointer to description of kernel updates in "Installation on Hardware Not Supported at Release".

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE15SP0
