### PR TITLE
Configuring multiqueue virtio-net in vorsh (bsc#1129856)

### DIFF
--- a/xml/libvirt_configuration_virsh.xml
+++ b/xml/libvirt_configuration_virsh.xml
@@ -1340,6 +1340,41 @@ pci_0000_04_11_5</screen>
    </tip>
   </sect2>
  </sect1>
+ <sect1 xml:id="virsh-network-devices">
+  <title>Configuring Network Devices</title>
+
+  <para>
+   This section describes how to configure specific aspects of virtual network
+   devices by using &virsh;.
+  </para>
+
+  <para>
+   Find more details about &libvirt; network interface specification in
+   <link xlink:href="https://libvirt.org/formatdomain.html#elementsDriverBackendOptions"/>.
+  </para>
+
+  <sect2 xml:id="virsh-multiqueue">
+   <title>Scaling Network Performance with Multiqueue virtio-net</title>
+   <para>
+    The multiqueue virtio-net feature scales the network performance by
+    allowing &vmguest;'s virtual CPUs to transfer packets in parallel. Refer to
+    <xref linkend="kvm-qemu-multiqueue"/> more general information.
+   </para>
+   <para>
+    To enable multiqueue virtio-net for a specific &vmguest;, edit its XML
+    configuration as described in
+    <xref linkend="sec-libvirt-config-editing-virsh"/> and modify its network
+    interface as follows:
+   </para>
+<screen>
+&lt;interface type='network'>
+ [...]
+ &lt;model type='virtio'/>
+ &lt;driver name='vhost' queues='<replaceable>NUMBER_OF_QUEUES</replaceable>'/>
+&lt;/interface>
+</screen>
+  </sect2>
+ </sect1>
  <sect1 xml:id="sec-libvirt-config-direct">
   <title>Using Macvtap to Share &vmhost; Network Interfaces</title>
 

--- a/xml/qemu_host_installation.xml
+++ b/xml/qemu_host_installation.xml
@@ -4,7 +4,6 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-qemu-host">
  <title>Setting Up a &kvm; &vmhost;</title>
  <info>
@@ -13,15 +12,15 @@
   </dm:docmanager>
  </info>
  <para>
-  This section documents how to set up and use &productname; &productnumber;
-  as a &qemu;-&kvm; based virtual machine host.
+  This section documents how to set up and use &productname; &productnumber; as
+  a &qemu;-&kvm; based virtual machine host.
  </para>
  <tip>
   <title>Resources</title>
   <para>
-   In general, the virtual guest system needs the same hardware resources as
-   if it were installed on a physical machine. The more guests you plan to run
-   on the host system, the more hardware resources&mdash;CPU, disk, memory, and
+   In general, the virtual guest system needs the same hardware resources as if
+   it were installed on a physical machine. The more guests you plan to run on
+   the host system, the more hardware resources&mdash;CPU, disk, memory, and
    network&mdash;you need to add to the &vmhost;.
   </para>
  </tip>
@@ -29,10 +28,9 @@
   <title>CPU Support for Virtualization</title>
 
   <para>
-   To run &kvm;, your CPU must support virtualization, and
-   virtualization needs to be enabled in BIOS. The file
-   <filename>/proc/cpuinfo</filename> includes information about your CPU
-   features.
+   To run &kvm;, your CPU must support virtualization, and virtualization needs
+   to be enabled in BIOS. The file <filename>/proc/cpuinfo</filename> includes
+   information about your CPU features.
   </para>
 
   <para os="sles;sled">
@@ -66,7 +64,6 @@
       </imageobject>
      </mediaobject>
     </figure>
-
     <figure os="osuse">
      <title>Installing the &kvm; Hypervisor and Tools</title>
      <mediaobject>
@@ -78,7 +75,6 @@
       </imageobject>
      </mediaobject>
     </figure>
-
    </step>
    <step>
     <para>
@@ -91,8 +87,8 @@
      During the installation process, you can optionally let &yast; create a
      <guimenu>Network Bridge</guimenu> for you automatically. If you do not
      plan to dedicate an additional physical network card to your virtual
-     guests, network bridge is a standard way to connect the guest machines
-     to the network.
+     guests, network bridge is a standard way to connect the guest machines to
+     the network.
     </para>
     <figure>
      <title>Network Bridge</title>
@@ -135,16 +131,14 @@ kvm                   411041  1 kvm_intel</screen>
    fully use specific features of the &vmhost;'s hardware
    (<emphasis>paravirtualization</emphasis>). This section introduces
    techniques to make the guests access the physical host's hardware
-   directly&mdash;without the emulation layer&mdash;to make the most use of
-   it.
+   directly&mdash;without the emulation layer&mdash;to make the most use of it.
   </para>
 
   <tip>
    <para>
     Examples included in this section assume basic knowledge of the
-    <command>qemu-system-<replaceable>ARCH</replaceable></command> command
-    line options. For more information, see
-    <xref linkend="cha-qemu-running"/>.
+    <command>qemu-system-<replaceable>ARCH</replaceable></command> command line
+    options. For more information, see <xref linkend="cha-qemu-running"/>.
    </para>
   </tip>
 
@@ -152,8 +146,8 @@ kvm                   411041  1 kvm_intel</screen>
    <title>Using the Host Storage with <systemitem>virtio-scsi</systemitem></title>
    <para>
     <systemitem>virtio-scsi</systemitem> is an advanced storage stack for
-    &kvm;. It replaces the former <systemitem>virtio-blk</systemitem> stack
-    for SCSI devices pass-through. It has several advantages over
+    &kvm;. It replaces the former <systemitem>virtio-blk</systemitem> stack for
+    SCSI devices pass-through. It has several advantages over
     <systemitem>virtio-blk</systemitem>:
    </para>
    <variablelist>
@@ -161,12 +155,12 @@ kvm                   411041  1 kvm_intel</screen>
      <term>Improved scalability</term>
      <listitem>
       <para>
-       &kvm; guests have a limited number of PCI controllers, which results
-       in a limited number of possibly attached devices.
-       <systemitem>virtio-scsi</systemitem> solves this limitation by
-       grouping multiple storage devices on a single controller. Each device
-       on a <systemitem>virtio-scsi</systemitem> controller is represented
-       as a logical unit, or <emphasis>LUN</emphasis>.
+       &kvm; guests have a limited number of PCI controllers, which results in
+       a limited number of possibly attached devices.
+       <systemitem>virtio-scsi</systemitem> solves this limitation by grouping
+       multiple storage devices on a single controller. Each device on a
+       <systemitem>virtio-scsi</systemitem> controller is represented as a
+       logical unit, or <emphasis>LUN</emphasis>.
       </para>
      </listitem>
     </varlistentry>
@@ -174,11 +168,10 @@ kvm                   411041  1 kvm_intel</screen>
      <term>Standard command set</term>
      <listitem>
       <para>
-       <systemitem>virtio-blk</systemitem> uses a small set of
-       commands that need to be known to both the
-       <systemitem>virtio-blk</systemitem> driver and the virtual machine
-       monitor, and so introducing a new command requires updating both the
-       driver and the monitor.
+       <systemitem>virtio-blk</systemitem> uses a small set of commands that
+       need to be known to both the <systemitem>virtio-blk</systemitem> driver
+       and the virtual machine monitor, and so introducing a new command
+       requires updating both the driver and the monitor.
       </para>
       <para>
        By comparison, <systemitem>virtio-scsi</systemitem> does not define
@@ -193,13 +186,13 @@ kvm                   411041  1 kvm_intel</screen>
      <listitem>
       <para>
        <systemitem>virtio-blk</systemitem> devices are presented inside the
-       guest as <filename>/dev/vd<replaceable>X</replaceable></filename>,
-       which is different from device
-       names in physical systems and may cause migration problems.
+       guest as <filename>/dev/vd<replaceable>X</replaceable></filename>, which
+       is different from device names in physical systems and may cause
+       migration problems.
       </para>
       <para>
-       <systemitem>virtio-scsi</systemitem> keeps the device names identical
-       to those on physical systems, making the virtual machines easily
+       <systemitem>virtio-scsi</systemitem> keeps the device names identical to
+       those on physical systems, making the virtual machines easily
        relocatable.
       </para>
      </listitem>
@@ -209,13 +202,11 @@ kvm                   411041  1 kvm_intel</screen>
      <listitem>
       <para>
        For virtual disks backed by a whole LUN on the host, it is preferable
-       for the guest to send SCSI commands directly to the LUN
-       (pass-through). This is limited in
-       <systemitem>virtio-blk</systemitem>, as guests need to use the
-       virtio-blk protocol instead of SCSI command pass-through, and,
-       moreover, it is not available for Windows guests.
-       <systemitem>virtio-scsi</systemitem> natively removes these
-       limitations.
+       for the guest to send SCSI commands directly to the LUN (pass-through).
+       This is limited in <systemitem>virtio-blk</systemitem>, as guests need
+       to use the virtio-blk protocol instead of SCSI command pass-through,
+       and, moreover, it is not available for Windows guests.
+       <systemitem>virtio-scsi</systemitem> natively removes these limitations.
       </para>
      </listitem>
     </varlistentry>
@@ -234,10 +225,10 @@ kvm                   411041  1 kvm_intel</screen>
   <sect2 xml:id="kvm-qemu-vnet">
    <title>Accelerated Networking with <systemitem>vhost-net</systemitem></title>
    <para>
-    The <systemitem>vhost-net</systemitem> module is used to accelerate
-    &kvm;'s paravirtualized network drivers. It provides better latency and
-    greater network throughput. Use the <literal>vhost-net</literal>
-    driver by starting the guest with the following example command line:
+    The <systemitem>vhost-net</systemitem> module is used to accelerate &kvm;'s
+    paravirtualized network drivers. It provides better latency and greater
+    network throughput. Use the <literal>vhost-net</literal> driver by starting
+    the guest with the following example command line:
    </para>
 <screen>&prompt.root;qemu-system-x86_64 [...] \
 -netdev tap,id=guest0,vhost=on,script=no \
@@ -251,12 +242,11 @@ kvm                   411041  1 kvm_intel</screen>
   <sect2 xml:id="kvm-qemu-multiqueue">
    <title>Scaling Network Performance with Multiqueue virtio-net</title>
    <para>
-    As the number of virtual CPUs increases in &vmguest;s, &qemu; offers a
-    way of improving the network performance using
-    <emphasis>multiqueue</emphasis>. Multiqueue virtio-net scales the
-    network performance by allowing &vmguest; virtual CPUs to transfer
-    packets in parallel. Multiqueue support is required on both the &vmhost;
-    and &vmguest; sides.
+    As the number of virtual CPUs increases in &vmguest;s, &qemu; offers a way
+    of improving the network performance using <emphasis>multiqueue</emphasis>.
+    Multiqueue virtio-net scales the network performance by allowing &vmguest;
+    virtual CPUs to transfer packets in parallel. Multiqueue support is
+    required on both the &vmhost; and &vmguest; sides.
    </para>
    <tip>
     <title>Performance Benefit</title>
@@ -272,9 +262,9 @@ kvm                   411041  1 kvm_intel</screen>
      </listitem>
      <listitem>
       <para>
-       &vmguest; has many connections active at the same time, mainly
-       between the guest systems, or between the guest and the host, or
-       between the guest and an external system.
+       &vmguest; has many connections active at the same time, mainly between
+       the guest systems, or between the guest and the host, or between the
+       guest and an external system.
       </para>
      </listitem>
      <listitem>
@@ -296,8 +286,8 @@ kvm                   411041  1 kvm_intel</screen>
     <para>
      The following procedure lists important steps to enable the multiqueue
      feature with <command>qemu-system-ARCH</command>. It assumes that a tap
-     network device with multiqueue capability (supported since kernel
-     version 3.8) is set up on the &vmhost;.
+     network device with multiqueue capability (supported since kernel version
+     3.8) is set up on the &vmhost;.
     </para>
     <step>
      <para>
@@ -312,13 +302,12 @@ kvm                   411041  1 kvm_intel</screen>
     <step>
      <para>
       In <command>qemu-system-ARCH</command>, enable multiqueue and specify
-      MSI-X (Message Signaled Interrupt) vectors for the virtio-net-pci
-      device:
+      MSI-X (Message Signaled Interrupt) vectors for the virtio-net-pci device:
      </para>
 <screen>-device virtio-net-pci,mq=on,vectors=<replaceable>2*N+2</replaceable></screen>
      <para>
-      where the formula for the number of MSI-X vectors results from: N
-      vectors for TX (transmit) queues, N for RX (receive) queues, one for
+      where the formula for the number of MSI-X vectors results from: N vectors
+      for TX (transmit) queues, N for RX (receive) queues, one for
       configuration purposes, and one for possible VQ (vector quantization)
       control.
      </para>
@@ -342,8 +331,8 @@ kvm                   411041  1 kvm_intel</screen>
     (<literal>guest0</literal> ) needs to be identical for both options.
    </para>
    <para>
-    Inside the running &vmguest;, specify the following command with
-    &rootuser; privileges:
+    Inside the running &vmguest;, specify the following command with &rootuser;
+    privileges:
    </para>
 <screen>&prompt.sudo;ethtool -L eth0 combined 8</screen>
    <para>
@@ -357,20 +346,19 @@ kvm                   411041  1 kvm_intel</screen>
    <para>
     Directly assigning a PCI device to a &vmguest; (PCI pass-through) avoids
     performance issues caused by avoiding any emulation in performance-critical
-    paths. VFIO replaces the traditional &kvm; &pciback; device
-    assignment. A prerequisite for this feature is a &vmhost; configuration
-    as described in <xref linkend="ann-vt-io-require"/>.
+    paths. VFIO replaces the traditional &kvm; &pciback; device assignment. A
+    prerequisite for this feature is a &vmhost; configuration as described in
+    <xref linkend="ann-vt-io-require"/>.
    </para>
    <para>
-    To be able to assign a PCI device via VFIO to a &vmguest;, you need to
-    find out which IOMMU Group it belongs to. The
+    To be able to assign a PCI device via VFIO to a &vmguest;, you need to find
+    out which IOMMU Group it belongs to. The
     <xref
     linkend="gloss-vt-acronym-iommu"/> (input/output memory
-    management unit that connects a direct memory access-capable I/O bus to
-    the main memory) API supports the notion of groups. A group is a set of
-    devices that can be isolated from all other devices in the system.
-    Groups are therefore the unit of ownership used by
-    <xref linkend="vt-io-vfio"/>.
+    management unit that connects a direct memory access-capable I/O bus to the
+    main memory) API supports the notion of groups. A group is a set of devices
+    that can be isolated from all other devices in the system. Groups are
+    therefore the unit of ownership used by <xref linkend="vt-io-vfio"/>.
    </para>
    <procedure>
     <title>Assigning a PCI Device to a &vmguest; via VFIO</title>
