### PR TITLE
Bug 1096276 - Docs: docker: document how to re-enable IP packet forwarding

### DIFF
--- a/xml/book_sles_docker.xml
+++ b/xml/book_sles_docker.xml
@@ -34,7 +34,8 @@ https://www.docker.com/legal/trademark-guidelines
   <abstract>
    <para>
     This guide introduces &deng;, a lightweight virtualization solution to run
-    virtual units simultaneously on a single control host.
+    multiple system or application containers simultaneously on a single Linux
+    instance.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">

--- a/xml/docker_building_images.xml
+++ b/xml/docker_building_images.xml
@@ -65,7 +65,8 @@
   <para>
    Pre-built images do not have repositories configured. But when the &docker;
    host has a &slea; subscription that provides access to the product used in the
-   image, Zypper will automatically have access to the right repositories.
+   image, <command>zypper</command> will automatically have access to the right
+   repositories.
   </para>
 
   <para>
@@ -119,7 +120,7 @@
   <title>Customizing &slsa; &docker; Images</title>
 
   <para>
-   The pre-built images do not have any repository configured and do not
+   The pre-built images do not have any repositories configured and do not
    include any modules or extensions. They contain a
    <link xlink:href="https://github.com/SUSE/container-suseconnect">zypper
    service</link> that contacts either the &sccreg; (&ncc;) or your

--- a/xml/docker_containers.xml
+++ b/xml/docker_containers.xml
@@ -18,7 +18,7 @@
  <itemizedlist>
   <listitem>
    <para>
-    A container name - it is recommended to name your container.
+    A container name (giving containers individual names is recommended).
    </para>
   </listitem>
   <listitem>
@@ -45,7 +45,7 @@
  </para>
  <screen>&prompt.user;docker start -ai &lt;container name&gt;</screen>
  <para>
-  You may need to remove unused containers, you can achieve this by using:
+  You may need to remove unused containers. You can do this with the command:
  </para>
  <screen>&prompt.user;docker rm &lt;container name&gt;</screen>
 
@@ -53,8 +53,8 @@
   <title>Linking Containers</title>
 
   <para>
-   &deng; enables you to link containers together which allows for
-   communication between containers on the same host server. If you use the
+   &deng; enables you to link containers together, which allows for containers
+   on the same host server to communicate with each other. If you use the
    standard networking model, you can link containers by using the
    <literal>--link</literal> option when running containers:
   </para>
@@ -71,8 +71,8 @@
   <screen>&prompt.user;docker run --link sles:sles sles12sp4 /bin/bash</screen>
 
   <para>
-   The container that links to <emphasis>sles</emphasis> has defined
-   environment variables that enable connecting to the linked container.
+   This defines environment variables in the new container which enable it to
+   link to the container named <emphasis>sles</emphasis>.
   </para>
  </sect1>
 </chapter>

--- a/xml/docker_dockerizing_application.xml
+++ b/xml/docker_dockerizing_application.xml
@@ -10,35 +10,34 @@
  xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>Creating &docker; Images of Applications</title>
  <para>
-  &deng; is a technology that can help minimize resources used to run or
-  build applications. There are several types of applications that are
-  suitable to run inside a &docker; container like daemons, Web pages or
-  applications that expose ports for communication. You can use &deng; to
-  automate building and deployment processes by adding the build process
-  into a &docker; image, then building the image and then running containers
-  based on that image.
+  &deng; is a technology that can help minimize the resources used to run
+  applications. Several types of applications are suitable to be run inside
+  &docker; containers, such as daemons, Web pages or applications that expose
+  IP ports for communications. You can use &deng; to automate the building and
+  deployment processes by performing the build process inside a &docker;
+  container, then building an image, then deploying containers based on that
+  image.
  </para>
  <para>
-  Running an application inside a &docker; container has the
-  following advantages:
+  Running an application inside a &docker; container has the following
+  advantages:
  </para>
  <itemizedlist>
   <listitem>
    <para>
-    You can minimize the runtime environment of the application as you can add
-    to the &docker; image of the application just the required processes and
-    applications.
+    You can minimize the size of an application's runtime environment by adding
+    only the required binaries to the &docker; image of the application.
    </para>
   </listitem>
   <listitem>
    <para>
