### PR TITLE
Add pointer to ARM and Power portals

### DIFF
--- a/xml/art_opensuse_install_quick.xml
+++ b/xml/art_opensuse_install_quick.xml
@@ -28,7 +28,7 @@
     &productname; on the x86_64 architecture.
    </para>
    <para>
-    For installing the the aarch64 and ppc64le ports, see <link
+    For installing the &aarch64; and &power; variants, see <link
     xlink:href="https://en.opensuse.org/Portal:ARM"/> and <link xlink:href="https://en.opensuse.org/Portal:PowerPC"/>.
    </para>
   </abstract>

--- a/xml/art_opensuse_install_quick.xml
+++ b/xml/art_opensuse_install_quick.xml
@@ -27,6 +27,10 @@
     overview on how to run through a default installation of
     &productname; on the x86_64 architecture.
    </para>
+   <para>
+    For installing the the aarch64 and ppc64le ports, see <link
+    xlink:href="https://en.opensuse.org/Portal:ARM"/> and <link xlink:href="https://en.opensuse.org/Portal:PowerPC"/>.
+   </para>
   </abstract>
  </info>
  <?suse-quickstart color="suse"?>


### PR DESCRIPTION
### Description
The "Ports" tab (aarch64 and ppc64le) of https://software.opensuse.org/distributions/leap page has a link to the openSUSE Startup Guide in the "Documentation" section.  It would be helpful for ARM and Power users, if the Startup Guide would link to the Portals where the user actually can find info.

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
