### PR TITLE
Check for rpmnew and rpmsave files after upgrade (bsc#1155552)

### DIFF
--- a/xml/sle_update_offline.xml
+++ b/xml/sle_update_offline.xml
@@ -311,7 +311,7 @@ Check with Simona, if this is supported or needed.
    <step>
     <para>
      On the <guimenu>Previously Used Repositories</guimenu> screen, adjust the
-     status of the repositories. By default all repositories are removed. If you have not added 
+     status of the repositories. By default all repositories are removed. If you have not added
      any custom repositories, do not change the settings. The packages for the upgrade will be
      installed from DVD, and you can optionally enable the default online repositories in the next step.
  </para>
@@ -326,14 +326,14 @@ If you have custom repositories, you have two choices:
 </listitem>
 <listitem>
     <para>
-    Update and enable the repository if it matches the new release. Change its URL 
-    by clicking the repository in the list, and then click <guimenu>Change</guimenu>. Enable the repository  
+    Update and enable the repository if it matches the new release. Change its URL
+    by clicking the repository in the list, and then click <guimenu>Change</guimenu>. Enable the repository
     by checking <guimenu>Toggle Status</guimenu> until it is set to <guimenu>Enable</guimenu>.
 </para>
 </listitem>
 </itemizedlist>
 <para>
-Do not keep repositories from the previous release, as the system may be unstable or not work at all. 
+Do not keep repositories from the previous release, as the system may be unstable or not work at all.
 Then proceed by clicking <guimenu>Next</guimenu>.
     </para>
    </step>
@@ -382,26 +382,60 @@ Then proceed by clicking <guimenu>Next</guimenu>.
      If all settings are according to your wishes, start the installation and
      removal procedure by clicking <guimenu>Update</guimenu>.
     </para>
+    <tip>
+     <title>Upgrade Failure on &smt; Clients</title>
+     <para>
+      If the machine to upgrade is an &smt; client, and the upgrade fails,
+      see <xref linkend="pro-sec-update-prep-smt-de-register"/> and restart the
+      upgrade procedure afterward.
+     </para>
+    </tip>
    </step>
    <step>
     <para>
-     After the upgrade process was finished successfully, check for any
-     <quote>orphaned packages</quote>. Orphaned packages are packages which
-     belong to no active repository anymore. The following command gives you a
-     list of these:
-    </para>
-<screen>&prompt.user;zypper packages --orphaned</screen>
-    <para>
-     With this list, you can decide if a package is still needed or can be
-     uninstalled safely.
+     After the upgrade process has finished successfully, perform post-upgrade
+     checks as described in <xref linkend="sec-upgrade-postupgrade-checks"/>.
     </para>
    </step>
   </procedure>
-  <para>
-   If the machine to upgrade is an &smt; client, and the upgrade fails,
-   see <xref linkend="pro-sec-update-prep-smt-de-register"/> and restart the
-   upgrade procedure afterward.
-  </para>
+  <sect2 xml:id="sec-upgrade-postupgrade-checks">
+   <title>Post-upgrade Checks</title>
+   <itemizedlist>
+    <listitem>
+     <para>
+      Check for any <quote>orphaned packages</quote>. Orphaned packages are
+      packages which belong to no active repository anymore. The following
+      command gives you a list of these:
+     </para>
+<screen>&prompt.user;zypper packages --orphaned</screen>
+     <para>
+      With this list, you can decide if a package is still needed or can be
+      uninstalled safely.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Check for any <filename>*.rpmnew</filename> and
+      <filename>*.rpmsave</filename> files, examine their content, and possibly
+      merge desirable changes.  When an upgrade includes changes to a default
+      configuration file, instead of overwriting the configuration file, the
+      package will write one of these file types.  While
+      <filename>*.rpmnew</filename> contains the new default configuration and
+      leaves your original file untouched, <filename>*.rpmsave</filename> is a
+      copy of your original configuration that has been replaced by the new
+      default file.
+     </para>
+     <para>
+      You do not need to search the whole file system for
+      <filename>*.rpmnew</filename> and <filename>*.rpmsave</filename> files,
+      the most important are stored in the <filename>/etc</filename>
+      directory.  Use the following command to list them:
+     </para>
+<screen>&prompt.user;find /etc -print | egrep "rpmnew$|rpmsave$"</screen>
+    </listitem>
+   </itemizedlist>
+  </sect2>
+
  </sect1>
 
  <sect1 xml:id="sec-upgrade-offline-automated" os="sles">


### PR DESCRIPTION
### Description
This update describes why and how to check for changed system-wide
configuration files after the upgrade of RPM packages.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3