### PR TITLE
AutoYaST: improve description of how partitioning works

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -794,7 +794,7 @@ exit 0
    <callout arearefs="co-ay-general-storage">
     <para>
 <!-- The Storage Section -->
-     <xref linkend="CreateProfile-General-storage" xrefstyle="HeadingOnPage"/>
+     <xref linkend="CreateProfile-Partitioning" xrefstyle="HeadingOnPage"/>
     </para>
    </callout>
    <callout arearefs="co-ay-general-wait">
@@ -2511,12 +2511,319 @@ openssl x509 -noout -fingerprint -sha256
 &lt;/device_map&gt;</screen>
    </sect2>
   </sect1>
+
   <sect1 xml:id="CreateProfile-Partitioning">
    <title>Partitioning</title>
 
    <para>
-    <remark role="fixme">Add a short description</remark>
+    When it comes to partitioning, we can categorize &ay; use cases into three
+    different levels:
    </para>
+
+   <itemizedlist mark="bullet" spacing="normal">
+    <listitem>
+     <para>
+      Automatic partitioning. The user does not care about the partitioning and
+      trusts in &ay; to do the right thing.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Guided partitioning. The user would like to set some basic settings.
+      E.g., a user would like to use LVM but has no idea about how to configure
+      partitions, volume groups, and so on.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Expert partitioning. The user specifies how the layout should look.
+      However, a complete definition is not required, and AutoYaST should propose
+      reasonable defaults for missing parts.
+     </para>
+    </listitem>
+   </itemizedlist>
+
+   <para>
+    To some extent, it is like using the regular installer. You can skip
+    the partitioning screen and trust in &yast;, use the <emphasis>Guided
+    Proposal</emphasis>, or define the partitioning layout through the
+    <emphasis>Expert Partitioner</emphasis>.
+   </para>
+
+   <sect2 xml:id="CreateProfile-Guided-Partitioning">
+    <title>Guided Partitioning</title>
+
+    <para>
+     Although &ay; can come up with a partitioning layout without any user
+     indication, sometimes it is useful to set some generic parameters and let
+     &ay; do the rest. For instance, you may be interested in using LVM or
+     encrypting your file systems without having to deal with the details. It is
+     similar to what you would do when using the guided proposal in a regular
+     installation.
+    </para>
+
+    <para>
+     The <literal>storage</literal> section in <xref
+     linkend="example-lvm-guided"/> instructs &ay; to set up a partitioning
+     layout using LVM and deleting all Windows partitions, no matter if needed
+     or not.
+    </para>
+
+    <example xml:id="example-lvm-guided">
+     <title>LVM-based Guided Partitioning</title>
+     <screen>&lt;general&gt;
+   &lt;storage&gt;
+     &lt;proposal&gt;
+       &lt;lvm config:type="boolean"&gt;true&lt;lvm&gt;
+       &lt;windows_delete_mode config:type="symbol"&gt;all&lt;windows_delete_mode&gt;
+     &lt;/proposal&gt;
+   &lt;storage&gt;
+&lt;general&gt;</screen>
+    </example>
+
+    <informaltable>
+     <tgroup cols="3">
+      <thead>
+       <row>
+        <entry>
+         <para>
+          Attribute
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Values
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Description
+         </para>
+        </entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>
+         <para>
+          <literal>lvm</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Boolean
+          <screen>&lt;lvm config:type="boolean"&gt;true&lt;/lvm&gt;</screen>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Create a LVM-based proposal. The default is <literal>false</literal>.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>resize_windows</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Boolean
+          <screen>&lt;resize_windows config:type="boolean"
+&gt;false&lt;/resize_windows&gt;</screen>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          When set to <literal>true</literal>, &ay; resizes Windows partitions
+          if needed to make room for the installation.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>windows_delete_mode</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Choose between:
+          <itemizedlist mark="bullet" spacing="normal">
+           <listitem>
+            <para>
+             <literal>none</literal> does not remove Windows partitions.
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>ondemand</literal> removes Windows partitions if needed.
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>all</literal> removes all Windows partitions.
+            </para>
+           </listitem>
+          </itemizedlist>
+          <screen>&lt;windows_delete_mode config:type="symbol"
+&gt;ondemand&lt;/windows_delete_mode&gt;</screen>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          By default, &ay; deletes Windows partitions on-demand.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>linux_delete_mode</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Choose between:
+          <itemizedlist mark="bullet" spacing="normal">
+           <listitem>
+            <para>
+             <literal>none</literal> does not remove Linux partitions.
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>ondemand</literal> removes Linux partitions if needed.
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>all</literal> removes all Linux partitions.
+            </para>
+           </listitem>
+          </itemizedlist>
+          <screen>&lt;linux_delete_mode config:type="symbol"
+&gt;ondemand&lt;/linux_delete_mode&gt;</screen>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          By default, &ay; deletes Linux partitions on-demand.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>other_delete_mode</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Choose between:
+          <itemizedlist mark="bullet" spacing="normal">
+           <listitem>
+            <para>
+             <literal>none</literal> does not remove other partitions (non
+             Windows or Linux).
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>ondemand</literal> removes other partitions if needed.
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>all</literal> removes all other partitions.
+            </para>
+           </listitem>
+          </itemizedlist>
+          <screen>&lt;other_delete_mode config:type="symbol"
+&gt;ondemand&lt;/other_delete_mode&gt;</screen>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          By default, &ay; deletes other partitions on-demand.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>encryption_password</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          String
+          <screen>&lt;encryption_password
+&gt;some-secret&lt;/encryption_password&gt;</screen>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Enables encryption using the specified password. By default,
+          encryption is disabled.
+         </para>
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </sect2>
+
+   <sect2 xml:id="CreateProfile-Expert-Partitioning">
+    <title>Expert Partitioning</title>
+
+    <para>
+     As an alternative to the guided partitioning, &ay; allows to describe the
+     partitioning layout through the use of a <literal>partitioning</literal>
+     section. However, &ay; does not need to know every single detail and it is
+     able to build a sensible layout from a rather incomplete specification.
+    </para>
+
+    <para>
+     The <literal>partitioning</literal> section is a list of
+     <literal>drive</literal> elements. Each of these sections describes an
+     element of the partitioning layout like a disk, an LVM volume group, a
+     RAID, a multi-device Btrfs file system, and so on.
+    </para>
+
+    <para>
+     In <xref linkend="example-partitioning"/>, asks &ay; to create a
+     <literal>/</literal>, a <literal>/home</literal> and a
+     <literal>swap</literal> partition using the whole disk. Note that some
+     information is missing, like which file systems each partition should
+     use. However, that is not a problem, and &ay; will propose sensible values
+     for them.
+    </para>
+
+    <example xml:id="example-partitioning">
+     <title>Creating <literal>/</literal>, <literal>/home</literal> and
+     <literal>swap</literal> partitions</title>
+     <screen>&lt;partitioning config:type="list"&gt;
+  &lt;drive&gt;
+    &lt;use&gt;all&lt;/use&gt;
+    &lt;partitions config:type="list"&gt;
+      &lt;partition&gt;
+        &lt;mount&gt;/&lt;/mount&gt;
+        &lt;size&gt;20GiB&lt;/size&gt;
+      &lt;/partition&gt;
+      &lt;partition&gt;
+        &lt;mount&gt;/home&lt;/mount&gt;
+        &lt;size&gt;max&lt;/size&gt;
+      &lt;/partition&gt;
+      &lt;partition&gt;
+        &lt;mount&gt;swap&lt;/mount&gt;
+        &lt;size&gt;1GiB&lt;/size&gt;
+      &lt;/partition&gt;
+    &lt;/partitions&gt;
+  &lt;/drive&gt;</screen>
+</example>
+   </sect2>
 
    <sect2 xml:id="CreateProfile-Partitioning-config">
     <title>Drive Configuration</title>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2512,10 +2512,11 @@ openssl x509 -noout -fingerprint -sha256
 
     <para>
      &ay; is able to come up with a sensible partitioning layout without any
-     user indication. By default, &ay; proposes a Btrfs root file system, a
-     separate <literal>/home</literal> using XFS and a swap partition.
-     Additionally, depending on the architecture, it adds any partition that
-     might be needed in order to boot (like BIOS Grub partitions).
+     user indication. Although it depends on the selected product to install,
+     &ay; usually proposes a Btrfs root file system, a separate
+     <literal>/home</literal> using XFS and a swap partition. Additionally,
+     depending on the architecture, it adds any partition that might be needed
+     in order to boot (like BIOS Grub partitions).
     </para>
 
     <para>
@@ -2653,7 +2654,7 @@ openssl x509 -noout -fingerprint -sha256
         </entry>
         <entry>
          <para>
-          By default, &ay; deletes Windows partitions on-demand.
+          Usually, &ay; deletes Windows partitions on-demand.
          </para>
         </entry>
        </row>
@@ -2689,7 +2690,7 @@ openssl x509 -noout -fingerprint -sha256
         </entry>
         <entry>
          <para>
