### PR TITLE
Aligned yast2-vm module scope (bsc#1138740)

### DIFF
--- a/xml/qemu_host_installation.xml
+++ b/xml/qemu_host_installation.xml
@@ -49,6 +49,13 @@
   <procedure>
    <step>
     <para>
+     Verify that the <package>yast2-vm</package> package is installed. This package
+     is &yast;'s configuration tool that simplifies the installation of virtualization
+     hypervisors.
+    </para>
+   </step>
+   <step>
+    <para>
      Run <menuchoice><guimenu>&yast;</guimenu><guimenu>
      Virtualization</guimenu><guimenu>Install Hypervisor and
      Tools</guimenu></menuchoice>.

--- a/xml/vt_installation.xml
+++ b/xml/vt_installation.xml
@@ -16,7 +16,7 @@
  <para>
   Depending on the scope of the installation, none of the virtualization tools
   may be installed on your system. They will be automatically installed when
-  configuring the hyperviosor with the &yast; module <menuchoice>
+  configuring the hypervisor with the &yast; module <menuchoice>
   <guimenu>Virtualization</guimenu> <guimenu>Install Hypervisor and
   Tools</guimenu></menuchoice>. In case this module is not available in &yast;,
   install the package <package>yast2-vm</package>.
@@ -30,6 +30,13 @@
   </para>
 
   <procedure>
+   <step>
+    <para>
+     Verify that the <package>yast2-vm</package> package is installed. This package
+     is &yast;'s configuration tool that simplifies the installation of virtualization
+     hypervisors.
+    </para>
+   </step>
    <step>
     <para>
      Start &yast; and choose <menuchoice>


### PR DESCRIPTION
### Description
When installing virtualization hypervisors and related tools from YAST,
the module description was not always accurate and installing the `yast2-vm` package was omitted.

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [x] To maintenance/SLE12SP4
- [x] To maintenance/SLE12SP3
