### PR TITLE
Configuring dual head using libvirt (bsc#1155894)

### DIFF
--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -298,6 +298,7 @@ they also have a trademark policy, let's be careful here. -->
 <!--                    Miscellaneous                              -->
 <!-- ============================================================= -->
 <!ENTITY kiwi            "KIWI">
+<!ENTITY virsh           "<command xmlns='http://docbook.org/ns/docbook'>virsh</command>">
 <!ENTITY ptp             "Precision Time Protocol">
 <!ENTITY ntp             "Network Time Protocol">
 <!ENTITY chrony          "<systemitem xmlns='http://docbook.org/ns/docbook' class='resource'>chrony</systemitem>">

--- a/xml/libvirt_configuration_virsh.xml
+++ b/xml/libvirt_configuration_virsh.xml
@@ -5,18 +5,15 @@
     %entities;
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" xml:base="libvirt_configuration_virsh.xml" version="5.0" xml:id="cha-libvirt-config-virsh">
- <title>Configuring Virtual Machines with virsh</title>
+ <title>Configuring Virtual Machines with &virsh;</title>
  <info>
   <abstract>
    <para>
-    You can use <command>virsh</command> to configure the &vmguest; in addition
-    to using the Virtual Machine Manager. <command>virsh</command> is a command
-    line tool that manages virtual machines created by VM software, such as
-    &kvm;, &xen;, &vmware;, and LXC. With <command>virsh</command>, you can control
-    the state of a VM, edit the configuration of a VM or even migrate a VM to
-    another host. The following section shows the management of a VM with
-    virsh. Examples include modifying memory allocation, input devices, CPU
-    settings, and video configuration.
+    You can use &virsh; to configure virtual machines (VM) on the command line
+    as an alternative to using the &vmm;. With &virsh;, you can control the
+    state of a VM, edit the configuration of a VM or even migrate a VM to
+    another host. The following sections describe how to manage VMs by using
+    &virsh;.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -32,118 +29,119 @@
   </para>
 
   <example>
-   <title>Example XML Configuration file</title>
+   <title>Example XML Configuration File</title>
 <screen>
-    &lt;domain type='kvm'&gt;
-      &lt;name&gt;sles15&lt;/name&gt;
-      &lt;uuid&gt;ab953e2f-9d16-4955-bb43-1178230ee625&lt;/uuid&gt;
-      &lt;memory unit='KiB'&gt;2097152&lt;/memory&gt;
-      &lt;currentMemory unit='KiB'&gt;2097152&lt;/currentMemory&gt;
-      &lt;vcpu placement='static'&gt;2&lt;/vcpu&gt;
-      &lt;os&gt;
-        &lt;type arch='x86_64' machine='pc-i440fx-2.11'&gt;hvm&lt;/type&gt;
-      &lt;/os&gt;
-      &lt;features&gt;...&lt;/features&gt;
-      &lt;cpu mode='custom' match='exact' check='partial'&gt;
-        &lt;model fallback='allow'&gt;Skylake-Client-IBRS&lt;/model&gt;
-      &lt;/cpu&gt;
-      &lt;clock&gt;...&lt;/clock&gt;
-      &lt;on_poweroff&gt;destroy&lt;/on_poweroff&gt;
-      &lt;on_reboot&gt;restart&lt;/on_reboot&gt;
-      &lt;on_crash&gt;destroy&lt;/on_crash&gt;
-      &lt;pm&gt;
-        &lt;suspend-to-mem enabled='no'/&gt;
-        &lt;suspend-to-disk enabled='no'/&gt;
-      &lt;/pm&gt;
-      &lt;devices&gt;
-        &lt;emulator&gt;/usr/bin/qemu-system-x86_64&lt;/emulator&gt;
-        &lt;disk type='file' device='disk'&gt;...&lt;/disk&gt;
-      &lt;/devices&gt;
-      ...
-    &lt;/domain&gt;
-    </screen>
+&lt;domain type='kvm'&gt;
+  &lt;name&gt;sles15&lt;/name&gt;
+  &lt;uuid&gt;ab953e2f-9d16-4955-bb43-1178230ee625&lt;/uuid&gt;
+  &lt;memory unit='KiB'&gt;2097152&lt;/memory&gt;
+  &lt;currentMemory unit='KiB'&gt;2097152&lt;/currentMemory&gt;
+  &lt;vcpu placement='static'&gt;2&lt;/vcpu&gt;
+  &lt;os&gt;
+    &lt;type arch='x86_64' machine='pc-i440fx-2.11'&gt;hvm&lt;/type&gt;
+  &lt;/os&gt;
+  &lt;features&gt;...&lt;/features&gt;
+  &lt;cpu mode='custom' match='exact' check='partial'&gt;
+    &lt;model fallback='allow'&gt;Skylake-Client-IBRS&lt;/model&gt;
+  &lt;/cpu&gt;
+  &lt;clock&gt;...&lt;/clock&gt;
+  &lt;on_poweroff&gt;destroy&lt;/on_poweroff&gt;
+  &lt;on_reboot&gt;restart&lt;/on_reboot&gt;
+  &lt;on_crash&gt;destroy&lt;/on_crash&gt;
+  &lt;pm&gt;
+    &lt;suspend-to-mem enabled='no'/&gt;
+    &lt;suspend-to-disk enabled='no'/&gt;
+  &lt;/pm&gt;
+  &lt;devices&gt;
+    &lt;emulator&gt;/usr/bin/qemu-system-x86_64&lt;/emulator&gt;
+    &lt;disk type='file' device='disk'&gt;...&lt;/disk&gt;
+  &lt;/devices&gt;
+  ...
+&lt;/domain&gt;
+</screen>
   </example>
 
   <para>
-   If you want to edit the configuration of the &vmguest;, check if the guest
-   is offline:
+   If you want to edit the configuration of the &vmguest;, check if it is
+   offline:
   </para>
 
 <screen>&prompt.sudo;<command>virsh list --inactive</command></screen>
 
   <para>
-   If your &vmguest; is in this list, you can safely edit its configuration
-   with:
+   If your &vmguest; is in this list, you can safely edit its configuration:
   </para>
 
 <screen>&prompt.sudo;<command>virsh edit <replaceable>NAME_OF_VM_GUEST</replaceable></command>
     </screen>
 
   <para>
-   Before saving the changes, <command>virsh</command> validates your input
-   against a RelaxNG schema.
+   Before saving the changes, &virsh; validates your input against a RelaxNG
+   schema.
   </para>
  </sect1>
- 
  <sect1 xml:id="sec-libvirt-config-maxgrantframes-virsh">
-     <title>Managing Guest Memory Allocation (&xen; only)</title>
-         <para>
-             <command>libvirt</command> now includes support for adjusting
-             memory allocation per guest with <command>virsh</command>. &xen; 
-             paravirtual devices connect to the  <literal>xenbus </literal> controller, which is 
-             analogous to a physical device bus such as a PCI controller.        
-             &xen;'s <literal>max_grant_frames</literal> attribute sets how many
-             frames, which are analogous to memory, are allocated to
-             the <literal>xenbus </literal> controller for each guest. 
-         </para>
-         <para>
-             The default is 32, and this can be increased as needed, up to the 
-             amount set for dom0, or decreased. How much is enough? 
-             This depends on the number of devices and workload demand,
-             such as a saturated network interface or heavy I/O.
-             Use <command>xen-diag</command> to see your current used
-             and maximum <literal>max_grant_frames</literal> values for 
-             dom0 and your  guests. The guests must be running:
-         </para>
-         <screen>&prompt.sudo;virsh list 
+  <title>Managing Guest Memory Allocation (&xen; only)</title>
+
+  <para>
+   <command>libvirt</command> now includes support for adjusting memory
+   allocation per guest with &virsh;. &xen; paravirtual devices connect to the
+   <literal>xenbus </literal> controller, which is analogous to a physical
+   device bus such as a PCI controller. &xen;'s
+   <literal>max_grant_frames</literal> attribute sets how many frames, which
+   are analogous to memory, are allocated to the <literal>xenbus </literal>
+   controller for each guest.
+  </para>
+
+  <para>
+   The default is 32, and this can be increased as needed, up to the amount set
+   for dom0, or decreased. How much is enough? This depends on the number of
+   devices and workload demand, such as a saturated network interface or heavy
+   I/O. Use <command>xen-diag</command> to see your current used and maximum
+   <literal>max_grant_frames</literal> values for dom0 and your guests. The
+   guests must be running:
+  </para>
+
+<screen>&prompt.sudo;virsh list
  Id   Name             State
 --------------------------------
  0    Domain-0         running
  3    sle15sp1         running
- 
+
  &prompt.sudo;xen-diag gnttab_query_size 0
 domid=0: nr_frames=1, max_nr_frames=256
 
 &prompt.sudo;xen-diag gnttab_query_size 3
 domid=3: nr_frames=3, max_nr_frames=32
 </screen>
-<para>
-    The sle15sp1 guest is using only 3 frames out of 32. If you
-    are seeing performance issues, and log entries that point
-    to insufficient frames, increase the value with 
-    <command>virsh</command>. Look for the
-    <literal>&lt;controller type='xenbus'</literal> line 
-    in the guest's configuration file and
-    add the <literal>maxGrantFrames</literal> control element:
-</para>
+
+  <para>
+   The sle15sp1 guest is using only 3 frames out of 32. If you are seeing
+   performance issues, and log entries that point to insufficient frames,
+   increase the value with &virsh;. Look for the <literal>&lt;controller
+   type='xenbus'</literal> line in the guest's configuration file and add the
+   <literal>maxGrantFrames</literal> control element:
+  </para>
+
 <screen>&prompt.sudo;virsh edit sle15sp1
  &lt;controller type='xenbus' index='0' maxGrantFrames='40'/>
 </screen>
-<para>
-    Save your changes and restart the guest. Now it should show
-    your change:
-</para>
+
+  <para>
+   Save your changes and restart the guest. Now it should show your change:
+  </para>
+
 <screen>&prompt.sudo;xen-diag gnttab_query_size 3
 domid=3: nr_frames=3, max_nr_frames=40
 </screen>
-<para>
-    See the <citetitle>Controllers</citetitle> section of the libvirt
-    <citetitle>Domain XML format</citetitle> manual at 
-    <link xlink:href="https://libvirt.org/formatdomain.html#elementsControllers"/>
-    for more information.
-</para>
-</sect1>      
-         
+
+  <para>
+   See the <citetitle>Controllers</citetitle> section of the libvirt
+   <citetitle>Domain XML format</citetitle> manual at
+   <link xlink:href="https://libvirt.org/formatdomain.html#elementsControllers"/>
+   for more information.
+  </para>
+ </sect1>
  <sect1 xml:id="sec-libvirt-config-machinetype-virsh">
   <title>Changing the Machine Type</title>
 
@@ -151,8 +149,7 @@ domid=3: nr_frames=3, max_nr_frames=40
    When installing with the <command>virt-install</command> tool, the machine
    type for a &vmguest; is <emphasis>pc-i440fx</emphasis> by default. The
    machine type is stored in the &vmguest;'s configuration file in the
-   <tag>type</tag>
-   element:
+   <tag>type</tag> element:
   </para>
 
 <screen>&lt;type arch='x86_64' machine='pc-i440fx-2.3'&gt;hvm&lt;/type&gt;</screen>
@@ -187,11 +184,8 @@ Id    Name                           State
    </step>
    <step>
     <para>
-     Replace the value of the
-     <tag class="attribute">machine</tag>
-     attribute with
-     <tag class="attvalue">pc-q35-2.0</tag>
-     :
+     Replace the value of the <tag class="attribute">machine</tag> attribute
+     with <tag class="attvalue">pc-q35-2.0</tag> :
     </para>
 <screen>&lt;type arch='x86_64' machine='pc-q35-2.0'&gt;hvm&lt;/type&gt;</screen>
    </step>
@@ -215,9 +209,9 @@ Product Name: Standard PC (Q35 + ICH9, 2009)</screen>
    <title>Machine Type Update Recommendations</title>
    <para>
     Whenever the QEMU version on the host system is upgraded (for example, when
-    upgrading the &vmhost; to a new service pack), upgrade the machine
-    type of the &vmguest;s to the latest available version. To check, use the
-    command <command>qemu-system-x86_64 -M help</command> on the &vmhost;.
+    upgrading the &vmhost; to a new service pack), upgrade the machine type of
+    the &vmguest;s to the latest available version. To check, use the command
+    <command>qemu-system-x86_64 -M help</command> on the &vmhost;.
    </para>
    <para>
     The default machine type <literal>pc-i440fx</literal>, for example, is
