### PR TITLE
AutoYaST: Add a note about the old way of using the whole disk

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -3916,6 +3916,14 @@ openssl x509 -noout -fingerprint -sha256
       member. See <xref linkend="ay-partition-lvm"/> and <xref linkend="ay-partition-sw-raid"/>
       for further details about setting up an LVM or a software RAID.
      </para>
+
+     <para>
+      For backward compatibility reasons, it is possible to achieve the same
+      result by setting the <literal>&lt;partition_nr&gt;</literal> element to
+      <literal>0</literal>. However, this usage of the
+      <literal>&lt;partition_nr&gt;</literal> element is deprecated since
+      &productname; 15.
+     </para>
     </sect3>
 
     <sect3 xml:id="ay-auto-partitioning">


### PR DESCRIPTION
### Description

Mention that, for compatibility reasons, setting the `partition_nr` to `0` is still supported but deprecated. It applies to SLE 15 based versions.

### Checklist
* Check all items that apply.

*Are backports required?*

- [X] To maintenance/SLE15SP1
- [X] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
