### PR TITLE
Add crypt_key note

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2913,7 +2913,8 @@ openssl x509 -noout -fingerprint -sha256
         </entry>
         <entry>
          <para>
-          Only needed if <literal>crypt_fs</literal> has been set to <literal>true</literal>.
+          Needed if <literal>crypt_fs</literal> has been set to <literal>true</literal>.
+          Also needed to open and reuse an existing encrypted device.
          </para>
         </entry>
        </row>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2913,8 +2913,8 @@ openssl x509 -noout -fingerprint -sha256
         </entry>
         <entry>
          <para>
-          Needed if <literal>crypt_fs</literal> has been set to <literal>true</literal>.
-          Also needed to open and reuse an existing encrypted device.
+          Needed if <literal>crypt_fs</literal> has been set to <literal>true</literal>,
+          as well as to open and reuse an existing encrypted device.
          </para>
         </entry>
        </row>


### PR DESCRIPTION
### Description

Add note to clarify that `crypt_key` is needed when reusing an existing encrypted device.

### Checklist
* Check all items that apply.

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
