### PR TITLE
README: update 'develop' -> 'master'

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -9,7 +9,6 @@ This repository hosts the documentation sources including translations (if
 available) for the following products:
 
 * SUSE Linux Enterprise Desktop (SLED)
-* SUSE Linux Enterprise Real Time Extension (SLE RT)
 * SUSE Linux Enterprise Server (SLES)
 * openSUSE Leap
 
@@ -20,14 +19,42 @@ found at http://doc.opensuse.org/.
 
 == Branches
 
+***On Sep 4, 2019, we changed to a new branching model. We switch the default branch from `develop` to `master`.***
+
+* *Use the master branch* as the basis of your commits/of new feature branches.
+
+* The *develop branch has been deleted* on the server. Do not to push to the `develop` branch.
+  Your changes may go lost in the medium term and never make it to the proper branch.
+
+=== How to Update Your Local Repository
+
+If you *created* a local clone or GitHub fork of this repo *before Sep 4, 2019, do the following*:
+
+1. Make sure that your `master` and `develop` branches do not contain any important changes.
+  If there are changes on either branch, export them using `git format-patch` or put them on a
+  different branch.
+
+1. Go to the master branch: `git checkout master`
+.
+
+1. To pull the latest changes from the remote repository and to delete references to branches
+   that do not exist anymore on the server, run the following command: `git pull --prune`
+.
+
+1. Delete your local develop branch: `git branch -D develop`.
+
+1. To check for stale local branches, run: `git branch -v`.
+   For any branches marked as `[gone]`, check if you still need them. If not, delete them:
+   `git branch -D BRANCHNAME`
+
+
 .Overview of important branches
 [options="header"]
 |================================================
 | Name            | Purpose
-| `develop`        | doc development (latest development version)
-| `maintenance/*`  | maintenance for released versions
-| `trans/*`        | translations for released versions
-| `master`         | latest released version 
+| `master`        | doc development (latest development version)
+| `maintenance/*` | maintenance for released versions
+| `trans/*`       | translations for released versions
 |================================================
 
 == Reporting Bugs
@@ -40,18 +67,20 @@ As component select `Documentation`.
 
 == Contributing
 
-If you would like to contribute, please fork this repository and send
-pull requests. To contribute to the latest development version, use the
-`develop` branch for your edits! Documentation for already released
-versions can be found in the respective maintenance branches. +
-Contributors with direct access to the repository are encouraged to use the
-git-flow-avh workflow (package `git-flow-avh`). However, this is not a must.
-For help on style and structure, refer to the https://doc.opensuse.org/products/opensuse/Styleguide/opensuse_documentation_styleguide_sd/[Documentation Styleguide] 
+Thank you for contributing to this repo. When creating a pull request, please follow the guidelines below:
 
+. If you want to contribute to the most recent release, create your pull request against the `master` branch (not `develop`). The `master` branch is protected.
 
-.*No commits to master*
-NOTE: Please do not make any commits to the `master` branch. `master` is
-reserved for releases only. Always commit to `develop`.
+. If you want to contribute to a previous release, please create your pull request against the respective `maintenance/*` branch. These branches are also protected.
+
+. Make sure all validation (Travis CI) checks are passed.
+
+. For your pull request to be reviewed, please tag the relevant subject matter expert(s) from the development team (if applicable) and members of the documentation team.
+
+. Implement the required changes. If you have any questions, ping a documentation team member in #susedoc on RocketChat.
+
+. For help on style and structure, refer to the https://doc.opensuse.org/products/opensuse/Styleguide/opensuse_documentation_styleguide_sd/[Documentation Styleguide].
+
 
 == Editing DocBook
 
@@ -59,9 +88,15 @@ To contribute to the documentation, you need to write DocBook.
 
 * You can learn about DocBook syntax at http://docbook.org/tdg5/en/html .
 * SUSE documents are generally built with DAPS (package `daps`) and the
-  SUSE XSL Stylesheets (package `suse-xsl-stylesheets`). Ideally, you should
-  get these from the repository `Documentation:Tools`. However, slightly
-  older versions are also available from the SLE and openSUSE repositories.
+  SUSE XSL Stylesheets (package `suse-xsl-stylesheets`).
+
+*  Install the documentation environment with the following command:
++
+[source]
+----
+sudo /sbin/OneClickInstallUI https://gitlab.nue.suse.com/susedoc/doc-ymp/raw/master/Documentation.ymp
+----
+
 * Basic daps usage:
 ** `$ daps -d DC-<YOUR_BOOK> validate`: Make sure what you have written is
     well-formed XML and valid DocBook 5
@@ -69,5 +104,5 @@ To contribute to the documentation, you need to write DocBook.
 ** `$ daps -d DC-<YOUR_BOOK> html`: Build multi-page HTML document
 ** `$ daps -d DC-<YOUR_BOOK> optipng`: Always optimize new PNG images
 ** Learn more at https://opensuse.github.io/daps
-* All commits to maintenance and development branches are automatically
+* All commits to maintenance branches and `master` are automatically
   build and stored at https://susedoc.github.io


### PR DESCRIPTION
### Description
Updating the README with regards to the recent changes (including the switch from `develop` to `master` as default branch). 

@cjschroder @cwickert @lproven @tomschr @fsundermeyer
This is just for your information. 