### PR TITLE
yast self-upd disabled for QU

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -1083,14 +1083,14 @@ exit 0
     for further information about this feature.
    </para>
 <!--taroth 2019-09-12: same note used in deployment_yast_installer.xml-->
-   <important>
+  <important>
    <title>Quarterly Media Update: Self-Update Disabled</title>
    <para>
-    The installer self-update is only available if you use the GM images of the
-    &leanos; and Packages ISOs. If you install from the ISOs published as quarterly
-    update (they can be identified by the string <literal>QU</literal> in the name),
-    the installer cannot update itself, because this feature has been disabled
-    in the updated media.
+    The installer self-update is only available if you use the <literal>GM</literal>
+    images of the &leanos; and Packages ISOs. If you install from the ISOs published
+    as quarterly update (they can be identified by the string <literal>QU</literal>
+    in the name), the installer cannot update itself, because this feature has
+    been disabled in the updated media.
    </para>
   </important>
    <para>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -1080,8 +1080,21 @@ exit 0
    <para>
     During the installation, &yast; can update itself to solve bugs in the
     installer that were discovered after the release. Refer to the &deploy;
-    for further information about this feature. Use the following tags to
-    configure the &yast; self-update:
+    for further information about this feature.
+   </para>
+<!--taroth 2019-09-12: same note used in deployment_yast_installer.xml-->
+   <important>
+   <title>Quarterly Media Update: Self-Update Disabled</title>
+   <para>
+    The installer self-update is only available if you use the GM images of the
+    &leanos; and Packages ISOs. If you install from the ISOs published as quarterly
+    update (they can be identified by the string <literal>QU</literal> in the name),
+    the installer cannot update itself, because this feature has been disabled
+    in the updated media.
+   </para>
+  </important>
+   <para>
+    Use the following tags to configure the &yast; self-update:
    </para>
 
    <variablelist>

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -188,6 +188,7 @@
    see <xref linkend="sec-boot-parameters-advanced-self-update"/>.
   </para>
 
+<!--taroth 2019-09-12: same note used in ay_bigfile.xml-->
   <important>
    <title>Quarterly Media Update: Self-Update Disabled</title>
    <para>

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -192,11 +192,11 @@
   <important>
    <title>Quarterly Media Update: Self-Update Disabled</title>
    <para>
-    The installer self-update is only available if you use the GM images of the
-    &leanos; and Packages ISOs. If you install from the ISOs published as quarterly
-    update (they can be identified by the string <literal>QU</literal> in the name),
-    the installer cannot update itself, because this feature has been disabled
-    in the updated media.
+    The installer self-update is only available if you use the <literal>GM</literal>
+    images of the &leanos; and Packages ISOs. If you install from the ISOs published
+    as quarterly update (they can be identified by the string <literal>QU</literal>
+    in the name), the installer cannot update itself, because this feature has
+    been disabled in the updated media.
    </para>
   </important>
 

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -189,6 +189,17 @@
   </para>
 
   <important>
+   <title>Quarterly Media Update: Self-Update Disabled</title>
+   <para>
+    The installer self-update is only available if you use the GM images of the
+    &leanos; and Packages ISOs. If you install from the ISOs published as quarterly
+    update (they can be identified by the string <literal>QU</literal> in the name),
+    the installer cannot update itself, because this feature has been disabled
+    in the updated media.
+   </para>
+  </important>
+
+  <important>
    <title>Networking during Self-Update</title>
    <para>
     To download installer updates, &yast; needs network access. By default,


### PR DESCRIPTION
### Description
Add a note to the documentation that with the quarterly released media the self-update is not possible (input by jsrain via mail).

 ### Checklist
* Check all items that apply.

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
