### PR TITLE
AY: Clarify that enable_snapshots only applies to root Btrfs

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2810,8 +2810,8 @@ openssl x509 -noout -fingerprint -sha256
         </entry>
         <entry>
          <para>
-          Enables snapshots for Btrfs file systems. It does not apply to other
-          kinds of file systems.
+          Enables snapshots. It only applies to a Btrfs file system
+          which is mounted as root (/).
          </para>
 <screen>&lt;enable_snapshots config:type="boolean"
 &gt;false&lt;/enable_snapshots&gt;</screen>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2810,8 +2810,9 @@ openssl x509 -noout -fingerprint -sha256
         </entry>
         <entry>
          <para>
-          Enables snapshots. It only applies to a Btrfs file system
-          which is mounted as root (/).
+          Enables snapshots on Btrfs file systems mounted at <literal>/</literal>
+          (does not apply to other file systems, or Btrfs file systems not mounted
+          at <literal>/</literal>).
          </para>
 <screen>&lt;enable_snapshots config:type="boolean"
 &gt;false&lt;/enable_snapshots&gt;</screen>


### PR DESCRIPTION
### Description

It is not clear that the AutoYaST `enable_snapshots` can be only applied to Btrfs file systems that are mounted as root (/).

To be honest, I am not sure whether it is clear enough.

### Checklist

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [x] To maintenance/SLE12SP4
- [x] To maintenance/SLE12SP3