-    The image with your application is portable across machines also with
-    different Linux host systems.
+    The image with your application is portable across servers running different
+    Linux host distributions and versions.
    </para>
   </listitem>
   <listitem>
    <para>
-    You can share the image of your application by using a repository.
+    You can share the image of your application using a repository.
    </para>
   </listitem>
   <listitem>
@@ -60,7 +59,7 @@
  <itemizedlist>
   <listitem>
    <para>
-    You can prepare a complete building image.
+    You can prepare an image of the complete build environment.
    </para>
   </listitem>
   <listitem>
@@ -76,7 +75,7 @@
   </listitem>
   <listitem>
    <para>
-    You can set up an automated building process.
+    You can set up automated build processes.
    </para>
   </listitem>
  </itemizedlist>

--- a/xml/docker_installation.xml
+++ b/xml/docker_installation.xml
@@ -25,7 +25,7 @@
     Starting with &deng; 1.12, container orchestration is now an integral
     part of &deng;. Even though this feature is available in
     &productname;, it is not supported by &suse; and is only provided as a
-    technical preview. Use Kubernetes for &docker; container orchestration; for
+    technical preview. Use Kubernetes for &docker; container orchestration. For
     details, refer to the <link
      xlink:href="http://kubernetes.io/docs/getting-started-guides/kubeadm/">Kubernetes
      documentation</link>.

--- a/xml/docker_installation.xml
+++ b/xml/docker_installation.xml
@@ -40,7 +40,7 @@
     
     <para>
      Start &yast;, and select <menuchoice> <guimenu>Software</guimenu>
-      <guimenu> Software Repositories</guimenu> </menuchoice>.
+      <guimenu>Software Repositories</guimenu> </menuchoice>.
     </para>
    </step>
    <step>

--- a/xml/docker_installation.xml
+++ b/xml/docker_installation.xml
@@ -221,6 +221,24 @@
     or accessing arbitrary ports of each other.
    </para>
   </sect2>
+  
+  <sect2 xml:id="sec-docker-setup-net-docs">
+   <title>How the &deng; Interacts with <command>iptables</command></title>
+   <para>
+    To learn more about &docker; containers interact with each other and the
+    system firewall, refer to the <link
+     xlink:href="https://docs.docker.com/v17.09/engine/userguide/networking/default_network/container-communication/">
+     &docker; documentation</link>.
+   </para> 
+   <para>
+    It is also possible to completely prevent the &deng; from manipulating
+    <command>iptables</command> at all. Refer to the <link
+     xlink:href="https://docs.docker.com/network/iptables/#prevent-docker-from-manipulating-iptables">
+     &docker; documentation</link>.
+   </para>
+   
+  </sect2>
+  
  </sect1>
  
  <sect1 xml:id="sec-docker-setup-updates">

--- a/xml/docker_installation.xml
+++ b/xml/docker_installation.xml
@@ -225,7 +225,7 @@
   <sect2 xml:id="sec-docker-setup-net-docs">
    <title>How the &deng; Interacts with <command>iptables</command></title>
    <para>
-    To learn more about &docker; containers interact with each other and the
+    To learn more about how &docker; containers interact with each other and the
     system firewall, refer to the <link
      xlink:href="https://docs.docker.com/v17.09/engine/userguide/networking/default_network/container-communication/">
      &docker; documentation</link>.

--- a/xml/docker_installation.xml
+++ b/xml/docker_installation.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter
 [
-  <!ENTITY % entities SYSTEM "entity-decl.ent">
-    %entities;
+<!ENTITY % entities SYSTEM "entity-decl.ent">
+%entities;
 ]>
 <chapter xml:id="cha-docker-installation" xml:lang="en"
  xmlns="http://docbook.org/ns/docbook" version="5.0"
@@ -11,36 +11,36 @@
  <title>&deng; Installation</title>
  <sect1 xml:id="Preparation">
   <title>General Preparation</title>
-
+  
   <para>
    Prepare the host as described below. Before installing any &docker;-related
    packages, you need to enable the container module:
   </para>
-
+  
   <note>
    <!-- FIXME: Hard-coded version numbers! Is this still relevant? - sknorr,