-          By default, &ay; deletes Linux partitions on-demand.
+          Usually, &ay; deletes Linux partitions on-demand.
          </para>
         </entry>
        </row>
@@ -2726,7 +2727,7 @@ openssl x509 -noout -fingerprint -sha256
         </entry>
         <entry>
          <para>
-          By default, &ay; deletes other partitions on-demand.
+          Usually, &ay; deletes other partitions on-demand.
          </para>
         </entry>
        </row>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2802,326 +2802,349 @@ openssl x509 -noout -fingerprint -sha256
       &lt;/partition&gt;
     &lt;/partitions&gt;
   &lt;/drive&gt;</screen>
-</example>
-   </sect2>
+    </example>
 
-   <sect2 xml:id="CreateProfile-Partitioning-config">
-    <title>Drive Configuration</title>
-    <para>
-     The elements listed below must be placed within the following XML
-     structure:
-    </para>
-<screen>&lt;profile&gt;
+    <tip xml:id="ay-boot-partition">
+     <title>Proposing a Boot Partition</title>
+     <para>
+      &ay; checks whether the layout described in the profile is bootable or
+      not. If that is not the case, it adds the missing partitions. So, if you
+      are unsure about which partitions are needed to boot, you can rely on &ay;
+      to make the right decision.
+     </para>
+    </tip>
+
+    <sect3 xml:id="CreateProfile-Partitioning-config">
+     <title>Drive Configuration</title>
+     <para>
+      The elements listed below must be placed within the following XML
+      structure:
+     </para>
+
+     <screen>&lt;profile&gt;
   &lt;partitioning config:type="list"&gt;
     &lt;drive&gt;
      ...
     &lt;/drive&gt;
   &lt;/partitioning&gt;
 &lt;/profile&gt;</screen>
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Attribute
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Values
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>device</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          The device you want to configure in this section. You can use persistent
-          device names via ID, like
-          <filename>/dev/disk/by-id/ata-WDC_WD3200AAKS-75L9A0_WD-WMAV27368122</filename>
-          or <emphasis>by-path</emphasis>, like
-          <filename>/dev/disk/by-path/pci-0001:00:03.0-scsi-0:0:0:0</filename>.
-         </para>
-<screen>&lt;device&gt;/dev/sda&lt;/device&gt;</screen>
-        <para>
-          In case of volume groups, software RAID or &bcache; devices, the name in the installed
-          system may be different (to avoid clashes with existing devices).
-        </para>
-        </entry>
-        <entry>
-         <para>
-          Optional. If left out, &ay; tries to guess the device. See
-          <xref linkend="ay-partitioning-skip-devices"/> on how to influence
-          guessing.
-         </para>
-         <para>
-          If set to <literal>ask</literal>, &ay; will ask the user which device to use
-          during installation.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>initialize</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          If set to <literal>true</literal>, the partition table gets wiped
-          out before &ay; starts the partition calculation.
-         </para>
-<screen>&lt;initialize config:type="boolean"&gt;true&lt;/initialize&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          Optional. The default is <literal>false</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>partitions</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          A list of &lt;partition&gt; entries (see
-          <xref linkend="ay-partition-configuration"/>).
-         </para>
-<screen>&lt;partitions config:type="list"&gt;
-  &lt;partition&gt;...&lt;/partition&gt;
-  ...
-&lt;/partitions&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          Optional. If no partitions are specified, &ay; will create a
-          reasonable partitioning (see
-          <xref linkend="ay-auto-partitioning"/>).
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>pesize</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          This value only makes sense with LVM.
-         </para>
-<screen>&lt;pesize&gt;8M&lt;/pesize&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          Optional. Default is 4M for LVM volume groups.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>use</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Specifies the strategy &ay; will use to partition the hard
-          disk.
-         </para>
-         <para>
-          Choose between:
-         </para>
-         <itemizedlist mark="bullet" spacing="normal">
-          <listitem>
-           <para>
-            <literal>all</literal> (uses the whole device while calculating
-            the new partitioning),
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>linux</literal> (only existing Linux partitions are
-            used),
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>free</literal> (only unused space on the device is
-            used, no other partitions are touched),
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            1,2,3 (a list of comma separated partition numbers to use).
-           </para>
-          </listitem>
-         </itemizedlist>
-        </entry>
-        <entry>
-         <para>
-          This parameter should be provided.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>type</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Specify the type of the <literal>drive</literal>,
-         </para>
-         <para>
-          Choose between:
-         </para>
-         <itemizedlist mark="bullet" spacing="normal">
-          <listitem>
-           <para>
-            <literal>CT_DISK</literal> for physical hard disks (default),
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>CT_LVM</literal> for LVM volume groups,
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>CT_RAID</literal> for software RAID devices,
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>CT_BCACHE</literal> for software &bcache; devices.
-           </para>
-          </listitem>
-         </itemizedlist>
-<screen>&lt;type config:type="symbol"&gt;CT_LVM&lt;/type&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          Optional. Default is <literal>CT_DISK</literal> for a normal
-          physical hard disk.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>disklabel</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Describes the type of the partition table.
-         </para>
-         <para>
-          Choose between:
-         </para>
-         <itemizedlist mark="bullet" spacing="normal">
-          <listitem>
-           <para>
-            <literal>msdos</literal>
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>gpt</literal>
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>none</literal>
-           </para>
-          </listitem>
-         </itemizedlist>
-<screen>&lt;disklabel&gt;gpt&lt;/disklabel&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          Optional. By default &yast; decides what makes sense. If a partition
-          table of a different type already exists, it will be recreated with
-          the given type only if it does not include any partition that should
-          be kept or reused. To use the disk without creating any partition, set
-          this element to <literal>none</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>keep_unknown_lv</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          This value only makes sense for type=CT_LVM drives. If you are
-          reusing a logical volume group and you set this to
-          <literal>true</literal>, all existing logical volumes in that
-          group will not be touched unless they are specified in the
-          &lt;partitioning&gt; section. So you can keep existing
-          logical volumes without specifying them.
-         </para>
-<screen>&lt;keep_unknown_lv config:type="boolean"
-&gt;false&lt;/keep_unknown_lv&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          Optional. The default is <literal>false</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>enable_snapshots</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Enables snapshots on Btrfs file systems mounted at <literal>/</literal>
-          (does not apply to other file systems, or Btrfs file systems not mounted
-          at <literal>/</literal>).
-         </para>
-<screen>&lt;enable_snapshots config:type="boolean"
-&gt;false&lt;/enable_snapshots&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          Optional. The default is <literal>true</literal>.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-    <tip xml:id="ay-partitioning-skip-devices">
-     <title>Skipping Devices</title>
-     <para>
-      You can influence &ay;'s device-guessing for cases where you do not
-      specify a &lt;device&gt; entry on your own. Usually &ay;
-      would use the first device it can find that looks reasonable but you
-      can configure it to skip some devices like this:
-     </para>
-<screen>&lt;partitioning config:type="list"&gt;
+     <informaltable>
+      <tgroup cols="3">
+       <thead>
+        <row>
+         <entry>
+          <para>
+           Attribute
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Values
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Description
+          </para>
+         </entry>
+        </row>
+       </thead>
+       <tbody>
+        <row>
+         <entry>
+          <para>
+           <literal>device</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           The device you want to configure in this section. You can use persistent
+           device names via ID, like
+           <filename>/dev/disk/by-id/ata-WDC_WD3200AAKS-75L9A0_WD-WMAV27368122</filename>
+           or <emphasis>by-path</emphasis>, like
+           <filename>/dev/disk/by-path/pci-0001:00:03.0-scsi-0:0:0:0</filename>.
+          </para>
+          <screen>&lt;device&gt;/dev/sda&lt;/device&gt;</screen>
+          <para>
+           In case of volume groups, software RAID or &bcache; devices, the name in the installed
+           system may be different (to avoid clashes with existing devices).
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Optional. If left out, &ay; tries to guess the device. See
+           <xref linkend="ay-partitioning-skip-devices"/> on how to influence
+           guessing.
+          </para>
+          <para>
+           If set to <literal>ask</literal>, &ay; will ask the user which device to use
+           during installation.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>initialize</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           If set to <literal>true</literal>, the partition table gets wiped
+           out before &ay; starts the partition calculation.
+          </para>
+          <screen>&lt;initialize config:type="boolean"&gt;true&lt;/initialize&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           Optional. The default is <literal>false</literal>.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>partitions</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           A list of &lt;partition&gt; entries (see
+           <xref linkend="ay-partition-configuration"/>).
+          </para>
+          <screen>&lt;partitions config:type="list"&gt;
+          &lt;partition&gt;...&lt;/partition&gt;
+          ...
+          &lt;/partitions&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           Optional. If no partitions are specified, &ay; will create a
+           reasonable partitioning (see
+           <xref linkend="ay-auto-partitioning"/>).
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>pesize</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           This value only makes sense with LVM.
+          </para>
+          <screen>&lt;pesize&gt;8M&lt;/pesize&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           Optional. Default is 4M for LVM volume groups.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>use</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Specifies the strategy &ay; will use to partition the hard
+           disk.
+          </para>
+          <para>
+           Choose between:
+          </para>
+          <itemizedlist mark="bullet" spacing="normal">
+           <listitem>
+            <para>
+             <literal>all</literal> (uses the whole device while calculating
+             the new partitioning),
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>linux</literal> (only existing Linux partitions are
+             used),
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>free</literal> (only unused space on the device is
+             used, no other partitions are touched),
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             1,2,3 (a list of comma separated partition numbers to use).
+            </para>
+           </listitem>
+          </itemizedlist>
+         </entry>
+         <entry>
+          <para>
+           This parameter should be provided.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>type</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Specify the type of the <literal>drive</literal>,
+          </para>
+          <para>
+           Choose between:
+          </para>
+          <itemizedlist mark="bullet" spacing="normal">
+           <listitem>
+            <para>
+             <literal>CT_DISK</literal> for physical hard disks (default),
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>CT_LVM</literal> for LVM volume groups,
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>CT_RAID</literal> for software RAID devices,
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>CT_BCACHE</literal> for software &bcache; devices.
+            </para>
+           </listitem>
+          </itemizedlist>
+          <screen>&lt;type config:type="symbol"&gt;CT_LVM&lt;/type&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           Optional. Default is <literal>CT_DISK</literal> for a normal
+           physical hard disk.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>disklabel</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Describes the type of the partition table.
+          </para>
+          <para>
+           Choose between:
+          </para>
+          <itemizedlist mark="bullet" spacing="normal">
+           <listitem>
+            <para>
+             <literal>msdos</literal>
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>gpt</literal>
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>none</literal>
+            </para>
+           </listitem>
+          </itemizedlist>
+          <screen>&lt;disklabel&gt;gpt&lt;/disklabel&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           Optional. By default &yast; decides what makes sense. If a partition
+           table of a different type already exists, it will be recreated with
+           the given type only if it does not include any partition that should
+           be kept or reused. To use the disk without creating any partition, set
+           this element to <literal>none</literal>.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>keep_unknown_lv</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           This value only makes sense for type=CT_LVM drives. If you are
+           reusing a logical volume group and you set this to
+           <literal>true</literal>, all existing logical volumes in that
+           group will not be touched unless they are specified in the
+           &lt;partitioning&gt; section. So you can keep existing
+           logical volumes without specifying them.
+          </para>
+          <screen>&lt;keep_unknown_lv config:type="boolean"
+          &gt;false&lt;/keep_unknown_lv&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           Optional. The default is <literal>false</literal>.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>enable_snapshots</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Enables snapshots on Btrfs file systems mounted at <literal>/</literal>
+           (does not apply to other file systems, or Btrfs file systems not mounted
+           at <literal>/</literal>).
+          </para>
+          <screen>&lt;enable_snapshots config:type="boolean"
+          &gt;false&lt;/enable_snapshots&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           Optional. The default is <literal>true</literal>.
+          </para>
+         </entry>
+        </row>
+       </tbody>
+      </tgroup>
+     </informaltable>
+
+     <important>
+      <title>Beware of Data Loss</title>
+      <para>
+       The value provided in the <literal>use</literal> property determines
+       how existing data and partitions are treated. The value
+       <literal>all</literal> means that the entire disk will be erased. Make
+       backups and use the <literal>confirm</literal> property if you need to
+       keep some partitions with important data. Otherwise, no pop-ups will
+       notify you about partitions being deleted.
+      </para>
+     </important>
+
+     <tip xml:id="ay-partitioning-skip-devices">
+      <title>Skipping Devices</title>
+      <para>
+       You can influence &ay;'s device-guessing for cases where you do not
+       specify a &lt;device&gt; entry on your own. Usually &ay;
+       would use the first device it can find that looks reasonable but you
+       can configure it to skip some devices like this:
+      </para>
+      <screen>&lt;partitioning config:type="list"&gt;
   &lt;drive&gt;
     &lt;initialize config:type="boolean"&gt;true&lt;/initialize&gt;
     &lt;skip_list config:type="list"&gt;
