### PR TITLE
Document new 'transactional-update --continue' and 'snapper create

### DIFF
--- a/xml/snapper.xml
+++ b/xml/snapper.xml
@@ -1978,6 +1978,18 @@ local  | /local</screen>
    <para/>
    <variablelist>
     <varlistentry>
+     <term><command>snapper create --from <replaceable>17</replaceable> --description 
+        "with package2"</command>
+     </term>
+     <listitem>
+      <para>
+       Creates a stand-alone snapshot (type single) from an existing snapshot, which is specified
+       by the snapshot's number from <command>snapper list</command>. (This applies to Snapper version
+       0.8.4 and newer.)
+      </para>
+     </listitem>
+    </varlistentry> 
+    <varlistentry>
      <term><command>snapper create --description "Snapshot for week 2
       2014"</command>
      </term>
@@ -1990,7 +2002,7 @@ local  | /local</screen>
       </para>
      </listitem>
     </varlistentry>
-    <varlistentry>
+     <varlistentry>
      <term><command>snapper --config home create --description "Cleanup in
      ~&exampleuser_plain;"</command>
      </term>

--- a/xml/transactional_updates.xml
+++ b/xml/transactional_updates.xml
@@ -280,15 +280,12 @@
  <sect1>
   <title>The <command>transactional-update</command> Command</title>
   <para>
-   The <command>transactional-update</command> command enables you to install
-   or remove updates of your system in an atomic way. Updates are applied only
+   The <command>transactional-update</command> command enables installing
+   or removing updates of your system in atomically; updates are applied only
    if all of them can be successfully installed.
    <command>transactional-update</command> creates a snapshot of your system
-   before the update is applied, and you can restore this snapshot.
-  </para>
-
-  <para>
-   All changes become active only after reboot.
+   before the update is applied, and you can restore this snapshot. All changes become 
+   active only after reboot.
   </para>
 
 <variablelist>
@@ -305,15 +302,15 @@
          forget something, such as installing a new package, you have to reboot
          to apply your previous changes, run <command>transactional-update</command>
          again to install the forgotten package, and reboot again. You cannot run the
-         <command>transactional-update</command> multiple times without rebooting
-         to add more changes to the snapshot, because each call creates separate independent
-         snapshots that do not include changes from the previous snapshots.
+         <command>transactional-update</command> command multiple times without rebooting
+         to add more changes to the snapshot, because that creates separate 
+         independent snapshots that do not include changes from the previous snapshots.
      </para>
      <para>
          Use the <command>--continue</command> option to make as many changes as you
-         want without rebooting. A separate snapshot is made for each call, and each
+         want without rebooting. A separate snapshot is made each time, and each
          snapshot contains all the changes you made in the previous snapshots, plus your 
-         new changes. Repeat this process as many times as you want, and then when the final
+         new changes. Repeat this process as many times as you want, and when the final
          snapshot includes everything you want reboot the system, and your final snapshot
          becomes the new root filesystem.
      </para>
@@ -321,7 +318,8 @@
          Another useful feature of the <command>--continue</command> option is you may
          select any existing snapshot as the base for your new snapshot. The following example
          demonstrates running <command>transactional-update</command> to install a new
-         package to snapshot 13, and then running it again to install another package:
+         package in a snapshot based on snapshot 13, and then running it again to install 
+         another package:
      </para>
      <screen>&prompt.root;<command>transactional-update pkg install <replaceable>package_1</replaceable></command></screen>
     <screen>&prompt.root;<command>transactional-update --continue 13 pkg install <replaceable>package_2</replaceable></command></screen>

--- a/xml/transactional_updates.xml
+++ b/xml/transactional_updates.xml
@@ -291,10 +291,49 @@
    All changes become active only after reboot.
   </para>
 
-  <variablelist>
-      <varlistentry>
-          <term><literal>cleanup</literal></term>
-          <listitem>
+<variablelist>
+  <varlistentry>
+   <term><literal>--continue</literal></term>
+   <listitem>
+     <para>
+         The <command>--continue</command> option is for making multiple changes to an
+         existing snapshot without rebooting.
+     </para>
+     <para>
+         The default <command>transactional-update</command> behavior 
+         is to create a new snapshot from the current root filesystem. If you
+         forget something, such as installing a new package, you have to reboot
+         to apply your previous changes, run <command>transactional-update</command>
+         again to install the forgotten package, and reboot again. You cannot run the
+         <command>transactional-update</command> multiple times without rebooting
+         to add more changes to the snapshot, because each call creates separate independent
+         snapshots that do not include changes from the previous snapshots.
+     </para>
+     <para>
+         Use the <command>--continue</command> option to make as many changes as you
+         want without rebooting. A separate snapshot is made for each call, and each
+         snapshot contains all the changes you made in the previous snapshots, plus your 
+         new changes. Repeat this process as many times as you want, and then when the final
+         snapshot includes everything you want reboot the system, and your final snapshot
+         becomes the new root filesystem.
+     </para>
+     <para>
+         Another useful feature of the <command>--continue</command> option is you may
+         select any existing snapshot as the base for your new snapshot. The following example
+         demonstrates running <command>transactional-update</command> to install a new
+         package to snapshot 13, and then running it again to install another package:
+     </para>
+     <screen>&prompt.root;<command>transactional-update pkg install <replaceable>package_1</replaceable></command></screen>
+    <screen>&prompt.root;<command>transactional-update --continue 13 pkg install <replaceable>package_2</replaceable></command></screen>
+    <para>
+        The <command>--continue [num]</command> option calls <command>snapper create --from</command>,
+        see <xref linkend="sec-snapper-manage-create"/>.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term><literal>cleanup</literal></term>
+   <listitem>
   <para>
     If the current root filesystem is identical to the active root
     filesystem (after a reboot, before <command>transactional-update</command>

--- a/xml/transactional_updates.xml
+++ b/xml/transactional_updates.xml
@@ -281,7 +281,7 @@
   <title>The <command>transactional-update</command> Command</title>
   <para>
    The <command>transactional-update</command> command enables installing
-   or removing updates of your system in atomically; updates are applied only
+   or removing updates of your system atomically; updates are applied only
    if all of them can be successfully installed.
    <command>transactional-update</command> creates a snapshot of your system
    before the update is applied, and you can restore this snapshot. All changes become 

--- a/xml/transactional_updates.xml
+++ b/xml/transactional_updates.xml
@@ -280,8 +280,8 @@
  <sect1>
   <title>The <command>transactional-update</command> Command</title>
   <para>
-   The <command>transactional-update</command> command enables installing
-   or removing updates of your system atomically; updates are applied only
+   The <command>transactional-update</command> command enables atomic installation 
+   or removal of updates; updates are applied only
    if all of them can be successfully installed.
    <command>transactional-update</command> creates a snapshot of your system
    before the update is applied, and you can restore this snapshot. All changes become 


### PR DESCRIPTION
--from' options

Resolve Jira #SLE-7372. SLES 15 SP2 only.
New options for creating Snapper and transactional-update snapshots from selected snapshots, rather than the default root filesystem. Also allow stacking changes in transactional-update without rebooting.


*Are backports required?*
no
