### PR TITLE
Remove Occurances of YaST CA module

### DIFF
--- a/xml/book_security.xml
+++ b/xml/book_security.xml
@@ -66,7 +66,12 @@
   <xi:include href="security_ssh.xml"/>
   <xi:include href="security_firewall.xml"/>
   <xi:include href="security_vpnserver.xml"/>
+  <!--
+   toms 2019-09-06: Disabled as the YaST CA module is in SLE15 not available
+   anymore.
+   See https://trello.com/c/Ihx1Da48
   <xi:include href="security_yast2_ca.xml"/>
+   -->
  </part>
 
  <part xml:id="part-apparmor">

--- a/xml/kvm_appendix.xml
+++ b/xml/kvm_appendix.xml
@@ -30,7 +30,10 @@
    </para>
   </sect2>
  </sect1>
- <sect1 xml:id="app-kvm-certificates">
+
+ <!-- toms 2019-09-06: FIXME; need to be removed due to YaST CA module -->
+
+ <!--<sect1 xml:id="app-kvm-certificates">
   <title>Generating x509 Client/Server Certificates</title>
 
   <para>
@@ -84,7 +87,7 @@
        certificate and issue the following commands to split it into
        certificate and key (this example splits the server key):
       </para>
-<screen>&prompt.user;csplit -z -f s_ server.pem '/-----BEGIN/' '{1}'
+<screen>&prompt.user;csplit -z -f s_ server.pem '/-\-\-\-\-BEGIN/' '{1}'
        mv s_00 servercert.pem
        mv s_01 serverkey.pem</screen>
      </step>
@@ -119,4 +122,5 @@
    </step>
   </procedure>
  </sect1>
+-->
 </appendix>

--- a/xml/libvirt_connect.xml
+++ b/xml/libvirt_connect.xml
@@ -1013,8 +1013,8 @@ dynamic_ownership = 1</screen>
     <procedure>
      <step>
       <para>
-       Create the server certificate and export it together with the CA
-       certificate as described in <xref linkend="app-kvm-certificates"/>.
+       Create the server certificate and export it together with the
+       respective CA certificate.
       </para>
      </step>
      <step>
@@ -1070,8 +1070,8 @@ dynamic_ownership = 1</screen>
     <procedure>
      <step>
       <para>
-       Create the client certificate and export it together with the CA
-       certificate as described in <xref linkend="app-kvm-certificates"/>.
+       Create the client certificate and export it together with the
+       respective CA certificate.
       </para>
      </step>
      <step>

--- a/xml/qemu_running_vms_qemukvm.xml
+++ b/xml/qemu_running_vms_qemukvm.xml
@@ -1872,8 +1872,9 @@ sudo tunctl -d $tap<co xml:id="co-qemu-net-bridge-deltap"/></screen>
     some authentication methods in one &qemu; command.
    </para>
    <para>
-    See <xref linkend="app-kvm-certificates"/> for more information about the
-    x509 certificates generation. For more information about configuring x509
+    <!-- See <xref linkend="app-kvm-certificates"/> for more information
+     about the x509 certificates generation. -->
+    For more information about configuring x509
     certificates on a &vmhost; and the client, see
     <xref linkend="sec-libvirt-connect-remote-tls"/> and
     <xref linkend="sec-libvirt-connect-remote-tls-client"/>.

--- a/xml/security_auth.xml
+++ b/xml/security_auth.xml
@@ -341,11 +341,7 @@
        <para>
         Either <guimenu>Import Certificate</guimenu> by specifying the exact
         path to its location or enable the <guimenu>Use Common Server
-        Certificate</guimenu>. If the <guimenu>Use Common Server
-        Certificate</guimenu> is not available, because it has not been
-        created during installation, go for <guimenu>Launch CA Management
-        Module</guimenu> first&mdash;for more information, see
-        <xref linkend="sec-security-yast-ca-module"/>.
+        Certificate</guimenu>.
        </para>
 <!--
       <itemizedlist>

--- a/xml/security_vpnserver.xml
+++ b/xml/security_vpnserver.xml
@@ -252,7 +252,7 @@ cd /etc/openvpn
          <imagedata fileref="vpn_routed1.png" width="80%"/>
         </imageobject>
         <imageobject role="fo">
-         <imagedata fileref="vpn_routed1.svg" width="80%"/>
+         <imagedata fileref="vpn_routed1.svg" width="50%"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -289,7 +289,7 @@ cd /etc/openvpn
          <imagedata fileref="vpn_bridged1.png" width="80%"/>
         </imageobject>
         <imageobject role="fo">
-         <imagedata fileref="vpn_bridged1.svg" width="80%"/>
+         <imagedata fileref="vpn_bridged1.svg" width="50%"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -318,7 +318,7 @@ cd /etc/openvpn
          <imagedata fileref="vpn_bridged2.png" width="80%"/>
         </imageobject>
         <imageobject role="fo">