@@ -236,15 +230,15 @@ Product Name: Standard PC (Q35 + ICH9, 2009)</screen>
   <para>
    The number of allocated CPUs is stored in the &vmguest;'s XML configuration
    file in <filename>/etc/libvirt/qemu/</filename> in the
-   <tag class="attribute">vcpu</tag>
-   element:
+   <tag class="attribute">vcpu</tag> element:
   </para>
 
 <screen>&lt;vcpu placement='static'&gt;1&lt;/vcpu&gt;</screen>
 
   <para>
    In this example, the &vmguest; has only one allocated CPU. The following
-   procedure shows how to change the number of allocated CPUs for the &vmguest;:
+   procedure shows how to change the number of allocated CPUs for the
+   &vmguest;:
   </para>
 
   <procedure>
@@ -300,9 +294,8 @@ CPU Affinity:   yy
   <title>Changing Boot Options</title>
 
   <para>
-   The boot menu of the &vmguest; can be found in the
-   <tag>os</tag>
-   element and usually looks like this:
+   The boot menu of the &vmguest; can be found in the <tag>os</tag> element and
+   usually looks like this:
   </para>
 
 <screen>&lt;os&gt;
@@ -317,15 +310,10 @@ CPU Affinity:   yy
   &lt;/os&gt;</screen>
 
   <para>
