### PR TITLE
docker: Add clarifications about image building when connected to rmt

### DIFF
--- a/xml/docker_building_images.xml
+++ b/xml/docker_building_images.xml
@@ -150,6 +150,25 @@
    </para>
   </note>
 
+  <note>
+   <title>Building images on systems registered with &rmt;</title>
+
+   <para>
+    When the host system used for building the docker image is registered
+    against &rmt; it is only possible to build containers for the same &slea; code
+    base that the host system is running on. I.e. if you docker host is a
+    &slea;&nbsp; 15 system you can only build &slea;&nbsp; 15 based images
+    on that host by default.
+
+    To build images for a different &slea; version than what is running on
+    the host machine credentials for the target release can be injected into
+    the container as outlined below.
+
+    When the host system is registered again the &scc; this
+    restriction does not apply.
+   </para>
+  </note>
+
   <para>
    To obtain the list of repositories, use the following command:
   </para>

--- a/xml/docker_building_images.xml
+++ b/xml/docker_building_images.xml
@@ -202,15 +202,11 @@ RUN zypper -n in vim</screen>
    <para>
     When the &docker; host machine is registered against an internal &rmt;
     server, the &docker; image requires the SSL certificate used by &rmt;:
-   <remark>
-    taroth 2018-08-08: not sure the content of this file is still correct, as
-    SMT has been replaced by RMT (Repository Mirroring Tool) meanwhile - @DEV:
-    please check</remark>
    </para>
 <screen>FROM registry.suse.com/suse/sles12sp4
 
-# Import the crt file of our private SMT server
-ADD http://smt.test.lan/smt.crt /etc/pki/trust/anchors/smt.crt
+# Import the crt file of our private RMT server
+ADD http://rmt.test.lan/rmt.crt /etc/pki/trust/anchors/rmt.crt
 RUN update-ca-certificates
 
 RUN zypper ref -s
@@ -230,14 +226,11 @@ RUN zypper -n in vim</screen>
    <para>
     When the &docker; host machine is registered against an internal &rmt;
     server, the &docker; image requires the SSL certificate used by &rmt;:
-   <remark>
-    taroth 2018-08-08: not sure the content of this file is still correct, as
-    SMT has been replaced by RMT (Repository Mirroring Tool) meanwhile - @DEV:
-    please check</remark></para>
+   </para>
 <screen>FROM registry.suse.com/suse/sle15
 
-# Import the crt file of our private SMT server
-ADD http://smt.test.lan/smt.crt /etc/pki/trust/anchors/smt.crt
+# Import the crt file of our private RMT server
+ADD http://rmt.test.lan/rmt.crt /etc/pki/trust/anchors/rmt.crt
 RUN update-ca-certificates
 
 RUN zypper ref -s


### PR DESCRIPTION
### Description

There is slight difference in the functionality of container-suseconnect on systems that are using RMT/SMT instead of SCC. Add a note about that to the containers guide

For details see also: SUSE/container-suseconnect#37

I am not entirely sure if I got the markup right so feel free to correct that if needed.

### Checklist
* Check all items that apply.

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [x] To maintenance/SLE12SP4
- [x] To maintenance/SLE12SP3