-         <imagedata fileref="vpn_bridged2.svg" width="80%"/>
+         <imagedata fileref="vpn_bridged2.svg" width="50%"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -347,7 +347,7 @@ cd /etc/openvpn
          <imagedata fileref="vpn_bridged3.png" width="80%"/>
         </imageobject>
         <imageobject role="fo">
-         <imagedata fileref="vpn_bridged3.svg" width="80%"/>
+         <imagedata fileref="vpn_bridged3.svg" width="50%"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -621,9 +621,53 @@ PRE_DOWN_SCRIPT='systemd:openvpn@client'</screen>
     Before a VPN connection can be established, the client must authenticate
     the server certificate. Conversely, the server must also authenticate
     the client certificate. This is called <emphasis>mutual
-    authentication</emphasis>. To create such certificates, use the
+    authentication</emphasis>.
+   </para>
+   <para>
+    Creating certificates is not supported on &productname;. The following
+    assumes you have created a CA certificate, a server certificate and a
+    client certificate on another system.
+   </para>
+   <para>
+    The server certificate is required in the PEM and unencrypted
+    key in PEM formats. Copy the PEM version to
+    <filename>/etc/openvpn/server_crt.pem</filename> on the VPN server. The
+    unencrypted version needs to go to
+    <filename>/etc/openvpn/server_key.pem</filename>.
+   </para>
+   <para>
+    Client certificates need to be of the format PKCS12 (preferred) or PEM. The
+    certificate in PKCS12 format needs to contain the CA chain and needs to be
+    copied to
+    <filename>/etc/openvpn/<replaceable>CLIENT</replaceable>.p12</filename>. In
+    case you have client certificates in PEM format containing the CA chain,
+    copy them to
+    <filename>/etc/openvpn/<replaceable>CLIENT</replaceable>.pem</filename>. In
+    case you have split the PEM certificates into client certificate
+    (<filename>*.ca</filename>, client key (<filename>*.key</filename>), and
+    the CA certificate (<filename>*.ca</filename>), copy these files to
+    <filename>/etc/openvpn/</filename> on each client.
+   </para>
+   <para>
+    The CA certificate needs to be copied to
+    <filename>/etc/openvpn/vpn_ca.pem</filename> on the server and each client.
+   </para>
+
+   <important>
+    <title>Splitting Client Certificates</title>
+    <para>
+     If you split client certificates into client certificate, client key, and
+     the CA certificate, you need to provide the respective filenames in the
+     OpenVPN configuration file on the respective clients (see <xref
+     linkend="ex-vpn-serv-config"/>).
+    </para>
+   </important>
+  </sect2>
+<!--
+    To create such certificates, use the
     &yast; CA module. See <xref linkend="cha-security-yast-ca"/> for more
     details.
+
    </para>
    <para>
     To create a VPN root, server, and client CA, proceed as follows:
@@ -877,7 +921,6 @@ PRE_DOWN_SCRIPT='systemd:openvpn@client'</screen>
         Repeat <xref linkend="st-security-vpn-selectserverca"/> and
         <xref linkend="st-security-vpn-selectsaveca"/>, but choose the
         format <guimenu>Only the Key Unencrypted in PEM Format</guimenu>.
-<!--taroth 2014-12-19: fix for https://bugzilla.suse.com/show_bug.cgi?id=910133-->
         Save the file to <filename>/etc/openvpn/server_key.pem</filename>.
        </para>
       </step>
@@ -897,7 +940,6 @@ PRE_DOWN_SCRIPT='systemd:openvpn@client'</screen>
         <guimenu>Export to File</guimenu> </menuchoice>.
        </para>
       </step>
-<!--taroth 2014-12-19: fix for https://bugzilla.suse.com/show_bug.cgi?id=909494-->
       <step>
        <para> Select <guimenu>Like PKCS12 and Include the CA
                   Chain</guimenu>, enter your VPN client certificate key
@@ -955,6 +997,7 @@ PRE_DOWN_SCRIPT='systemd:openvpn@client'</screen>
     configuration file (see <xref linkend="ex-vpn-serv-config"/>).
    </para>
   </sect2>
+-->
 
   <sect2 xml:id="sec-security-vpn-config-server">
    <title>Configuring the VPN Server</title>
@@ -1028,9 +1071,9 @@ verb 4</screen>
     <callout arearefs="co-vpn-servconfig-remote-cert-tls">
      <para> Require that peer certificates have been signed with an
             explicit key usage and extended key usage based on RFC3280
-            TLS rules. There is a description of how to make a server
+            TLS rules. <!-- There is a description of how to make a server
             use this explicit key in <xref
-              linkend="pro-security-vpn-serverca"/>. </para>
+              linkend="pro-security-vpn-serverca"/>. --></para>
     </callout>
 <!--taroth 2014-12-19: fix for https://bugzilla.suse.com/show_bug.cgi?id=910148-->
     <callout arearefs="co-vpn-servconfig-dh">


### PR DESCRIPTION
### Description

The current situation about the YaST CA module is unsatisfying. We need to remove any text which refers to the `security_yast2_ca.xml` file.


### Checklist

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/openSUSE_Leap_15.0
