### PR TITLE
Add low_speed_limit and low_speed_time to RMT configuration section

### DIFF
--- a/xml/rmt_config_files.xml
+++ b/xml/rmt_config_files.xml
@@ -107,6 +107,23 @@
        The proxy server password.
       </para>
      </listitem>
+   </varlistentry>
+    <varlistentry>
+     <term><literal>low_speed_limit</literal></term>
+     <listitem>
+      <para>
+        Lower speed limit when a download should be aborted in bytes/sec.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><literal>low_speed_time</literal></term>
+     <listitem>
+      <para>
+        Time until a download gets aborted, when download speed is below
+        <literal>low_speed_limit</literal>.
+      </para>
+     </listitem>
     </varlistentry>
    </variablelist>
   </sect3>


### PR DESCRIPTION
### Description
Upcoming versions of RMT do have new configuration options.

@tbazant I tought right now might be a good time to add this as well, since it looks like you are working on the RMT documentation.

### Checklist

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
