### PR TITLE
Fix documentation.suse.com URLs for SLE 15 GA

### DIFF
--- a/xml/art_amd-sev.xml
+++ b/xml/art_amd-sev.xml
@@ -334,7 +334,7 @@
    For more information on using hugepages with VMs, refer to the
    <citetitle>Virtualization Best Practices Guide</citetitle>, 
    Chapter "Configuring the VM Host Server and the VM Guest to use Huge Pages":
-   <link xlink:href="https://www.suse.com/documentation/sles-15/book_quickstarts/data/sec_vt_best_hostlevel.html#sec_vt_best_mem_huge_pages"/>.
+   <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/article-vt-best-practices.html#sec-vt-best-mem-huge-pages"/>.
   </para>
   <para>
    Whilst the overhead incurred is no different to that required for

--- a/xml/art_amd-sev.xml
+++ b/xml/art_amd-sev.xml
@@ -334,7 +334,7 @@
    For more information on using hugepages with VMs, refer to the
    <citetitle>Virtualization Best Practices Guide</citetitle>, 
    Chapter "Configuring the VM Host Server and the VM Guest to use Huge Pages":
-   <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/article-vt-best-practices.html#sec-vt-best-mem-huge-pages"/>.
+   <link xlink:href="&dsc-sles;/html/SLES-all/article-vt-best-practices.html#sec-vt-best-mem-huge-pages"/>.
   </para>
   <para>
    Whilst the overhead incurred is no different to that required for

--- a/xml/art_sle_install_quick.xml
+++ b/xml/art_sle_install_quick.xml
@@ -175,15 +175,15 @@
      <itemizedlist>
       <listitem>
        <para>
