### PR TITLE
Add Tech Preview Definition to Docs

### DIFF
--- a/xml/common_intro_feedback_i.xml
+++ b/xml/common_intro_feedback_i.xml
@@ -60,6 +60,13 @@
      take you to the source code on GitHub, where you can open a pull request.
      A GitHub account is required.
     </para>
+    <para>
+     For more information about the documentation environment used for this
+     documentation, see the repository's README at
+     <link xlink:href="&github.url;"/>.
+     <!--taroth 2019-20-23: did not provide a direct link to the README on
+      purpose, as it might differ between the branches-->
+    </para>
    </listitem>
   </varlistentry>
   <varlistentry>

--- a/xml/common_intro_feedback_i.xml
+++ b/xml/common_intro_feedback_i.xml
@@ -62,10 +62,12 @@
     </para>
     <para>
      For more information about the documentation environment used for this
-     documentation, see the repository's README at
-     <link xlink:href="&github.url;"/>.
-     <!--taroth 2019-20-23: did not provide a direct link to the README on
-      purpose, as it might differ between the branches-->
+     documentation, see <link
+      xlink:href="&github.url;/blob/master/README.adoc">the repository's
+      README</link>.
+     <!--taroth 2020-01-09: Link needs to be adjusted in case the README changes
+      format. In case the READMEs differ between the branches, better just point
+      to &github.url;-->
     </para>
    </listitem>
   </varlistentry>

--- a/xml/common_intro_lifecycle_support_i.xml
+++ b/xml/common_intro_lifecycle_support_i.xml
@@ -166,7 +166,7 @@
     test new technologies within an enterprise environment. We would appreciate
     your feedback! If you try or test a technology preview, please contact your
     &suse; representative and let them know about your experience and use cases.
-    We will  consider your input for future development.
+    Your input is helpful for future development.
    </para>
    <para>
     However, technology previews come with the following limitations:

--- a/xml/common_intro_lifecycle_support_i.xml
+++ b/xml/common_intro_lifecycle_support_i.xml
@@ -164,7 +164,7 @@
     to provide insights into upcoming innovations. These previews are still in
     development, but are included for your convenience to give you the chance to
     test new technologies within an enterprise environment. We would appreciate
-    your feedback! If you try or test a technology preview, please contact your
+    your feedback! If you test a technology preview, please contact your
     &suse; representative and let them know about your experience and use cases.
     Your input is helpful for future development.
    </para>

--- a/xml/common_intro_lifecycle_support_i.xml
+++ b/xml/common_intro_lifecycle_support_i.xml
@@ -161,7 +161,7 @@
   <title>Technology Previews</title>
    <para>
     Technology previews are packages, stacks, or features delivered by &suse;
-    that provide insights into upcoming innovations. They are still in
+    to provide insights into upcoming innovations. These previews are still in
     development, but are included for your convenience to give you the chance to
     test new technologies within an enterprise environment. We would appreciate
     your feedback! If you try or test a technology preview, please contact your

--- a/xml/common_intro_lifecycle_support_i.xml
+++ b/xml/common_intro_lifecycle_support_i.xml
@@ -159,24 +159,58 @@
 
  <sect2>
   <title>Technology Previews</title>