-   In this example, two devices are available,
-   <tag class="attvalue">hd</tag>
-   and
-   <tag class="attvalue">cdrom</tag>
-   . The configuration also reflects the actual boot order, so the
-   <tag class="attvalue">cdrom</tag>
-   comes before the
-   <tag class="attvalue">hd</tag>
-   .
+   In this example, two devices are available, <tag class="attvalue">hd</tag>
+   and <tag class="attvalue">cdrom</tag> . The configuration also reflects the
+   actual boot order, so the <tag class="attvalue">cdrom</tag> comes before the
+   <tag class="attvalue">hd</tag> .
   </para>
 
   <sect2 xml:id="sec-libvirt-config-bootorder-virsh">
@@ -366,11 +354,8 @@ CPU Affinity:   yy
    <title>Using Direct Kernel Boot</title>
    <para>
     Direct Kernel Boot allows you to boot from a kernel and initrd stored on
-    the host. Set the path to both files in the
-    <tag>kernel</tag>
-    and
-    <tag>initrd</tag>
-    elements:
+    the host. Set the path to both files in the <tag>kernel</tag> and
+    <tag>initrd</tag> elements:
    </para>
 <screen>&lt;os&gt;
     ...
@@ -390,11 +375,8 @@ CPU Affinity:   yy
     </step>
     <step>
      <para>