@@ -3145,489 +3168,489 @@ openssl x509 -noout -fingerprint -sha256
     &lt;/skip_list&gt;
   &lt;/drive&gt;
 &lt;/partitioning&gt;</screen>
-     <para>
-      For a list of all possible &lt;skip_key&gt;s, run <command>yast2
-      ayast_probe</command> on a system that has already been installed.
-     </para>
-    </tip>
-   </sect2>
+      <para>
+       For a list of all possible &lt;skip_key&gt;s, run <command>yast2
+       ayast_probe</command> on a system that has already been installed.
+      </para>
+     </tip>
+    </sect3>
 
-   <sect2 xml:id="ay-partition-configuration">
-    <title>Partition Configuration</title>
-    <para>
-     The elements listed below must be placed within the following XML
-     structure:
-    </para>
-<screen>&lt;drive&gt;
+    <sect3 xml:id="ay-partition-configuration">
+     <title>Partition Configuration</title>
+     <para>
+      The elements listed below must be placed within the following XML
+      structure:
+     </para>
+     <screen>&lt;drive&gt;
   &lt;partitions config:type="list"&gt;
     &lt;partition&gt;
       ...
     &lt;/partition&gt;
   &lt;/partitions&gt;
 &lt;/drive&gt;</screen>
-    <informaltable>
-     <tgroup cols="3">
-      <colspec colwidth="1*"/>
-      <colspec colwidth="3*"/>
-      <colspec colwidth="2*"/>
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Attribute
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Values
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>create</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Specify if this partition or logical volume must be created or if it already exists.
-         </para>
-<screen>&lt;create config:type="boolean" &gt;false&lt;/create&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          If set to <literal>false</literal>, you also need to set one of
-          <literal>partition_nr</literal>, <literal>lv_name</literal>, <literal>label</literal>
-          or <literal>uuid</literal> to tell &ay; which device to use.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>crypt_method</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Partition will be encrypted using one of these methods:
-         </para>
+     <informaltable>
+      <tgroup cols="3">
+       <colspec colwidth="1*"/>
+       <colspec colwidth="3*"/>
+       <colspec colwidth="2*"/>
+       <thead>
+        <row>
+         <entry>
+          <para>
+           Attribute
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Values
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Description
+          </para>
+         </entry>
+        </row>
+       </thead>
+       <tbody>
+        <row>
+         <entry>
+          <para>
+           <literal>create</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Specify if this partition or logical volume must be created or if it already exists.
+          </para>
+          <screen>&lt;create config:type="boolean" &gt;false&lt;/create&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           If set to <literal>false</literal>, you also need to set one of
+           <literal>partition_nr</literal>, <literal>lv_name</literal>, <literal>label</literal>
+           or <literal>uuid</literal> to tell &ay; which device to use.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>crypt_method</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Partition will be encrypted using one of these methods:
+          </para>
 
-         <itemizedlist mark="bullet" spacing="normal">
-          <listitem>
-           <para>
-            <literal>luks1</literal>: regular LUKS1 encryption.
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>pervasive_luks2</literal>: pervasive volume encryption.
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>protected_swap</literal>: encryption with volatile
-            protected key.
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>secure_swap</literal>: encryption with volatile secure sey.
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>random_swap</literal>: encryption with volatile random key.
-           </para>
-          </listitem>
-         </itemizedlist>
-         <screen>&lt;crypt_method config:type="symbol"&gt;luks1&lt;/crypt_method&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          Optional. Encryption method selection was introduced in &productname;
-          <phrase os="sles;sled">15 SP2</phrase><phrase os="osuse">15.2</phrase>.
-          To mimic the behaviour of previous versions, use <literal>luks1</literal>.
-         </para>
-         <para>
-          See <literal>crypt_key</literal> element to find out how to specify
-          the encryption password if needed.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>crypt_fs</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Partition will be encrypted. This element is deprecated, use
-          <literal>crypt_method</literal> instead.
-         </para>
-<screen>&lt;crypt_fs config:type="boolean"&gt;true&lt;/crypt_fs&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          Default is <literal>false</literal>.
-         </para>
-        </entry>
-       </row>
+          <itemizedlist mark="bullet" spacing="normal">
+           <listitem>
+            <para>
+             <literal>luks1</literal>: regular LUKS1 encryption.
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>pervasive_luks2</literal>: pervasive volume encryption.
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>protected_swap</literal>: encryption with volatile
+             protected key.
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>secure_swap</literal>: encryption with volatile secure sey.
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>random_swap</literal>: encryption with volatile random key.
+            </para>
+           </listitem>
+          </itemizedlist>
+          <screen>&lt;crypt_method config:type="symbol"&gt;luks1&lt;/crypt_method&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           Optional. Encryption method selection was introduced in &productname;
+           <phrase os="sles;sled">15 SP2</phrase><phrase os="osuse">15.2</phrase>.
+           To mimic the behaviour of previous versions, use <literal>luks1</literal>.
+          </para>
+          <para>
+           See <literal>crypt_key</literal> element to find out how to specify
+           the encryption password if needed.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>crypt_fs</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Partition will be encrypted. This element is deprecated, use
+           <literal>crypt_method</literal> instead.
+          </para>
+          <screen>&lt;crypt_fs config:type="boolean"&gt;true&lt;/crypt_fs&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           Default is <literal>false</literal>.
+          </para>
+         </entry>
+        </row>
 
