### PR TITLE
fix example for param list (bsc#1143260)

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -12485,7 +12485,7 @@ echo "Testing the pre script" &gt; /tmp/pre-script_out.txt
           command line. If any shell quoting should be necessary (for
           example to protect embedded spaces) you need to include this.
          </para>
-<screen>&lt;param-list&gt;
+<screen>&lt;param-list config:type="list"&gt;
   &lt;param&gt;par1&lt;/param&gt;
   &lt;param&gt;par2 par3&lt;/param&gt;
   &lt;param&gt;"par4.1 par4.2"&lt;/param&gt;


### PR DESCRIPTION
### Description
Fix misleading example for autoyast parameter as xml parameter is mandatory.
https://bugzilla.suse.com/show_bug.cgi?id=1143260

### Checklist
* Check all items that apply.

*Are backports required?*
all maintained code streams are affected.

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [x] To maintenance/SLE12SP4
- [x] To maintenance/SLE12SP3
