### PR TITLE
Add warning to partitioning § describing GB/GiB difference (BSC#1155315)

### DIFF
--- a/xml/art_sle_install_quick.xml
+++ b/xml/art_sle_install_quick.xml
@@ -570,6 +570,45 @@
        </listitem>
       </varlistentry>
      </variablelist>
+     <warning>
+      <title>Disk Space Units</title>
+      <para>
+       Note that for partitioning purposes, disk space is measured in binary
+       units, rather than in decimal units. For example, if you enter sizes of
+       <literal>1GB</literal>, <literal>1GiB</literal> or <literal>1G</literal>,
+       all signify 1&nbsp;GiB (Gibibyte), as opposed to 1&nbsp;GB (Gigabyte).
+      </para>
+      <variablelist>
+       <varlistentry>
+        <term>Binary</term>
+        <listitem>
+         <para>
+          1&nbsp;GiB = 1&nbsp;073&nbsp;741&nbsp;824 bytes.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term>
+         Decimal
+        </term>
+        <listitem>
+         <para>
+          1&nbsp;GB = 1&nbsp;000&nbsp;000&nbsp;000 bytes.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term>
+         Difference
+        </term>
+        <listitem>
+         <para>
+          1&nbsp;GiB &asymp; 1.07&nbsp;GB.
+         </para>
+        </listitem>
+       </varlistentry>
+      </variablelist>
+     </warning>
      <para>
       To accept the proposed setup without any changes, choose
       <guimenu>Next</guimenu> to proceed.

--- a/xml/art_sle_install_quick.xml
+++ b/xml/art_sle_install_quick.xml
@@ -576,7 +576,7 @@
        Note that for partitioning purposes, disk space is measured in binary
        units, rather than in decimal units. For example, if you enter sizes of
        <literal>1GB</literal>, <literal>1GiB</literal> or <literal>1G</literal>,
-       all signify 1&nbsp;GiB (Gibibyte), as opposed to 1&nbsp;GB (Gigabyte).
+       they all signify 1&nbsp;GiB (Gibibyte), as opposed to 1&nbsp;GB (Gigabyte).
       </para>
       <variablelist>
        <varlistentry>

--- a/xml/deployment_expert_partitioner.xml
+++ b/xml/deployment_expert_partitioner.xml
@@ -29,6 +29,45 @@
   option to use iSCSI as a networked disk<phrase os="sles"> (read more about
   iSCSI in <xref linkend="cha-iscsi"/>)</phrase>.
  </para>
+ <warning>
+  <title>Disk Space Units</title>
+  <para>
+   Note that for partitioning purposes, disk space is measured in binary
+   units, rather than in decimal units. For example, if you enter sizes of
+   <literal>1GB</literal>, <literal>1GiB</literal> or <literal>1G</literal>,
+   they all signify 1&nbsp;GiB (Gibibyte), as opposed to 1&nbsp;GB (Gigabyte).
+  </para>
+  <variablelist>
+   <varlistentry>
+    <term>Binary</term>
+    <listitem>
+     <para>
+      1&nbsp;GiB = 1&nbsp;073&nbsp;741&nbsp;824 bytes.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     Decimal
+    </term>
+    <listitem>
+     <para>
+      1&nbsp;GB = 1&nbsp;000&nbsp;000&nbsp;000 bytes.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     Difference
+    </term>
+    <listitem>
+     <para>
+      1&nbsp;GiB &asymp; 1.07&nbsp;GB.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </warning>
  <xi:include href="deployment_expert_partitioner_overview.xml"/>
  <xi:include href="deployment_expert_partitioner_lvm.xml"/>
  <xi:include href="deployment_expert_partitioner_raid.xml"/>

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -1929,6 +1929,45 @@ disk:
      </listitem>
     </varlistentry>
    </variablelist>
+   <warning>
+    <title>Disk Space Units</title>
+    <para>
+     Note that for partitioning purposes, disk space is measured in binary
+     units, rather than in decimal units. For example, if you enter sizes of
+     <literal>1GB</literal>, <literal>1GiB</literal> or <literal>1G</literal>,
+     they all signify 1&nbsp;GiB (Gibibyte), as opposed to 1&nbsp;GB (Gigabyte).
+    </para>
+    <variablelist>
+     <varlistentry>
+      <term>Binary</term>
+      <listitem>
+       <para>
+        1&nbsp;GiB = 1&nbsp;073&nbsp;741&nbsp;824 bytes.
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>
+       Decimal
+      </term>
+      <listitem>
+       <para>
+        1&nbsp;GB = 1&nbsp;000&nbsp;000&nbsp;000 bytes.
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>
+       Difference
+      </term>
+      <listitem>
+       <para>
+        1&nbsp;GiB &asymp; 1.07&nbsp;GB.
+       </para>
+      </listitem>
+     </varlistentry>
+    </variablelist>
+   </warning>
   </sect2>
  </sect1>
 


### PR DESCRIPTION
### Description
This adds a Warning to the partitioning section of the Quick Install guide with a note about binary/decimal units, as per https://bugzilla.suse.com/show_bug.cgi?id=1155315 

If the working/formatting looks OK then I will insert the same warning in the various other partitioning section.
### Checklist
* Check all items that apply.

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
