### PR TITLE
Fix command output

### DIFF
--- a/xml/security_pam.xml
+++ b/xml/security_pam.xml
@@ -712,7 +712,7 @@ DISPLAY     DEFAULT=${REMOTEHOST}:0.0  OVERRIDE=${DISPLAY}
      <para>
       Before you finally apply your new PAM setup, check if it contains all
       the options you wanted to add. The <command>pam-config --query
-      --</command> <replaceable>MODULE</replaceable> lists both the type and
+      --</command><replaceable>MODULE</replaceable> lists both the type and
       the options for the queried PAM module.
      </para>
     </formalpara>

--- a/xml/security_pam.xml
+++ b/xml/security_pam.xml
@@ -712,7 +712,7 @@ DISPLAY     DEFAULT=${REMOTEHOST}:0.0  OVERRIDE=${DISPLAY}
      <para>
       Before you finally apply your new PAM setup, check if it contains all
       the options you wanted to add. The <command>pam-config --query
-      --</command><replaceable>MODULE</replaceable> lists both the type and
+      --</command><replaceable>MODULE</replaceable> command lists both the type and
       the options for the queried PAM module.
      </para>
     </formalpara>


### PR DESCRIPTION
I can’t test how this renders, but now there is a space between -- and MODULE in command example. This should give more explicit command look.

### Description
Making the command look correct for readers of the documentation.

### Checklist
* Check all items that apply.

*Are backports required?*

I’ve checked only SLED 15-SP1 documentation. Probably also master should be fixed.

- [X] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
