### PR TITLE
vt doc: Add a note about LTSS in migration scenarios

### DIFF
--- a/xml/libvirt_managing.xml
+++ b/xml/libvirt_managing.xml
@@ -1104,6 +1104,15 @@ Metadata:       yes
       Backward migration (for example from &slsa; 12 SP1 or SP2 to 12 or from
       &slsa; SP2 to SP1) is not supported.
      </para>
+     <para os="sles;sled">
+      SUSE strives to support live migration of &vmguest;s from a &vmhost;
+      running a service pack under LTSS to a &vmhost; running a newer
+      service pack, within the same &slsa; major version. For example &vmguest;
+      migration from a &slsa; 12 SP2 host to a &slsa; 12 SP5 host. SUSE only
+      performs minimal testing of LTSS-to-newer migration scenarios and
+      recommends thorough on-site testing before attempting to migrate
+      critical &vmguest;s.
+     </para>
     </listitem>
     <listitem>
      <para>


### PR DESCRIPTION
Some customers may want to migrate virtual machines running on a
LTSS host to a host running the latest service pack within a major
SLE release, e.g. SLES12 SP2 to SLES12 SP5. Add a note to the
supported migration scenarios that SUSE strives to support such
scenarios but recommends on-site testing.

### Description
Partial fix for https://bugzilla.suse.com/show_bug.cgi?id=1164744

### Checklist
* Check all items that apply.

*Are backports required?*

- [ x] To maintenance/SLE15SP1
- [ x] To maintenance/SLE15SP0
- [x ] To maintenance/SLE12SP5
- [ x] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
