### PR TITLE
Updates to cgroups resource limits (bsc#1132382)

### DIFF
--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -93,7 +93,7 @@
     <listitem>
      <para>
       Assigns a CPU time to processes. The value is a percentage
-      followed by a <literal>%</literal> as suffix. This requires
+      followed by a <literal>%</literal> as suffix. This implies
       <literal>CPUAccounting=yes</literal>.
      </para>
      <para>
@@ -121,13 +121,24 @@
      <para>
       Unused memory from processes below this limit will not be
       reclaimed for other use. Use suffixes K, M, G or T for
-      <replaceable>BYTES</replaceable>. This requires
+      <replaceable>BYTES</replaceable>. This implies
       <literal>MemoryAccounting=yes</literal>.
      </para>
      <para>
       Example:
      </para>
      <screen>&prompt.root;<command>systemctl set-property nginx.service MemoryLow=512M</command></screen>
+     <note>
+      <title>Unified Control Group Hierarchy</title>
+      <para>
+       This setting is supported only if the unified control group hierarchy is
+       used, and disables <option>MemoryLimit=</option>. To enable the unified
+       control group hierarchy, append
+       <option>systemd.unified_cgroup_hierarchy=1</option> as a kernel command
+       line parameter to the &grub; boot loader. Refer to <xref
+        linkend="cha-grub2"/> for more details about configuring &grub;.
+      </para>
+     </note>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -136,13 +147,25 @@
      <para>
       If more memory above this limit is used, memory is aggressively
       taken away from the processes. Use suffixes K, M, G or T for
-      <replaceable>BYTES</replaceable>. This requires
+      <replaceable>BYTES</replaceable>. This implies
       <literal>MemoryAccounting=yes</literal>.
      </para>
+
      <para>
       Example:
      </para>
      <screen>&prompt.root;<command>systemctl set-property nginx.service MemoryHigh=2G</command></screen>
+     <note>
+      <title>Unified Control Group Hierarchy</title>
+      <para>
+       This setting is supported only if the unified control group hierarchy is
+       used, and disables <option>MemoryLimit=</option>. To enable the unified
+       control group hierarchy, append
+       <option>systemd.unified_cgroup_hierarchy=1</option> as a kernel command
+       line parameter to the &grub; boot loader. Refer to <xref
+        linkend="cha-grub2"/> for more details about configuring &grub;.
+      </para>
+     </note>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -151,7 +174,7 @@
      <para>
       Sets a maximum limit for used memory. Processes will be killed if
       they use more memory than allowed. Use suffixes K, M, G or T for
-      <replaceable>BYTES</replaceable>. This requires
+      <replaceable>BYTES</replaceable>. This implies
       <literal>MemoryAccounting=yes</literal>.
      </para>
      <para>

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -131,7 +131,7 @@
      <note>
       <title>Unified Control Group Hierarchy</title>
       <para>
-       This setting is supported only if the unified control group hierarchy is
+       This setting is available only if the unified control group hierarchy is
        used, and disables <option>MemoryLimit=</option>. To enable the unified
        control group hierarchy, append
        <option>systemd.unified_cgroup_hierarchy=1</option> as a kernel command
@@ -158,7 +158,7 @@
      <note>
       <title>Unified Control Group Hierarchy</title>
       <para>
-       This setting is supported only if the unified control group hierarchy is
+       This setting is available only if the unified control group hierarchy is
        used, and disables <option>MemoryLimit=</option>. To enable the unified
        control group hierarchy, append
        <option>systemd.unified_cgroup_hierarchy=1</option> as a kernel command


### PR DESCRIPTION
### Description
The resource limit section was improved in the following points:
* MemoryAccounting and CPUAccounting options are 'implied' instead of 'required'
* added a note about unified control group hierarchy for selected options + reference how to enable it

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
