### PR TITLE
Update list of supported KVM/Xen hosts for SLE12SP4

### DIFF
--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -656,6 +656,16 @@
      &sls; 12 SP2 (&kvm;/&xen;)
     </para>
    </listitem>
+    <listitem>
+    <para>
+     &sls; 12 SP3 (&kvm;/&xen;)
+    </para>
+   </listitem>
+    <listitem>
+    <para>
+     &sls; 12 SP4 (&kvm;/&xen;)
+    </para>
+</listitem>
   </itemizedlist>
 
   <para>
@@ -679,6 +689,11 @@
    <listitem>
     <para>
      VMware ESXi 6.0
+    </para>
+   </listitem>
+      <listitem>
+    <para>
+     VMware ESXi 2016
     </para>
    </listitem>
    <listitem>
@@ -714,29 +729,6 @@
    <listitem>
     <para>
      Oracle VM 3.3
-    </para>
-   </listitem>
-  </itemizedlist>
-
-  <para>
-   The following host operating systems will be supported
-   when released:
-  </para>
-
-  <itemizedlist mark="bullet" spacing="normal">
-   <listitem>
-    <para>
-     &sls; 12 SP3 (&kvm;/&xen;)
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     VMware ESXi 2016
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     Citrix XenServer 6.5
     </para>
    </listitem>
   </itemizedlist>


### PR DESCRIPTION
resolves bsc#1152949, applies to SLE12SP3/4/5

### Description
Update the list of hypervisor hosts that support SLE12SP4 as a guest

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [x ] To maintenance/SLE12SP4
- [x ] To maintenance/SLE12SP3