-<!-- text below is taken from bnc#662712 -->
-  <para>
-   Technology previews are packages, stacks, or features delivered by &suse;
-   which are not supported. They may be functionally incomplete, unstable, or
-   in other ways not suitable for production use. They are included for your
-   convenience and give you a chance to test new technologies within an
-   enterprise environment.
-  </para>
-  <para>
-   Whether a technology preview becomes a fully supported technology later
-   depends on customer and market feedback. Technology previews can be dropped
-   at any time and &suse; does not commit to providing a supported version of
-   such technologies in the future.
-  </para>
-  <para>
-   Give your &suse; representative feedback about technology previews,
-   including your experience and use case.
-  </para>
+   <para>
+    Technology previews are packages, stacks, or features delivered by &suse;
+    that provide insights into upcoming innovations. They are still in
+    development, but are included for your convenience to give you the chance to
+    test new technologies within an enterprise environment. We would appreciate
+    your feedback! If you try or test a technology preview, please contact your
+    &suse; representative and let them know about your experience and use cases.
+    We will  consider your input for future development.
+   </para>
+   <para>
+    However, technology previews come with the following limitations:
+   </para>
+   <itemizedlist>
+    <listitem>
+     <para>
+      Technology previews may be functionally incomplete, unstable, or in other ways
+      <emphasis>not</emphasis> suitable for production use.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Technology previews are <emphasis>not</emphasis> supported.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Technology previews are <emphasis>not</emphasis> supported.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Technology previews may only be available for specific hardware
+      architectures.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Details and functionality of technology previews are subject to change.
+      As a result, upgrading to subsequent releases of a technology preview may
+      be impossible and require a fresh installation.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Technology previews can be dropped at any time (for example, if &suse;
+      discovers that a preview does not meet the customer or market needs, or does
+      not prove to comply with enterprise standards). &suse; does not commit to
+      providing a supported version of such technologies in the future.
+     </para>
+    </listitem>
+   </itemizedlist>
+
   <para>
    For an overview of technology previews shipped with your product, see the
    release notes at <link xlink:href="https://www.suse.com/releasenotes/"/>.

--- a/xml/common_intro_lifecycle_support_i.xml
+++ b/xml/common_intro_lifecycle_support_i.xml
@@ -129,18 +129,18 @@
    </listitem>
    <listitem>
     <para>
-     Sound, graphics, fonts and artwork
+     Sound, graphics, fonts and artwork.
     </para>
    </listitem>
    <listitem>
     <para>
-     Packages that require an additional customer contract
+     Packages that require an additional customer contract.
     </para>
    </listitem>
    <listitem>
     <para>
      Some packages shipped as part of the module <emphasis>Workstation
-     Extension</emphasis> are L2-supported only
+     Extension</emphasis> are L2-supported only.
     </para>
    </listitem>
    <listitem>

