### PR TITLE
Registering stand-alone custom RMT repos on client hosts

### DIFF
--- a/xml/rmt_client.xml
+++ b/xml/rmt_client.xml
@@ -255,7 +255,7 @@
     <para>
      On the client machine, add the discovered repository URL:
     </para>
-<screen>&prompt.sudo;zypper ar <replaceable>CUSTOM_REPO_URL</replaceable></screen>
+<screen>&prompt.sudo;zypper ar <replaceable>CUSTOM_REPO_URL</replaceable> <replaceable>CUSTOM_REPO_NAME</replaceable></screen>
    </step>
   </procedure>
  </sect1>

--- a/xml/rmt_client.xml
+++ b/xml/rmt_client.xml
@@ -212,7 +212,7 @@
    </step>
   </procedure>
  </sect1>
- 
+
 <!-- ================================================================ -->
  <sect1 xml:id="sec-rmt-client-yast">
   <title>Configuring Clients with &yast;</title>
@@ -227,6 +227,37 @@
     and enter its URL. Then click <guimenu>Next</guimenu> until the exit from
     the module.
    </para>
+ </sect1>
+ <sect1 xml:id="rmt-client-custom-repo">
+  <title>Configuring Clients for Custom Stand-alone Repositories</title>
+  <para>
+   If you created a custom stand-alone repository on the &rmt; server, it will
+   not be registered on client machines with <command>SUSEConnect</command>
+   because it has no parent product.
+  </para>
+  <para>
+   To add the repository manually, follow these steps:
+  </para>
+  <procedure>
+   <step>
+    <para>
+     Point your Web browser to the following RMT server URL:
+    </para>
+<screen>https://<replaceable>RMT_SERVER_HOSTNAME/repo/</replaceable></screen>
+   </step>
+   <step>
+    <para>
+     Navigate the browser through the directory structure to your custom
+     repository's <filename>repodata/</filename> subdirectory.
+    </para>
+   </step>
+   <step>
+    <para>
+     On the client machine, add the discovered repository URL:
+    </para>
+<screen>&prompt.sudo;zypper ar <replaceable>CUSTOM_REPO_URL</replaceable></screen>
+   </step>
+  </procedure>
  </sect1>
 
  <sect1 xml:id="sec-rmt-client-list-repositories">

--- a/xml/rmt_mirroring.xml
+++ b/xml/rmt_mirroring.xml
@@ -273,38 +273,6 @@ Repository successfully disabled.</screen>
    To get a list of all available custom repositories commands, see
    <xref linkend="sec-rmt-tools-rmt-cli-repos" />.
   </para>
-  <sect2>
-   <title>Adding Custom Stand-alone Repositories to Client Machines</title>
-   <para>
-    If you created a custom stand-alone repository on the &rmt; server, it will
-    not be registered on client machines with <command>SUSEConnect</command>
-    because it has no parent product.
-   </para>
-   <para>
-    To add the repository manually, follow these steps:
-   </para>
-    <procedure>
-     <step>
-      <para>
-       Point your browser to the RMT server URL:
-      </para>
-<screen>https://<replaceable>RMT_SERVER_HOSTNAME/repo/</replaceable></screen>
-     </step>
-     <step>
-      <para>
-       Navigate the browser through the directory structure to your custom
-       repository <filename>repodata/</filename> subdirectory.
-      </para>
-     </step>
-
-     <step>
-      <para>
-       On the client machine, add the discovered repository URL:
-      </para>
-<screen>&prompt.sudo;zypper ar <replaceable>CUSTOM_REPO_URL</replaceable></screen>
-     </step>
-    </procedure>
-  </sect2>
  </sect1>
 
  <sect1 xml:id="sec-rmt-mirroring-export-import">

--- a/xml/rmt_mirroring.xml
+++ b/xml/rmt_mirroring.xml
@@ -224,9 +224,9 @@ Repository successfully disabled.</screen>
    with <command>createrepo</command>.
   </para>
   <para>
-   Custom repositories can be attached to products. This allows you to
-   connect multiple repositories with one command on a client
-   registered to the &rmt; server.
+   Custom repositories can either be standalone, or you can attach them to
+   products. This allows you to connect multiple repositories with one command
+   on a client registered to the &rmt; server.
   </para>
   <para>
    The following example procedure illustrates the mirroring of a
@@ -273,6 +273,16 @@ Repository successfully disabled.</screen>
    To get a list of all available custom repositories commands, see
    <xref linkend="sec-rmt-tools-rmt-cli-repos" />.
   </para>
+  <tip>
+   <title>Adding a Custom Stand-alone Repository to Client Machines</title>
+   <para>
+    If you created a custom stand-alone repository on the &rmt; server, it will
+    not be registered on client machines with <command>SUSEConnect</command>
+    because it has no parent product. You need add such repository manually:
+   </para>
+<screen>&prompt.sudo;zypper ar <replaceable>CUSTOM_REPO_URL</replaceable></screen>
+  </tip>
+
  </sect1>
 
  <sect1 xml:id="sec-rmt-mirroring-export-import">

--- a/xml/rmt_mirroring.xml
+++ b/xml/rmt_mirroring.xml
@@ -273,16 +273,38 @@ Repository successfully disabled.</screen>
    To get a list of all available custom repositories commands, see
    <xref linkend="sec-rmt-tools-rmt-cli-repos" />.
   </para>
-  <tip>
-   <title>Adding a Custom Stand-alone Repository to Client Machines</title>
+  <sect2>
+   <title>Adding Custom Stand-alone Repositories to Client Machines</title>
    <para>
     If you created a custom stand-alone repository on the &rmt; server, it will
     not be registered on client machines with <command>SUSEConnect</command>
-    because it has no parent product. You need add such repository manually:
+    because it has no parent product.
    </para>
-<screen>&prompt.sudo;zypper ar <replaceable>CUSTOM_REPO_URL</replaceable></screen>
-  </tip>
+   <para>
+    To add the repository manually, follow these steps:
+   </para>
+    <procedure>
+     <step>
+      <para>
+       Point your browser to the RMT server URL:
+      </para>
+<screen>https://<replaceable>RMT_SERVER_HOSTNAME/repo/</replaceable></screen>
+     </step>
+     <step>
+      <para>
+       Navigate the browser through the directory structure to your custom
+       repository <filename>repodata/</filename> subdirectory.
+      </para>
+     </step>
 
+     <step>
+      <para>
+       On the client machine, add the discovered repository URL:
+      </para>
+<screen>&prompt.sudo;zypper ar <replaceable>CUSTOM_REPO_URL</replaceable></screen>
+     </step>
+    </procedure>
+  </sect2>
  </sect1>
 
  <sect1 xml:id="sec-rmt-mirroring-export-import">


### PR DESCRIPTION
### Description
If custom repositories do not have a parent product, you cannot register them on the client machines with `SUSEConnect`. This update describes manual steps to add them using the `zypper ar ...` command

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