@@ -384,8 +372,8 @@ kvm                   411041  1 kvm_intel</screen>
 Virtual Function [8086:10ca] (rev 01)
 [...]</screen>
      <para>
-      Note down the device ID (<literal>00:10.0</literal> in this case) and
-      the vendor ID (<literal>8086:10ca</literal>).
+      Note down the device ID (<literal>00:10.0</literal> in this case) and the
+      vendor ID (<literal>8086:10ca</literal>).
      </para>
     </step>
     <step>
@@ -411,8 +399,7 @@ Virtual Function [8086:10ca] (rev 01)
     </step>
     <step>
      <para>
-      Bind the device to the vfio-pci driver using the vendor ID from step
-      1:
+      Bind the device to the vfio-pci driver using the vendor ID from step 1:
      </para>
 <screen>&prompt.sudo;echo "8086 153a" &gt; /sys/bus/pci/drivers/vfio-pci/new_id</screen>
      <para>
@@ -439,8 +426,8 @@ Virtual Function [8086:10ca] (rev 01)
    <important>
     <title>No Hotplugging</title>
     <para>
-     As of &productname; &productnumber; hotplugging of PCI devices passed
-     to a &vmguest; via VFIO is not supported.
+     As of &productname; &productnumber; hotplugging of PCI devices passed to a
+     &vmguest; via VFIO is not supported.
     </para>
    </important>
 <!-- fs 2015-10-09: not yet supported