-   2017-12-07-->
+    2017-12-07-->
    <title>Built-in &docker; Orchestration Support</title>
    <para>
-    Starting with &deng; 1.12, the container orchestration is now an integral
+    Starting with &deng; 1.12, container orchestration is now an integral
     part of &deng;. Even though this feature is available in
     &productname;, it is not supported by &suse; and is only provided as a
-    technical preview. Use Kubernetes for &docker; container orchestration, for
-    details refer to the <link
-    xlink:href="http://kubernetes.io/docs/getting-started-guides/kubeadm/">Kubernetes
-    documentation</link>.
+    technical preview. Use Kubernetes for &docker; container orchestration; for
+    details, refer to the <link
+     xlink:href="http://kubernetes.io/docs/getting-started-guides/kubeadm/">Kubernetes
+     documentation</link>.
    </para>
   </note>
-
+  
   <!--taroth 2015-07-02: http://doccomments.provo.novell.com/comments/28724 -->
-
+  
   <procedure>
    <title>Enabling the Container Module Using &yast;</title>
    <step>
-
+    
     <para>
      Start &yast;, and select <menuchoice> <guimenu>Software</guimenu>
-     <guimenu> Software Repositories</guimenu> </menuchoice>.
+      <guimenu> Software Repositories</guimenu> </menuchoice>.
     </para>
    </step>
    <step>
@@ -70,7 +70,7 @@
     </para>
    </step>
   </procedure>
-
+  
   <procedure>
    <title>Enabling the Container Module Using SUSEConnect</title>
    <step>
@@ -80,14 +80,14 @@
     <screen>&prompt.sudo;SUSEConnect -p sle-module-containers/15/x86_64 -r ''</screen>
     <note>
      <title>SUSEConnect Syntax</title>
-      <para>
+     <para>
       The <option>-r ''</option> flag is required to avoid a known limitation
       of SUSEConnect.
      </para>
     </note>
    </step>
   </procedure>
-
+  
   <procedure>
    <title>Installing and Setting Up &deng;</title>
    <step>
@@ -102,21 +102,21 @@
     </para>
     <screen>&prompt.sudo;systemctl enable docker.service</screen>
     <para>
-     This will automatically enable docker.socket in consequence.
+     This will also automatically enable <literal>docker.socket</literal>.
     </para>
    </step>
    <step>
     <para>
-     In case you will use Portus and an SSL secured registry, open the
+     In case you will use Portus and an SSL-secured registry, open the
      <filename>/etc/sysconfig/docker</filename> file. Search for the parameter
      <parameter>DOCKER_OPTS</parameter> and add <literal>--insecure-registry
-     <replaceable>ADDRESS_OF_YOUR_REGISTRY</replaceable></literal>.
+      <replaceable>ADDRESS_OF_YOUR_REGISTRY</replaceable></literal>.
     </para>
    </step>
    <step>
     <para>
-     In the production environment when using the SSL secured registry with
-     Portus, add CA certificates to the directory
+     In a production environment when using an SSL-secured registry with
+     Portus, add your CA certificates to the directory
      <filename>/etc/docker/certs.d/<replaceable>REGISTRY_ADDRESS</replaceable></filename>
      and copy the CA certificates to your system:
     </para>
@@ -132,7 +132,7 @@
     </para>
    </step>
   </procedure>
-
+  
   <para>
    The &docker; daemon listens on a local socket which is accessible only by the
    <systemitem class="username">root</systemitem> user and by the members of
@@ -142,60 +142,61 @@
    the local &docker; daemon, use the following command:
   </para>
   <screen>&prompt.sudo;/usr/sbin/usermod -aG docker <replaceable>USERNAME</replaceable></screen>
-
+  
   <para>
-   The user can communicate with the local &docker; daemon upon their next login.
+   After their next login, the user will be able to communicate with the local 
+   &docker; daemon.
   </para>
  </sect1>
  <sect1 xml:id="sec-docker-setup-net">
   <title>Networking</title>
-
+  
   <para>
    If you want your containers to be able to access the external network, you
    must enable the <option>ipv4 ip_forward</option> rule. This can be done
    using &yast; by browsing to <menuchoice> <guimenu>System</guimenu>