-      Inside the
-      <tag>os</tag>
-      element, add a
-      <tag>kernel</tag>
-      element and the path to the kernel file on the host:
+      Inside the <tag>os</tag> element, add a <tag>kernel</tag> element and the
+      path to the kernel file on the host:
      </para>
 <screen>...
 &lt;kernel&gt;/root/f8-i386-vmlinuz&lt;/kernel&gt;
@@ -402,9 +384,8 @@ CPU Affinity:   yy
     </step>
     <step>
      <para>
-      Add an
-      <tag>initrd</tag>
-      element and the path to the initrd file on the host:
+      Add an <tag>initrd</tag> element and the path to the initrd file on the
+      host:
      </para>
 <screen>...
 &lt;initrd&gt;/root/f8-i386-initrd&lt;/initrd&gt;
@@ -424,9 +405,7 @@ CPU Affinity:   yy
 
   <para>
    The amount of memory allocated for the &vmguest; can also be configured with
-   virsh. It is stored in the
-   <tag>memory</tag>
-   element. Follow these steps:
+   virsh. It is stored in the <tag>memory</tag> element. Follow these steps:
   </para>
 
   <procedure>
@@ -438,9 +417,8 @@ CPU Affinity:   yy
    </step>
    <step>
     <para>
-     Search for the
-     <tag>memory</tag>
-     element and set the amount of allocated RAM:
+     Search for the <tag>memory</tag> element and set the amount of allocated
+     RAM:
     </para>
 <screen>...
 &lt;memory unit='KiB'&gt;524288&lt;/memory&gt;
@@ -458,8 +436,7 @@ CPU Affinity:   yy
   <title>Adding a PCI Device</title>
 
   <para>
-   To assign a PCI device to &vmguest; with <command>virsh</command>, follow
-   these steps:
+   To assign a PCI device to &vmguest; with &virsh;, follow these steps:
   </para>
 
   <procedure>
@@ -520,10 +497,10 @@ CPU Affinity:   yy
      <para>
       When using a multi-function PCI device that does not support FLR
       (function level reset) or PM (power management) reset, you need to detach
