### PR TITLE
Disconnecting NIC from network (jsc#SLE-10888)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ locale/*/build/
 .#*
 *~
 *.bak
+*.swp
 *.orig
 .directory

--- a/xml/net_wicked.xml
+++ b/xml/net_wicked.xml
@@ -652,24 +652,33 @@ ip route show</screen>
    <para>
     To activate it again, use
    </para>
+<screen>&prompt.sudo;ip link set eth0 up</screen>
    <tip>
     <title>Disconnecting NIC Device</title>
     <para>
      If you deactivate a device with
-     </para>
-<screen>&prompt.sudo;ip link set <replaceable>DEV_NAME</replaceable> down</screen>
-    <para>
-     it disables a number of its internal features, but the device remains
-     connected to the physical network environment. To disconnect the device
-     completely, run
     </para>
-<screen>&prompt.sudo;ip link set <replaceable>DEV_NAME</replaceable> carrier off</screen>
+    <screen>&prompt.sudo;ip link set <replaceable>DEV_NAME</replaceable> down</screen>
+    <para>
+     it disables the network interface on a software level.
+    </para>
+    <para>
+     If you want to simulate losing the link as if the ethernet cable is unplugged
+     or the connected switch is turned off, run
+    </para>
+    <screen>&prompt.sudo;ip link set <replaceable>DEV_NAME</replaceable> carrier off</screen>
+    <para>
+     For example, while <command>ip link set
+      <replaceable>DEV_NAME</replaceable> down</command> drops all routes using
+     <replaceable>DEV_NAME</replaceable>, <command>ip link set DEV carrier
+      off</command> does not. Be aware that <command>carrier off</command>
+     requires support from the network device driver.
+    </para>
     <para>
      To connect the device back to the physical network, run
     </para>
-<screen>&prompt.sudo;ip link set <replaceable>DEV_NAME</replaceable> carrier on</screen>
+    <screen>&prompt.sudo;ip link set <replaceable>DEV_NAME</replaceable> carrier on</screen>
    </tip>
-<screen>&prompt.sudo;ip link set eth0 up</screen>
    <para>
     After activating a device, you can configure it. To set the IP address, use
    </para>
@@ -683,12 +692,7 @@ ip route show</screen>
     To have a working connection, you must also configure the default gateway.
     To set a gateway for your system, enter
    </para>
-<screen>&prompt.sudo;ip route add gateway_ip_address</screen>
-   <para>
-    To translate one IP address to another, use <emphasis>network address
-     translation (NAT):</emphasis>
-    </para>
-<screen>&prompt.sudo;ip route add nat <replaceable>IP_ADDRESS</replaceable> via <replaceable>OTHER_IP_ADDRESS</replaceable></screen>
+<screen>&prompt.sudo;ip route add default via gateway_ip_address</screen>
    <para>
     To display all devices, use
    </para>
@@ -702,7 +706,13 @@ ip route show</screen>
    </para>
 <screen>&prompt.sudo;ip -s link ls <replaceable>DEV_NAME</replaceable></screen>
     <para>
-					To view addresses of your devices, enter
+     To view additional useful information, specifically about virtual
+     network devices, enter
+    </para>
+<screen>&prompt.sudo;ip -d link ls <replaceable>DEV_NAME</replaceable></screen>
+    <para>
+     Moreover, to view network layer (IPv4, IPv6) addresses of your devices,
+     enter
     </para>
 <screen>&prompt.sudo;ip addr</screen>
     <para>

--- a/xml/net_wicked.xml
+++ b/xml/net_wicked.xml
@@ -717,7 +717,7 @@ ip route show</screen>
     is also available for all <command>ip</command> subcommands, such as:
    </para>
 <screen>&prompt.sudo;ip addr help</screen>
-    <para>
+   <para>
     Find the <command>ip</command> manual in
     <filename>/usr/share/doc/packages/iproute2/ip-cref.pdf</filename>.
    </para>

--- a/xml/net_wicked.xml
+++ b/xml/net_wicked.xml
@@ -560,64 +560,6 @@ ip route show</screen>
   </note>
   <sect3 xml:id="sec-network-manconf-ip">
    <title>Configuring a Network Interface with <command>ip</command></title>
-   <remark>
-From: Marius Tomaschewski mt@suse.de&gt;
-Subject: Re: Manual Network Config
-To: Karl Eichwalder ke@suse.de&gt;
-Date: Mon, 24 Aug 2009 14:21:44 +0200
-
-Das ifconfig utility ist obsolete und unterstützt nur Interface-
-Namen bis 9 Zeichen, z.B. "foo012345". Die restlichen Zeichen
-werden abgeschnitten und nicht angezeigt.
-Das "ip" utility unterstützt hingegen die derzeit volle Länge von
-15 Zeichen, z.B. "foo012345678901".
-
-Statt "ifconfig" sollte "ip addr" und "ip link" verwendet werden,
-um routing zu konfigurieren, sollte nicht "route", sondern "ip route"
-verwendendet werden.
-
-...
-
-IMO besser wäre es die Beispiel-Ausgaben von route und ifconfig zu
-entfernen und stattdessen Beispiel-Ausgaben von:
-
-"ip link show", "ip addr show",
-"ip -4 route show", "ip -6 route show"
-(und ggf. auch "ip rule show")
-
-im "Configuring a Network Interface with ip" zu bringen. Eventuell
-mit ein Paar Beispielen als eine Art Kurzanleitung, in etwa:
-
-ip link set up dev eth0
-
-ip addr add 192.168.0.100/24 dev eth0
-ip addr add 2001:DB8:cafe::dead/64 dev eth0
-
-ip route add 192.168.1.0/24 via 192.168.0.200 dev eth0
-ip route add 2001:DB8:cafe:1::/64 via 2001:DB8:cafe::feed dev eth0
-
-ip route add default via 192.168.0.254 dev eth0
-ip route add default via 2001:DB8:cafe::beef dev eth0
-
-ip addr show dev eth0
-ip -4 route show # dev eth0
-ip -6 route show # dev eth0
-
-ip route del 192.168.1.0/24 via 192.168.0.200 dev eth0
-ip route del 2001:DB8:cafe:1::/64 via 2001:DB8:cafe::feed dev eth0
-
-ip route del default via 192.168.0.254 dev eth0
-ip route del default via 2001:DB8:cafe::beef dev eth0
-
-ip addr del 192.168.0.100/24 dev eth0
-ip addr del 2001:DB8:cafe::dead/64 dev eth0
-
-ip link set down dev eth0
-</remark>
-   <remark>
- ke 2014-05-15: ifconfig and route is removed sind quite some time.
- Maybe, we should add more ip examples as Marius proposes...
-</remark>
    <para>
     <command>ip</command> is a tool to show and configure network devices,
     routing, policy routing, and tunnels.
@@ -700,46 +642,83 @@ ip link set down dev eth0
     <command>list</command>).
    </para>
    <para>
