### PR TITLE
tuning, io: Add/change notes related to blk-mq I/O scheduler

### DIFF
--- a/xml/tuning_storagescheduler.xml
+++ b/xml/tuning_storagescheduler.xml
@@ -83,9 +83,19 @@
   <note os="sles" arch="x86_64">
    <title>Scheduler in case of block multi-queue (blk-mq) I/O path</title>
    <para>
-     If the device is using blk-mq I/O path (refer to <xref
-     linkend="cha-tuning-io-scsimq"/>)
-     <replaceable>SCHEDULER</replaceable> should be set to either
+     The <literal>elevator</literal> boot parameter does not apply to
+     devices using blk-mq I/O path (refer to <xref
+     linkend="cha-tuning-io-scsimq"/>).
+   </para>
+   <para>
+     Default elevator is <option>mq-deadline</option> for conventional
+     devices (e.g. rotational hard disks, SSDs) and
+     <option>none</option> for faster storage devices (devices with
+     multiple hardware queues).
+   </para>
+   <para>
+     Changing the elevator for a specific device in a running system
+     is possible. <replaceable>SCHEDULER</replaceable> should be set to either
      <option>mq-deadline</option>, <option>kyber</option>,
      <option>bfq</option>, or <option>none</option>
    </para>
@@ -621,6 +631,18 @@ sys     0m1.516s</screen>
 
 <screen>&prompt.user;cat /sys/block/sda/queue/scheduler
 [mq-deadline] kyber bfq none</screen>
+
+  <note os="sles" arch="x86_64">
+    <title>Comparability of scheduler options when switching from
+    legacy block to blk-mq I/O path</title>
+    <para>
+      When switching from legacy block to blk-mq I/O path for a device
+      a rough guideline is that <option>none</option> is comparable to
+      <option>noop</option>, <option>mq-deadline</option> comparable
+      to <option>deadline</option>, and <option>bfq</option> is
+      comparable to <option>cfq</option>.
+     </para>
+  </note>
 
   <sect2 xml:id="sec-tuning-io-schedulers-mqdeadline">
    <title><systemitem class="resource">MQ-DEADLINE</systemitem></title>


### PR DESCRIPTION
Point out
o that 'elevator' command line option is not supported
o that default I/O schedulers are either mq-deadline or none
o what blk-mq schedulers are comparable to which legacy I/O schedulers

### Description
Customers are confused that elevator command line option is no
longer working with blk-mq, see for example
https://bugzilla.suse.com/show_bug.cgi?id=1149988

The recent update to document blk-mq I/O scheduler options
did not yet contain related information. This short update
should fix this.

### Checklist
* Check all items that apply.

*Are backports required?*

4 branches are affected:
The patch is for SLE12SP4.
Backports are required to SLE15SP1,  SLE15SP0 and SLE12SP5.

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [x] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
