### PR TITLE
Add RMT support for SLP discovery

### DIFF
--- a/xml/rmt_install.xml
+++ b/xml/rmt_install.xml
@@ -169,16 +169,39 @@
 
   <para>
    &rmt; includes the SLP service description file
-   (<filename>/etc/slp.reg.d/rmt.reg</filename>). To enable SLP
-   announcements of the &rmt; service, open respective ports in your
-   firewall and enable the SLP service:
+   <filename>/etc/slp.reg.d/rmt-server.reg</filename>. To enable SLP
+   announcements of the &rmt; service, follow these steps:
   </para>
-
+  <procedure>
+   <step>
+    <para>
+     If &firewalld; is running, open relevant ports and reload the &firewalld;
+     configuration:
+    </para>
 <screen>
-sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "427"
-sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_UDP "427"
-systemctl enable slpd.service
-systemctl start slpd.service
-  </screen>
+&prompt.sudo;firewall-cmd --permanent --add-port=427/tcp
+success
+&prompt.sudo;firewall-cmd --permanent --add-port=427/udp
+success
+&prompt.sudo;firewall-cmd --reload
+</screen>
+   </step>
+   <step>
+    <para>
+     Verify that SLP server is installed and possibly install it:
+    </para>
+<screen>&prompt.sudo;zypper install openslp-server</screen>
+   </step>
+   <step>
+    <para>
+     Enable and start the SLP service:
+    </para>
+<screen>
+&prompt.sudo;systemctl enable slpd.service
+&prompt.sudo;systemctl restart slpd.service
+</screen>
+   </step>
+  </procedure>
+
  </sect1>
 </chapter>

--- a/xml/rmt_install.xml
+++ b/xml/rmt_install.xml
@@ -163,5 +163,22 @@
     </para>
    </step>
   </procedure>
+  </sect1>
+  <sect1>
+  <title>Enabling SLP Announcements</title>
+
+  <para>
+   &rmt; includes the SLP service description file
+   (<filename>/etc/slp.reg.d/rmt.reg</filename>). To enable SLP
+   announcements of the &rmt; service, open respective ports in your
+   firewall and enable the SLP service:
+  </para>
+
+<screen>
+sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_TCP "427"
+sysconf_addword /etc/sysconfig/SuSEfirewall2 FW_SERVICES_EXT_UDP "427"
+systemctl enable slpd.service
+systemctl start slpd.service
+  </screen>
  </sect1>
 </chapter>


### PR DESCRIPTION
### Description
RMT server service can be propagated/discovered through SLP.
This update describes steps to accomplish it.

### Checklist

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
