### PR TITLE
&leanos entity doesn't yet say "Unified Installer" for SP0 so spell i…

### DIFF
--- a/xml/planning.xml
+++ b/xml/planning.xml
@@ -171,14 +171,14 @@
 
   <para>
    Starting with &productname; 15, all &sle;-based products on each
-   supported architecture are installed using a &leanos; from a single
+   supported architecture are installed using a Unified Installer from a single
    set of installation media.
   </para>
 
  <sect2 xml:id="sec-planning-leanos-products">
  <title>&leanos; for &sle;-based Products</title>
   <para>
-   As of &productname; 15 SP1, this includes the following base products.
+   As of &productname; 15, this includes the following base products.
   </para>
 
   <informaltable>


### PR DESCRIPTION
### Description
Reference to new-in-SLE15 Unified Installer isn't correct.

The &leanos; entity doesn't say "Unified Installer" in this version, just "Installer". So using the entity doesn't give the desired result.

In case the entity is used elsewhere, I have just replaced the entity in the Planning chapter with the  text "Unified Installer". 

This problem does not apply to later versions.

I've also amended the product list to refer to SLE15 instead of SLE15 SP1 as these are the GM/SP0 docs.

UPDATE: changed to point to correct branch (maintenance/SLE15SP0 instead of master).

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
