### PR TITLE
mark obsolete suse_btrfs key and add documentation for trusted boot a…

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2363,7 +2363,8 @@ openssl x509 -noout -fingerprint -sha256
         </entry>
         <entry>
          <para>
-          Obsolete and no longer used. It is auto detected nowadays.
+          Obsolete and no longer used. Booting from Btrfs snapshots is
+          automatically enabled since SLES 12 SP2.
          </para>
         </entry>
        </row>
@@ -2436,8 +2437,8 @@ openssl x509 -noout -fingerprint -sha256
         </entry>
         <entry>
          <para>
-          If set to <literal>true</literal>, then trusted grub is used.
-          Trusted grub supports Trusted Platform Module (TPM).
+          If set to <literal>true</literal>, then Trusted GRUB is used.
+          Trusted GRUB supports Trusted Platform Module (TPM).
           Works only for <literal>grub2</literal> bootloader.
          </para>
 <screen>&lt;trusted_boot"&gt;true&lt;/trusted_boot&gt;</screen>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2363,10 +2363,8 @@ openssl x509 -noout -fingerprint -sha256
         </entry>
         <entry>
          <para>
-          If set to <literal>true</literal>, booting from Btrfs snapshots
-          will be enabled.
+          Obsolete and no longer used. It is auto detected nowadays.
          </para>
-<screen>&lt;suse_btrfs config:type="boolean"&gt;false&lt;/suse_btrfs&gt;</screen>
         </entry>
        </row>
        <row>
@@ -2383,6 +2381,20 @@ openssl x509 -noout -fingerprint -sha256
 <screen>&lt;serial&gt;
   serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1
 &lt;/serials&gt;</screen>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>secure_boot</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          If set to <literal>false</literal>, then UEFI secure boot is disabled.
+          Works only for <literal>grub2-efi</literal> bootloader.
+         </para>
+<screen>&lt;secure_boot"&gt;false&lt;/secure_boot&gt;</screen>
         </entry>
        </row>
        <row>
@@ -2414,6 +2426,21 @@ openssl x509 -noout -fingerprint -sha256
           automatically.
          </para>
 <screen>&lt;timeout config:type="integer"&gt;10&lt;/timeout&gt;</screen>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>trusted_boot</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          If set to <literal>true</literal>, then trusted grub is used.
+          Trusted grub supports Trusted Platform Module (TPM).
+          Works only for <literal>grub2</literal> bootloader.
+         </para>
+<screen>&lt;trusted_boot"&gt;true&lt;/trusted_boot&gt;</screen>
         </entry>
        </row>
        <row>


### PR DESCRIPTION
…nd secure boot options

### Description
Mark obsolete suse_btrfs key which is now ignored.
Add trusted boot option that is already in bootloader.
Add secure boot option that is now implemented for SP2 due to JSC#SLE-8787

### Checklist
* Check all items that apply.

*Are backports required?*

well, for sure not for secure boot. For trusted I need to check when it is implemented and same for obsoleting suse_btrfs.

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
