### PR TITLE
Need to activate 'Encrypt device' AND 'Format partition' (bsc#1142814)

### DIFF
--- a/xml/security_cryptofs.xml
+++ b/xml/security_cryptofs.xml
@@ -121,7 +121,8 @@
     </step>
     <step>
      <para>
-      Activate the <guimenu>Encrypt device</guimenu> check box.
+       Activate both the <guimenu>Encrypt device</guimenu> and
+       <guimenu>Format partition</guimenu> check boxes.
      </para>
      <note>
       <title>Additional Software Required</title>
@@ -137,7 +138,7 @@
      <para>
       If the encrypted file system needs to be mounted only when necessary,
       enable <guimenu>Do not mount partition</guimenu> in the <guimenu>Fstab
-      Options</guimenu>. otherwise enable <guimenu>Mount partition</guimenu>
+      Options</guimenu>. Otherwise enable <guimenu>Mount partition</guimenu>
       and enter the mount point.
      </para>
     </step>


### PR DESCRIPTION
### Description
When encrypting a partition, you need to activate 'Format partition' as well, otherwise
an error occurs. This addition emphasizes this fact.

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [x] To maintenance/SLE12SP4
- [x] To maintenance/SLE12SP3