-      all its functions from the &vmhost;. The whole device must be reset
-      for security reasons. <systemitem>libvirt</systemitem> will refuse to
-      assign the device if one of its functions is still in use by the &vmhost;
-      or another &vmguest;.
+      all its functions from the &vmhost;. The whole device must be reset for
+      security reasons. <systemitem>libvirt</systemitem> will refuse to assign
+      the device if one of its functions is still in use by the &vmhost; or
+      another &vmguest;.
      </para>
     </tip>
    </step>
@@ -599,8 +576,7 @@ CPU Affinity:   yy
   <title>Adding a USB Device</title>
 
   <para>
-   To assign a USB device to &vmguest; using <command>virsh</command>, follow
-   these steps:
+   To assign a USB device to &vmguest; using &virsh;, follow these steps:
   </para>
 
   <procedure>
@@ -633,13 +609,10 @@ Bus 001 Device 003: ID <emphasis role="bold">0557:2221</emphasis> ATEN Internati
      <title>Vendor/Product or Device's Address</title>
      <para>
       Instead of defining the host device with
-      <tag class="emptytag">vendor</tag>
-      and
-      <tag class="emptytag">product</tag>
-      IDs, you can use the
-      <tag class="emptytag">address</tag>
-      element as described for host PCI devices in
-      <xref linkend="sec-libvirt-config-pci-virsh"/>.
+      <tag class="emptytag">vendor</tag> and
+      <tag class="emptytag">product</tag> IDs, you can use the
+      <tag class="emptytag">address</tag> element as described for host PCI
+      devices in <xref linkend="sec-libvirt-config-pci-virsh"/>.
      </para>
     </tip>
    </step>
@@ -749,8 +722,8 @@ Bus 001 Device 003: ID <emphasis role="bold">0557:2221</emphasis> ATEN Internati
    <note>
     <title>Adding an SR-IOV Device at &vmguest; Creation</title>
     <para>
-     Before adding an SR-IOV device to a &vmguest; when initially setting it up,
-     the &vmhost; already needs to be configured as described in
+     Before adding an SR-IOV device to a &vmguest; when initially setting it
+     up, the &vmhost; already needs to be configured as described in
      <xref linkend="sec-libvirt-config-io-config"/>.
     </para>
    </note>
@@ -926,8 +899,8 @@ virsh nodedev-detach pci_0000_06_08_0</screen>
    <title>Adding a VF Network Device to a &vmguest;</title>
    <para>
     When the <xref linkend="vt-io-sriov"/> hardware is properly set up on the
-    &vmhost;, you can add VFs to &vmguest;s. To do so, you need to collect
-    some data first.
+    &vmhost;, you can add VFs to &vmguest;s. To do so, you need to collect some
+    data first.
    </para>
    <procedure>
     <title>Adding a VF Network Device to an Existing &vmguest;</title>
@@ -1036,9 +1009,9 @@ pci_0000_04_11_5</screen>
         with <tag class="attribute">hostdev</tag>, it would require to
         reconfigure the &vmguest;'s network device after each reboot of the
         host, because of the MAC address change. To avoid this kind of problem,
-        &libvirt; introduced the <tag class="attvalue">hostdev</tag> value, which
-        sets up network-specific data <emphasis>before</emphasis> assigning the
-        device.
+        &libvirt; introduced the <tag class="attvalue">hostdev</tag> value,
+        which sets up network-specific data <emphasis>before</emphasis>
+        assigning the device.
        </para>
       </callout>
       <callout arearefs="sriov-data">
@@ -1068,8 +1041,7 @@ pci_0000_04_11_5</screen>
      </para>
      <variablelist>
       <varlistentry>
-       <term><option>--persistent</option>
-       </term>
+       <term><option>--persistent</option></term>
        <listitem>
         <para>
          This option will always add the device to the domain's persistent XML.
@@ -1078,8 +1050,7 @@ pci_0000_04_11_5</screen>
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term><option>--config</option>
-       </term>
+       <term><option>--config</option></term>
        <listitem>
         <para>
          This option will only affect the persistent XML, even if the domain is
@@ -1088,8 +1059,7 @@ pci_0000_04_11_5</screen>
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term><option>--live</option>
-       </term>
+       <term><option>--live</option></term>
        <listitem>
         <para>
          This option will only affect a running domain. If the domain is
@@ -1099,8 +1069,7 @@ pci_0000_04_11_5</screen>
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term><option>--current</option>
-       </term>
+       <term><option>--current</option></term>
        <listitem>
         <para>
          This option affects the current state of the domain. If the domain is
