### PR TITLE
PXE/autoyast install fails, jira SLE-8071

### DIFF
--- a/xml/deployment_pxe.xml
+++ b/xml/deployment_pxe.xml
@@ -47,36 +47,55 @@
   can reside on different machines without any problems. Make sure to
   change the IP addresses as required.
  </para>
+ 
  <sect1 xml:id="sec-deployment-dhcp-server">
   <title>Setting Up a DHCP Server</title>
   <para>
-   In addition to providing automatic address allocation to your
-   network clients, the DHCP server announces the IP address of the
-   TFTP server and the paths to the Kernel and Initrd files. Which file
-   needs to be loaded depends on the architecture of the target machine
-   and whether legacy BIOS or UEFI boot is used. The clients transmit
-   their architecture type in the DHCP request. Based on this
-   information, the DHCP server can decide which files the client must
-   download for booting.
+   A DHCP server provides both dynamic
+   (<xref linkend="sec-deployment-dhcp-dynamic"/>) and static IP address
+   assignments (<xref linkend="sec-deployment-dhcp-static"/>) to your network
+   clients. It advertises servers, routes, and domains. For TFTP servers, DHCP
+   also provides the kernel and initrd files. Which files are loaded depends
+   on the architecture of the target machine, and whether legacy BIOS or UEFI
+   boot is used. The clients transmit their architecture type in their DHCP
+   requests. Based on this information, the DHCP server decides which files the
+   client must download for booting.
   </para>
-  <procedure xml:id="pro-deployment-dhcp-server">
-   <step>
-    <para>
-     Log in as &rootuser; to the machine hosting the DHCP server.
-    </para>
-   </step>
-   <step>
-    <para>
-     Enable the DHCP server by executing <command>systemctl enable
-     dhcpd</command>.
-    </para>
-   </step>
-   <step>
-    <para>
-     Append the following lines to a subnet configuration of your DHCP
-     server's configuration file located under
-     <filename>/etc/dhcpd.conf</filename>:
-    </para>
+  <warning>
+   <title>PXE and &ay; Installation Failure</title>
+   <para>
+    Starting with &sle; 15.0, there are special conditions that cause PXE boot 
+    and &ay; installations to fail. See
+    <xref linkend="sec-deployment-dhcp-rfc4361"/> for more information and
+    the solution.
+   </para>
+  </warning>
+
+  <sect2  xml:id="sec-deployment-dhcp-dynamic">
+   <title>Dynamic Address Assignment</title>
+   <para>
+    The following example shows how to set up a DHCP server that dynamically
+    assigns IP addresses to clients, and advertises servers, routers, domains,
+    and boot files.
+   </para>
+   <procedure xml:id="pro-deployment-dhcp-server">
+    <step>
+     <para>
+      Log in as &rootuser; to the machine hosting the DHCP server.
+     </para>
+    </step>
+    <step>
+     <para>
+      Enable the DHCP server by executing <command>systemctl enable
+      dhcpd</command>.
+     </para>
+    </step>
+    <step>
+     <para>
+      Append the following lines to a subnet configuration of your DHCP
+      server's configuration file located under
+      <filename>/etc/dhcpd.conf</filename>:
+     </para>
 <screen># The following lines are optional
 option domain-name "my.lab";
 option domain-name-servers 192.168.1.1;
@@ -102,27 +121,37 @@ subnet 192.168.1.0 netmask 255.255.255.0 {
    filename "/BIOS/x86/pxelinux.0";
  }
 }</screen>
-    <para>
-     This configuration example uses the subnet <literal>192.168.1.0/24</literal> with the
-     DHCP, DNS and gateway on the server with the IP <literal>192.168.1.1</literal>. Make sure
-     that all used IP addresses are changed according to your network layout.
-     For more information about the options available in <filename>dhcpd.conf</filename>,
-     refer to the <systemitem>dhcpd.conf</systemitem> manual page.
-    </para>
-   </step>
-   <step>
-    <para>
-     Restart the DHCP server by executing <command>systemctl restart
-     dhcpd</command>.
-    </para>
-   </step>
-  </procedure>
-  <para>
-   If you plan to use SSH for the remote control of a PXE and Wake on LAN
-   installation, specify the IP address DHCP should provide to the
-   installation target. To achieve this, modify the above mentioned DHCP
-   configuration according to the following example:
+     <para>
+      This configuration example uses the subnet
+      <literal>192.168.1.0/24</literal> with the DHCP, DNS and gateway on the
+      server with the IP <literal>192.168.1.1</literal>. Make sure that all
+      IP addresses are changed according to your network layout. For more
+      information about the options available in
+      <filename>dhcpd.conf</filename>, refer to the
+      <systemitem>dhcpd.conf</systemitem> manual page.
+     </para>
+    </step>
+    <step>
+     <para>
+      Restart the DHCP server by executing <command>systemctl restart
+      dhcpd</command>.
+     </para>
+    </step>
+   </procedure>
+  </sect2>
+
+  <sect2  xml:id="sec-deployment-dhcp-static">
+   <title>Assigning Static IP Addresses</title>
+   <para>
+    A DHCP server may also assign static IP addresses and host names to
+    network clients. One use case is assigning static addresses to servers.
+    Another use case is restricting which clients may join the network to 
+    those with assigned static IP addresses, and providing no dynamic address 
+    pools.
   </para>
