### PR TITLE
AutoYaST: Clarify how to refer to multipath devices

### DIFF
--- a/xml/ay_bigfile.xml
+++ b/xml/ay_bigfile.xml
@@ -2779,6 +2779,10 @@ openssl x509 -noout -fingerprint -sha256
            In case of volume groups, software RAID or &bcache; devices, the name in the installed
            system may be different (to avoid clashes with existing devices).
           </para>
+          <para>
+           See <xref linkend="ay-partition-multipath"/> for further information
+           about dealing with multipath devices.
+          </para>
          </entry>
          <entry>
           <para>
@@ -4795,16 +4799,19 @@ openssl x509 -noout -fingerprint -sha256
 
     <para>
      If you want to specify the device, you could use the World Wide Identifier
-     (WWID), its device name (e.g., <literal>/dev/dm-0</literal>) or any other path
-     under <literal>/dev/disk</literal> that refers to the multipath device.
+     (WWID), its device name (e.g., <literal>/dev/dm-0</literal>), any other
+     path under <literal>/dev/disk</literal> that refers to the multipath device
+     or any of its paths.
     </para>
 
     <para>
      For instance, given the <literal>multipath</literal> listing from <xref
      linkend="multipath-ll-output"/>, you could use
      <literal>/dev/mapper/14945540000000000f86756dce9286158be4c6e3567e75ba5</literal>,
-     <literal>/dev/dm-3</literal> or any other corresponding path under <literal>/dev/disk</literal>,
-     like shown in the <xref linkend="multipath-wwid-example"/>
+     <literal>/dev/dm-3</literal>, any other corresponding path under
+     <literal>/dev/disk</literal> (like shown in the <xref
+     linkend="multipath-wwid-example"/>), or any of its paths
+     (<literal>/dev/sda</literal> or <literal>/dev/sdb</literal>).
     </para>
 
     <example xml:id="multipath-ll-output">


### PR DESCRIPTION
### Description

When referring to multipath devices, it is possible to use any of its paths. Related to https://github.com/yast/yast-storage-ng/pull/1011. Just for SLE 15 SP2.

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
