### PR TITLE
Tbazant qemu moniotr console bsc#1145970

### DIFF
--- a/xml/qemu_monitor.xml
+++ b/xml/qemu_monitor.xml
@@ -29,20 +29,32 @@
  </note>
  <sect1 xml:id="sec-qemu-monitor-access">
   <title>Accessing Monitor Console</title>
+  <tip>
+   <title>No Monitor Console for &libvirt;</title>
+   <para>
+    You can access the monitor console only if you started the virtual machine
+    directly with the &qemusystemarch; command and are viewing its graphical output
+    in a native &qemu; window.
+   </para>
+   <para>
+    If you started the virtual machine with &libvirt; (for example using
+    <command>virt-manager</command>) and are viewing its output via VNC or Spice
+    sessions, you cannot access the monitor console directly. You can, however,
+    send the monitor command to the virtual machine via &virsh;:
+   </para>
+<screen>&prompt.root;virsh qemu-monitor-command <replaceable>COMMAND</replaceable></screen>
+  </tip>
 
   <para>
-   You can access the monitor console from &qemu; window either by a
-   keyboard shortcut&mdash;press <keycombo><keycap function="control"/>
-   <keycap function="alt"/><keycap>2</keycap></keycombo> (to return to
-   &qemu;, press <keycombo><keycap function="control"/>
-   <keycap function="alt"/><keycap>1</keycap></keycombo>)&mdash;or
-   alternatively by clicking <guimenu>View</guimenu> in the &qemu; GUI
-   window, then <guimenu>compatmonitor0</guimenu>. The most convenient way
-   is to show the &qemu; window tabs with
-   <menuchoice><guimenu>View</guimenu> <guimenu>Show
-   Tabs</guimenu></menuchoice>. Then you can easily switch between the guest
-   screen, monitor screen, and the output of the serial and parallel
-   console.
+   The way you access the monitor console depends on which display device you
+   use to view the output of a virtual machine. Find more details about
+   displays in <xref linkend="cha-qemu-running-devices-graphic-display"/>.
+   For example, to view the monitor while the <option>-display gtk</option>
+   option is in use, press <keycombo><keycap function="control"/> <keycap
+   function="alt"/><keycap>2</keycap></keycombo>. Similarly, when the
+   <option>-nographic</option> option is in use, you can switch to the
+   monitor console by pressing <keycombo><keycap
+   function="control"/><keycap>a</keycap></keycombo><keycap>c</keycap>
   </para>
 
   <para>


### PR DESCRIPTION
### Description
You can access the QEMU monitor console only when the command is run by the direct qemu-* command. This update makes this clear and includes examples of key shortcuts to access the monitor for different display targets.

### Checklist
* Check all items that apply.

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [x] To maintenance/SLE12SP4
- [x] To maintenance/SLE12SP3