@@ -466,10 +453,10 @@ Virtual Function [8086:10ca] (rev 01)
    </itemizedlist>
 -->
    <para>
-    You can find more detailed information on the
-    <xref linkend="vt-io-vfio"/> driver in the
-    <filename>/usr/src/linux/Documentation/vfio.txt</filename> file (package
-    <systemitem>kernel-source</systemitem> needs to be installed).
+    You can find more detailed information on the <xref linkend="vt-io-vfio"/>
+    driver in the <filename>/usr/src/linux/Documentation/vfio.txt</filename>
+    file (package <systemitem>kernel-source</systemitem> needs to be
+    installed).
    </para>
   </sect2>
 
@@ -477,8 +464,8 @@ Virtual Function [8086:10ca] (rev 01)
    <title>VirtFS: Sharing Directories between Host and Guests</title>
    <para>
     &vmguest;s usually run in a separate computing space&mdash;they are
-    provided their own memory range, dedicated CPUs, and file system space.
-    The ability to share parts of the &vmhost;'s file system makes the
+    provided their own memory range, dedicated CPUs, and file system space. The
+    ability to share parts of the &vmhost;'s file system makes the
     virtualization environment more flexible by simplifying mutual data
     exchange. Network file systems, such as CIFS and NFS, have been the
     traditional way of sharing directories. But as they are not specifically