-   <guimenu>Network Settings</guimenu> <guimenu>Routing</guimenu> </menuchoice>
+    <guimenu>Network Settings</guimenu> <guimenu>Routing</guimenu> </menuchoice>
    menu and ensuring <option>Enable IPv4 Forwarding</option> is checked.
   </para>
-
+  
   <para>
-   This option cannot be changed when networking is handled by the Network
-   Manager. In such cases you must configure &firewalld; to enable IPv4 masquerading,
-   either from the command line or using the graphical <command>firewalld-config</command>
-   tool. By default, the <literal>external</literal> zone has masquerading enabled.
-</para>
-<para>
-    You may add masquerading to any zone with <command>firewall-cmd</command>:
-</para>
-<screen>&prompt.sudo;firewall-cmd --zone=<replaceable>containers</replaceable> --add-masquerade
-</screen>
-<para>
-    When you are satisfied that this is operating correctly, make it permanent:
-</para>
+   This option cannot be changed when networking is handled by <literal>Network
+    Manager</literal>. In such cases you must configure &firewalld; to enable
+   IPv4 masquerading, either from the command line or using the graphical
+   <command>firewalld-config</command> tool. By default, the
+   <literal>external</literal> zone has masquerading enabled.
+  </para>
+  <para>
+   You may add masquerading to any zone with <command>firewall-cmd</command>:
+  </para>
+ <screen>&prompt.sudo;firewall-cmd --zone=<replaceable>containers</replaceable> --add-masquerade</screen>
+  <para>
+   When you are satisfied that this is operating correctly, make it permanent:
+  </para>
 <screen>&prompt.sudo;firewall-cmd --runtime-to-permanent</screen>
-<para>
-    In the <command>firewalld-config</command> interface, look for the 
-    <guimenu>Masquerade</guimenu> tab to enable and disable masquerading.
-</para>
-<para>
-    See Chapter 16 of the &secguide; for more information on &firewalld;.
-</para>
-
+  <para>
+   In the <command>firewalld-config</command> interface, look for the 
+   <guimenu>Masquerade</guimenu> tab to enable and disable masquerading.
+  </para>
+  <para>
+   See Chapter 16 of the &secguide; for more information on &firewalld;.
+  </para>
+  
   <sect2 xml:id="sec-docker-setup-net-power">
-   <title>Networking Limitations on Power Architecture</title>
+   <title>Networking Limitations on &power; Architecture</title>
    <para>
     Currently &docker; networking has two limitations on the &power; architecture.
    </para>
    <para>
-    The first limitation is about iptables. &slea; machines cannot run
-    &deng; with the iptables support enabled. An update of the kernel is going
-    to solve this issue. In the meantime the <package>docker</package> package
-    for &power; has
-    iptables support disabled via a dedicated directive inside of
-    <filename>/etc/sysconfig/docker</filename>.
+    The first limitation is about <command>iptables</command>. &slea; machines
+    cannot run &deng; with <command>iptables</command> support enabled. An
+    update of the kernel will solve this issue. In the meantime, the
+    <package>docker</package> package for &power; has
+    <command>iptables</command> support disabled via a dedicated directive
+    inside <filename>/etc/sysconfig/docker</filename>.
    </para>
    <para>
-    As a result of this limitation &docker; containers will not have access to
+    As a result of this limitation, &docker; containers will not have access to
     the outer network. A possible workaround is to share the same network
     namespace between the host and the containers. This however reduces the
     isolation of the containers.
@@ -209,8 +210,8 @@
     <title>iptables Support on &productname;</title>
     <para>
      &productname; hosts are not affected by this limitation but they may have
-     iptables support disabled. This can be changed by removing the
-     <option>-iptables=false</option> setting inside of
+     <command>iptables</command> support disabled. This can be changed by
+     removing the <option>-iptables=false</option> setting inside of
      <filename>/etc/sysconfig/docker</filename>.
     </para>
    </note>
@@ -220,24 +221,22 @@
     or accessing arbitrary ports of each other.
    </para>
   </sect2>
-  </sect1>
-
-  <sect1 xml:id="sec-docker-setup-updates">
+ </sect1>
+ 
+ <sect1 xml:id="sec-docker-setup-updates">
   <title>Updates</title>
   <para>
    All updates to the <package>docker</package> package are marked as
