### PR TITLE
AMD SEV article: Fix policy example

### DIFF
--- a/xml/art_amd-sev.xml
+++ b/xml/art_amd-sev.xml
@@ -135,7 +135,7 @@
     &lt;launchSecurity <co xml:id="sec-amd-sev-ex-launchsecurity"/> type='sev'&gt;
     &lt;cbitpos&gt;47&lt;/cbitpos&gt; <co xml:id="sec-amd-sev-ex-cbitpos"/>
     &lt;reducedPhysBits&gt;1&lt;/reducedPhysBits&gt; <co xml:id="sec-amd-sev-ex-reducedphysbits"/>
-    &lt;policy&gt;0x0037&lt;/policy&gt; <co xml:id="sec-amd-sev-ex-policy"/>
+    &lt;policy&gt;0x0033&lt;/policy&gt; <co xml:id="sec-amd-sev-ex-policy"/>
     &lt;/launchSecurity&gt;
     &lt;devices&gt;
     &lt;disk type='file' device='disk'&gt;


### PR DESCRIPTION
### Description
The <policy> example in SEV guest XML has bit 2 set, which states that
SEV-ES is required. SEV-ES is not supported on SLE12 SP4 or SLE15 SP1.
Remove that bit from the policy example since it wont work and is
confusing to users.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1141095

### Checklist
* Check all items that apply.

This fix should be added to any AMD SEV article that is published for SLE12 >= SP4 and SLE15 >= SP1.

- [x] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [x] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