-       <row>
-        <entry>
-         <para>
-          <literal>crypt_key</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Encryption key
-         </para>
-<screen>&lt;crypt_key&gt;xxxxxxxx&lt;/crypt_key&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          Needed if <literal>crypt_method</literal> has been set to
-          a method that requires a password (i.e., <literal>luks1</literal>
-          or <literal>pervasive_luks2</literal>).
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>mount</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          The mount point of this partition.
-         </para>
-<screen>&lt;mount&gt;/&lt;/mount&gt;
+        <row>
+         <entry>
+          <para>
+           <literal>crypt_key</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Encryption key
+          </para>
+          <screen>&lt;crypt_key&gt;xxxxxxxx&lt;/crypt_key&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           Needed if <literal>crypt_method</literal> has been set to
+           a method that requires a password (i.e., <literal>luks1</literal>
+           or <literal>pervasive_luks2</literal>).
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>mount</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           The mount point of this partition.
+          </para>
+          <screen>&lt;mount&gt;/&lt;/mount&gt;
 &lt;mount&gt;swap&lt;/mount&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          You should have at least a root partition (/) and a swap
-          partition.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>fstopt</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Mount options for this partition.
-         </para>
-<screen>&lt;fstopt&gt;
+         </entry>
+         <entry>
+          <para>
+           You should have at least a root partition (/) and a swap
+           partition.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>fstopt</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Mount options for this partition.
+          </para>
+          <screen>&lt;fstopt&gt;
   ro,noatime,user,data=ordered,acl,user_xattr
 &lt;/fstopt&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          See <command>man mount</command> for available mount options.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>label</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          The label of the partition. Useful when formatting the device
-          (especially if the <literal>mountby</literal> parameter is set to
-          <literal>label</literal>) and for identifying a device that already
-          exists (see <literal>create</literal> above).
-         </para>
-<screen>&lt;label&gt;mydata&lt;/label&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          See <command>man e2label</command> for an example.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>uuid</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          The uuid of the partition. Only useful for indentifying an
-          existing device (see <literal>create</literal> above),
-          the uuid cannot be enforced for new devices.
-         </para>
-<screen>&lt;uuid
+         </entry>
+         <entry>
+          <para>
+           See <command>man mount</command> for available mount options.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>label</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           The label of the partition. Useful when formatting the device
+           (especially if the <literal>mountby</literal> parameter is set to
+           <literal>label</literal>) and for identifying a device that already
+           exists (see <literal>create</literal> above).
+          </para>
+          <screen>&lt;label&gt;mydata&lt;/label&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           See <command>man e2label</command> for an example.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>uuid</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           The uuid of the partition. Only useful for indentifying an
+           existing device (see <literal>create</literal> above),
+           the uuid cannot be enforced for new devices.
+          </para>
+          <screen>&lt;uuid
 &gt;1b4e28ba-2fa1-11d2-883f-b9a761bde3fb&lt;/uuid&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          See <command>man uuidgen</command>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>size</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          The size of the partition, for example 4G, 4500M, etc. The /boot
-          partition and the swap partition can have <literal>auto</literal>
-          as size. Then &ay; calculates a reasonable size. One partition
-          can have the value <literal>max</literal> to use all remaining
-          space.
-         </para>
-         <para>
-          You can also specify the size in percentage. So 10% will use 10%
-          of the size of the hard disk or volume group. You can mix auto,
-          max, size, and percentage as you like.
-         </para>
-<screen>&lt;size&gt;10G&lt;/size&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          Starting with &productname; 15, all values (including
-          <literal>auto</literal> and <literal>max</literal>) can be used for
-          resizing partitions as well.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>format</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Specify if &ay; should format the partition.
-         </para>
-<screen>&lt;format config:type="boolean"&gt;false&lt;/format&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          If you set <literal>create</literal> to <literal>true</literal>,
-          then you likely want this option set to <literal>true</literal> as
-          well.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>file system</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Specify the file system to use on this partition:
-         </para>
-         <itemizedlist mark="bullet" spacing="normal">
-          <listitem>
-           <para>
-            <literal>btrfs</literal>
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>ext2</literal>
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>ext3</literal>
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>ext4</literal>
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>fat</literal>
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>xfs</literal>
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>swap</literal>
-           </para>
-          </listitem>
-         </itemizedlist>
-<screen>&lt;filesystem config:type="symbol"
+         </entry>
+         <entry>
+          <para>
+           See <command>man uuidgen</command>.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>size</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           The size of the partition, for example 4G, 4500M, etc. The /boot
+           partition and the swap partition can have <literal>auto</literal>
+           as size. Then &ay; calculates a reasonable size. One partition
+           can have the value <literal>max</literal> to use all remaining
+           space.
+          </para>
+          <para>
+           You can also specify the size in percentage. So 10% will use 10%
+           of the size of the hard disk or volume group. You can mix auto,
+           max, size, and percentage as you like.
+          </para>
+          <screen>&lt;size&gt;10G&lt;/size&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           Starting with &productname; 15, all values (including
+           <literal>auto</literal> and <literal>max</literal>) can be used for
+           resizing partitions as well.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>format</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Specify if &ay; should format the partition.
+          </para>
+          <screen>&lt;format config:type="boolean"&gt;false&lt;/format&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           If you set <literal>create</literal> to <literal>true</literal>,
+           then you likely want this option set to <literal>true</literal> as
+           well.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>file system</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Specify the file system to use on this partition:
+          </para>
+          <itemizedlist mark="bullet" spacing="normal">
+           <listitem>
+            <para>
+             <literal>btrfs</literal>
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>ext2</literal>
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>ext3</literal>
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>ext4</literal>
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>fat</literal>
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>xfs</literal>
+            </para>
+           </listitem>
+           <listitem>
+            <para>
+             <literal>swap</literal>
+            </para>
+           </listitem>
+          </itemizedlist>
+          <screen>&lt;filesystem config:type="symbol"
 &gt;ext3&lt;/filesystem&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          Optional. The default is <literal>btrfs</literal> for the root
-          partition (<filename>/</filename>) and <literal>xfs</literal> for
-          data partitions.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>mkfs_options</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Specify an option string that is added to the mkfs command.
-         </para>
-<screen>&lt;mkfs_options&gt;-I 128&lt;/mkfs_options&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          Optional. Only use this when you know what you are doing.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>partition_nr</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          The partition number of this partition. If you have set
-          <literal>create=false</literal> or if you use LVM, then you can
-          specify the partition via <literal>partition_nr</literal>. You can
-          force &ay; to only create primary partitions by assigning
-          numbers below 5.
-         </para>
-<screen>&lt;partition_nr config:type="integer"
+         </entry>
+         <entry>
+          <para>
+           Optional. The default is <literal>btrfs</literal> for the root
+           partition (<filename>/</filename>) and <literal>xfs</literal> for
+           data partitions.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>mkfs_options</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Specify an option string that is added to the mkfs command.
+          </para>
+          <screen>&lt;mkfs_options&gt;-I 128&lt;/mkfs_options&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           Optional. Only use this when you know what you are doing.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>partition_nr</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           The partition number of this partition. If you have set
+           <literal>create=false</literal> or if you use LVM, then you can
+           specify the partition via <literal>partition_nr</literal>. You can
+           force &ay; to only create primary partitions by assigning
+           numbers below 5.
+          </para>
+          <screen>&lt;partition_nr config:type="integer"
 &gt;2&lt;/partition_nr&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          Usually, numbers 1 to 4 are primary partitions while 5 and higher
-          are logical partitions.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>partition_id</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          The <literal>partition_id</literal> sets the id of the partition.
-          If you want different identifiers than 131 for Linux partition or
-          130 for swap, configure them with partition_id.
-         </para>
-<screen>&lt;partition_id config:type="integer"
+         </entry>
+         <entry>
+          <para>
+           Usually, numbers 1 to 4 are primary partitions while 5 and higher
+           are logical partitions.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>partition_id</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           The <literal>partition_id</literal> sets the id of the partition.
+           If you want different identifiers than 131 for Linux partition or
+           130 for swap, configure them with partition_id.
+          </para>
+          <screen>&lt;partition_id config:type="integer"
 &gt;131&lt;/partition_id&gt;</screen>