-   interactive (that is, no
-   automatic updates) to avoid accidental updates break running container
-   workloads. In general, we recommend stopping all running containers before
-   applying an update to &deng;.
+   interactive (that is, no automatic updates) to avoid accidental updates
+   breaking running container workloads. In general, we recommend stopping all
+   running containers before applying an update to &deng;.
   </para>
   <para>
    To avoid the potential for data loss, we do not recommend having workloads
    rely on containers being startable after an update to &deng;. Although it
-   is technically possible to keep containers running
-   during an update via the <option>--live-restore</option> option, experience
-   has shown that such updates can introduce regressions. &suse; does
-   not support this feature.
+   is technically possible to keep containers running during an update via the
+   <option>--live-restore</option> option, experience has shown that such
+   updates can introduce regressions. &suse; does not support this feature.
   </para>
-  </sect1>
+ </sect1>
 </chapter>

--- a/xml/docker_overview.xml
+++ b/xml/docker_overview.xml
@@ -10,16 +10,17 @@
  xmlns:xlink="http://www.w3.org/1999/xlink">
  <title>&deng; Overview</title>
  <para>
-  &deng; is a lightweight virtualization solution to run multiple virtual units
-  (containers) simultaneously on a single control host. Containers are isolated
-  with Kernel Control Groups (<xref linkend="vle-docker-cgroup"/>) and
-  <xref linkend="vle-docker-namespace"/>.
+  &deng; is a lightweight virtualization solution to run multiple virtual Linux
+  enviroments (containers) simultaneously on top of a single Linux kernel,
+  without a hypervisor. Containers are isolated with Kernel Control Groups
+  (<xref linkend="vle-docker-cgroup"/>) and <xref linkend="vle-docker-namespace"/>.
  </para>
  <para>
   Full virtualization solutions such as &xen;, &kvm;, or &libvirt; are based on
-  the processor simulating a complete hardware environment and controlling the
-  virtual machines. However, &deng; only provides operating system-level
-  virtualization where the Linux kernel controls isolated containers.
+  simulating a complete hardware environment and running multiple operating 
+  system instances inside these virtual machines. Instead, the &deng; provides
+  operating-system-level virtualization, where a single Linux kernel controls
+  multiple isolated containers.
  </para>
  <para>
   Before going into detail about &deng;, let us define some of the terms used:
@@ -30,8 +31,7 @@
    <listitem>
     <para>
      &deng; is a server-client type application that performs all
-     tasks related to virtual machines. &deng; comprises the
-     following:
+     tasks related to containers. &deng; comprises the following:
     </para>
     <itemizedlist>
      <listitem>
@@ -70,7 +70,7 @@
    <listitem>
     <para>
      An <emphasis>image</emphasis> is a read-only template used to create a
-     <emphasis>virtual machine</emphasis> on the host server. A &docker; image is
+     <emphasis>container</emphasis> on the host server. A &docker; image is
      made by a series of layers built one over the other. Each layer
      corresponds to a permanent change, for example an update of an
      application. The changes are stored in a file called a
@@ -113,14 +113,14 @@
     <itemizedlist>
      <listitem>
       <para>
-       public registry - where everyone (usually registered) can download and
-       use images. A typical public registry is
+       public registry: any (usually, registered) user can download and use
+       images. A typical example of a public registry is
        <link xlink:href="https://hub.docker.com/">Docker Hub</link>.
       </para>
      </listitem>
      <listitem>
       <para>
-       private registry - these are accessible for particular users or from a
+       private registry: access is restricted to particular users, or from a
        particular private network.
       </para>
      </listitem>
@@ -133,7 +133,7 @@
     <para>
      A <emphasis>repository</emphasis> is storage in a
      <emphasis>registry</emphasis> that stores a different version of a
-     particular image. You can pull or push images from or to a repository.
+     particular image. You can pull images from, or push them to, a repository.
     </para>
    </listitem>
   </varlistentry>
@@ -181,12 +181,12 @@
  <itemizedlist mark="bullet" spacing="normal">
   <listitem>
    <para>
-    Isolation of applications and operating systems through containers.
+    Isolation of applications through containers.
    </para>
   </listitem>
   <listitem>
    <para>
