### PR TITLE
Cgroup resource limits

### DIFF
--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -51,7 +51,15 @@
 
  <sect1 xml:id="sec-tuning-cgroups-usage">
   <title>Setting Hardware Limits</title>
-
+  <note>
+    <title>Implicit resource consumption</title>
+    <para>
+      Beware that resource consumption implicitly depends on the environment
+      where your workload executes (e.g. size of data structures in libraries/kernel,
+      forking behavior of utilities, computational efficiency),
+      hence it is recommended to (re)calibrate your limits should the environment change.
+    </para>
+  </note>
   <para>
    Limitations to <literal>cgroups</literal> can be set with the
    <command>systemctl set-property</command> command. The syntax is:

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -15,7 +15,7 @@
   <abstract>
    <para>
     Kernel Control Groups (<quote>cgroups</quote>) are a kernel feature
-    that allows assigning and limiting hardware resources for processes.
+    that allows assigning and limiting hardware and system resources for processes.
     Processes can also be organized in a hierarchical tree structure.
    </para>
   </abstract>
@@ -50,7 +50,7 @@
  </sect1>
 
  <sect1 xml:id="sec-tuning-cgroups-usage">
-  <title>Setting Hardware Limits</title>
+  <title>Setting Resource Limits</title>
   <note>
     <title>Implicit resource consumption</title>
     <para>

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -28,7 +28,7 @@
  <sect1 xml:id="sec-tuning-cgroups-overview">
   <title>Overview</title>
   <para>
-   Every process is assigned exactly one cgroups. cgroups are ordered
+   Every process is assigned exactly one administrative cgroup. cgroups are ordered
    in a hierarchical tree structure. Resource limitations can be set
    for single processes or for whole branches of the hierarchy tree.
    Limitations for CPU, memory, disk I/O, or network bandwidth usage


### PR DESCRIPTION
### Description
Users may encounter former limits not applying to new environments, hence add explanations about limit setting. Also few minor fixes when being around.

### Checklist
* Check all items that apply.

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [x] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