@@ -1131,11 +1100,11 @@ pci_0000_04_11_5</screen>
     configuration must be modified prior to each start.
    </para>
    <para>
-    Another approach is to create a &libvirt; network with a device pool
-    that contains all the VFs of an <xref linkend="vt-io-sriov"/> device. The
-    &vmguest; then references this network, and each time it is started, a single
-    VF is dynamically allocated to it. When the &vmguest; is stopped, the VF is
-    returned to the pool, available for another guest.
+    Another approach is to create a &libvirt; network with a device pool that
+    contains all the VFs of an <xref linkend="vt-io-sriov"/> device. The
+    &vmguest; then references this network, and each time it is started, a
+    single VF is dynamically allocated to it. When the &vmguest; is stopped,
+    the VF is returned to the pool, available for another guest.
    </para>
    <sect3 xml:id="libvirt-config-io-pool-host">
     <title>Defining Network with Pool of VFs on &vmhost;</title>
@@ -1164,8 +1133,8 @@ pci_0000_04_11_5</screen>
    <sect3 xml:id="libvirt-config-io-pool-guest">
     <title>Configuring &vmguest;s to Use VF from the Pool</title>
     <para>
-     The following example of &vmguest; device interface definition uses a VF of
-     the <xref linkend="vt-io-sriov"/> device from the pool created in
+     The following example of &vmguest; device interface definition uses a VF
+     of the <xref linkend="vt-io-sriov"/> device from the pool created in
      <xref linkend="libvirt-config-io-pool-host"/>. &libvirt; automatically
      derives the list of all VFs associated with that PF the first time the
      guest is started.
@@ -1174,8 +1143,8 @@ pci_0000_04_11_5</screen>
   &lt;source network='passthrough'&gt;
 &lt;/interface&gt;</screen>
     <para>
-     After the first &vmguest; starts that uses the network with the pool of VFs,
-     verify the list of associated VFs. Do so by running <command>virsh
+     After the first &vmguest; starts that uses the network with the pool of
+     VFs, verify the list of associated VFs. Do so by running <command>virsh
      net-dumpxml passthrough</command> on the host.
     </para>
 <screen>&lt;network connections='1'&gt;
@@ -1199,46 +1168,29 @@ pci_0000_04_11_5</screen>
   <title>Configuring Storage Devices</title>
 
   <para>
-   Storage devices are defined within the
-   <tag>disk</tag>
-   element. The usual
-   <tag>disk</tag>
-   element supports several attributes. The following two attributes are the
-   most important:
+   Storage devices are defined within the <tag>disk</tag> element. The usual
+   <tag>disk</tag> element supports several attributes. The following two
+   attributes are the most important:
   </para>
 
   <itemizedlist>
    <listitem>
     <para>
-     The
-     <tag class="attribute">type</tag>
-     attribute describes the source of the virtual disk device. Valid values
-     are
-     <tag class="attvalue">file</tag>
-     ,
-     <tag class="attvalue">block</tag>
-     ,
-     <tag class="attvalue">dir</tag>
-     ,
-     <tag class="attvalue">network</tag>
-     , or
-     <tag class="attvalue">volume</tag>
-     .
+     The <tag class="attribute">type</tag> attribute describes the source of
+     the virtual disk device. Valid values are <tag class="attvalue">file</tag>
+     , <tag class="attvalue">block</tag> , <tag class="attvalue">dir</tag> ,
+     <tag class="attvalue">network</tag> , or
+     <tag class="attvalue">volume</tag> .
     </para>
    </listitem>
    <listitem>
     <para>
-     The
-     <tag class="attribute">device</tag>
-     attribute indicates how the disk is exposed to the &vmguest; OS. As an
-     example, possible values can include
+     The <tag class="attribute">device</tag> attribute indicates how the disk
+     is exposed to the &vmguest; OS. As an example, possible values can include
      <tag
-      class="attvalue">floppy</tag>
-     ,
-     <tag class="attvalue">disk</tag>
-     ,
-     <tag class="attvalue">cdrom</tag>
-     , and others.
+      class="attvalue">floppy</tag> ,
+     <tag class="attvalue">disk</tag> , <tag class="attvalue">cdrom</tag> , and
+     others.
     </para>
    </listitem>
   </itemizedlist>
@@ -1250,18 +1202,16 @@ pci_0000_04_11_5</screen>
   <itemizedlist>
    <listitem>
     <para>
