### PR TITLE
Tbazant kvm on arm64 bsc#1140138

### DIFF
--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -787,10 +787,10 @@
    </listitem>
    <listitem>
     <para>
-     On the &arm64; architecture, &kvm; is generally supported, except for
-     specific technical limitations, such as the Raspberry Pi 3 platform.
+     On the &arm64; architecture, virtualization support was initially added to
+     ARMv7-A processors starting with Cortex-A15 and including Cortex-A7
+     and Cortex-A17. ARMv8-A processors include support for virtualization.
     </para>
-
    </listitem>
 
   </itemizedlist>

--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -754,35 +754,47 @@
   <title>&kvm; Hardware Requirements</title>
 
   <para>
-   Currently, &suse; only supports &kvm; full virtualization on
-   &x86-64; hosts and on &zseries;. On the &x86-64; architecture, &kvm;
-   is designed around hardware virtualization features included in AMD*
-   (AMD-V) and Intel* (VT-x) CPUs. It supports virtualization features
-   of chipsets, and PCI devices, such as an I/O Memory Mapping Unit
-   (<xref linkend="gloss-vt-acronym-iommu"/>) and Single Root I/O
-   Virtualization (<xref linkend="vt-io-sriov"/>).
+   Currently, &suse; supports &kvm; full virtualization on
+    &x86-64; and &arm64; hosts, and on &zseries;.
   </para>
-
-  <para>
-   On the &x86-64; architecture, you can test whether your CPU supports
-   hardware virtualization with the following command:
-  </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     On the &x86-64; architecture, &kvm;
+     is designed around hardware virtualization features included in AMD*
+     (AMD-V) and Intel* (VT-x) CPUs. It supports virtualization features
+     of chipsets and PCI devices, such as an I/O Memory Mapping Unit
+     (<xref linkend="gloss-vt-acronym-iommu"/>) and Single Root I/O
+     Virtualization (<xref linkend="vt-io-sriov"/>). You can test whether
+     your CPU supports hardware virtualization with the following command:
+    </para>
 
 <screen>&prompt.user;egrep '(vmx|svm)' /proc/cpuinfo</screen>
 
-  <para>
-   If this command returns no output, your processor either does not support
-   hardware virtualization, or this feature has been disabled in the BIOS or
-   Firmware.
-  </para>
+    <para>
+     If this command returns no output, your processor either does not support
+     hardware virtualization, or this feature has been disabled in the BIOS or
+     firmware.
+    </para>
 
-  <para>
-   The following Web sites identify &x86-64; processors that support hardware
-   virtualization:
-   <link xlink:href="http://ark.intel.com/Products/VirtualizationTechnology"/>
-   (for Intel CPUs), and <link xlink:href="http://products.amd.com/"/> (for
-   AMD CPUs).
-  </para>
+    <para>
+     The following Web sites identify &x86-64; processors that support hardware
+     virtualization:
+     <link xlink:href="http://ark.intel.com/Products/VirtualizationTechnology"/>
+     (for Intel CPUs), and <link xlink:href="http://products.amd.com/"/> (for
+     AMD CPUs).
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     On the &arm64; architecture, &kvm; is generally supported, except for
+     specific technical limitations, such as the Raspberry Pi 3 platform.
+    </para>
+
+   </listitem>
+
+  </itemizedlist>
+
 
   <note>
    <title>&kvm; Kernel Modules Not Loading</title>


### PR DESCRIPTION
### Description
KVM support statement for ARM64 was missing. This update solves it and
closely specifies supported CPU families.

### Checklist
* Check all items that apply.

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [x] To maintenance/SLE12SP4
- [x] To maintenance/SLE12SP3
