### PR TITLE
'duperemove' can operate on large number of files (jsc#sle-11375)

### DIFF
--- a/xml/storage_filesystems.xml
+++ b/xml/storage_filesystems.xml
@@ -770,12 +770,17 @@ sync</screen>
     available, install the package <package>duperemove</package> .
    </para>
    <note>
-    <title>Use Cases</title>
+    <title>Deduplicating Large Datasets</title>
     <para>
-     As of &productname; &productnumber; duperemove is not suited to
-     deduplicate the entire file system. It is intended to be used to
-     deduplicate a set of 10 to 50 large files that possibly have lots of
-     blocks in common, such as virtual machine images.
+     If you intend to deduplicate a large amount of files, use the <option>--hashfile</option> option:
+    </para>
+<screen>&prompt.sudo;duperemove <option>--hashfile <replaceable>HASH_FILE</replaceable></option> file1 file2 file3</screen>
+    <para>
+     The <option>--hashfile</option> option stores hashes of all specified
+     files into the <replaceable>HASH_FILE</replaceable> instead of RAM and
+     prevents it from being exhausted.  <replaceable>HASH_FILE</replaceable> is
+     reusable&mdash;you can deduplicate changes to large datasets very quickly
+     after an initial run that generated a baseline hash file.
     </para>
    </note>
    <para>

--- a/xml/storage_filesystems.xml
+++ b/xml/storage_filesystems.xml
@@ -765,14 +765,16 @@ sync</screen>
     system with logical links to a single copy of the block in a common storage
     location. &productname; provides the tool <command>duperemove</command> for
     scanning the file system for identical blocks. When used on a Btrfs file
-    system, it can also be used to deduplicate these blocks.
-    <command>duperemove</command> is not installed by default. To make it
-    available, install the package <package>duperemove</package> .
+    system, it can also be used to deduplicate these blocks and thus save space
+    on the file system.  <command>duperemove</command> is not installed by
+    default. To make it available, install the package
+    <package>duperemove</package> .
    </para>
    <note>
     <title>Deduplicating Large Datasets</title>
     <para>
-     If you intend to deduplicate a large amount of files, use the <option>--hashfile</option> option:
+     If you intend to deduplicate a large amount of files, use the
+     <option>--hashfile</option> option:
     </para>
 <screen>&prompt.sudo;duperemove <option>--hashfile <replaceable>HASH_FILE</replaceable></option> file1 file2 file3</screen>
     <para>


### PR DESCRIPTION
### Description
duperemove can link duplicate blocks on Btrfs. This updated fixes the information that it should not be used on a large group of files.

### Checklist
* Check all items that apply.

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