-         <para>
-          Possible values are:
-         </para>
-         <simplelist>
-          <member>Swap: <literal>130</literal></member>
-          <member>Linux: <literal>131</literal></member>
-          <member>LVM: <literal>142</literal></member>
-          <member>MD RAID: <literal>253</literal></member>
-          <member>EFI partition: <literal>259</literal></member>
-         </simplelist>
-        </entry>
-        <entry>
-         <para>
-          The default is <literal>131</literal> for Linux partition and
-          <literal>130</literal> for swap.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>partition_type</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          When using an <literal>msdos</literal> partition table, this
-          element sets the type of the partition. The value can be
-          <literal>primary</literal> or <literal>logical</literal>.
-          This value is ignored when using a <literal>gpt</literal>
-          partition table, because such a distinction does not exist in
-          that case.
-         </para>
-<screen>&lt;partition_type&gt;primary&lt;/partition_type&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          Optional. Allowed values are <literal>primary</literal> (default) and
-          <literal>logical</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>mountby</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Instead of a partition number, you can tell &ay; to mount a
-          partition by <literal>device</literal>, <literal>label</literal>,
-          <literal>uuid</literal>, <literal>path</literal> or
-          <literal>id</literal>, which are the udev path and udev id (see
-          <filename>/dev/disk/...</filename>).
-         </para>
-<screen>&lt;mountby config:type="symbol"
+<para>
+ Possible values are:
+</para>
+<simplelist>
+ <member>Swap: <literal>130</literal></member>
+ <member>Linux: <literal>131</literal></member>
+ <member>LVM: <literal>142</literal></member>
+ <member>MD RAID: <literal>253</literal></member>
+ <member>EFI partition: <literal>259</literal></member>
+</simplelist>
+         </entry>
+         <entry>
+          <para>
+           The default is <literal>131</literal> for Linux partition and
+           <literal>130</literal> for swap.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>partition_type</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           When using an <literal>msdos</literal> partition table, this
+           element sets the type of the partition. The value can be
+           <literal>primary</literal> or <literal>logical</literal>.
+           This value is ignored when using a <literal>gpt</literal>
+           partition table, because such a distinction does not exist in
+           that case.
+          </para>
+          <screen>&lt;partition_type&gt;primary&lt;/partition_type&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           Optional. Allowed values are <literal>primary</literal> (default) and
+           <literal>logical</literal>.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>mountby</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Instead of a partition number, you can tell &ay; to mount a
+           partition by <literal>device</literal>, <literal>label</literal>,
+           <literal>uuid</literal>, <literal>path</literal> or
+           <literal>id</literal>, which are the udev path and udev id (see
+           <filename>/dev/disk/...</filename>).
+          </para>
+          <screen>&lt;mountby config:type="symbol"
 &gt;label&lt;/mountby&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          See <literal>label</literal> and <literal>uuid</literal>
-          documentation above. The default depends on &yast; and usually
-          is <literal>id</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>subvolumes</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          List of subvolumes to create for a file system of type Btrfs. This
-          key only makes sense for file systems of type Btrfs. See
-          <xref linkend="ay-btrfs-subvolumes"/> for more information.
-         </para>
-<screen>&lt;subvolumes config:type="list"&gt;
+         </entry>
+         <entry>
+          <para>
+           See <literal>label</literal> and <literal>uuid</literal>
+           documentation above. The default depends on &yast; and usually
+           is <literal>id</literal>.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>subvolumes</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           List of subvolumes to create for a file system of type Btrfs. This
+           key only makes sense for file systems of type Btrfs. See
+           <xref linkend="ay-btrfs-subvolumes"/> for more information.
+          </para>
+          <screen>&lt;subvolumes config:type="list"&gt;
   &lt;path&gt;tmp&lt;/path&gt;
   &lt;path&gt;opt&lt;/path&gt;
   &lt;path&gt;srv&lt;/path&gt;
@@ -3638,274 +3661,274 @@ openssl x509 -noout -fingerprint -sha256
   &lt;path&gt;var/spool&lt;/path&gt;
   ...
 &lt;/subvolumes&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          If no <tag>subvolumes</tag> section has been defined for a partition
-          description, &ay; will create a predefined set of subvolumes for the
-          given mount point.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>create_subvolumes</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Determine whether Btrfs subvolumes should be created or not.
-         </para>
-        </entry>
-        <entry>
-         <para>
-          It is set to <literal>true</literal> by default. When set to
-          <literal>false</literal>, no subvolumes will be created.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>subvolumes_prefix</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Set the Btrfs subvolumes prefix name. If no prefix is wanted,
-          it must be set to an empty value:
-         </para>
-         <screen>&lt;subvolumes_prefix&gt;&lt;![CDATA[]]&gt;&lt;/subvolumes_prefix&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          It is set to <literal>@</literal> by default.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>lv_name</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          If this partition is on a logical volume in a volume group, specify
-          the logical volume name here (see the <literal>is_lvm_vg</literal>
-          parameter in the drive configuration).
-         </para>
-<screen>&lt;lv_name&gt;opt_lv&lt;/lv_name&gt;</screen>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>stripes</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          An integer that configures LVM striping. Specify across how many
-          devices you want to stripe (spread data).
-         </para>
-<screen>&lt;stripes config:type="integer"&gt;2&lt;/stripes&gt;</screen>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>stripesize</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Specify the size of each block in KB.
-         </para>
-<screen>&lt;stripesize config:type="integer"
+         </entry>
+         <entry>
+          <para>
+           If no <tag>subvolumes</tag> section has been defined for a partition
+           description, &ay; will create a predefined set of subvolumes for the
+           given mount point.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>create_subvolumes</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Determine whether Btrfs subvolumes should be created or not.
+          </para>
+         </entry>
+         <entry>
+          <para>
+           It is set to <literal>true</literal> by default. When set to
+           <literal>false</literal>, no subvolumes will be created.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>subvolumes_prefix</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Set the Btrfs subvolumes prefix name. If no prefix is wanted,
+           it must be set to an empty value:
+          </para>
+          <screen>&lt;subvolumes_prefix&gt;&lt;![CDATA[]]&gt;&lt;/subvolumes_prefix&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           It is set to <literal>@</literal> by default.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>lv_name</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           If this partition is on a logical volume in a volume group, specify
+           the logical volume name here (see the <literal>is_lvm_vg</literal>
+           parameter in the drive configuration).
+          </para>
+          <screen>&lt;lv_name&gt;opt_lv&lt;/lv_name&gt;</screen>
+         </entry>
+         <entry>
+          <para/>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>stripes</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           An integer that configures LVM striping. Specify across how many
+           devices you want to stripe (spread data).
+          </para>
+          <screen>&lt;stripes config:type="integer"&gt;2&lt;/stripes&gt;</screen>
+         </entry>
+         <entry>
+          <para/>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>stripesize</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Specify the size of each block in KB.
+          </para>
+          <screen>&lt;stripesize config:type="integer"
 &gt;4&lt;/stripesize&gt;</screen>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>lvm_group</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          If this is a physical partition used by (part of) a volume group
-          (LVM), you need to specify the name of the volume group here.
-         </para>
+         </entry>
+         <entry>
+          <para/>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>lvm_group</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           If this is a physical partition used by (part of) a volume group
+           (LVM), you need to specify the name of the volume group here.
+          </para>
 <screen>&lt;lvm_group&gt;system&lt;/lvm_group&gt;</screen>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>pool</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          <literal>pool</literal> must be set to <literal>true</literal> if