-    Change the state of a device with the command <command>ip link
-    set</command>&nbsp;<option><replaceable>DEVICE_NAME</replaceable></option>&nbsp;<command/>
-    . For example, to deactivate device eth0, enter <command>ip link
-    set</command> <option>eth0 down</option>. To activate it again, use
-    <command>ip link set</command> <option>eth0 up</option>.
+    Change the state of a device with the command:
    </para>
+<screen>&prompt.sudo;ip link set <replaceable>DEV_NAME</replaceable></screen>
+   <para>
+    For example, to deactivate device eth0, enter
+    </para>
+<screen>&prompt.sudo;ip link set eth0 down</screen>
+   <para>
+    To activate it again, use
+   </para>
+   <tip>
+    <title>Disconnecting NIC Device</title>
+    <para>
+     If you deactivate a device with
+     </para>
+<screen>&prompt.sudo;ip link set <replaceable>DEV_NAME</replaceable> down</screen>
+    <para>
+     it disables a number of its internal features, but the device remains
+     connected to the physical network environment. To disconnect the device
+     completely, run
+    </para>
+<screen>&prompt.sudo;ip link set <replaceable>DEV_NAME</replaceable> carrier off</screen>
+    <para>
+     To connect the device back to the physical network, run
+    </para>
+<screen>&prompt.sudo;ip link set <replaceable>DEV_NAME</replaceable> carrier on</screen>
+   </tip>
+<screen>&prompt.sudo;ip link set eth0 up</screen>
    <para>
     After activating a device, you can configure it. To set the IP address, use
