### PR TITLE
Change "sle-12_x86_64" to "sle-12-x86_64" (BSC#1158682)

### DIFF
--- a/xml/smt_mirroring.xml
+++ b/xml/smt_mirroring.xml
@@ -813,7 +813,7 @@ sudo chmod go-rwx -R /var/lib/smt/.gnupg</screen>
     <para>
      Enable the repositories to be mirrored with the &smt;, for example:
     </para>
-<screen>smt-repos -e SLES12-Updates sle-12_x86_64</screen>
+<screen>smt-repos -e SLES12-Updates sle-12-x86_64</screen>
    </step>
    <step>
     <para>


### PR DESCRIPTION
### Description
Addresses https://bugzilla.suse.com/show_bug.cgi?id=1158682
Fixes a typo in the repo architecture name.

### Checklist
* Check all items that apply.

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [x] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