-          the LVM logical volume should be an LVM thin pool.
-         </para>
-<screen>&lt;pool config:type="boolean"&gt;false&lt;/pool&gt;</screen>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>used_pool</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          The name of the LVM thin pool that is used as a data store for
-          this thin logical volume. If this is set to something non-empty,
-          it implies that the volume is a so-called thin logical volume.
-         </para>
-<screen>&lt;used_pool&gt;my_thin_pool&lt;/used_pool&gt;</screen>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>raid_name</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          If this physical volume is part of a RAID, specify the name of the
-          RAID.
-         </para>
-<screen>&lt;raid_name&gt;/dev/md/0&lt;/raid_name&gt;</screen>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>raid_options</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Specify RAID options, see below.
-         </para>
-<screen>&lt;raid_options&gt;...&lt;/raid_options&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          Setting the RAID options at <literal>partition</literal> level is deprecated.
-          See <xref linkend="ay-partition-sw-raid"/>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          bcache_backing_for
-         </para>
-        </entry>
-        <entry>
-         <para>
-          If this device is used as a <emphasis>&bcache; backing device</emphasis>, specify the name
-          of the &bcache; device.
-         </para>
-<screen>&lt;bcache_backing_for&gt;/dev/bcache0&lt;/bcache_backing_for&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          See <xref linkend="ay-partition-bcache"/> for further details.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          bcache_caching_for
-         </para>
-        </entry>
-        <entry>
-         <para>
-          If this device is used as a <emphasis>&bcache; caching device</emphasis>, specify the names
-          of the &bcache; devices.
-         </para>
-<screen>&lt;bcache_caching_for config:type="list"&gt;
+         </entry>
+         <entry>
+          <para/>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>pool</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           <literal>pool</literal> must be set to <literal>true</literal> if
+           the LVM logical volume should be an LVM thin pool.
+          </para>
+          <screen>&lt;pool config:type="boolean"&gt;false&lt;/pool&gt;</screen>
+         </entry>
+         <entry>
+          <para/>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>used_pool</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           The name of the LVM thin pool that is used as a data store for
+           this thin logical volume. If this is set to something non-empty,
+           it implies that the volume is a so-called thin logical volume.
+          </para>
+          <screen>&lt;used_pool&gt;my_thin_pool&lt;/used_pool&gt;</screen>
+         </entry>
+         <entry>
+          <para/>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>raid_name</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           If this physical volume is part of a RAID, specify the name of the
+           RAID.
+          </para>
+          <screen>&lt;raid_name&gt;/dev/md/0&lt;/raid_name&gt;</screen>
+         </entry>
+         <entry>
+          <para/>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>raid_options</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Specify RAID options, see below.
+          </para>
+          <screen>&lt;raid_options&gt;...&lt;/raid_options&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           Setting the RAID options at <literal>partition</literal> level is deprecated.
+           See <xref linkend="ay-partition-sw-raid"/>.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           bcache_backing_for
+          </para>
+         </entry>
+         <entry>
+          <para>
+           If this device is used as a <emphasis>&bcache; backing device</emphasis>, specify the name
+           of the &bcache; device.
+          </para>
+          <screen>&lt;bcache_backing_for&gt;/dev/bcache0&lt;/bcache_backing_for&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           See <xref linkend="ay-partition-bcache"/> for further details.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           bcache_caching_for
+          </para>
+         </entry>
+         <entry>
+          <para>
+           If this device is used as a <emphasis>&bcache; caching device</emphasis>, specify the names
+           of the &bcache; devices.
+          </para>
+          <screen>&lt;bcache_caching_for config:type="list"&gt;
   &lt;listentry&gt;/dev/bcache0&lt;/listentry&gt;
 &lt;/bcache_caching_for&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          See <xref linkend="ay-partition-bcache"/> for further details.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>resize</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          This boolean must be <literal>true</literal> if an existing
-          partition should be resized. In this case, you need to tell &ay;
-          to reuse the device (see <literal>create</literal>) and specify
-          a <literal>size</literal>.
-         </para>
-<screen>&lt;resize config:type="boolean"&gt;false&lt;/resize&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          Starting with &productname; 15 resizing works with physical disk
-          partitions and with LVM volumes.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+         </entry>
+         <entry>
+          <para>
+           See <xref linkend="ay-partition-bcache"/> for further details.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>resize</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           This boolean must be <literal>true</literal> if an existing
+           partition should be resized. In this case, you need to tell &ay;
+           to reuse the device (see <literal>create</literal>) and specify
+           a <literal>size</literal>.
+          </para>
+          <screen>&lt;resize config:type="boolean"&gt;false&lt;/resize&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           Starting with &productname; 15 resizing works with physical disk
+           partitions and with LVM volumes.
+          </para>
+         </entry>
+        </row>
+       </tbody>
+      </tgroup>
+     </informaltable>
 
-    <important>
-     <title>Creating Boot Partitions Automatically</title>
-     <para>
-      When &ay; determines that a boot partition might be required in order
-      to boot properly, it will automatically add one even if it is not specified
-      in the profile.
-     </para>
-     <para>
-      However, if for any reason the boot partition does not fit in the current
-      partitioning layout, &ay; will just display a warning, allowing the
-      installation to proceed.
-     </para>
-    </important>
-   </sect2>
+     <important>
+      <title>Creating Boot Partitions Automatically</title>
+      <para>
+       When &ay; determines that a boot partition might be required in order
+       to boot properly, it will automatically add one even if it is not specified
+       in the profile.
+      </para>
+      <para>
+       However, if for any reason the boot partition does not fit in the current
+       partitioning layout, &ay; will just display a warning, allowing the
+       installation to proceed.
+      </para>
+     </important>
+    </sect3>
 
-   <sect2 xml:id="ay-btrfs-subvolumes">
+    <sect3 xml:id="ay-btrfs-subvolumes">
      <title>Btrfs subvolumes</title>
      <para>
       As mentioned in <xref linkend="ay-partition-configuration"/>, it is
@@ -3947,28 +3970,28 @@ openssl x509 -noout -fingerprint -sha256
       <literal>subvolumes_prefix</literal>.
      </para>
 
-<screen>&lt;subvolumes_prefix&gt;&lt;![CDATA[]]&gt;&lt;/subvolumes_prefix&gt;</screen>
-   </sect2>
+     <screen>&lt;subvolumes_prefix&gt;&lt;![CDATA[]]&gt;&lt;/subvolumes_prefix&gt;</screen>
+    </sect3>
 
-   <sect2 xml:id="ay-use-whole-disk">
-    <title>Using the Whole Disk</title>
+    <sect3 xml:id="ay-use-whole-disk">
+     <title>Using the Whole Disk</title>
 
-    <para>
-     &ay; allows to use a whole disk without creating any partition by setting
-     the <literal>disklabel</literal> to <literal>none</literal> as described
-     in <xref linkend="CreateProfile-Partitioning-config"/>. In such cases, the configuration in the first
-     <literal>partition</literal> from the <literal>drive</literal> will be
-     applied to the whole disk.
-    </para>
+     <para>
+      &ay; allows to use a whole disk without creating any partition by setting
+      the <literal>disklabel</literal> to <literal>none</literal> as described
+      in <xref linkend="CreateProfile-Partitioning-config"/>. In such cases, the
+      configuration in the first <literal>partition</literal> from the
+      <literal>drive</literal> will be applied to the whole disk.
+     </para>
 
-    <para>
-     In the example below, we are using the second disk (<literal>/dev/sdb</literal>)
-     as the <literal>/home</literal> file system.
-    </para>
+     <para>
+      In the example below, we are using the second disk (<literal>/dev/sdb</literal>)
+      as the <literal>/home</literal> file system.
+     </para>
 
-    <example>
-     <title>Using a Whole Disk as a File System</title>
-<screen>&lt;partitioning config:type="list"&gt;
+     <example>
+      <title>Using a Whole Disk as a File System</title>
+      <screen>&lt;partitioning config:type="list"&gt;
   &lt;drive&gt;
     &lt;device&gt;/dev/sda&lt;/device&gt;
     &lt;partitions config:type="list"&gt;
@@ -3990,164 +4013,46 @@ openssl x509 -noout -fingerprint -sha256
       &lt;/partition&gt;
     &lt;/partitions&gt;
   &lt;/drive&gt;</screen>
-    </example>
+     </example>
 
-    <para>
-     In addition, the whole disk can be used as an LVM physical volume or as a software RAID
-     member. See <xref linkend="ay-partition-lvm"/> and <xref linkend="ay-partition-sw-raid"/>
-     for further details about setting up an LVM or a software RAID.
-    </para>
-   </sect2>
+     <para>
+      In addition, the whole disk can be used as an LVM physical volume or as a software RAID
+      member. See <xref linkend="ay-partition-lvm"/> and <xref linkend="ay-partition-sw-raid"/>
+      for further details about setting up an LVM or a software RAID.
+     </para>
+    </sect3>
 
-   <sect2 xml:id="ay-auto-partitioning">
-    <title>Automated Partitioning</title>
-    <para>
-     For automated partitioning, you only need to provide the sizes and
-     mount points of partitions. All other data needed for successful
-     partitioning is calculated during installation—unless provided in the
-     control file.
-    </para>
-    <para>
-     If no partitions are defined and the specified drive is also the drive
-     where the root partition should be created, the following partitions
-     are created automatically:
-    </para>
-    <itemizedlist mark="bullet" spacing="normal">
-     <listitem>
-      <para>
-       <filename>/boot</filename>
-      </para>
-      <para>
-       The size of the <filename>/boot</filename> partition is determined by
-       the architecture of the target system.
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       <filename>swap</filename>
-      </para>
-      <para>
-       The size of the swap partition is determined by the amount of memory
-       available in the system.
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       <filename>/</filename> (root partition)
-      </para>
-      <para>
-       The size of the root partition is determined by the space left after
-       creating <filename>swap</filename> and <filename>/boot</filename>.
-      </para>
-     </listitem>
-    </itemizedlist>
-    <para>
-     Depending on the initial status of the drive and how it was previously
-     partitioned, it is possible to create the default partitioning in the
-     following ways:
-    </para>
-    <variablelist>
-     <varlistentry>
-      <term>Use Free Space</term>
-      <listitem>
-       <para>
-        If the drive is already partitioned, it is possible to create the
-        new partitions using the free space on the hard disk. This requires
-        the availability of sufficient space for all selected packages in
-        addition to swap.
-       </para>
-      </listitem>
-     </varlistentry>
-     <varlistentry>
-      <term>Reuse all available space</term>
-      <listitem>
-       <para>
-        Use this option to delete all existing partitions (Linux and
-        non-Linux).
-       </para>
-      </listitem>
-     </varlistentry>
-     <varlistentry>
-      <term>Reuse all available Linux partitions</term>
-      <listitem>
-       <para>
-        This option deletes all existing Linux partitions. Other partitions
-        (for example Windows partitions) remain untouched. Note that this
-        works only if the Linux partitions are at the end of the device.
-       </para>
-      </listitem>
-     </varlistentry>
-     <varlistentry>
-      <term>Reuse only specified partitions</term>
-      <listitem>
-       <para>
-        This option allows you to select specific partitions to delete.
-        Start the selection with the last available partition.
-       </para>
-      </listitem>
-     </varlistentry>
-    </variablelist>
-    <para>
-     Repartitioning only works if the selected partitions are neighbors and
-     located at the end of the device.
-    </para>
-    <important>
-     <title>Beware of Data Loss</title>
+    <sect3 xml:id="ay-auto-partitioning">
+     <title>Filling the Gaps</title>
      <para>