-     <tag>driver</tag>
-     contains the driver and the bus. These are used by the &vmguest; to work
-     with the new disk device.
+     <tag>driver</tag> contains the driver and the bus. These are used by the
+     &vmguest; to work with the new disk device.
     </para>
    </listitem>
    <listitem>
     <para>
-     The
-     <tag>target</tag>
-     element contains the device name under which the new disk is shown in the
-     &vmguest;. It also contains the optional bus attribute, which defines the
-     type of bus on which the new disk should operate.
+     The <tag>target</tag> element contains the device name under which the new
+     disk is shown in the &vmguest;. It also contains the optional bus
+     attribute, which defines the type of bus on which the new disk should
+     operate.
     </para>
    </listitem>
   </itemizedlist>
@@ -1279,22 +1229,15 @@ pci_0000_04_11_5</screen>
    </step>
    <step>
     <para>
-     Add a
-     <tag>disk</tag>
-     element inside the
-     <tag>disk</tag>
-     element together with the attributes
-     <tag class="attvalue">type</tag>
-     and
+     Add a <tag>disk</tag> element inside the <tag>disk</tag> element together
+     with the attributes <tag class="attvalue">type</tag> and
      <tag class="attvalue">device</tag>:
     </para>
 <screen>&lt;disk type='file' device='disk'&gt;</screen>
    </step>
    <step>
     <para>
-     Specify a
-     <tag>driver</tag>
-     element and use the default values:
+     Specify a <tag>driver</tag> element and use the default values:
     </para>
 <screen>&lt;driver name='qemu' type='qcow2'/&gt;</screen>
    </step>
@@ -1399,7 +1342,7 @@ pci_0000_04_11_5</screen>
  </sect1>
  <sect1 xml:id="sec-libvirt-config-direct">
   <title>Using Macvtap to Share &vmhost; Network Interfaces</title>
-  
+
   <para>
    Macvtap provides direct attachment of a &vmguest; virtual interface to a
    host network interface. The macvtap-based interface extends the &vmhost;
@@ -1407,7 +1350,7 @@ pci_0000_04_11_5</screen>
    Typically, this is used to make both the &vmguest; and the &vmhost; show up
    directly on the switch that the &vmhost; is connected to.
   </para>
-  
+
   <note>
    <title>Macvtap Cannot Be Used with a Linux Bridge</title>
    <para>
@@ -1416,7 +1359,7 @@ pci_0000_04_11_5</screen>
     interface from the bridge.
    </para>
   </note>
-  
+
   <note>
    <title>&vmguest; to &vmhost; Communication with Macvtap</title>
    <para>
@@ -1431,24 +1374,24 @@ pci_0000_04_11_5</screen>
     bridge for forwarding to the &vmguest;.
    </para>
   </note>
-  
+
   <para>
    Virtual network interfaces based on macvtap are supported by libvirt by
    specifying an interface type of <literal>direct</literal>. For example:
   </para>
-  
-  <screen>&lt;interface type='direct'&gt;
+
+<screen>&lt;interface type='direct'&gt;
    &lt;mac address='aa:bb:cc:dd:ee:ff'/&gt;
    &lt;source dev='eth0' mode='bridge'/&gt;
    &lt;model type='virtio'/&gt;
    &lt;/interface&gt;</screen>
-  
+
   <para>
    The operation mode of the macvtap device can be controlled with the
    <literal>mode</literal> attribute. The following list show its possible
    values and a description for each:
   </para>
-  
+
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
@@ -1493,16 +1436,17 @@ pci_0000_04_11_5</screen>
  </sect1>
  <sect1 xml:id="sec-libvirt-config-disable-virtio-mellon">
   <title>Disabling a Memory Balloon Device</title>
-   <para>
-    Memory Balloon has become a default option for KVM. The device will be
-    added to the &vmguest; explicitly, so you do not need to add this element in the
-    &vmguest;'s XML configuration. However, if you want to disable Memory Balloon
-    in the &vmguest; for any reason, you need to set <literal>model='none'</literal>
-    as shown below:
+
+  <para>
+   Memory Balloon has become a default option for KVM. The device will be added
+   to the &vmguest; explicitly, so you do not need to add this element in the
+   &vmguest;'s XML configuration. However, if you want to disable Memory
+   Balloon in the &vmguest; for any reason, you need to set
+   <literal>model='none'</literal> as shown below:
   </para>
 