--- a/xml/common_intro_lifecycle_support_i.xml
+++ b/xml/common_intro_lifecycle_support_i.xml
@@ -1,0 +1,185 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect1
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+    %entities;
+]>
+<sect1 version="5.0" xmlns="http://docbook.org/ns/docbook"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Product Life Cycle and Support</title>
+
+ <info>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker>
+<!--<dm:assignee></dm:assignee>-->
+   </dm:bugtracker>
+   <dm:translation>yes</dm:translation>
+  </dm:docmanager>
+ </info>
+
+ <para>
+  &suse; products are supported for up to 13 years. To check the life cycle
+  dates for your product, see
+  <link
+   xlink:href="https://www.suse.com/lifecycle/"/>.
+ </para>
+
+ <para>
+  For &sle; the following life cycles and release cycles apply:
+ </para>
+
+ <itemizedlist>
+  <listitem>
+   <para>
+    &sls; has a 13-year life cycle: 10 years of general support and three years
+    of extended support.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    &sled; has a 10-year life cycle: seven years of general support and three
+    years of extended support.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    Major releases are published every four years. Service packs are published
+    every 12-14 months.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    &suse; supports previous &sle; service packs for six months after the
+    release of a new service pack.
+   </para>
+  </listitem>
+ </itemizedlist>
+
+ <para>
+  For some products, Long Term Service Pack Support (LTSS) is available. Find
+  information about our support policy and options at
+  <link
+   xlink:href="https://www.suse.com/support/policy.html"/> and
+  <link
+   xlink:href="https://www.suse.com/support/programs/long-term-service-pack-support.html"
+  />.
+ </para>
+
+ <para os="sles;sled">
+  In contrast to products, individual modules have a different life cycle and
+  update timeline. Modules contain software packages and are fully supported
+  parts of &productname;. For more information, see the <xref
+   linkend="art-modules"/>.
+ </para>
+
+ <sect2>
+  <title>Support Statement for &productname;</title>
+  <para>
+   To receive support, you need an appropriate subscription with &suse;. To
+   view the specific support offerings available to you, go to
+   <link xlink:href="https://www.suse.com/support/"/> and select your product.
+  </para>
+  <para>
+   The support levels are defined as follows:
+  </para>
+  <variablelist>
+   <varlistentry>
+    <term>L1</term>
+    <listitem>
+     <para>
+      Problem determination, which means technical support designed to provide
+      compatibility information, usage support, ongoing maintenance,
+      information gathering and basic troubleshooting using available
+      documentation.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>L2</term>
+    <listitem>
+     <para>
+      Problem isolation, which means technical support designed to analyze
+      data, reproduce customer problems, isolate problem area and provide a
+      resolution for problems not resolved by Level&nbsp;1 or prepare for
+      Level&nbsp;3.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>L3</term>
+    <listitem>
+     <para>
+      Problem resolution, which means technical support designed to resolve
+      problems by engaging engineering to resolve product defects which have
+      been identified by Level&nbsp;2 Support.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+  <para>
+   For contracted customers and partners, &productname; is delivered with L3
+   support for all packages, except for the following:
+  </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     Technology Previews
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Sound, graphics, fonts and artwork
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Packages that require an additional customer contract
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Some packages shipped as part of the module <emphasis>Workstation
+     Extension</emphasis> are L2-supported only
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Packages with names ending in <package>-devel</package> (containing header
+     files and similar developer resources) will only be supported together
+     with their main packages.
+    </para>
+   </listitem>
+  </itemizedlist>
+  <para>
+   &suse; will only support the usage of original packages. That is, packages
+   that are unchanged and not recompiled.
+  </para>
+ </sect2>
+
+ <sect2>
+  <title>Technology Previews</title>
+<!-- bnc#662712 -->
+  <para>
+   Technology previews are packages, stacks, or features delivered by &suse;
+   which are not supported. They may be functionally incomplete, unstable or in
+   other ways not suitable for production use. They are included for your
+   convenience and give you a chance to test new technologies within an
+   enterprise environment.
+  </para>
+  <para>
+   Whether a technology preview becomes a fully supported technology later
+   depends on customer and market feedback. Technology previews can be dropped
+   at any time and &suse; does not commit to providing a supported version of
+   such technologies in the future.
+  </para>
+  <para>
+   Give your &suse; representative feedback about technology previews,
+   including your experience and use case.
+  </para>
+  <para>
+   For an overview of technology previews shipped with your product, check the
+   release notes at <link xlink:href="https://www.suse.com/releasenotes/"/>.
+  </para>
+ </sect2>
+</sect1>

--- a/xml/common_intro_lifecycle_support_i.xml
+++ b/xml/common_intro_lifecycle_support_i.xml
@@ -65,7 +65,7 @@
   />.
  </para>
 
- <para>
+ <para os="sles;sled">
   Modules have a different life cycle, update policy, and update timeline than
   their base products. Modules contain software packages and are fully
   supported parts of &productname;. For more information, see the

--- a/xml/common_intro_lifecycle_support_i.xml
+++ b/xml/common_intro_lifecycle_support_i.xml
@@ -161,12 +161,11 @@
   <title>Technology Previews</title>
    <para>
     Technology previews are packages, stacks, or features delivered by &suse;
-    to provide insights into upcoming innovations. These previews are still in
-    development, but are included for your convenience to give you the chance to
-    test new technologies within an enterprise environment. We would appreciate
-    your feedback! If you test a technology preview, please contact your
-    &suse; representative and let them know about your experience and use cases.
-    Your input is helpful for future development.
+    to provide glimpses into upcoming innovations. The previews are included for
+    your convenience to give you the chance to test new technologies within your
+    environment. We would appreciate your feedback! If you test a technology
+    preview, please contact your &suse; representative and let them know about
+    your experience and use cases. Your input is helpful for future development.
    </para>
    <para>
     However, technology previews come with the following limitations:
@@ -174,8 +173,9 @@
    <itemizedlist>
     <listitem>
      <para>
-      Technology previews may be functionally incomplete, unstable, or in other ways
-      <emphasis>not</emphasis> suitable for production use.
+      Technology previews are still in development. Therefore, they may be functionally
+      incomplete, unstable, or in other ways  <emphasis>not</emphasis> suitable
+      for production use.
      </para>
     </listitem>
     <listitem>
