### PR TITLE
add susefirewall2 > firewalld migration steps, bsc1134404

### DIFF
--- a/xml/security_firewall.xml
+++ b/xml/security_firewall.xml
@@ -28,10 +28,10 @@
  <para>
      &sle; 15 introduces &firewalld; as the new software firewall, replacing &susefirewall;.
       &susefirewall; has not been removed from &sle; 15 and is still in the Main
-      repository. However, it is not included in the default installation, and  &firewalld;
-      is installed by default. This chapter provides guidance for configuring &firewalld;,
-      and migrating from &susefirewall; for users who have upgraded from older &sle;
-      releases.
+      repository. However, it is not included in the default installation, and &firewalld;
+      is installed by default in new installations. This chapter provides guidance for 
+      configuring &firewalld;, and migrating from &susefirewall; for users who have 
+      upgraded from older &sle; releases.
   </para>     
 
  <sect1 xml:id="sec-security-firewall-iptables">
@@ -280,7 +280,17 @@
  </sect1>
  <sect1 xml:id="sec-security-firewall-firewalld">
   <title>&firewalld;</title>
-
+      <note>
+      <title>&firewalld; Replaces &susefirewall;</title>
+  <para>
+      &sle; 15 introduces &firewalld;, replacing &susefirewall;.
+      &susefirewall; has not been removed from &sle; 15 and is still in the Main
+      repository. However, it is not included in the default installation, and &firewalld;
+      is installed by default in new installations. If you are upgrading from a &sle; 
+      release older than &slea; 15.0, &susefirewall; will be unchanged and you must 
+      manually upgrade to  &firewalld; (see <xref linkend="sec-security-firewall-upgrade"/>).
+  </para>
+</note>
   <para>
    &firewalld; is a daemon that maintains the system's
    <command>iptables</command> rules and offers a D-Bus interface for
@@ -291,7 +301,6 @@
    interface it allows other applications to request changes to the iptables
    rules, for example to set up virtual machine networking.
   </para>
-
   <para>
    &firewalld; implements different security zones. A number of predefined
    zones like <literal>internal</literal> and <literal>public</literal> exist.
@@ -935,10 +944,13 @@ nfs-rpc
  
  <sect1 xml:id="sec-security-firewall-upgrade">
      <title>Migrating From &susefirewall;</title>
+     <note>
+         <title>Creating a a &firewalld; Configuration for &ay;</title>
      <para>
          See the <citetitle>Firewall Configuration</citetitle> section of the &ayguide;
          to learn how to create a &firewalld; configuration for &ay;.
      </para>
+ </note>
      <para>
          When upgrading from &sle; 12.x to &sle; &productnumber;, &susefirewall;
          is not changed and remains active. There is no automatic migration, so you must


### PR DESCRIPTION
add migration steps to Security Guide.
resolves https://bugzilla.suse.com/show_bug.cgi?id=1134404.
firewalld is mentioned in multiple books, which will be
addressed in a separate commit

### Description
A few sentences describing the overall goals of this pull request.
If there are relevant Bugzilla or FATE entries, reference them.

### Checklist
* Check all items that apply.

*Are backports required?*

- [x ] To maintenance/SLE15SP1
- [x ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