-  <screen>&lt;devices&gt;
+<screen>&lt;devices&gt;
    &lt;memballoon model='none'/&gt;
 &lt;/device&gt;</screen>
-  </sect1>
+ </sect1>
 </chapter>

--- a/xml/libvirt_configuration_virsh.xml
+++ b/xml/libvirt_configuration_virsh.xml
@@ -62,7 +62,7 @@
   </example>
 
   <para>
-   If you want to edit the configuration of the &vmguest;, check if it is
+   If you want to edit the configuration of a &vmguest;, check if it is
    offline:
   </para>
 
@@ -86,7 +86,7 @@
   <para>
    <command>libvirt</command> now includes support for adjusting memory
    allocation per guest with &virsh;. &xen; paravirtual devices connect to the
-   <literal>xenbus </literal> controller, which is analogous to a physical
+   <literal>xenbus</literal> controller, which is analogous to a physical
    device bus such as a PCI controller. &xen;'s
    <literal>max_grant_frames</literal> attribute sets how many frames, which
    are analogous to memory, are allocated to the <literal>xenbus </literal>
@@ -1448,5 +1448,90 @@ pci_0000_04_11_5</screen>
 <screen>&lt;devices&gt;
    &lt;memballoon model='none'/&gt;
 &lt;/device&gt;</screen>
+ </sect1>
+ <sect1 xml:id="virsh-video-dual-head">
+  <title>Configuring Multiple Monitors (Dual Head)</title>
+
+  <para>
+   &libvirt; supports a dual head configuration to display the video output of
+   the &vmguest; on multiple monitors.
+  </para>
+
+  <important>
+   <title>No Support for &xen;</title>
+   <para>
+    The &xen; hypervisor does not support dual head configuration.
+   </para>
+  </important>
+
+  <procedure>
+   <title>Configuring Dual Head</title>
+   <step>
+    <para>
+     While the virtual machine is running, verify that the
+     <package>xf86-video-qxl</package> package is installed in the &vmguest;:
+    </para>
+<screen>&prompt.user;rpm -q xf86-video-qxl</screen>
+   </step>
+   <step>
+    <para>
+     Shutdown the &vmguest; and start editing its configuration XML as
+     described in <xref linkend="sec-libvirt-config-editing-virsh"/>.
+    </para>
+   </step>
+   <step>
+    <para>
+     Verify that the model of the virtual graphics card is 'qxl':
+    </para>
+<screen>
+&lt;video>
+ &lt;model type='qxl' ... />
+</screen>
+   </step>
+   <step>
+    <para>
+     Increase the <option>heads</option> parameter in the graphics card model
+     specification from the default '1' to for example '2':
+    </para>
+<screen>
+&lt;video>
+ &lt;model type='qxl' ram='65536' vram='65536' vgamem='16384' heads='2' primary='yes'/>
+ &lt;alias name='video0'/>
+ &lt;address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x0'/>
+&lt;/video>
+</screen>
+   </step>
+   <step>
+    <para>
+     Configure the virtual machine to use the Spice display instead of VNC:
+    </para>
+<screen>
+&lt;graphics type='spice' port='5916' autoport='yes' listen='0.0.0.0'>
+ &lt;listen type='address' address='0.0.0.0'/>
+&lt;/graphics>
+</screen>
+   </step>
+   <step>
+    <para>
+     Start the virtual machine and connect to its display with
+     <command>virt-viewer</command>, for example:
+    </para>
+<screen>&prompt.user;virt-viewer --connect qemu+ssh://<replaceable>USER@VM_HOST</replaceable>/system</screen>
+   </step>
+   <step>
+    <para>
+     From the list of VMs, select the one whose configuration you have modified
+     and confirm with <guimenu>Connect</guimenu>.
+    </para>
+   </step>
+   <step>
+    <para>
+     After the graphical subsystem (Xorg) loads in the &vmguest;, select
+     <menuchoice><guimenu>View</guimenu><guimenu>Displays</guimenu><guimenu>Display
+     2</guimenu></menuchoice> to open a new window with the second monitor's
+     output.
+    </para>
+   </step>
+  </procedure>
  </sect1>
 </chapter>


### PR DESCRIPTION
Since SLE 12, it is possible to add additional 'heads' to a virtual graphics card to emulate
the video output on multiple monitors. This PR introduces steps to help customers with the setup.

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [x] To maintenance/SLE12SP4
- [x] To maintenance/SLE12SP3
