### PR TITLE
Opening firewalld ports using the YaST RMT module (jsc#SLE-4560)

### DIFF
--- a/xml/rmt_install.xml
+++ b/xml/rmt_install.xml
@@ -140,7 +140,7 @@
    <step>
     <para>
      If &firewalld; is enabled on this system, enable the checkbox to open the
-     required ports. Click <guimenu>Next</guimenu>.
+     required ports.
     </para>
     <figure>
      <title>Enabling Ports in &firewalld;</title>
@@ -153,7 +153,21 @@
       </imageobject>
      </mediaobject>
     </figure>
-
+    <para>
+     If &firewalld; is not enabled now and you plan to enabled it later, you
+     can always open relevant ports by running the <command>yast2 rmt</command>
+     module.
+    </para>
+    <tip>
+     <title>Fine-tuning &firewalld; Settings</title>
+     <para>
+      By clicking <guimenu>Firewall Details</guimenu>, you can open the
+      relevant ports for specific network interfaces only.
+     </para>
+    </tip>
+    <para>
+     Continue with <guimenu>Next</guimenu>.
+    </para>
    </step>
    <step>
     <para>


### PR DESCRIPTION
### Description
Opening firwalld ports is now automated in the YaST RMT module.

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