-        &sls; (<phrase os="sles">covered here</phrase><phrase os="sled">refer
-        to <link xlink:href="https://www.suse.com/documentation/sles/"/> for
+        &sls; &productnumber; (<phrase os="sles">covered here</phrase><phrase os="sled">refer
+        to <link xlink:href="https://documentation.suse.com/sles/"/> for
         installation instructions</phrase>)
        </para>
       </listitem>
       <listitem>
        <para>
-        &sled; (<phrase os="sled">covered here</phrase><phrase os="sles">refer
-        to <link xlink:href="https://www.suse.com/documentation/sled/"/> for
+        &sled; &productnumber; (<phrase os="sled">covered here</phrase><phrase os="sles">refer
+        to <link xlink:href="https://documentation.suse.com/sled/"/> for
         installation instructions</phrase>)
        </para>
       </listitem>
@@ -195,8 +195,8 @@
       </listitem>
       <listitem>
        <para>
-        &sles4sap; (refer to <link
-        xlink:href="https://www.suse.com/documentation/sles-for-sap/"/> for
+        &sles4sap; &productnumber; (refer to <link
+        xlink:href="https://documentation.suse.com/sles-sap/"/> for
         installation instructions)
        </para>
       </listitem>

--- a/xml/art_sle_install_quick.xml
+++ b/xml/art_sle_install_quick.xml
@@ -176,14 +176,14 @@
       <listitem>
        <para>
         &sls; &productnumber; (<phrase os="sles">covered here</phrase><phrase os="sled">refer
-        to <link xlink:href="https://documentation.suse.com/sles/"/> for
+        to <link xlink:href="&dsc-sles;/"/> for
         installation instructions</phrase>)
        </para>
       </listitem>
       <listitem>
        <para>
         &sled; &productnumber; (<phrase os="sled">covered here</phrase><phrase os="sles">refer
-        to <link xlink:href="https://documentation.suse.com/sled/"/> for
+        to <link xlink:href="&dsc-sled;/"/> for
         installation instructions</phrase>)
        </para>
       </listitem>
@@ -196,7 +196,7 @@
       <listitem>
        <para>
         &sles4sap; &productnumber; (refer to <link
-        xlink:href="https://documentation.suse.com/sles-sap/"/> for
+        xlink:href="&dsc-sap;/"/> for
         installation instructions)
        </para>
       </listitem>

--- a/xml/art_sles_rpi_quick.xml
+++ b/xml/art_sles_rpi_quick.xml
@@ -935,16 +935,11 @@ Device setup complete</screen>
     the built-in Wi-Fi network adapter.
    </para>
    <para>
-    For detailed information about the network configuration in &productnamearch;,
-    consult the respective sections of the
-    <link
-          xlink:href="https://www.suse.com/documentation/sles-12/book_sle_deployment/data/book_sle_deployment.html"
-          >SUSE
-    Linux Enterprise Server Deployment Guide</link> and the
-    <link
-          xlink:href="https://www.suse.com/documentation/sles-12/book_sle_admin/data/book_sle_admin.html"
-          >SUSE
-    Linux Enterprise Server Administration Guide</link>.
+    For detailed information about the network configuration in
+    &productnamearch;, consult the respective sections of the
+    <citetitle>&sls; Deployment</citetitle> and
+    <citetitle>Administration</citetitle> guides at <link
+     xlink:href="https://documentation.suse.com/sles/"/>.
    </para>
   </sect2>
 
@@ -1096,8 +1091,8 @@ Device setup complete</screen>
   <sect2 xml:id="sec-rpi-documentation-sle">
    <title>Product Documentation</title>
    <para>
-    You can find the complete documentation for &productnamearch; &productnumber;
-    at <link xlink:href="https://suse.com/documentation" />.
+    You can find the complete documentation for &productnamearch;
+    &productnumber; at <link xlink:href="https://documentation.suse.com/"/>.
    </para>
    <note>
     <title>Applicability of Product Documentation</title>

--- a/xml/art_sles_rpi_quick.xml
+++ b/xml/art_sles_rpi_quick.xml
@@ -939,7 +939,7 @@ Device setup complete</screen>
     &productnamearch;, consult the respective sections of the
     <citetitle>&sls; Deployment</citetitle> and
     <citetitle>Administration</citetitle> guides at <link
-     xlink:href="https://documentation.suse.com/sles/"/>.
+     xlink:href="&dsc-sles;/"/>.
    </para>
   </sect2>
 
@@ -1092,7 +1092,7 @@ Device setup complete</screen>
    <title>Product Documentation</title>
    <para>
     You can find the complete documentation for &productnamearch;
-    &productnumber; at <link xlink:href="https://documentation.suse.com/"/>.
+    &productnumber; at <link xlink:href="&dsc;/"/>.
    </para>
    <note>
     <title>Applicability of Product Documentation</title>

--- a/xml/ay_12_migrate_15.xml
+++ b/xml/ay_12_migrate_15.xml
@@ -974,7 +974,7 @@
     <listitem os="sles;sled">
      <para>
       <link
-       xlink:href="https://documentation.suse.com/sles-12/html/SLES-all/configuration.html#CreateProfile-firewall">&susefirewall;/&ay;
+       xlink:href="&dsc-sles-12;//html/SLES-all/configuration.html#CreateProfile-firewall">&susefirewall;/&ay;
       Documentation for &slea; 12</link>
      </para>
     </listitem>

--- a/xml/ay_12_migrate_15.xml
+++ b/xml/ay_12_migrate_15.xml
@@ -974,7 +974,7 @@
     <listitem os="sles;sled">
      <para>
       <link
-      xlink:href="https://www.suse.com/documentation/sles-12/book_autoyast/data/createprofile_firewall.html">&susefirewall;/&ay;
+       xlink:href="https://documentation.suse.com/sles-12/html/SLES-all/configuration.html#CreateProfile-firewall">&susefirewall;/&ay;
       Documentation for &slea; 12</link>
      </para>
     </listitem>

--- a/xml/common_intro_available_doc_i.xml
+++ b/xml/common_intro_available_doc_i.xml
@@ -24,7 +24,7 @@
   <title>Online Documentation and Latest Updates</title>
   <para>
    Documentation for our products is available at
-   <link os="sles;sled" xlink:href="http://www.suse.com/documentation/"/><link os="osuse" xlink:href="http://doc.opensuse.org/"/>,
+   <link os="sles;sled" xlink:href="https://documentation.suse.com/"/><link os="osuse" xlink:href="http://doc.opensuse.org/"/>,
    where you can also find the latest updates, and browse or download the documentation in various formats.
    The latest documentation updates are usually available in the English version of the documentation.
   </para>

--- a/xml/common_intro_available_doc_i.xml
+++ b/xml/common_intro_available_doc_i.xml
@@ -24,7 +24,7 @@
   <title>Online Documentation and Latest Updates</title>
   <para>
    Documentation for our products is available at
-   <link os="sles;sled" xlink:href="https://documentation.suse.com/"/><link os="osuse" xlink:href="http://doc.opensuse.org/"/>,
+   <link os="sles;sled" xlink:href="&dsc;/"/><link os="osuse" xlink:href="http://doc.opensuse.org/"/>,
    where you can also find the latest updates, and browse or download the documentation in various formats.
    The latest documentation updates are usually available in the English version of the documentation.
   </para>

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -450,15 +450,15 @@
   <itemizedlist os="sles;sled">
    <listitem>
     <para>
-     &sls; (<phrase os="sles">covered here</phrase><phrase os="sled">refer
-     to <link xlink:href="https://www.suse.com/documentation/sles/"/> for
+     &sls; &productnumber; (<phrase os="sles">covered here</phrase><phrase os="sled">refer
+     to <link xlink:href="https://documentation.suse.com/sles/"/> for
      installation instructions</phrase>)
     </para>
    </listitem>
    <listitem>
     <para>
-     &sled; (<phrase os="sled">covered here</phrase><phrase os="sles">refer
-     to <link xlink:href="https://www.suse.com/documentation/sled/"/> for
+     &sled; &productnumber; (<phrase os="sled">covered here</phrase><phrase os="sles">refer
+     to <link xlink:href="https://documentation.suse.com/sled/"/> for
      installation instructions</phrase>)
     </para>
    </listitem>
@@ -470,8 +470,15 @@
    </listitem>
    <listitem>
     <para>
-     &sles4sap; (refer to <link
-     xlink:href="https://www.suse.com/documentation/sles-for-sap/"/> for
+     &slert; &productnumber; (refer to <link
+      xlink:href="https://documentation.suse.com/sle-rt/"/> for
+     installation instructions)
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     &sles4sap;  &productnumber; (refer to <link
+      xlink:href="https://documentation.suse.com/sles-sap/"/> for
      installation instructions)
     </para>
    </listitem>

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -451,14 +451,14 @@
    <listitem>
     <para>
      &sls; &productnumber; (<phrase os="sles">covered here</phrase><phrase os="sled">refer
-     to <link xlink:href="https://documentation.suse.com/sles/"/> for
+     to <link xlink:href="&dsc-sles;/"/> for
      installation instructions</phrase>)
     </para>
    </listitem>
    <listitem>
     <para>
      &sled; &productnumber; (<phrase os="sled">covered here</phrase><phrase os="sles">refer
-     to <link xlink:href="https://documentation.suse.com/sled/"/> for
+     to <link xlink:href="&dsc-sled;/"/> for
      installation instructions</phrase>)
     </para>
    </listitem>
@@ -471,14 +471,14 @@
    <listitem>
     <para>
      &slert; &productnumber; (refer to <link
-      xlink:href="https://documentation.suse.com/sle-rt/"/> for
+      xlink:href="&dsc-rt;/"/> for
      installation instructions)
     </para>
    </listitem>
    <listitem>
     <para>
      &sles4sap;  &productnumber; (refer to <link
-      xlink:href="https://documentation.suse.com/sles-sap/"/> for
+      xlink:href="&dsc-sap;/"/> for
      installation instructions)
     </para>
    </listitem>

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -317,11 +317,18 @@ they also have a trademark policy, let's be careful here. -->
 
 <!ENTITY dsc            "https://documentation.suse.com">
 <!ENTITY dsc-sles       "&dsc;/sles">
+<!ENTITY dsc-sles-11    "&dsc;/sles-11">
+<!ENTITY dsc-sles-12    "&dsc;/sles-12">
 <!ENTITY dsc-sled       "&dsc;/sled">
+<!ENTITY dsc-sled-12    "&dsc;/sled-12">
 <!ENTITY dsc-ha         "&dsc;/sle-ha">
+<!ENTITY dsc-rt         "&dsc;/sle-rt">
 <!ENTITY dsc-sap        "&dsc;/sles-sap">
+<!ENTITY dsc-sbp        "&dsc;/sbp">
 <!ENTITY dsc-ses        "&dsc;/ses">
 <!ENTITY dsc-suma       "&dsc;/suma">
+<!ENTITY dsc-suma-retail "&dsc;/suma-retail">
+<!ENTITY dsc-vmdp       "&dsc;/sle-vmdp">
 
 
 <!-- ============================================================= -->
@@ -889,7 +896,7 @@ they also have a trademark policy, let's be careful here. -->
   &susemgr; documentation. The <citetitle>Client Migration</citetitle>
   procedure is described in the <citetitle>&susemgr; Upgrade Guide</citetitle>,
   available at <link xmlns:xlink="http://www.w3.org/1999/xlink"
-  xlink:href="https://documentation.suse.com/suma/"/>.
+  xlink:href="&dsc-suma;/"/>.
  </para>'>
 
  <!ENTITY note-upgrade-reduce-install-size

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -310,6 +310,20 @@ they also have a trademark policy, let's be careful here. -->
 <!ENTITY fate           "Fate #">
 <!ENTITY dc             "Doc Comment #">
 
+
+<!-- ============================================================= -->
+<!--              documentation.suse.com links                     -->
+<!-- ============================================================= -->
+
+<!ENTITY dsc            "https://documentation.suse.com">
+<!ENTITY dsc-sles       "&dsc;/sles-12">
+<!ENTITY dsc-sled       "&dsc;/sled-12">
+<!ENTITY dsc-ha         "&dsc;/sle-ha-12">
+<!ENTITY dsc-sap        "&dsc;/sles-sap-12">
+<!ENTITY dsc-ses        "&dsc;/ses">
+<!ENTITY dsc-suma        "&dsc;/suma">
+
+
 <!-- ============================================================= -->
 <!--                    Book Abstracts                             -->
 <!-- ============================================================= -->

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -316,12 +316,12 @@ they also have a trademark policy, let's be careful here. -->
 <!-- ============================================================= -->
 
 <!ENTITY dsc            "https://documentation.suse.com">
-<!ENTITY dsc-sles       "&dsc;/sles-12">
-<!ENTITY dsc-sled       "&dsc;/sled-12">
-<!ENTITY dsc-ha         "&dsc;/sle-ha-12">
-<!ENTITY dsc-sap        "&dsc;/sles-sap-12">
+<!ENTITY dsc-sles       "&dsc;/sles">
+<!ENTITY dsc-sled       "&dsc;/sled">
+<!ENTITY dsc-ha         "&dsc;/sle-ha">
+<!ENTITY dsc-sap        "&dsc;/sles-sap">
 <!ENTITY dsc-ses        "&dsc;/ses">
-<!ENTITY dsc-suma        "&dsc;/suma">
+<!ENTITY dsc-suma       "&dsc;/suma">
 
 
 <!-- ============================================================= -->

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -875,7 +875,7 @@ they also have a trademark policy, let's be careful here. -->
   &susemgr; documentation. The <citetitle>Client Migration</citetitle>
   procedure is described in the <citetitle>&susemgr; Upgrade Guide</citetitle>,
   available at <link xmlns:xlink="http://www.w3.org/1999/xlink"
-  xlink:href="https://www.suse.com/documentation/suse-manager"/>.
+  xlink:href="https://documentation.suse.com/suma/"/>.
  </para>'>
 
  <!ENTITY note-upgrade-reduce-install-size

--- a/xml/help_admin.xml
+++ b/xml/help_admin.xml
@@ -421,7 +421,7 @@
    all documentation available for &productname; check out your
    product-specific documentation Web page at
    <phrase os="sles;sled"><link
-   xlink:href="https://documentation.suse.com/"/></phrase><phrase os="osuse"><link
+   xlink:href="&dsc;/"/></phrase><phrase os="osuse"><link
    xlink:href="http:/doc.opensuse.org/"/></phrase>.
   </para>
 

--- a/xml/help_admin.xml
+++ b/xml/help_admin.xml
@@ -421,7 +421,7 @@
    all documentation available for &productname; check out your
    product-specific documentation Web page at
    <phrase os="sles;sled"><link
-   xlink:href="http://www.suse.com/doc/"/></phrase><phrase os="osuse"><link
+   xlink:href="https://documentation.suse.com/"/></phrase><phrase os="osuse"><link
    xlink:href="http:/doc.opensuse.org/"/></phrase>.
   </para>
 

--- a/xml/help_user.xml
+++ b/xml/help_user.xml
@@ -121,7 +121,7 @@
    also access the product-specific manuals and documentation on the Web. For
    an overview of all documentation available for &productname; check out your
    product-specific documentation Web page at <link os="sles;sled"
-   xlink:href="https://documentation.suse.com/"/><link os="osuse"
+   xlink:href="&dsc;/"/><link os="osuse"
    xlink:href="https://doc.opensuse.org/"/>.
   </para>
 

--- a/xml/help_user.xml
+++ b/xml/help_user.xml
@@ -121,7 +121,7 @@
    also access the product-specific manuals and documentation on the Web. For
    an overview of all documentation available for &productname; check out your
    product-specific documentation Web page at <link os="sles;sled"
-   xlink:href="http://www.suse.com/documentation/"/><link os="osuse"
+   xlink:href="https://documentation.suse.com/"/><link os="osuse"
    xlink:href="https://doc.opensuse.org/"/>.
   </para>
 

--- a/xml/libvirt_storage.xml
+++ b/xml/libvirt_storage.xml
@@ -1392,7 +1392,7 @@ I/O size (minimum/optimal): 512 bytes / 512 bytes</screen>
   <para os="sles;sled">
    For more details, refer to the &ses; <citetitle>&admin;</citetitle>, chapter
    <citetitle>Using libvirt with Ceph</citetitle>. The &ses; documentation is
-   available from <link xlink:href="https://www.suse.com/documentation/ses"/>.
+   available from <link xlink:href="https://documentation.suse.com/ses/"/>.
   </para>
  </sect1>
 </chapter>

--- a/xml/libvirt_storage.xml
+++ b/xml/libvirt_storage.xml
@@ -1392,7 +1392,7 @@ I/O size (minimum/optimal): 512 bytes / 512 bytes</screen>
   <para os="sles;sled">
    For more details, refer to the &ses; <citetitle>&admin;</citetitle>, chapter
    <citetitle>Using libvirt with Ceph</citetitle>. The &ses; documentation is
-   available from <link xlink:href="https://documentation.suse.com/ses/"/>.
+   available from <link xlink:href="&dsc-ses;/"/>.
   </para>
  </sect1>
 </chapter>

--- a/xml/lxc.xml
+++ b/xml/lxc.xml
@@ -14,7 +14,7 @@ Resources:
  - http://en.opensuse.org/LXC
  - http://www.linuxtag.org/2011/fileadmin/www.linuxtag.org/slides/Christoph%20Mitasch%20-%20Lightweight%20virtualization%3A%20LXC%20vs.%20OpenVZ.pdf
 
- - http://www.suse.com/documentation/sles11/book_sle_tuning/data/cha_tuning_cgroups.html
+ - https://documentation.suse.com/sles/11-SP4/html/SLES-all/cha-tuning-cgroups.html
  - https://www.ibm.com/developerworks/linux/library/l-lxc-containers/
  - http://berrange.com/posts/2011/09/27/getting-started-with-lxc-using-libvirt/
  - http://blog.flameeyes.eu/2010/09/04/linux-containers-and-networking

--- a/xml/net_sync.xml
+++ b/xml/net_sync.xml
@@ -453,7 +453,7 @@ pid file = /var/lock/rsync.lock
       A disaster recovery framework, see the <citetitle>Administration
       Guide</citetitle> of the &sle; &hasi;
       <link
-       xlink:href="https://www.suse.com/documentation/sle-ha-12/"/>.
+       xlink:href="https://www.suse.com/documentation/sle-ha/"/>.
      </para>
     </listitem>
    </varlistentry>

--- a/xml/net_sync.xml
+++ b/xml/net_sync.xml
@@ -452,7 +452,7 @@ pid file = /var/lock/rsync.lock
      <para>
       A disaster recovery framework, see the <citetitle>Administration
       Guide</citetitle> of the &sle; &hasi;
-      <link xlink:href="https://documentation.suse.com/sle-ha/"/>.
+      <link xlink:href="https://&dsc-ha;/"/>.
      </para>
     </listitem>
    </varlistentry>

--- a/xml/net_sync.xml
+++ b/xml/net_sync.xml
@@ -452,8 +452,7 @@ pid file = /var/lock/rsync.lock
      <para>
       A disaster recovery framework, see the <citetitle>Administration
       Guide</citetitle> of the &sle; &hasi;
-      <link
-       xlink:href="https://www.suse.com/documentation/sle-ha/"/>.
+      <link xlink:href="https://documentation.suse.com/sle-ha/"/>.
      </para>
     </listitem>
    </varlistentry>

--- a/xml/qemu_running_vms_qemukvm.xml
+++ b/xml/qemu_running_vms_qemukvm.xml
@@ -716,7 +716,7 @@ based iSCSI:
      <para os="sles;sled">
       For more details, refer to the &ses; <citetitle>&admin;</citetitle>, chapter
       <citetitle>Ceph as a Back-end for QEMU KVM Instance</citetitle>. The &ses; documentation is
-      available from <link xlink:href="https://documentation.suse.com/ses/"/>.
+      available from <link xlink:href="&dsc-ses;/"/>.
      </para>
    </sect3>
 

--- a/xml/qemu_running_vms_qemukvm.xml
+++ b/xml/qemu_running_vms_qemukvm.xml
@@ -716,7 +716,7 @@ based iSCSI:
      <para os="sles;sled">
       For more details, refer to the &ses; <citetitle>&admin;</citetitle>, chapter
       <citetitle>Ceph as a Back-end for QEMU KVM Instance</citetitle>. The &ses; documentation is
-      available from <link xlink:href="https://www.suse.com/documentation/ses"/>.
+      available from <link xlink:href="https://documentation.suse.com/ses/"/>.
      </para>
    </sect3>
 

--- a/xml/rmt_overview.xml
+++ b/xml/rmt_overview.xml
@@ -85,7 +85,7 @@
   <para>
    For an overview of the documentation available for your product and the
    latest documentation updates, refer to
-   <link xlink:href="http://www.suse.com/documentation"/>.
+   <link xlink:href="http://documentation.suse.com"/>.
   </para>
  </sect1>
  <xi:include href="common_intro_feedback_i.xml"/>

--- a/xml/rmt_overview.xml
+++ b/xml/rmt_overview.xml
@@ -85,7 +85,7 @@
   <para>
    For an overview of the documentation available for your product and the
    latest documentation updates, refer to
-   <link xlink:href="http://documentation.suse.com"/>.
+   <link xlink:href="&dsc;"/>.
   </para>
  </sect1>
  <xi:include href="common_intro_feedback_i.xml"/>

--- a/xml/security_auth.xml
+++ b/xml/security_auth.xml
@@ -32,7 +32,9 @@
 
   <para>
    For information about configuring an Authentication Server, see the &sls;
-   documentation.
+   <citetitle>Security Guide</citetitle>, chapter <citetitle>Setting Up
+   Authentication Servers and Clients Using &yast;</citetitle>. It is available
+   from <link xlink:href="https://www.suse.com/documentation/sles/"/>.
   </para>
  </sect1>
 <!-- ============================================================ -->

--- a/xml/security_auth.xml
+++ b/xml/security_auth.xml
@@ -34,7 +34,7 @@
    For information about configuring an Authentication Server, see the &sls;
    <citetitle>Security Guide</citetitle>, chapter <citetitle>Setting Up
    Authentication Servers and Clients Using &yast;</citetitle>. It is available
-   from <link xlink:href="https://www.suse.com/documentation/sles/"/>.
+   from <link xlink:href="&dsc-sles;/"/>.
   </para>
  </sect1>
 <!-- ============================================================ -->

--- a/xml/security_pcidss.xml
+++ b/xml/security_pcidss.xml
@@ -497,7 +497,7 @@
         &productnamex; and automatically enabling an evaluated configuration.
         This setup procedure can also be automated with the &susemgr;. For
         more information, see the &susemgr; documentation at
-        <link xlink:href="https://documentation.suse.com/suma/"/>.
+        <link xlink:href="&dsc-suma;/"/>.
        </para>
        <para>
         By default, &productnamex; does not create additional accounts
@@ -979,7 +979,7 @@
       <para>
        For information about &susemgr;, see the
        <link
-         xlink:href="https://documentation.suse.com/suma/">&susemgr;
+         xlink:href="&dsc-suma;/">&susemgr;
          product page</link>.
       </para>
      </listitem>

--- a/xml/security_pcidss.xml
+++ b/xml/security_pcidss.xml
@@ -497,7 +497,7 @@
         &productnamex; and automatically enabling an evaluated configuration.
         This setup procedure can also be automated with the &susemgr;. For
         more information, see the &susemgr; documentation at
-        <link xlink:href="https://www.suse.com/documentation/suse-manager"/>.
+        <link xlink:href="https://documentation.suse.com/suma/"/>.
        </para>
        <para>
         By default, &productnamex; does not create additional accounts
@@ -979,7 +979,7 @@
       <para>
        For information about &susemgr;, see the
        <link
-         xlink:href="https://www.suse.com/documentation/suse-manager/">&susemgr;
+         xlink:href="https://documentation.suse.com/suma/">&susemgr;
          product page</link>.
       </para>
      </listitem>

--- a/xml/sle_update_online.xml
+++ b/xml/sle_update_online.xml
@@ -93,7 +93,7 @@
     Use the <citetitle>Client Migration</citetitle> procedure instead. It is
     described in the <citetitle>&susemgr; Upgrade Guide</citetitle>, available
     at <link xmlns:xlink="http://www.w3.org/1999/xlink"
-    xlink:href="https://documentation.suse.com/suma/"/>.
+    xlink:href="&dsc-suma;/"/>.
    </para>
   </important>
 

--- a/xml/sle_update_online.xml
+++ b/xml/sle_update_online.xml
@@ -93,7 +93,7 @@
     Use the <citetitle>Client Migration</citetitle> procedure instead. It is
     described in the <citetitle>&susemgr; Upgrade Guide</citetitle>, available
     at <link xmlns:xlink="http://www.w3.org/1999/xlink"
-    xlink:href="https://www.suse.com/documentation/suse-manager"/>.
+    xlink:href="https://documentation.suse.com/suma/"/>.
    </para>
   </important>
 

--- a/xml/sle_update_upgrading.xml
+++ b/xml/sle_update_upgrading.xml
@@ -97,7 +97,7 @@
      <para>
       If you cannot do a fresh install, first upgrade your installed &slea;
       11 Service Pack to &slea; 11 SP4. These steps are described in the
-      <link xlink:href="https://documentation.suse.com/sles-11/">&sle; 11
+      <link xlink:href="&dsc-sles-11;//">&sle; 11
       Deployment Guide</link>.
      </para>
     </listitem>

--- a/xml/sle_update_upgrading.xml
+++ b/xml/sle_update_upgrading.xml
@@ -97,7 +97,7 @@
      <para>
       If you cannot do a fresh install, first upgrade your installed &slea;
       11 Service Pack to &slea; 11 SP4. These steps are described in the
-      <link xlink:href="https://www.suse.com/documentation/sles11/">&sle; 11
+      <link xlink:href="https://documentation.suse.com/sles-11/">&sle; 11
       Deployment Guide</link>.
      </para>
     </listitem>

--- a/xml/sle_update_upgrading.xml
+++ b/xml/sle_update_upgrading.xml
@@ -143,7 +143,7 @@
     <term>Upgrading &sle; Public Cloud Guests</term>
     <listitem>
      <para>
-      See <link xlink:href="https://documentation.suse.com/suse-distribution-migration-system/1.0/single-html/distribution-migration-system/"/>
+      See <link xlink:href="https://&dsc;/suse-distribution-migration-system/1.0/single-html/distribution-migration-system/"/>
       for instructions on upgrading &slea; guests in public clouds.
      </para>
     </listitem>

--- a/xml/sled_planning.xml
+++ b/xml/sled_planning.xml
@@ -211,8 +211,7 @@
      <para>
       &sled; enables you to secure your applications by enforcing
       security profiles tailor-made for your applications. To learn more
-      about &aa;, refer to
-      <link xlink:href="http://www.suse.com/documentation/apparmor/"/>.
+      about &aa;, refer to <xref linkend="part-apparmor"/>.
      </para>
     </listitem>
    </varlistentry>

--- a/xml/storage_filesystems.xml
+++ b/xml/storage_filesystems.xml
@@ -39,7 +39,7 @@
   Distributed Replicated Block Device (DRBD) in the &hasi; add-on. These
   advanced storage systems are not covered in this guide. For information, see
   the <citetitle>&sle; &hasi; &haguide;</citetitle> at
-  <link xlink:href="https://documentation.suse.com/"/>.
+  <link xlink:href="&dsc;/"/>.
  </para>
  <para>
   It is very important to remember that no file system best suits all kinds of

--- a/xml/storage_filesystems.xml
+++ b/xml/storage_filesystems.xml
@@ -39,7 +39,7 @@
   Distributed Replicated Block Device (DRBD) in the &hasi; add-on. These
   advanced storage systems are not covered in this guide. For information, see
   the <citetitle>&sle; &hasi; &haguide;</citetitle> at
-  <link xlink:href="http://www.suse.com/doc"/>.
+  <link xlink:href="https://documentation.suse.com/"/>.
  </para>
  <para>
   It is very important to remember that no file system best suits all kinds of

--- a/xml/storage_raid.xml
+++ b/xml/storage_raid.xml
@@ -31,7 +31,7 @@
    Software RAID underneath clustered file systems needs to be set up using a
    cluster multi-device (Cluster MD). Refer to the &haguide; for &hasi; at
    <link
-     xlink:href="https://documentation.suse.com/sle-ha/"/>.
+     xlink:href="&dsc-ha;/"/>.
   </para>
  </important>
  <para>

--- a/xml/storage_raid.xml
+++ b/xml/storage_raid.xml
@@ -31,7 +31,7 @@
    Software RAID underneath clustered file systems needs to be set up using a
    cluster multi-device (Cluster MD). Refer to the &haguide; for &hasi; at
    <link
-     xlink:href="https://www.suse.com/documentation/sle-ha"/>.
+     xlink:href="https://documentation.suse.com/sle-ha/"/>.
   </para>
  </important>
  <para>

--- a/xml/vmdp_drivers.xml
+++ b/xml/vmdp_drivers.xml
@@ -45,7 +45,7 @@
  </para>
  <para>
   Refer to the Official VMDP Installation Guide at
-  <link xlink:href="https://www.suse.com/documentation/sle-vmdp-22/"/> for
+  <link xlink:href="https://documentation.suse.com/sle-vmdp/"/> for
   more information.
  </para>
 </appendix>

--- a/xml/vmdp_drivers.xml
+++ b/xml/vmdp_drivers.xml
@@ -45,7 +45,7 @@
  </para>
  <para>
   Refer to the Official VMDP Installation Guide at
-  <link xlink:href="https://documentation.suse.com/sle-vmdp/"/> for
+  <link xlink:href="&dsc-vmdp;/"/> for
   more information.
  </para>
 </appendix>

--- a/xml/vnc.xml
+++ b/xml/vnc.xml
@@ -293,7 +293,7 @@ role='description'><phrase>Add new session</phrase></textobject><imageobject rol
      session, take screenshots of the session, or set the image quality.
     </para>
     <figure>
-     <title>Remmina Viewing SLES 15 Remote Session</title>
+     <title>Remmina Viewing &slesa; &productnumber; Remote Session</title>
      <mediaobject>
       <imageobject role="fo">
        <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>

--- a/xml/vnc.xml
+++ b/xml/vnc.xml
@@ -293,7 +293,7 @@ role='description'><phrase>Add new session</phrase></textobject><imageobject rol
      session, take screenshots of the session, or set the image quality.
     </para>
     <figure>
-     <title>Remmina Viewing &slesa; &productnumber; Remote Session</title>
+     <title>Remmina Viewing &slsa; &productnumber; Remote Session</title>
      <mediaobject>
       <imageobject role="fo">
        <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>

--- a/xml/xen2kvm_quick.xml
+++ b/xml/xen2kvm_quick.xml
@@ -61,7 +61,7 @@
     Machine Driver Pack (VMDP). Additional details on converting Windows
     guests with the VMDP can be found in the separate Virtual Machine Driver
     Pack documentation at <link
-     xlink:href="https://documentation.suse.com/sle-vmdp/"/>.
+     xlink:href="&dsc-vmdp;/"/>.
    </para>
   </tip>
 
@@ -1182,7 +1182,7 @@ getty@xvc1.service -&gt; /usr/lib/systemd/system/getty@xvc1.service
   <para>
    For more information on virtualization with &xen; and &kvm;, see
    the &productname; documentation at
-   <link xlink:href="https://documentation.suse.com/"/>.
+   <link xlink:href="&dsc;/"/>.
   </para>
  </sect1>
  <!--

--- a/xml/xen2kvm_quick.xml
+++ b/xml/xen2kvm_quick.xml
@@ -61,7 +61,7 @@
     Machine Driver Pack (VMDP). Additional details on converting Windows
     guests with the VMDP can be found in the separate Virtual Machine Driver
     Pack documentation at <link
-    xlink:href="https://www.suse.com/documentation/sle-vmdp-22/"/>.
+     xlink:href="https://documentation.suse.com/sle-vmdp/"/>.
    </para>
   </tip>
 
@@ -1182,7 +1182,7 @@ getty@xvc1.service -&gt; /usr/lib/systemd/system/getty@xvc1.service
   <para>
    For more information on virtualization with &xen; and &kvm;, see
    the &productname; documentation at
-   <link xlink:href="http://www.suse.com/doc/"/>.
+   <link xlink:href="https://documentation.suse.com/"/>.
   </para>
  </sect1>
  <!--

--- a/xml/xen_administrating.xml
+++ b/xml/xen_administrating.xml
@@ -266,7 +266,7 @@
       data is mirrored over the network. <phrase os="sles;sled">For more information, see the
       <citetitle>SUSE Linux Enterprise High Availability Extension
       &productnumber;</citetitle> documentation at
-      <link xlink:href="https://documentation.suse.com/sle-ha/"/></phrase>.
+      <link xlink:href="&dsc-ha;/"/></phrase>.
      </para>
     </listitem>
     <listitem>

--- a/xml/xen_administrating.xml
+++ b/xml/xen_administrating.xml
@@ -266,7 +266,7 @@
       data is mirrored over the network. <phrase os="sles;sled">For more information, see the
       <citetitle>SUSE Linux Enterprise High Availability Extension
       &productnumber;</citetitle> documentation at
-      <link xlink:href="http://www.suse.com/doc/"/></phrase>.
+      <link xlink:href="https://documentation.suse.com/sle-ha/"/></phrase>.
      </para>
     </listitem>
     <listitem>


### PR DESCRIPTION
### Description
I've updated the suse.com/doc/ URLs in SLE 15 GA to the new website. I cherry-picked to preserve all the history. master, maintenance/SLE15SP1 and maintenance/SLE15SP0 will be in sync for all commits regarding the URLs, so please don't squeeze when merging.

### Checklist
* Check all items that apply.

*Are backports required?*

Nope. I will open a separate PR for SLE 12.