### PR TITLE
Updated LEDMON project URL (bsc#1163799)

### DIFF
--- a/xml/storage_raid-leds.xml
+++ b/xml/storage_raid-leds.xml
@@ -839,8 +839,8 @@
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     <link xlink:href="http://sourceforge.net/projects/ledmon/">LEDMON open
-     source project on Sourceforge.net</link>
+     <link xlink:href="https://github.com/intel/ledmon.git">LEDMON open
+     source project on GitHub.com</link>
     </para>
    </listitem>
    <listitem>


### PR DESCRIPTION
### Description
LEDMON project moved from Sourceforge to Github, this update reflects that.

### Checklist
* Check all items that apply.

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [x] To maintenance/SLE12SP4
- [x] To maintenance/SLE12SP3
