### PR TITLE
Add mention of which archs support NVDIMM (BSC #1129957)

### DIFF
--- a/xml/hardware_nvdimm.xml
+++ b/xml/hardware_nvdimm.xml
@@ -11,7 +11,7 @@
  <info>
   <abstract>
    <para>
-    This chapter contains additional information about using &productname; with
+    This chapter contains additional information about using &sle; with
     non-volatile main memory, also known as <emphasis>Persistent Memory</emphasis>,
     comprising one or more NVDIMMs.
    </para>
@@ -31,9 +31,15 @@
   </para>
 
   <para>
-   Like conventional RAM, it is installed directly into motherboard memory
-   slots. As such, it is supplied in the same physical form factor as RAM&mdash;as
-   DIMMs. These are known as NVDIMMs: non-volatile dual inline memory modules.
+   &suse; currently supports the use of persistent memory with &sls; on machines
+   with the &x86-64; and &power; architectures.
+  </para>
+  
+  <para>
+   Like conventional RAM, persistent memory is installed directly into
+   motherboard memory slots. As such, it is supplied in the same physical form
+   factor as RAM&mdash;as DIMMs. These are known as NVDIMMs: non-volatile dual
+   inline memory modules.
   </para>
 
   <para>


### PR DESCRIPTION
### Description
Specify that SLE supports NVDIMMs on x86-64 and POWER. (Explicitly it is POWER64 but POWER32 is no longer supported at all AFAIK.)
https://bugzilla.suse.com/show_bug.cgi?id=1129957

Thanks to @sknorr for reminding me.

### Checklist
* Check all items that apply.

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