-    Near native performance, as &deng; manages allocation of resources in real
+    Near-native performance, as &deng; manages allocation of resources in real
     time.
    </para>
   </listitem>
@@ -219,13 +219,13 @@
   <title>Limitations of &deng;</title>
   <listitem>
    <para>
-    Containers run inside the host system's kernel and cannot use a different
+    Containers run on the host system's kernel and cannot use a different
     kernel.
    </para>
   </listitem>
   <listitem>
    <para>
-    Only allows Linux <emphasis>guest</emphasis> operating systems.
+    Only supports Linux applications and not other operating systems.
    </para>
   </listitem>
   <listitem>
@@ -316,8 +316,8 @@
     </listitem>
    </itemizedlist>
    <para>
-    &slea;&nbsp;12 uses the Btrfs file system by default, which leads &deng; to
-    use the <systemitem class="resource">btrfs</systemitem> driver.
+    Since version 12, &slea; uses the Btrfs file system by default, which leads
+    &deng; to use the <systemitem class="resource">btrfs</systemitem> driver.
    </para>
    <para>
     It is possible to specify which driver to use by changing the value of the

--- a/xml/docker_registry.xml
+++ b/xml/docker_registry.xml
@@ -32,14 +32,13 @@
   </listitem>
   <listitem>
    <para>
-    Run an on-site &dreg; where to store all the &docker; images used by your
-    organization or company and combine them with Portus to secure the
-    registry.
+    Run an on-site &dreg; where you can store all the &docker; images used by
+    your organization or company, combined with Portus to secure the registry.
    </para>
   </listitem>
  </itemizedlist>
  <para>
-  This chapter describes the second option, how to set up an on-site &dreg; and
+  This chapter describes the second option: how to set up an on-site &dreg; and
   how to combine it with Portus.
  </para>
  <sect1 xml:id="sec-docker-registry-definition">
@@ -56,41 +55,49 @@
    perspective, is made of the following parts at least:
   </para>
 
-  <itemizedlist>
-   <listitem>
-    <para>
-     The user interface (UI): The part that is accessed by users with their
-     browser. The UI provides a nice and intuitive way to browse the contents
-     of &dhub; either manually or by using a search feature. It also allows to
-     create organizations made by different users.
+  <variablelist>
+   <varlistentry>
+    <term>The user interface (UI)</term>
+    <listitem>
+     <para>
+     The part that is accessed by users with their browser. The UI provides an
+     easy way to browse the contents of &dhub; either manually or using a search
+     feature. It also allows the creation of organizations by different users.
     </para>
-    <para>
+     <para>
      This component is closed-source.
     </para>
-   </listitem>
-   <listitem>
-    <para>
-     The authentication component: This is used to protect the images stored
-     inside of &dhub;. It validates all push, pull and search requests.
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>The authentication component</term>
+    <listitem>
+     <para>
+     This is used to protect the images stored inside of &dhub;. It validates
+     all push, pull and search requests.
     </para>
-    <para>
+     <para>
      This component is closed-source.
     </para>
-   </listitem>
-   <listitem>
-    <para>
-     The storage back-end: This is where &docker; images are sent and
-     downloaded from. It is provided by &dreg;.
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>The storage back-end</term>
+    <listitem>
+     <para>
+     This is where &docker; images are sent and downloaded from. It is provided
+     by &dreg;.
     </para>
-    <para>
+     <para>
      This component is open-source.
     </para>
-   </listitem>
-  </itemizedlist>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </sect1>
+ 
  <sect1 xml:id="sec-docker-registry-installation">
   <title>Installing and Setting Up &dreg;</title>
-
   <procedure>
    <step>
     <para>

--- a/xml/docker_registry.xml
+++ b/xml/docker_registry.xml
@@ -74,7 +74,7 @@
     <listitem>
      <para>
      This is used to protect the images stored inside of &dhub;. It validates
-     all push, pull and search requests.
+     all push, pull, and search requests.
     </para>
      <para>
      This component is closed-source.


### PR DESCRIPTION
### Description
Bugfix/bsc#1096276 addresses long-standing bug requesting that our docs link to the upstream documentation on the interactions between Docker containers and the system firewall. Also did a copy-edit on the Docker chapter while I was in there.

### Checklist
* Check all items that apply.

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