+  <para>
+    Modify the above DHCP configuration according to the  following example:
+   </para>
 <screen>group {
  host test {
    hardware ethernet <replaceable>MAC_ADDRESS</replaceable>;
@@ -130,16 +159,92 @@ subnet 192.168.1.0 netmask 255.255.255.0 {
    }
 }
 </screen>
-  <para>
-   The host statement introduces the host name of the installation target. To
-   bind the host name and IP address to a specific host, you must know and
-   specify the system's hardware (MAC) address. Replace all the variables used
-   in this example with the actual values that match your environment.
-  </para>
-  <para>
-   After restarting the DHCP server, it provides a static IP to the host
-   specified, enabling you to connect to the system via SSH.
-  </para>
+   <para>
+    The host statement assigns a host name to the installation target. To
+    bind the host name and IP address to a specific host, you must 
+    specify the client's hardware (MAC) address. Replace all the variables used
+    in this example with the actual values that match your environment, then
+    save your changes and restart the DHCP server.
+   </para>
+  </sect2>
+
+  <sect2 xml:id="sec-deployment-dhcp-rfc4361">
+   <title>PXE and &ay; Installation Failures</title>
+   <para>
+    Starting with &sle; 15.0 and ISC DHCP 4.3.x, there are special circumstances 
+    that cause PXE boot and &ay; installations to fail. If your DHCP server does not 
+    have a pool of available dynamic IP addresses, but allows only pre-defined static
+    addresses per client, and the clients send RFC 4361 client identifiers, then
+    PXE/&ay; installations will not work. (Allowing only addresses assigned to
+    specific network clients, and providing no dynamic address pools, prevents 
+    random machines from joining the network.)
+   </para>
+   <para>
+    When a new system starts in PXE, it sends a request to the DHCP server and
+    identifies itself using a client identifier constructed from the hardware type plus
+    the MAC address of the network interface. This is a RFC 2132 <literal>client-id</literal>. The DHCP 
+    server then offers the assigned IP address. Next, the installation kernel is loaded, 
+    and sends another DHCP request, but this <literal>client-id</literal> is different, and is sent in 
+    RFC 4361 format. The DHCP server will not recognize this as the same client, and 
+    will look for a free dynamic IP address, which is not available, and the installation stops.
+   </para>
+   <para>
+    The solution is to configure clients to send RFC 2132 client IDs. 
+    To send a RFC 2132 <literal>client-id</literal> during the installation, use
+    <literal>linuxrc</literal> to pass
+    the following <literal>ifcfg</literal> command:
+   </para>   
+<screen>ifcfg=eth0=dhcp,DHCLIENT_CLIENT_ID=<replaceable>01:03:52:54:00:02:c2:67</replaceable>, 
+DHCLIENT6_CLIENT_ID=<replaceable>00:03:52:54:00:02:c2:67</replaceable></screen>
+   <para>
+    The traditionally-used RFC 2132 DHCPv4 <literal>client-id</literal> on
+    Ethernet is constructed from the hardware type (<literal>01</literal> for
+    Ethernet) and followed by the hardware address (the MAC address), for
+    example:
+   </para>
+<screen>01:52:54:00:02:c2:67</screen>
+   <para>
+    The RFC 4361 DHCPv4 <literal>client-id</literal> attempts to correct the problem
+    of identifying a machine that has more than one network interface. The new
+    DHCPv4 <literal>client-id</literal> has the same format as the DHCPv6
+    <literal>client-id</literal>. It starts with the
+    <literal>0xff</literal> prefix, instead of the hardware type, followed by the
+    DHCPv6 IAID (the interface-address association ID that describes the
+    interface on the machine), followed by the DHCPv6 DHCP Unique
+    Identifier (DUID), which uniquely identifies the machine.
+   </para>
+   <para>
+    Using the above hardware type-based and hardware address-based DUID, the new 
+    RFC 4361 DHCPv4 <literal>client-id</literal> would be:
+   </para>
+   <itemizedlist>
+    <listitem>
+     <para>
+      Using the last bytes of the MAC address as the IAID:
+      <literal>ff:00:02:c2:67:00:01:xx:xx:xx:xx:52:54:00:02:c2:67</literal>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      When the IAID is a simple incremented number:
+      <literal>ff:00:00:00:01:00:01:xx:xx:xx:xx:52:54:00:02:c2:67</literal>
+     </para>
+    </listitem>
+   </itemizedlist>
+   <para>
+    The <replaceable>xx:xx:xx:xx</replaceable> fields in the DUID-Link-Layer Timestamp 
+    (DUID-LLT) is a creation timestamp. A DUID-Link-Layer (DUID-LL) (<literal>00:03:00:01:$MAC</literal>) 
+    does not have a timestamp.
+   </para>
+   <para>
+    For more information on using <literal>linuxrc</literal>, see the &ayguide;.
+    Also see <literal>man 4 initrd</literal>, and the 
+    documentation for the options <literal>dhcp4
+    "create-cid"</literal>, <literal>dhcp6 "default-duid"</literal> in
+    <literal>man 5 wicked-config</literal>, <literal>wicked duid
+    --help</literal>, and <literal>wicked iaid --help</literal>.
+   </para>   
+  </sect2>
  </sect1>
 
  <sect1 xml:id="sec-deployment-tftp-server">


### PR DESCRIPTION
PXE/autoyast will fail on SLES 15.x when there are no
free IP addresses in DHCP, even with static assignments
per network client, because of RFC 2132 and RFC 4361
client ID conflicts. solution: send RFC 2132 IDs

### Checklist
* Check all items that apply.

*Are backports required?*

- [ x] To maintenance/SLE15SP1
- [x ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
