### PR TITLE
vt_best_practices: reword the CPU assignment/overcommit section

### DIFF
--- a/xml/vt_best_practices.xml
+++ b/xml/vt_best_practices.xml
@@ -1332,19 +1332,47 @@ calls      retrans    authrefrsh
    <sect3 xml:id="sec-vt-best-perf-cpu-assign">
     <title>Assigning CPUs</title>
     <para>
-     You should avoid overcommitting CPUs. Unless you know exactly how many
-     virtual CPUs are required for a &vmguest;, you should start with a single
-     virtual CPU per &vmguest;. Each virtual CPU should match one hardware
-     processor or core on the &vmhost;.
+     CPU overcommit occurs when the cumulative number of virtual CPUs of
+     all &vmguest;s becomes higher than the number of host CPUs.
+     Best performance is likely to be achieved when there is no overcommit
+     and each virtual CPU matches one hardware processor or core on the
+     &vmhost;.
+     In fact, &vmguest;s running on an overcommitted host will experience
+     increased latency and a negative effect on per-&vmguest; throughput
+     is also likely to be observed. Therefore, you should try to avoid
+     overcommitting CPUs.
     </para>
     <para>
-     You should target a CPU workload of approximately 70% inside your VM (see
+     Deciding whether to allow CPU overcommit or not requires good a-priori
+     knowledge of workload as a whole.
+     For instance, if you know that all the &vmguest;s virtual CPUs will not
+     be loaded more than 50% then you can assume that overcommitting the host
+     by a factor of 2 (which means having 128 virtual CPUs in total, on a host
+     with 64 CPUs) will work well.
+     On the other hand, if you know that all the virtual CPUs of the &vmguest;s
+     will try to run at 100% for most of the time then even having one virtual
+     CPU more than than the host has CPUs is already a misconfiguration.
+    </para>
+    <para>
+     Overcommitting to a point where the cumulative number of virtual CPUs is
+     higher than 8 times the number of physical cores of the &vmhost; will most
+     likely lead to a malfunctioning and unstable system and should hence be
+     avoided.
+    </para>
+    <para>
+     Unless you know exactly how many virtual CPUs are required for a &vmguest;,
+     you should start with one. A good rule of thumb is to target a CPU workload
+     of approximately 70% inside your VM (see
      <xref linkend="sec-util-processes"/> for information on monitoring tools).
      If you allocate more processors than needed in the &vmguest;, this will
-     negatively affect the performance of host and guest: cycle efficiency will
-     be degraded, the unused vCPU will consume timer interrupts and will
-     idle-loop. In case you primarily run single threaded applications on a
-     &vmguest;, a single virtual CPU is the best choice.
+     negatively affect the performance of host and guest. Cycle efficiency will
+     be degraded, as the unused vCPU will still cause timer interrupts.
+     In case you primarily run single threaded applications on a &vmguest;, a
+     single virtual CPU is the best choice.
+    </para>
+    <para>
+      A single &vmguest; with more virtual CPUs than the &vmhost; has CPUs
+      is always a misconfiguration.
     </para>
    </sect3>
    <sect3 xml:id="sec-vt-best-perf-cpu-guests">


### PR DESCRIPTION
### Description

The introduction of the "Assigning CPUs" section was just strongly
discouraging CPU overcommit, without much explanation of why this was
the case.

Add some hints about that, and also include some basic advice on how to
decide whether overcommitting may or not be sustainable.

Add the indication to absolutely avoid overcommitting by more than 8
times the number of CPUs. This, right now, comes from a mix of common
sense and experience, but it should be good to have tests that actually
check whether "8 times" is really the best limit.

Signed-off-by: Dario Faggioli <dfaggioli@suse.com>

### Checklist

- I have run `daps -d DC-foobar validate`
- I don't know how to run this through the Travis CI (or does it happen automatically?)
- This commit has gone through some internal review within the Virtualization Team, mostly by @jfehlig . I am not sure who to tag from the doc team, sorry

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [x] To maintenance/SLE12SP4
- [x] To maintenance/SLE12SP3