@@ -198,9 +198,9 @@
     </listitem>
     <listitem>
      <para>
-      Technology previews can be dropped at any time (for example, if &suse;
+      Technology previews can be dropped at any time. For example, if &suse;
       discovers that a preview does not meet the customer or market needs, or does
-      not prove to comply with enterprise standards). &suse; does not commit to
+      not prove to comply with enterprise standards. &suse; does not commit to
       providing a supported version of such technologies in the future.
      </para>
     </listitem>

--- a/xml/common_intro_lifecycle_support_i.xml
+++ b/xml/common_intro_lifecycle_support_i.xml
@@ -21,12 +21,11 @@
  <para>
   &suse; products are supported for up to 13 years. To check the life cycle
   dates for your product, see
-  <link
-   xlink:href="https://www.suse.com/lifecycle/"/>.
+  <link xlink:href="https://www.suse.com/lifecycle/"/>.
  </para>
 
  <para>
-  For &sle; the following life cycles and release cycles apply:
+  For &sle;, the following life cycles and release cycles apply:
  </para>
 
  <itemizedlist>
@@ -66,10 +65,11 @@
   />.
  </para>
 
- <para os="sles;sled">
-  In contrast to products, individual modules have a different life cycle and
-  update timeline. Modules contain software packages and are fully supported
-  parts of &productname;. For more information, see the <xref
+ <para>
+  Modules have a different life cycle, update policy, and update timeline than
+  their base products. Modules contain software packages and are fully
+  supported parts of &productname;. For more information, see the
+  <xref
    linkend="art-modules"/>.
  </para>
 
@@ -159,11 +159,11 @@
 
  <sect2>
   <title>Technology Previews</title>
-<!-- bnc#662712 -->
+<!-- text below is taken from bnc#662712 -->
   <para>
    Technology previews are packages, stacks, or features delivered by &suse;
-   which are not supported. They may be functionally incomplete, unstable or in
-   other ways not suitable for production use. They are included for your
+   which are not supported. They may be functionally incomplete, unstable, or
+   in other ways not suitable for production use. They are included for your
    convenience and give you a chance to test new technologies within an
    enterprise environment.
   </para>
@@ -178,7 +178,7 @@
    including your experience and use case.
   </para>
   <para>
-   For an overview of technology previews shipped with your product, check the
+   For an overview of technology previews shipped with your product, see the
    release notes at <link xlink:href="https://www.suse.com/releasenotes/"/>.
   </para>
  </sect2>

--- a/xml/common_intro_lifecycle_support_i.xml
+++ b/xml/common_intro_lifecycle_support_i.xml
@@ -185,11 +185,6 @@
     </listitem>
     <listitem>
      <para>
-      Technology previews are <emphasis>not</emphasis> supported.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
       Technology previews may only be available for specific hardware
       architectures.
      </para>

--- a/xml/deployment_intro.xml
+++ b/xml/deployment_intro.xml
@@ -72,6 +72,5 @@
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>
- <xi:include href="common_intro_making_i.xml"/>
  <xi:include href="common_intro_lifecycle_support_i.xml"/>
 </preface>

--- a/xml/deployment_intro.xml
+++ b/xml/deployment_intro.xml
@@ -69,8 +69,9 @@
    </listitem>
   </varlistentry>
  </variablelist>
- <xi:include href="common_intro_target_audience_i.xml"/>
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>
+ <xi:include href="common_intro_making_i.xml"/>
+ <xi:include href="common_intro_lifecycle_support_i.xml"/>
 </preface>

--- a/xml/gnomeuser_intro.xml
+++ b/xml/gnomeuser_intro.xml
@@ -91,6 +91,5 @@
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>
- <xi:include href="common_intro_making_i.xml"/>
  <xi:include href="common_intro_lifecycle_support_i.xml"/>
 </preface>

--- a/xml/gnomeuser_intro.xml
+++ b/xml/gnomeuser_intro.xml
@@ -91,4 +91,6 @@
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>
+ <xi:include href="common_intro_making_i.xml"/>
+ <xi:include href="common_intro_lifecycle_support_i.xml"/>
 </preface>