@@ -486,12 +473,11 @@ Virtual Function [8086:10ca] (rev 01)
     and feature issues.
    </para>
    <para>
-    &kvm; introduces a new optimized method called
-    <emphasis>VirtFS</emphasis> (sometimes called <quote>file system
-    pass-through</quote>). VirtFS uses a paravirtual file system driver,
-    which avoids converting the guest application file system operations
-    into block device operations, and then again into host file system
-    operations.
+    &kvm; introduces a new optimized method called <emphasis>VirtFS</emphasis>
+    (sometimes called <quote>file system pass-through</quote>). VirtFS uses a
+    paravirtual file system driver, which avoids converting the guest
+    application file system operations into block device operations, and then
+    again into host file system operations.
    </para>
    <para>
     You typically use VirtFS for the following situations:
@@ -505,8 +491,8 @@ Virtual Function [8086:10ca] (rev 01)
     </listitem>
     <listitem>
      <para>
-      To replace the virtual disk as the root file system to which the
-      guest's RAM disk connects during the guest boot process.
+      To replace the virtual disk as the root file system to which the guest's
+      RAM disk connects during the guest boot process.
      </para>
     </listitem>
     <listitem>
@@ -555,10 +541,10 @@ Virtual Function [8086:10ca] (rev 01)
       <callout arearefs="co-virtfs-host-sec-model">
        <para>
         Security model to be used&mdash;<literal>mapped</literal> keeps the
