### PR TITLE
AutoYaST: clarify usage of uuid (bsc#1148477)

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -3008,7 +3008,7 @@ openssl x509 -noout -fingerprint -sha256
         <entry>
          <para>
           The label of the partition. Useful when formatting the device
-          (specially if the <literal>mountby</literal> parameter is set to
+          (especially if the <literal>mountby</literal> parameter is set to
           <literal>label</literal>) and for identifying a device that already
           exists (see <literal>create</literal> above).
          </para>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2916,9 +2916,9 @@ openssl x509 -noout -fingerprint -sha256
         </entry>
         <entry>
          <para>
-          If set to <literal>false</literal>, you also need to set
-          <literal>partition_nr</literal>, <literal>lv_name</literal> or <literal>uuid</literal>
-          to tell &ay; which device to use.
+          If set to <literal>false</literal>, you also need to set one of
+          <literal>partition_nr</literal>, <literal>lv_name</literal>, <literal>label</literal>
+          or <literal>uuid</literal> to tell &ay; which device to use.
          </para>
         </entry>
        </row>
@@ -3007,8 +3007,10 @@ openssl x509 -noout -fingerprint -sha256
         </entry>
         <entry>
          <para>
-          The label of the partition (useful for the
-          <literal>mountby</literal> parameter; see below).
+          The label of the partition. Useful when formatting the device
+          (specially if the <literal>mountby</literal> parameter is set to
+          <literal>label</literal>) and for identifying a device that already
+          exists (see <literal>create</literal> above).
          </para>
 <screen>&lt;label&gt;mydata&lt;/label&gt;</screen>
         </entry>
@@ -3026,8 +3028,9 @@ openssl x509 -noout -fingerprint -sha256
         </entry>
         <entry>
          <para>
-          The uuid of the partition (only useful for the
-          <literal>mountby</literal> parameter; see below).
+          The uuid of the partition. Only useful for indentifying an
+          existing device (see <literal>create</literal> above),
+          the uuid cannot be enforced for new devices.
          </para>
 <screen>&lt;uuid
 &gt;1b4e28ba-2fa1-11d2-883f-b9a761bde3fb&lt;/uuid&gt;</screen>
@@ -3888,8 +3891,8 @@ openssl x509 -noout -fingerprint -sha256
       </listitem>
      </itemizedlist>
      <para>
-      If you choose to mount the partition using a label, the name entered
-      for the <literal>label</literal> property is used as the volume label.
+      If you choose to mount a new partition using a label, use the
+      <literal>label</literal> property to specify its value.
      </para>
      <para>
       Add any valid mount option in the fourth field of


### PR DESCRIPTION
### Description

The `uuid` property in a `<partition>` section of AutoYaST should only be specified when the user wants to find a certain partition or logical volume to reuse it. It was never intended to be used to enforce a particular UUID for newly created filesystems.

That was not that clear in the documentation that is [available here](https://documentation.suse.com/sles/15-SP1/single-html/SLES-autoyast/). That fact manages to confuse even some YaST developers. All that ended in the introduction of [bug#1148477](https://bugzilla.suse.com/show_bug.cgi?id=1148477)

This pull request should clarify how the uuid property is used.

### Checklist

*Are backports required?* Good question. We are fixing the bug for SLE-15-SP1 and for the upcoming releases. That means the [documentation available for SLE-15-SP1](https://documentation.suse.com/sles/15-SP1/single-html/SLES-autoyast/) should be updated as well. But as far as I can see, that documentation is not generated from the `maintenance/SLE15SP1` branch as I expected. It seems to be the result of rendering `master`.

Anyways, I'm opening the PR against master and marking SLE15SP1 for the backport. I'm sure you will know what to do. ;-)

- [X] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
