### PR TITLE
Replace ugly table with nice clean variablelist

### DIFF
--- a/xml/storage_multipath.xml
+++ b/xml/storage_multipath.xml
@@ -2547,7 +2547,7 @@ prio_args ""</screen>
         Example prioritizer programs include:
        </para>
        <informaltable>
-        <tgroup cols="2">
+        <tgroup cols="3">
          <colspec colnum="1" colname="1" colwidth="2907*"/>
          <colspec colnum="2" colname="2" colwidth="7096*"/>
          <thead>
@@ -2694,142 +2694,99 @@ prio_args ""</screen>
        </informaltable>
       </listitem>
      </varlistentry>
-     <varlistentry>
-      <term><literal>prio_args</literal></term>
-      <listitem>
-       <para>
+ </variablelist>
+
+<bridgehead><literal>prio_args</literal> options</bridgehead>
+    <para>
         Specifies the arguments for the specified prioritizer program that
         requires arguments. Most <literal>prio</literal> programs do not need
-        arguments.
-       </para>
-       <para>
-        There is no default. The values depend on the <literal>prio</literal>
-        setting and whether the prioritizer requires arguments.
-       </para>
-       <informaltable>
-        <tgroup cols="2">
-         <colspec colnum="1" colname="1" colwidth="2907*"/>
-         <colspec colnum="2" colname="2" colwidth="7096*"/>
-         <thead>
-          <row>
-           <entry>
-            <para>
-             <literal>prio_args</literal> arguments
-            </para>
-           </entry>
-           <entry>
-            <para>
-             Description
-            </para>
-           </entry>
-          </row>
-         </thead>
-         <tbody>
-          <row>
-           <entry>
-            <para>
-             <literal>weighted</literal>
-            </para>
-           </entry>
-           <entry>
-            <para>
-             Requires a value of the form
+        arguments. There is no default. The values depend on the <literal>prio</literal>
+        setting and whether the prioritizer requires any of the following arguments:
+      </para>
+   <variablelist>
+       <varlistentry>
+           <term>weighted</term>
+             <listitem>
+               <para>
+              Requires a value of the form
              <literal>[hbtl|devname|serial|wwn]</literal>
              <replaceable>REGEX1</replaceable> <replaceable>PRIO1</replaceable>
              <replaceable>REGEX2</replaceable>
              <replaceable>PRIO2</replaceable>...
-            </para>
-<screen>hbtl  
-   Regex must be of SCSI H:B:T:L format, for example 1:0:.:.
-   and *:0:0:., with a weight value, where H, B, T, L are the
-   host, bus, target, and LUN  IDs for a device. For example:
-   
-   prio "weightedpath"
-   prio_args "hbtl 1:.:.:. 2 4:.:.:. 4"   
-</screen>
-           </entry>
-          </row>
-          <row>
-           <entry>
+                </para>
+            </listitem>
+        </varlistentry>
+        <varlistentry>
+         <term>hbtl</term>
+         <listitem>
+             <para>
+             Regex must be of SCSI H:B:T:L format, for example 1:0:.:.
+             and *:0:0:., with a weight value, where H, B, T, L are the
+             host, bus, target, and LUN  IDs for a device. For example:
+             </para>
+             <screen>prio "weightedpath"
+prio_args "hbtl 1:.:.:. 2 4:.:.:. 4"</screen>            
+        </listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>devname</term>
+        <listitem>
             <para>
-             <literal>devname</literal>
+                Regex is in device name format. For example: sda, sd.e
             </para>
-           </entry>
-           <entry>
-            <para>
-             Regex is in device name format. For example: sda, sd.e
-            </para>
-           </entry>
-          </row>
-           <row>
-           <entry>
-            <para>
-             <literal>serial</literal>
-            </para>
-           </entry>
-           <entry>
+        </listitem>
+    </varlistentry>
+    <varlistentry>
+        <term>serial</term>
+        <listitem>
             <para>
              Regex is in serial number format. For example: .*J1FR.*324. Look up your serial
              with the <command>multipathd show paths format %z</command> command.
              (<command>multipathd show wildcards</command> displays all 
-             <literal>format</literal>
-             wildcards.)
+             <literal>format</literal> wildcards.)
             </para>
-           </entry>
-          </row>
-           <row>
-           <entry>
-            <para>
-             <literal>path_latency</literal>
-            </para>
-           </entry>
-           <entry>
-            <para>
-                <literal>path_latency</literal> allows you to adjust latencies
-                between remote and local storage arrays, if both arrays
-                use the same type of hardwarehardware. Usually the latency on 
-                the remote array
-                will be much higher. This requires a value pair of the form 
-                <literal>io_num=<replaceable>20</replaceable> 
-                    base_num=<replaceable>10</replaceable></literal>.
-               </para>
-               <screen>io_num
-   The number of read IOs sent to the current path continuously, which 
-   are used to calculate the average path latency. Valid values are 
-   integers from  2 to 200.
-   
-base_num
-   The base number value of logarithmic scale, used to partition 
-   different priority ranks. Valid values: Integer, 2 - 10. The maximum 
-   average latency value is 100s, the minimum is 1us. For example:  
-   If  base_num=10, the paths will be grouped in priority groups with 
-   path  latency &lt;=1us, (1us, 10us], (10us, 100us], (100us, 1ms], 
-   (1ms, 10ms], (10ms, 100ms], (100ms, 1s], (1s, 10s], (10s, 100s], 
-   >100s
-   </screen>                   
-           </entry>
-          </row>
-           <row>
-           <entry>
-            <para>
-             <literal>alua</literal>
-            </para>
-           </entry>
-           <entry>
+        </listitem>
+    </varlistentry>
+
+    <varlistentry>
+        <term>alua</term>
+        <listitem>
             <para>
                 If <literal>exclusive_pref_bit</literal> is set for a device 
                 (<literal>alua exclusive_pref_bit</literal>), paths with
                 the <literal>preferred path</literal> bit set will 
                 always be in their own path group.
