### PR TITLE
Joined 2 clumsy procedure steps into 1 (bsc#1137710)

### DIFF
--- a/xml/rmt_migrate_from_smt.xml
+++ b/xml/rmt_migrate_from_smt.xml
@@ -581,7 +581,6 @@
  <sect1 xml:id="sec-rmt-migrate-rmt-import">
   <title>Importing &smt; Data to &rmt;</title>
   <procedure>
-   <title>Importing &smt; Data to &rmt;</title>
    <step>
     <para>
      To make sure your &rmt; installation is up to date, run
@@ -595,8 +594,7 @@
     </para>
 <screen>&prompt.user;<command>mkdir <replaceable>EMPTY_DIR</replaceable></command>
 &prompt.user;<command>cd <replaceable>EMPTY_DIR</replaceable></command>
-&prompt.user;<command>cp <replaceable>/PATH/TO/</replaceable>smt-export.<replaceable>XXXXXX</replaceable>.tar.gz ./</command>
-&prompt.user;<command>tar xf smt-export.<replaceable>XXXXXX</replaceable>.tar.gz</command>
+&prompt.user;<command>tar xf <replaceable>/PATH/TO/</replaceable>smt-export.<replaceable>XXXXXX</replaceable>.tar.gz</command>
 &prompt.user;<command>cd smt-export</command>
 </screen>
    </step>


### PR DESCRIPTION
### Description
RMT import procedure included 2 steps that could be easily merged into 1 step with the same functionality. This update improves that.

### Checklist

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