-      The value provided in the <literal>use</literal> property determines
-      how existing data and partitions are treated. The value
-      <literal>all</literal> means that the entire disk will be erased. Make
-      backups and use the <literal>confirm</literal> property if you need to
-      keep some partitions with important data. Otherwise, no pop-ups will
-      notify you about partitions being deleted.
+      When using the Expert Partitioner approach, &ay; is able to create a
+      partition plan from a rather incomplete profile. The following profiles
+      show how you can describe just some details of the partitioning layout and
+      let &ay; do the rest.
      </para>
-    </important>
-    <para>
-     If multiple drives are in the target system, identify all drives with
-     their device names and specify how the partitioning should be
-     performed.
-    </para>
-    <para>
-     Partition sizes can be given in gigabytes, megabytes or can be set to a
-     flexible value using the keywords <literal>auto</literal> and
-     <literal>max</literal>. <literal>max</literal> uses all available space
-     on a drive, therefore should only be set for the last partition on the
-     drive. With <literal>auto</literal> the size of a
-     <literal>swap</literal> or <literal>boot</literal> partition is
-     determined automatically, depending on the memory available and the
-     type of the system.
-    </para>
-    <para>
-     A fixed size can be given as shown below:
-    </para>
-    <para>
-     <literal>1GB</literal>, <literal>1G</literal>,
-     <literal>1000MB</literal>, or <literal>1000M</literal> will all create a
-     partition of the size 1 Gigabyte.
-    </para>
-    <example>
-     <title>Automated Partitioning</title>
-     <para>
-      The following is an example of a single drive system, which is not
-      pre-partitioned and should be automatically partitioned according to
-      the described pre-defined partition plan. If you do not specify the
-      device, it will be automatically detected.
-     </para>
-<screen>&lt;partitioning config:type="list"&gt;
+     <example>
+      <title>Automated Partitioning on Selected Drives</title>
+      <para>
+       The following is an example of a single drive system, which is not
+       pre-partitioned and should be automatically partitioned according to
+       the described pre-defined partition plan. If you do not specify the
+       device, it will be automatically detected.
+      </para>
+      <screen>&lt;partitioning config:type="list"&gt;
   &lt;drive&gt;
     &lt;device&gt;/dev/sda&lt;/device&gt;
     &lt;use&gt;all&lt;/use&gt;
   &lt;/drive&gt;
 &lt;/partitioning&gt;
 </screen>
-    </example>
-    <para>
-     A more detailed example shows how existing partitions and multiple
-     drives are handled.
-    </para>
-    <example>
-     <title>Detailed Automated Partitioning</title>
-<screen>&lt;partitioning config:type="list"&gt;
+     </example>
+     <para>
+      A more detailed example shows how existing partitions and multiple
+      drives are handled.
+     </para>
+     <example>
+      <title>Installing on Multiple Drives</title>
+      <screen>&lt;partitioning config:type="list"&gt;
   &lt;drive&gt;
     &lt;device&gt;/dev/sda&lt;/device&gt;
     &lt;use&gt;all&lt;/use&gt;
@@ -4180,7 +4085,8 @@ openssl x509 -noout -fingerprint -sha256
   &lt;/drive&gt;
 &lt;/partitioning&gt;
 </screen>
-    </example>
+     </example>
+    </sect3>
    </sect2>
 
    <sect2 xml:id="ay-partition-advanced">

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2603,7 +2603,7 @@ openssl x509 -noout -fingerprint -sha256
           </para>
          </listitem>
         </itemizedlist>
-       <screen>&lt;windows_delete_mode config:type="symbol" &gt;ondemand&lt;/windows_delete_mode&gt;</screen>
+       <screen>&lt;windows_delete_mode config:type="symbol"&gt;ondemand&lt;/windows_delete_mode&gt;</screen>
       </listitem>
      </varlistentry>
      <varlistentry>
@@ -2627,7 +2627,7 @@ openssl x509 -noout -fingerprint -sha256
           </para>
          </listitem>
         </itemizedlist>
-       <screen>&lt;linux_delete_mode config:type="symbol" &gt;ondemand&lt;/linux_delete_mode&gt;</screen>
+       <screen>&lt;linux_delete_mode config:type="symbol"&gt;ondemand&lt;/linux_delete_mode&gt;</screen>
       </listitem>
      </varlistentry>
      <varlistentry>
@@ -2650,7 +2650,7 @@ openssl x509 -noout -fingerprint -sha256
           </para>
          </listitem>
         </itemizedlist>
-       <screen>&lt;other_delete_mode config:type="symbol" &gt;ondemand&lt;/other_delete_mode&gt;</screen>
+       <screen>&lt;other_delete_mode config:type="symbol"&gt;ondemand&lt;/other_delete_mode&gt;</screen>
       </listitem>
      </varlistentry>
      <varlistentry>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2507,6 +2507,29 @@ openssl x509 -noout -fingerprint -sha256
     <emphasis>Expert Partitioner</emphasis>.
    </para>
 
+   <sect2 xml:id="CreateProfile-Automatic-Partitioning">
+    <title>Automatic Partitioning</title>
+
+    <para>
+     &ay; is able to come up with a sensible partitioning layout without any
+     user indication. By default, &ay; proposes a Btrfs root file system, a
+     separate <literal>/home</literal> using XFS and a swap partition.
+     Additionally, depending on the architecture, it adds any partition that
+     might be needed in order to boot (like BIOS Grub partitions).
+    </para>
+
+    <para>
+     However, these defaults might change depending on factors like the
+     available disk space. E.g., having a separate <literal>/home</literal>
+     depends on the amount of available disk space.
+    </para>
+
+    <para>
+     If you want to influence these default values, you can use the approach
+     described in <xref linkend="CreateProfile-Guided-Partitioning" />.
+    </para>
+   </sect2>
+
    <sect2 xml:id="CreateProfile-Guided-Partitioning">
     <title>Guided Partitioning</title>
 

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -1336,49 +1336,6 @@ exit 0
    </variablelist>
   </sect2>
 
-  <sect2 xml:id="CreateProfile-General-storage">
-   <title>The Storage Section</title>
-
-   <para>
-    This section lets you enable multipath support for the installation. You
-    may also configure the partition alignment settings here.
-   </para>
-
-   <variablelist>
-    <varlistentry>
-     <term><tag class="element">btrfs_set_default_subvolume_name</tag>
-     </term>
-     <listitem>
-      <para>
-       See <xref linkend="ay-btrfs-subvolumes"/> for more information.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><tag class="element">start_multipath</tag>
-     </term>
-     <listitem>
-      <para>
-       When installing on a network storage that is accessed via multiple
-       paths, you need to enable multipath for the installation by setting this
-       parameter to <literal>true</literal>. Setting this value is optional.
-       The default is <literal>false</literal>.
-      </para>
-<screen><![CDATA[<general>
- <storage>
-  <start_multipath config:type="boolean">false</start_multipath>
- </storage>
- ...
-<general>]]></screen>
-      <para>
-       Alternatively, you can use the following parameter on the Kernel command
-       line: <literal>LIBSTORAGE_MULTIPATH_AUTOSTART=ON</literal>
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </sect2>
-
   <sect2 xml:id="CreateProfile-General-wait">
    <title>The Wait Section</title>
 
@@ -4972,16 +4929,17 @@ openssl x509 -noout -fingerprint -sha256
    <title>Multipath Support</title>
    <para>
     &ay; is able to handle multipath devices. In order to take advantage of
-    them, you need to enable multipath support, as described in <xref
-    linkend="CreateProfile-General-storage"/>. Unlike &sle; 12, it is not required
-    to set the drive section type to <literal>CT_DMMULTIPATH</literal>. You should
-    use <literal>CT_DISK</literal>, although for historical reasons, both values
-    are equivalent.
+    them, you need to enable multipath support, as shown in <xref
+    linkend="multipath-example"/>. Alternatively, you can use the following
+    parameter on the Kernel command line:
+    <literal>LIBSTORAGE_MULTIPATH_AUTOSTART=ON</literal>.
    </para>
 
    <para>