-    <command>ip addr
-    add</command>&nbsp;<option><replaceable>IP_ADDRESS</replaceable> + dev
-    <replaceable>DEVICE_NAME</replaceable></option>. For example, to set the
-    address of the interface eth0 to 192.168.12.154/30 with standard broadcast
-    (option <option>brd</option>), enter <command>ip
-    addr</command>&nbsp;<option>add 192.168.12.154/30 brd + dev eth0</option>.
    </para>
+<screen>&prompt.sudo;ip addr add <replaceable>IP_ADDRESS</replaceable> + dev <replaceable>DEV_NAME</replaceable></screen>
+   <para>
+    For example, to set the address of the interface eth0 to 192.168.12.154/30
+    with standard broadcast (option <option>brd</option>), enter
+   </para>
+<screen>&prompt.sudo;ip addr add 192.168.12.154/30 brd + dev eth0</screen>
    <para>
     To have a working connection, you must also configure the default gateway.
-    To set a gateway for your system, enter <command>ip route
-    add</command>&nbsp;<option>gateway_ip_address</option>. To translate one IP
-    address to another, use <command>nat</command>: <command>ip route add
-    nat</command>&nbsp;<option>ip_address</option>&nbsp;<command>via</command>&nbsp;<option>other_ip_address</option>.
+    To set a gateway for your system, enter
    </para>
+<screen>&prompt.sudo;ip route add gateway_ip_address</screen>
    <para>
-    To display all devices, use <command>ip link ls</command>. To display the
-    running interfaces only, use <command>ip link ls up</command>. To print
-    interface statistics for a device, enter <command>ip -s link
-    ls</command>&nbsp;<option>device_name</option>. To view addresses of your
-    devices, enter <command>ip addr</command>. In the output of the <command>ip
-    addr</command>, also find information about MAC addresses of your devices.
-    To show all routes, use <command>ip route show</command>.
+    To translate one IP address to another, use <emphasis>network address
+     translation (NAT):</emphasis>
+    </para>
+<screen>&prompt.sudo;ip route add nat <replaceable>IP_ADDRESS</replaceable> via <replaceable>OTHER_IP_ADDRESS</replaceable></screen>
+   <para>
+    To display all devices, use
    </para>
+   <screen>&prompt.sudo;ip link ls</screen>
+   <para>
+    To display the running interfaces only, use
+   </para>
+<screen>&prompt.sudo;ip link ls up</screen>
+   <para>
+    To print interface statistics for a device, enter
+   </para>
+<screen>&prompt.sudo;ip -s link ls <replaceable>DEV_NAME</replaceable></screen>
+    <para>
+					To view addresses of your devices, enter
+    </para>
+<screen>&prompt.sudo;ip addr</screen>
+    <para>
+					In the output, you can find information about MAC addresses of your
+					devices. To show all routes, use
+   </para>
+<screen>&prompt.sudo;ip route show</screen>
    <para>
     For more information about using <command>ip</command>, enter
     <command>ip</command>&nbsp;<option>help</option> or see the
-    <systemitem>ip(8)</systemitem> man page. The <option>help</option> option
-    is also available for all <command>ip</command> subcommands. If, for
-    example, you need help for
-    <command>ip</command>&nbsp;<option>addr</option>, enter
-    <command>ip</command>&nbsp;<option>addr help</option>. Find the
-    <command>ip</command> manual in
+    <command>man 8 ip</command> manual page. The <option>help</option> option
+    is also available for all <command>ip</command> subcommands, such as:
+   </para>
+<screen>&prompt.sudo;ip addr help</screen>
+			<para>
+    Find the <command>ip</command> manual in
     <filename>/usr/share/doc/packages/iproute2/ip-cref.pdf</filename>.
    </para>
   </sect3>

--- a/xml/net_wicked.xml
+++ b/xml/net_wicked.xml
@@ -717,7 +717,7 @@ ip route show</screen>
     is also available for all <command>ip</command> subcommands, such as:
    </para>
 <screen>&prompt.sudo;ip addr help</screen>
-			<para>
+    <para>
     Find the <command>ip</command> manual in
     <filename>/usr/share/doc/packages/iproute2/ip-cref.pdf</filename>.
    </para>


### PR DESCRIPTION
### Description
While `ip link set down` deactivates a NIC, `ip link set carrier off' dosconnects it from the network completely. This update adds that new command to the docs.

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