-        guest file system modes and permissions isolated from the host,
-        while <literal>none</literal> invokes a <quote>pass-through</quote>
-        security model in which permission changes on the guest's files are
-        reflected on the host as well.
+        guest file system modes and permissions isolated from the host, while
+        <literal>none</literal> invokes a <quote>pass-through</quote> security
+        model in which permission changes on the guest's files are reflected on
+        the host as well.
        </para>
       </callout>
       <callout arearefs="co-virtfs-host-fsdev">
@@ -579,8 +565,8 @@ Virtual Function [8086:10ca] (rev 01)
 <screen>&prompt.sudo;mount -t 9p -o trans=virtio v_tmp /mnt</screen>
      <para>
       where <literal>v_tmp</literal> is the mount tag defined earlier with
-      <literal>-device mount_tag=</literal> and <literal>/mnt</literal> is
-      the mount point where you want to mount the exported file system.
+      <literal>-device mount_tag=</literal> and <literal>/mnt</literal> is the
+      mount point where you want to mount the exported file system.
      </para>
     </example>
    </sect3>
@@ -592,15 +578,15 @@ Virtual Function [8086:10ca] (rev 01)
     Kernel Same Page Merging (<xref linkend="gloss-vt-acronym-ksm"/>) is a
     Linux kernel feature that merges identical memory pages from multiple
     running processes into one memory region. Because &kvm; guests run as
-    processes under Linux, <xref linkend="gloss-vt-acronym-ksm"/> provides
-    the memory overcommit feature to hypervisors for more efficient use of
-    memory. Therefore, if you need to run multiple virtual machines on a
-    host with limited memory, <xref linkend="gloss-vt-acronym-ksm"/> may be
-    helpful to you.
+    processes under Linux, <xref linkend="gloss-vt-acronym-ksm"/> provides the
+    memory overcommit feature to hypervisors for more efficient use of memory.
+    Therefore, if you need to run multiple virtual machines on a host with
+    limited memory, <xref linkend="gloss-vt-acronym-ksm"/> may be helpful to
+    you.
    </para>
    <para>
-    <xref linkend="gloss-vt-acronym-ksm"/> stores its status information in
-    the files under the <filename>/sys/kernel/mm/ksm</filename> directory:
+    <xref linkend="gloss-vt-acronym-ksm"/> stores its status information in the
+    files under the <filename>/sys/kernel/mm/ksm</filename> directory:
    </para>
 <screen>&prompt.user;ls -1 /sys/kernel/mm/ksm
 full_scans
@@ -632,9 +618,9 @@ sleep_millisecs</screen>
     </step>
     <step>
      <para>
-      Now run several &vmguest;s under &kvm; and inspect the content of
-      files <filename>pages_sharing</filename> and
-      <filename>pages_shared</filename>, for example:
+      Now run several &vmguest;s under &kvm; and inspect the content of files
+      <filename>pages_sharing</filename> and <filename>pages_shared</filename>,
+      for example:
      </para>
 <screen>&prompt.user;while [ 1 ]; do cat /sys/kernel/mm/ksm/pages_shared; sleep 1; done
 13522


### PR DESCRIPTION
### Description
This PR introduces a procedure to configure multiqueue virtio-net via libvirt's virsh.
It also includes XML formatting fixes for relevant fiels.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
