### PR TITLE
online upgrade: add note about SuMa clients

### DIFF
--- a/xml/sle_update_online.xml
+++ b/xml/sle_update_online.xml
@@ -79,6 +79,17 @@
     </para>
    </listitem>
   </itemizedlist>
+
+  <important>
+   <title>Upgrading &susemgr; Clients</title>
+   <para>If the system to upgrade is a &susemgr; client, it cannot be
+    upgraded by &yast; online migration nor <command>zypper migration</command>.
+    Use the <citetitle>Client Migration</citetitle> procedure instead. It is
+    described in the <citetitle>&susemgr; Upgrade Guide</citetitle>, available
+    at <link xmlns:xlink="http://www.w3.org/1999/xlink"
+    xlink:href="https://www.suse.com/documentation/suse-manager"/>.
+   </para>
+  </important>
  </sect1>
  <sect1 xml:id="sec-update-migr-workflow">
   <title>Service Pack Migration Workflow</title>


### PR DESCRIPTION
### Description

Addresses jsc#SLE-6049 'zypper migration detect SUMA client and present fail message'.
Need to check if the note in the docs applies to both 'zypper migration' and 'yast online migration' (or only to 'zypper migration' as listed in jsc#SLE-6049). 

Also not sure if this doc change needs to be 'backported' to SLE 15 and higher.

### Checklist

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