-    <xref linkend="multipath-example"/> shows the relevant parts of a profile which
-    instructs &ay; to partition a multipath device.
+    Unlike &sle; 12, it is not required to set the drive section type to
+    <literal>CT_DMMULTIPATH</literal>. You should use
+    <literal>CT_DISK</literal>, although for historical reasons, both values are
+    equivalent.
    </para>
 
     <example xml:id="multipath-example">

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -3912,20 +3912,6 @@ openssl x509 -noout -fingerprint -sha256
        </tbody>
       </tgroup>
      </informaltable>
-
-     <important>
-      <title>Creating Boot Partitions Automatically</title>
-      <para>
-       When &ay; determines that a boot partition might be required in order
-       to boot properly, it will automatically add one even if it is not specified
-       in the profile.
-      </para>
-      <para>
-       However, if for any reason the boot partition does not fit in the current
-       partitioning layout, &ay; will just display a warning, allowing the
-       installation to proceed.
-      </para>
-     </important>
     </sect3>
 
     <sect3 xml:id="ay-btrfs-subvolumes">

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -7,6 +7,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
+<?xml-model href="/usr/share/xml/geekodoc/rng/geekodoc5-flat.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <book version="5.0" xml:lang="en" xml:id="book-autoyast"
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
@@ -2585,7 +2586,6 @@ openssl x509 -noout -fingerprint -sha256
      <varlistentry>
       <term>windows_delete_mode</term>
       <listitem>
-       <para>
         <itemizedlist mark="bullet" spacing="normal">
          <listitem>
           <para>
@@ -2603,14 +2603,13 @@ openssl x509 -noout -fingerprint -sha256
           </para>
          </listitem>
         </itemizedlist>
-       </para>
        <screen>&lt;windows_delete_mode config:type="symbol" &gt;ondemand&lt;/windows_delete_mode&gt;</screen>
       </listitem>
      </varlistentry>
      <varlistentry>
       <term>linux_delete_mode</term>
       <listitem>
-       <para>
+
         <itemizedlist mark="bullet" spacing="normal">
          <listitem>
           <para>
@@ -2628,14 +2627,12 @@ openssl x509 -noout -fingerprint -sha256
           </para>
          </listitem>
         </itemizedlist>
-       </para>
        <screen>&lt;linux_delete_mode config:type="symbol" &gt;ondemand&lt;/linux_delete_mode&gt;</screen>
       </listitem>
      </varlistentry>
      <varlistentry>
       <term>other_delete_mode</term>
       <listitem>
-       <para>
         <itemizedlist mark="bullet" spacing="normal">
          <listitem>
           <para>
@@ -2653,7 +2650,6 @@ openssl x509 -noout -fingerprint -sha256
           </para>
          </listitem>
         </itemizedlist>
-       </para>
        <screen>&lt;other_delete_mode config:type="symbol" &gt;ondemand&lt;/other_delete_mode&gt;</screen>
       </listitem>
      </varlistentry>
@@ -5251,7 +5247,7 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
    </example>
 
    <informaltable>
-      <tgroup cols="3">
+      <tgroup cols="2">
        <thead>
         <row>
          <entry>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2562,198 +2562,111 @@ openssl x509 -noout -fingerprint -sha256
 &lt;general&gt;</screen>
     </example>
 
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Attribute
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Values
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>lvm</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Boolean
-          <screen>&lt;lvm config:type="boolean"&gt;true&lt;/lvm&gt;</screen>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Create a LVM-based proposal. The default is <literal>false</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>resize_windows</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Boolean
-          <screen>&lt;resize_windows config:type="boolean"
-&gt;false&lt;/resize_windows&gt;</screen>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          When set to <literal>true</literal>, &ay; resizes Windows partitions
-          if needed to make room for the installation.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>windows_delete_mode</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Choose between:
-          <itemizedlist mark="bullet" spacing="normal">
-           <listitem>
-            <para>
-             <literal>none</literal> does not remove Windows partitions.
-            </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>ondemand</literal> removes Windows partitions if needed.
-            </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>all</literal> removes all Windows partitions.
-            </para>
-           </listitem>
-          </itemizedlist>
-          <screen>&lt;windows_delete_mode config:type="symbol"
-&gt;ondemand&lt;/windows_delete_mode&gt;</screen>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Usually, &ay; deletes Windows partitions on-demand.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>linux_delete_mode</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Choose between:
-          <itemizedlist mark="bullet" spacing="normal">
-           <listitem>
-            <para>
-             <literal>none</literal> does not remove Linux partitions.
-            </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>ondemand</literal> removes Linux partitions if needed.
-            </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>all</literal> removes all Linux partitions.
-            </para>
-           </listitem>
-          </itemizedlist>
-          <screen>&lt;linux_delete_mode config:type="symbol"
-&gt;ondemand&lt;/linux_delete_mode&gt;</screen>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Usually, &ay; deletes Linux partitions on-demand.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>other_delete_mode</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Choose between:
-          <itemizedlist mark="bullet" spacing="normal">
-           <listitem>
-            <para>
-             <literal>none</literal> does not remove other partitions (non
-             Windows or Linux).
-            </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>ondemand</literal> removes other partitions if needed.
-            </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>all</literal> removes all other partitions.
-            </para>
-           </listitem>
-          </itemizedlist>
-          <screen>&lt;other_delete_mode config:type="symbol"
-&gt;ondemand&lt;/other_delete_mode&gt;</screen>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Usually, &ay; deletes other partitions on-demand.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>encryption_password</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          String
-          <screen>&lt;encryption_password
-&gt;some-secret&lt;/encryption_password&gt;</screen>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Enables encryption using the specified password. By default,
-          encryption is disabled.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+    <variablelist>
+     <varlistentry>
+      <term>lvm</term>
+      <listitem>
+       <para>
+        Create a LVM-based proposal. The default is <literal>false</literal>.
+       </para>
+       <screen>&lt;lvm config:type="boolean"&gt;true&lt;/lvm&gt;</screen>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>resize_windows</term>
+      <listitem>
+       <para>
+        When set to <literal>true</literal>, &ay; resizes Windows partitions
+        if needed to make room for the installation.
+       </para>
+       <screen>&lt;resize_windows config:type="boolean"&gt;false&lt;/resize_windows&gt;</screen>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>windows_delete_mode</term>
+      <listitem>
+       <para>
+        <itemizedlist mark="bullet" spacing="normal">
+         <listitem>
+          <para>
+           <literal>none</literal> does not remove Windows partitions.
+          </para>
+         </listitem>
+         <listitem>
+          <para>
+           <literal>ondemand</literal> removes Windows partitions if needed.
+          </para>
+         </listitem>
+         <listitem>
+          <para>
+           <literal>all</literal> removes all Windows partitions.
+          </para>
+         </listitem>
+        </itemizedlist>
+       </para>
+       <screen>&lt;windows_delete_mode config:type="symbol" &gt;ondemand&lt;/windows_delete_mode&gt;</screen>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>linux_delete_mode</term>
+      <listitem>
+       <para>
+        <itemizedlist mark="bullet" spacing="normal">
+         <listitem>
+          <para>
+           <literal>none</literal> does not remove Linux partitions.
+          </para>
+         </listitem>
+         <listitem>
+          <para>
+           <literal>ondemand</literal> removes Linux partitions if needed.
+          </para>
+         </listitem>
+         <listitem>
+          <para>
+           <literal>all</literal> removes all Linux partitions.
+          </para>
+         </listitem>
+        </itemizedlist>
+       </para>
+       <screen>&lt;linux_delete_mode config:type="symbol" &gt;ondemand&lt;/linux_delete_mode&gt;</screen>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>other_delete_mode</term>
+      <listitem>
+       <para>
+        <itemizedlist mark="bullet" spacing="normal">
+         <listitem>
+          <para>
+           <literal>none</literal> does not remove other partitions.
+          </para>
+         </listitem>
+         <listitem>
+          <para>
+           <literal>ondemand</literal> removes other partitions if needed.
+          </para>
+         </listitem>
+         <listitem>
+          <para>
+           <literal>all</literal> removes all other partitions.
+          </para>
+         </listitem>
+        </itemizedlist>
+       </para>
+       <screen>&lt;other_delete_mode config:type="symbol" &gt;ondemand&lt;/other_delete_mode&gt;</screen>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>encryption_password</term>
+      <listitem>
+       <para>
+        Enables encryption using the specified password. By default, encryption is disabled.
+       </para>
+       <screen>&lt;encryption_password&gt;some-secret&lt;/encryption_password&gt;</screen>
+      </listitem>
+     </varlistentry>
+    </variablelist>
    </sect2>
 
    <sect2 xml:id="CreateProfile-Expert-Partitioning">


### PR DESCRIPTION
### Description

This PR describes how the partitioning works in AutoYaST. It describes the three different approaches (automatic, guided and expert partitioning) and how you can implement them.

Additionally, it removes the section about `<general><storage>` because:

* `start_multipath` is now documented in the section about multipath,
* `proposal` is now documented in the (new) guided proposal section,
* and `btrfs_set_default_subvolume_name` is not supported anymore.

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
