### PR TITLE
Document crypt_method element

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2925,14 +2925,68 @@ openssl x509 -noout -fingerprint -sha256
        <row>
         <entry>
          <para>
+          <literal>crypt_method</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Partition will be encrypted using one of these methods:
+         </para>
+
+         <itemizedlist mark="bullet" spacing="normal">
+          <listitem>
+           <para>
+            <literal>luks1</literal>: regular LUKS1 encryption.
+           </para>
+          </listitem>
+          <listitem>
+           <para>
+            <literal>pervasive_luks2</literal>: pervasive volume encryption.
+           </para>
+          </listitem>
+          <listitem>
+           <para>
+            <literal>protected_swap</literal>: encryption with volatile
+            protected key.
+           </para>
+          </listitem>
+          <listitem>
+           <para>
+            <literal>secure_swap</literal>: encryption with volatile secure sey.
+           </para>
+          </listitem>
+          <listitem>
+           <para>
+            <literal>random_swap</literal>: encryption with volatile random key.
+           </para>
+          </listitem>
+         </itemizedlist>
+         <screen>&lt;crypt_method config:type="symbol"&gt;luks1&lt;/crypt_method&gt;</screen>
+        </entry>
+        <entry>
+         <para>
+          Optional. Encryption method selection was introduced in &productname;
+          <phrase os="sles;sled">15 SP2</phrase><phrase os="osuse">15.2</phrase>.
+          To mimic the behaviour of previous versions, use <literal>luks1</literal>.
+         </para>
+         <para>
+          See <literal>crypt_key</literal> element to find out how to specify
+          the encryption password if needed.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
           <literal>crypt_fs</literal>
          </para>
         </entry>
         <entry>
          <para>
-          Partition will be encrypted.
+          Partition will be encrypted. This element is deprecated, use
+          <literal>crypt_method</literal> instead.
          </para>
-<screen>&lt;crypt_fs config:type="boolean"&gt;false&lt;/crypt_fs&gt;</screen>
+<screen>&lt;crypt_fs config:type="boolean"&gt;true&lt;/crypt_fs&gt;</screen>
         </entry>
         <entry>
          <para>
@@ -2940,6 +2994,7 @@ openssl x509 -noout -fingerprint -sha256
          </para>
         </entry>
        </row>
+
        <row>
         <entry>
          <para>
@@ -2954,8 +3009,9 @@ openssl x509 -noout -fingerprint -sha256
         </entry>
         <entry>
          <para>
-          Needed if <literal>crypt_fs</literal> has been set to <literal>true</literal>,
-          as well as to open and reuse an existing encrypted device.
+          Needed if <literal>crypt_method</literal> has been set to
+          a method that requires a password (i.e., <literal>luks1</literal>
+          or <literal>pervasive_luks2</literal>).
          </para>
         </entry>
        </row>


### PR DESCRIPTION
### Description

Starting in SLE 15 SP2, it is possible to select the encryption method in AutoYaST. To implement such a feature, a new `crypt_method` element has been introduced. Moreover, `crypt_fs` is now deprecated, although it is still supported for the time being.

See https://jira.suse.com/browse/SLE-7376.

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