--- a/xml/kvm_intro.xml
+++ b/xml/kvm_intro.xml
@@ -29,4 +29,6 @@
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>
+ <xi:include href="common_intro_making_i.xml"/>
+ <xi:include href="common_intro_lifecycle_support_i.xml"/>
 </preface>

--- a/xml/kvm_intro.xml
+++ b/xml/kvm_intro.xml
@@ -29,6 +29,5 @@
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>
- <xi:include href="common_intro_making_i.xml"/>
  <xi:include href="common_intro_lifecycle_support_i.xml"/>
 </preface>

--- a/xml/security_intro.xml
+++ b/xml/security_intro.xml
@@ -31,6 +31,5 @@
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>
- <xi:include href="common_intro_making_i.xml"/>
  <xi:include href="common_intro_lifecycle_support_i.xml"/>
 </preface>

--- a/xml/security_intro.xml
+++ b/xml/security_intro.xml
@@ -31,4 +31,6 @@
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>
+ <xi:include href="common_intro_making_i.xml"/>
+ <xi:include href="common_intro_lifecycle_support_i.xml"/>
 </preface>

--- a/xml/sle_admin_intro.xml
+++ b/xml/sle_admin_intro.xml
@@ -99,4 +99,5 @@
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>
  <xi:include href="common_intro_making_i.xml"/>
+ <xi:include href="common_intro_lifecycle_support_i.xml"/>
 </preface>

--- a/xml/sle_admin_intro.xml
+++ b/xml/sle_admin_intro.xml
@@ -98,6 +98,5 @@
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>
- <xi:include href="common_intro_making_i.xml"/>
  <xi:include href="common_intro_lifecycle_support_i.xml"/>
 </preface>

--- a/xml/storage_intro.xml
+++ b/xml/storage_intro.xml
@@ -25,6 +25,5 @@
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>
- <xi:include href="common_intro_making_i.xml"/>
  <xi:include href="common_intro_lifecycle_support_i.xml"/>
 </preface>

--- a/xml/storage_intro.xml
+++ b/xml/storage_intro.xml
@@ -25,4 +25,6 @@
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>
+ <xi:include href="common_intro_making_i.xml"/>
+ <xi:include href="common_intro_lifecycle_support_i.xml"/>
 </preface>

--- a/xml/tuning_intro.xml
+++ b/xml/tuning_intro.xml
@@ -150,4 +150,6 @@
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>
+ <xi:include href="common_intro_making_i.xml"/>
+ <xi:include href="common_intro_lifecycle_support_i.xml"/>
 </preface>

--- a/xml/tuning_intro.xml
+++ b/xml/tuning_intro.xml
@@ -150,6 +150,5 @@
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>
- <xi:include href="common_intro_making_i.xml"/>
  <xi:include href="common_intro_lifecycle_support_i.xml"/>
 </preface>

--- a/xml/upgrade_intro.xml
+++ b/xml/upgrade_intro.xml
@@ -38,4 +38,6 @@
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>
+ <xi:include href="common_intro_making_i.xml"/>
+ <xi:include href="common_intro_lifecycle_support_i.xml"/>
 </preface>

--- a/xml/upgrade_intro.xml
+++ b/xml/upgrade_intro.xml
@@ -38,6 +38,5 @@
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>
- <xi:include href="common_intro_making_i.xml"/>
  <xi:include href="common_intro_lifecycle_support_i.xml"/>
 </preface>


### PR DESCRIPTION
### Description
https://bugzilla.suse.com/show_bug.cgi?id=1140073 requested to add the definition of 'Technical Preview' to the documentation. In addition to this, we also would like to include some basic info about support and product life cycle in the introduction of our manuals.

I collect the information from several sources (release notes for SLE 12 and SLE 15, the section about product lifecycle in our Upgrade Guide, the Modules & Extensions Quick Start and the relevant pages on www.suse.com). I created a new section which is hopefully generic enough to not be outdated already for the next releases.

I will also create a pull request in https://github.com/openSUSE/doc-kit/ after having incorporated the feedback.

### Checklist

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [x] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