-            </para>                   
-           </entry>
-          </row>
-         </tbody>
-        </tgroup>
-       </informaltable>
-      </listitem>
-     </varlistentry>
-    </variablelist>
+            </para>
+        </listitem>
+    </varlistentry>    
+
+<varlistentry>
+    <term>path_latency</term>
+     <listitem>
+          <para>
+               <literal>path_latency</literal> adjusts latencies
+                between remote and local storage arrays, if both arrays
+                use the same type of hardwarehardware. Usually the latency on 
+                the remote array will be higher. This requires a value pair of the form 
+                <literal>io_num=<replaceable>20</replaceable> 
+                base_num=<replaceable>10</replaceable></literal>.
+            </para>
+            <para>
+                <literal>io_num</literal> is the number of read IOs sent to the current path 
+                continuously, which are used to calculate the average path latency. Valid values 
+                are integers from  2 to 200.
+            </para>
+            <para>   
+              <literal>base_num</literal> is the logarithmic base number, 
+              used to partition different priority ranks. Valid values are integer from 2 - 10. The 
+              maximum average latency value is 100s, the minimum is 1us. For example,  
+              if  <literal>base_num=10</literal>, the paths will be grouped in priority groups with 
+               path  latency &lt;=1us, (1us, 10us], (10us, 100us], (100us, 1ms], 
+              (1ms, 10ms], (10ms, 100ms], (100ms, 1s], (1s, 10s], (10s, 100s], >100s
+             </para>
+        </listitem>
+    </varlistentry>
+</variablelist>
   
     <bridgehead>Multipath Attributes</bridgehead>
     <para>

--- a/xml/storage_multipath.xml
+++ b/xml/storage_multipath.xml
@@ -2696,10 +2696,10 @@ prio_args ""</screen>
      </varlistentry>
  </variablelist>
 
-<bridgehead><literal>prio_args</literal> options</bridgehead>
+<bridgehead><literal>prio_args</literal> arguments</bridgehead>
     <para>
-        Specifies the arguments for the specified prioritizer program that
-        requires arguments. Most <literal>prio</literal> programs do not need
+        These are the arguments for the prioritizer programs that
+        require arguments. Most <literal>prio</literal> programs do not need
         arguments. There is no default. The values depend on the <literal>prio</literal>
         setting and whether the prioritizer requires any of the following arguments:
       </para>
@@ -2714,11 +2714,6 @@ prio_args ""</screen>
              <replaceable>REGEX2</replaceable>
              <replaceable>PRIO2</replaceable>...
                 </para>
-            </listitem>
-        </varlistentry>
-        <varlistentry>
-         <term>hbtl</term>
-         <listitem>
              <para>
              Regex must be of SCSI H:B:T:L format, for example 1:0:.:.
              and *:0:0:., with a weight value, where H, B, T, L are the
@@ -2741,7 +2736,8 @@ prio_args "hbtl 1:.:.:. 2 4:.:.:. 4"</screen>
         <listitem>
             <para>
              Regex is in serial number format. For example: .*J1FR.*324. Look up your serial
-             with the <command>multipathd show paths format %z</command> command.
+             number with the <command>multipathd show paths format %z</command> 
+             command.
              (<command>multipathd show wildcards</command> displays all 
              <literal>format</literal> wildcards.)
             </para>
@@ -2766,8 +2762,9 @@ prio_args "hbtl 1:.:.:. 2 4:.:.:. 4"</screen>
           <para>
                <literal>path_latency</literal> adjusts latencies
                 between remote and local storage arrays, if both arrays
-                use the same type of hardwarehardware. Usually the latency on 
-                the remote array will be higher. This requires a value pair of the form 
+                use the same type of hardware. Usually the latency on 
+                the remote array will be higher, so you can tune the latency 
+                to bring them closer together. This requires a value pair of the form 
                 <literal>io_num=<replaceable>20</replaceable> 
                 base_num=<replaceable>10</replaceable></literal>.
             </para>

--- a/xml/storage_multipath.xml
+++ b/xml/storage_multipath.xml
@@ -2547,7 +2547,7 @@ prio_args ""</screen>
         Example prioritizer programs include:
        </para>
        <informaltable>
-        <tgroup cols="3">
+        <tgroup cols="2">
          <colspec colnum="1" colname="1" colwidth="2907*"/>
          <colspec colnum="2" colname="2" colwidth="7096*"/>
          <thead>


### PR DESCRIPTION
## Description
The table for prio_args options was not working; this is cleaner and easier to read.

### Checklist
* Check all items that apply.

*Are backports required?*

- [x ] To maintenance/SLE15SP1
- [ x] To maintenance/SLE15SP0
- [ x] To maintenance/SLE12SP5
- [ x] To maintenance/SLE12SP4
- [ x] To maintenance/SLE12SP3
