### PR TITLE
Bugfix/bsc#1155315 sle12sp5

### DIFF
--- a/xml/inst_yast2.xml
+++ b/xml/inst_yast2.xml
@@ -2234,6 +2234,47 @@ sle_update.xml#sec.update.sle.terminology: "Modules" -->
       and configuring advanced features, refer to
       <xref linkend="sec-yast2-i-y2-part-expert"/>.
      </para>
+     
+     <warning>
+      <title>Disk Space Units</title>
+      <para>
+       Note that for partitioning purposes, disk space is measured in binary
+       units, rather than in decimal units. For example, if you enter sizes of
+       <literal>1GB</literal>, <literal>1GiB</literal> or <literal>1G</literal>,
+       they all signify 1&nbsp;GiB (Gibibyte), as opposed to 1&nbsp;GB (Gigabyte).
+      </para>
+      <variablelist>
+       <varlistentry>
+        <term>Binary</term>
+        <listitem>
+         <para>
+          1&nbsp;GiB = 1&nbsp;073&nbsp;741&nbsp;824 bytes.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term>
+         Decimal
+        </term>
+        <listitem>
+         <para>
+          1&nbsp;GB = 1&nbsp;000&nbsp;000&nbsp;000 bytes.
+         </para>
+        </listitem>
+       </varlistentry>
+       <varlistentry>
+        <term>
+         Difference
+        </term>
+        <listitem>
+         <para>
+          1&nbsp;GiB &asymp; 1.07&nbsp;GB.
+         </para>
+        </listitem>
+       </varlistentry>
+      </variablelist>
+     </warning>
+     
      <warning>
       <title>Custom Partitioning on UEFI Machines</title>
       <para>


### PR DESCRIPTION
### Description
Backport warning about unit sizes from SLE15 SP2 docs into SLE12 SP5.

This explicitly compares GB to GiB with examples.

I already added this to the InstallQuick article in the maintenance/SLE12SP5 branch by mistake:
https://github.com/SUSE/doc-sle/commit/bc580f825f4858c32638e5c63abf0ffe08ac1abd

This is the same warning in the main Deployment Guide, done in a separate branch.

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
