### PR TITLE
AutoYaST: add some clarification about multipath scenarios

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -4601,6 +4601,90 @@ openssl x509 -noout -fingerprint -sha256
    </sect3>
   </sect2>
 
+  <sect2 xml:id="ay-partition-multipath">
+   <title>Multipath Support</title>
+   <para>
+    &ay; is able to handle multipath devices. In order to take advantage of
+    them, you need to enable multipath support, as described in <xref
+    linkend="CreateProfile-General-storage"/>. Unlike &sle; 12, it is not required
+    to set the drive section type to <literal>CT_DMMULTIPATH</literal>. You should
+    use <literal>CT_DISK</literal>, although for historical reasons, both values
+    are equivalent.
+   </para>
+
+   <para>
+    <xref linkend="multipath-example"/> shows the relevant parts of a profile which
+    instructs &ay; to partition a multipath device.
+   </para>
+
+    <example xml:id="multipath-example">
+     <title>Using Multipath Devices</title>
+     <screen><![CDATA[<general>
+  <storage>
+    <start_multipath config:type="boolean">true</start_multipath>
+  <storage>
+</general>
+<partitioning>
+  <drive>
+    <partitions config:type="list">
+      <partition>
+        <size>20G</size>
+        <mount>/</mount>
+        <filesystem config:type="symbol">ext4</filesystem>
+      </partition>
+      <partition>
+        <size>auto</size>
+        <mount>swap</mount>
+      </partition>
+    </partitions>
+    <type config:type="symbol">CT_DISK</type>
+    <use>all</use>
+  </drive>
+</partitioning>]]></screen>
+    </example>
+
+    <para>
+     If you want to specify the device, you could use the World Wide Identifier
+     (WWID), its device name (e.g., <literal>/dev/dm-0</literal>) or any other path
+     under <literal>/dev/disk</literal> that refers to the multipath device.
+    </para>
+
+    <para>
+     For instance, given the <literal>multipath</literal> listing from <xref
+     linkend="multipath-ll-output"/>, you could use
+     <literal>/dev/mapper/14945540000000000f86756dce9286158be4c6e3567e75ba5</literal>,
+     <literal>/dev/dm-3</literal> or any other corresponding path under <literal>/dev/disk</literal>,
+     like shown in the <xref linkend="multipath-wwid-example"/>
+    </para>
+
+    <example xml:id="multipath-ll-output">
+     <title>Listing multipath devices</title>
+     <screen><![CDATA[# multipath -l
+14945540000000000f86756dce9286158be4c6e3567e75ba5 dm-3 ATA,VIRTUAL-DISK
+size=40G features='0' hwhandler='0' wp=rw
+|-+- policy='service-time 0' prio=1 status=active
+| `- 2:0:0:0 sda 8:0  active ready running
+`-+- policy='service-time 0' prio=1 status=enabled
+  `- 3:0:0:0 sdb 8:16 active ready running]]></screen>
+    </example>
+
+    <example xml:id="multipath-wwid-example">
+     <title>Using the WWID to Identify a Multipath Device</title>
+     <screen><![CDATA[<drive>
+  <partitions config:type="list">
+    <device>/dev/mapper/14945540000000000f86756dce9286158be4c6e3567e75ba5</device>
+    <partition>
+      <size>20G</size>
+      <mount>/</mount>
+      <filesystem config:type="symbol">ext4</filesystem>
+    </partition>
+  </partitions>
+  <type config:type="symbol">CT_DISK</type>
+  <use>all</use>
+</drive>]]></screen>
+    </example>
+  </sect2>
+
   <sect2 xml:id="ay-partition-bcache">
    <title>&bcache; Configuration</title>
    <para>


### PR DESCRIPTION
### Description

The intention of this PR is to clarify how multipath scenarios are handled through AutoYaST. In SLE 15 it is just an alias of `CT_DISK`. See #495 for the SLE 12 documentation update.

I am not sure whether I am opening the PR against the correct branch. Sorry if I did it wrong.

### Checklist
* Check all items that apply.

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
