### PR TITLE
Added VROC support as supported RAID volume (bsc#1163804)

### DIFF
--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -1763,7 +1763,7 @@ disk:
        </listitem>
        <listitem>
         <para>
-         Intel Virtual RAID on CPU (Intel VROC)
+         Intel Virtual RAID on CPU (Intel VROC, see <link xlink:href="https://www.intel.com/content/www/us/en/support/articles/000024498/memory-and-storage/ssd-software.html"/> for more details)
         </para>
        </listitem>
       </itemizedlist>

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -1761,6 +1761,11 @@ disk:
          Edition
         </para>
        </listitem>
+       <listitem>
+        <para>
+         Intel Virtual RAID on CPU (Intel VROC)
+        </para>
+       </listitem>
       </itemizedlist>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
### Description
This update adds a statement  about VROC support as a RAID volume

### Checklist
* Check all items that apply.

*Are backports required?*

- [x] To maintenance/SLE15SP1
