### PR TITLE
SLE 12 SP5: Using the whole disk as file system in AutoYaST

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -3450,6 +3450,55 @@ openssl x509 -noout -fingerprint -sha256
 </screen>
    </sect2>
 
+   <sect2 xml:id="ay-use-whole-disk">
+    <title>Using the Whole Disk</title>
+
+    <para>
+     &ay; allows to use a whole disk without creating any partition by setting
+     the <literal>partition_nr</literal> to <literal>0</literal> as described
+     in <xref linkend="CreateProfile-Partitioning-config"/>. In such cases, the
+     configuration in the first <literal>partition</literal> from the
+     <literal>drive</literal> will be applied to the whole disk.
+    </para>
+
+    <para>
+     In the example below, we are using the second disk (<literal>/dev/sdb</literal>)
+     as the <literal>/home</literal> file system.
+    </para>
+
+    <example>
+     <title>Using a Whole Disk as a File System</title>
+     <screen>&lt;partitioning config:type="list"&gt;
+  &lt;drive&gt;
+    &lt;device&gt;/dev/sda&lt;/device&gt;
+    &lt;partitions config:type="list"&gt;
+      &lt;partition&gt;
+        &lt;create config:type="boolean"&gt;true&lt;/create&gt;
+        &lt;format config:type="boolean"&gt;true&lt;/format&gt;
+        &lt;mount&gt;/&lt;/mount&gt;
+        &lt;size&gt;max&lt;/size&gt;
+      &lt;/partition&gt;
+    &lt;/partitions&gt;
+  &lt;/drive&gt;
+  &lt;drive&gt;
+    &lt;device&gt;/dev/sdb&lt;/device&gt;
+    &lt;partitions config:type="list"&gt;
+      &lt;partition&gt;
+        &lt;partition_nr config:type="integer"&gt;0&lt;partition_nr&gt;
+        &lt;format config:type="boolean"&gt;true&lt;/format&gt;
+        &lt;mount&gt;/home&lt;/mount&gt;
+      &lt;/partition&gt;
+    &lt;/partitions&gt;
+  &lt;/drive&gt;</screen>
+    </example>
+
+    <para>
+     In addition, the whole disk can be used as an LVM physical volume or as a software RAID
+     member. See <xref linkend="ay-partition-lvm"/> and <xref linkend="ay-partition-sw-raid"/>
+     for further details about setting up an LVM or a software RAID.
+    </para>
+   </sect2>
+
    <sect2 xml:id="ay-raid-configuration">
     <title>RAID Options</title>
     <para>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -3454,7 +3454,7 @@ openssl x509 -noout -fingerprint -sha256
     <title>Using the Whole Disk</title>
 
     <para>
-     &ay; allows to use a whole disk without creating any partition by setting
+     &ay; will format a whole disk as a single partition by setting
      the <literal>partition_nr</literal> to <literal>0</literal> as described
      in <xref linkend="CreateProfile-Partitioning-config"/>. In such cases, the
      configuration in the first <literal>partition</literal> from the
@@ -3462,8 +3462,8 @@ openssl x509 -noout -fingerprint -sha256
     </para>
 
     <para>
-     In the example below, we are using the second disk (<literal>/dev/sdb</literal>)
-     as the <literal>/home</literal> file system.
+     In the example below, we are using the second disk (<filename>/dev/sdb</filename>)
+     as the <filename>/home</filename> file system.
     </para>
 
     <example>

--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2382,7 +2382,7 @@ openssl x509 -noout -fingerprint -sha256
           Trusted GRUB supports Trusted Platform Module (TPM).
           Works only for <literal>grub2</literal> bootloader.
          </para>
-<screen>&lt;trusted_boot"&gt;true&lt;/trusted_boot&gt;</screen>
+<screen>&lt;trusted_boot&gt;true&lt;/trusted_boot&gt;</screen>
         </entry>
        </row>
        <row>


### PR DESCRIPTION
### Description

SLE 12 documentation does not explain how to use a whole disk (no partitions) as a file system (or as an LVM PV or RAID member). For SLE 15, this feature has been changed and properly documented.

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [x] To maintenance/SLE12SP4
- [x] To maintenance/SLE12SP3
