### PR TITLE
SLE15Sp2 ISO1 too big for DVD (bsc#1167156)

### DIFF
--- a/xml/art_sle_install_quick.xml
+++ b/xml/art_sle_install_quick.xml
@@ -87,7 +87,7 @@
     <link xlink:href="https://download.suse.com/"/>.
    </para>
    <!-- cwickert 2020-03-11: Old content from the 'offline' section -->
-   <!-- 
+   <!--
    <para>
     If you perform an installation without connecting to a registration server,
     you cannot register your system during the installation. Therefore you will
@@ -102,7 +102,7 @@
     installation. This can be achieved by copying it to a local hard disk or a
     removable flash disk or by making it available in the local network. Choose
     a method that is supported by your hardware.
-   </para> 
+   </para>
    -->
    <tip>
     <title>

--- a/xml/ay_12_migrate_15.xml
+++ b/xml/ay_12_migrate_15.xml
@@ -25,7 +25,7 @@
  </info>
  <sect1 os="sles;sled" xml:id="sec-ay-12vs15-product-selection">
   <title>Product Selection</title>
-  
+
   <para>
    For backward compatibility with profiles created for pre-<phrase
    os="sles;sled">&slea;</phrase><phrase os="osuse">Leap</phrase> 15 products,
@@ -38,9 +38,9 @@
   </para>
   <para>
    For information about explicit product selection, refer to
-   <xref linkend="Software-Selections-base-product"/>. 
+   <xref linkend="Software-Selections-base-product"/>.
   </para>
-  
+
   <para>
    If automatic product selection fails, an error is shown and the installation
    will not be continued.
@@ -134,7 +134,7 @@
    <para>
     To add a module or extension using the &packagemedia; image, create entries in
     the add-on section as shown in the example below. The following XML code
-    adds the Basesystem module from a USB flash drive that contains the image:
+    adds the Basesystem module from a &usbflashdrive; that contains the image:
    </para>
 
    <example xml:id="ex-ay-12vs15-software-packagemedia">
@@ -166,7 +166,7 @@
    <tip>
     <title>Using the Packages Image from a Local Server</title>
     <para>
-     You can share the content of the USB flash drive on the local network via an NFS, FTP or HTTP
+     You can share the content of the &usbflashdrive; on the local network via an NFS, FTP or HTTP
      server. To do so replace the URL in the <tag
      class="element">media_url</tag> tag so it points to root of the medium on
      the server, for example:

--- a/xml/deployment_boot_parameters.xml
+++ b/xml/deployment_boot_parameters.xml
@@ -730,8 +730,8 @@
   <sect2 xml:id="sec-boot-parameters-list-install-source">
    <title>Specifying the Installation Source</title>
    <para>
-    If you are not using the DVD for installation, specify an alternative
-    installation source.
+    If you are not using the &usbflashdrive; for installation, specify an
+    alternative installation source.
    </para>
    <variablelist>
     <varlistentry>
@@ -757,7 +757,7 @@
        with the URL. These parameters are optional and anonymous or guest login
        is assumed if they are not given. Example:
       </para>
-<screen>install=ftp://<replaceable>USER</replaceable>:<replaceable>PASSWORD</replaceable>@<replaceable>SERVER</replaceable>/<replaceable>DIRECTORY</replaceable>/DVD1/</screen>
+<screen>install=ftp://<replaceable>USER</replaceable>:<replaceable>PASSWORD</replaceable>@<replaceable>SERVER</replaceable>/<replaceable>DIRECTORY</replaceable>/Media1/</screen>
       <para>
        To install over an encrypted connection, use an
        <literal>https</literal> URL. If the certificate cannot be verified, use
@@ -768,7 +768,7 @@
        In case of a Samba or CIFS installation, you can also specify the domain
        that should be used:
       </para>
-<screen>install=smb://<replaceable>WORKDOMAIN</replaceable>;<replaceable>USER</replaceable>:<replaceable>PASSWORD</replaceable>@<replaceable>SERVER</replaceable>/<replaceable>DIRECTORY</replaceable>/DVD1/</screen>
+<screen>install=smb://<replaceable>WORKDOMAIN</replaceable>;<replaceable>USER</replaceable>:<replaceable>PASSWORD</replaceable>@<replaceable>SERVER</replaceable>/<replaceable>DIRECTORY</replaceable>/Media1/</screen>
       <para>
        To use <literal>cd</literal>, <literal>hd</literal> or <literal>slp</literal>,
        set them as the following example:

--- a/xml/deployment_boot_parameters.xml
+++ b/xml/deployment_boot_parameters.xml
@@ -757,7 +757,7 @@
        with the URL. These parameters are optional and anonymous or guest login
        is assumed if they are not given. Example:
       </para>
-<screen>install=ftp://<replaceable>USER</replaceable>:<replaceable>PASSWORD</replaceable>@<replaceable>SERVER</replaceable>/<replaceable>DIRECTORY</replaceable>/Media1/</screen>
+<screen>install=ftp://<replaceable>USER</replaceable>:<replaceable>PASSWORD</replaceable>@<replaceable>SERVER</replaceable>/<replaceable>DIRECTORY</replaceable>/DVD1/</screen>
       <para>
        To install over an encrypted connection, use an
        <literal>https</literal> URL. If the certificate cannot be verified, use

--- a/xml/deployment_boot_parameters.xml
+++ b/xml/deployment_boot_parameters.xml
@@ -768,7 +768,7 @@
        In case of a Samba or CIFS installation, you can also specify the domain
        that should be used:
       </para>
-<screen>install=smb://<replaceable>WORKDOMAIN</replaceable>;<replaceable>USER</replaceable>:<replaceable>PASSWORD</replaceable>@<replaceable>SERVER</replaceable>/<replaceable>DIRECTORY</replaceable>/Media1/</screen>
+<screen>install=smb://<replaceable>WORKDOMAIN</replaceable>;<replaceable>USER</replaceable>:<replaceable>PASSWORD</replaceable>@<replaceable>SERVER</replaceable>/<replaceable>DIRECTORY</replaceable>/DVD1/</screen>
       <para>
        To use <literal>cd</literal>, <literal>hd</literal> or <literal>slp</literal>,
        set them as the following example:

--- a/xml/deployment_boot_parameters.xml
+++ b/xml/deployment_boot_parameters.xml
@@ -730,7 +730,7 @@
   <sect2 xml:id="sec-boot-parameters-list-install-source">
    <title>Specifying the Installation Source</title>
    <para>
-    If you are not using the &usbflashdrive; for installation, specify an
+    If you are not using DVD or &usbflashdrive; for installation, specify an
     alternative installation source.
    </para>
    <variablelist>

--- a/xml/deployment_customize_installation_image.xml
+++ b/xml/deployment_customize_installation_image.xml
@@ -13,11 +13,11 @@
   <abstract>
    <para>
     You may customize the standard &sle; installation images by
-    editing a file in the installation ISO image, 
-    <filename>media.1/products</filename>. 
+    editing a file in the installation ISO image,
+    <filename>media.1/products</filename>.
     Add modules and extensions to create a single
     customized installation image. Then copy your
-    custom image to a CD, DVD, or USB device to create a bootable customized
+    custom image to a CD, DVD, or &usbflashdrive; to create a bootable customized
     installation medium. See <citetitle>How to Create a Custom Installation
     Medium for SUSE Linux Enterprise 15</citetitle>
     <link xlink:href="https://documentation.suse.com/sbp/all/single-html/SBP-SLE15-Custom-Installation-Medium/"/>

--- a/xml/deployment_expert_partitioner_overview.xml
+++ b/xml/deployment_expert_partitioner_overview.xml
@@ -425,7 +425,7 @@
        </para>
        <para>
         The UDF file system can be used on optical rewritable and non-rewritable
-        media, USB flash drives and hard drives. It is supported by multiple
+        media, &usbflashdrive;s and hard drives. It is supported by multiple
         operating systems.
        </para>
        <para>

--- a/xml/deployment_installserver.xml
+++ b/xml/deployment_installserver.xml
@@ -170,24 +170,24 @@
    server module. Then select <guimenu>Add</guimenu> in the overview of existing
    repositories to configure the new repository.
   </para>
-  
+
   <warning>
    <title>&yast; Installation Server Will Conflict with &rmt; Server</title>
    <para>
     Configuring a server to be an installation server with &yast; automatically
-    installs and configures the Apache web server, listening on port 80.    
+    installs and configures the Apache web server, listening on port 80.
    </para>
    <para>
     However, configuring a machine to be an &rmt; server (&rmtool;)
     automatically installs the NGINX web server and configures it to listen on
-    port 80.   
+    port 80.
    </para>
    <para>
     Do not try to enable both these functions on the same server. It is not
     possible for a single server to host both simultaneously.
    </para>
   </warning>
-      
+
  </sect1>
  <sect1 xml:id="sec-deployment-instserver-nfs">
   <title>Setting Up an NFS Repository Manually</title>
@@ -232,30 +232,27 @@
    </step>
    <step>
     <para>
-     For each DVD contained in the media kit execute the following commands:
+     For each installation media contained in the media kit execute the following commands:
     </para>
     <substeps performance="required">
      <step>
       <para>
-       Copy the entire content of the installation DVD into the installation
+       Copy the entire content of the installation media into the installation
        server directory:
       </para>
-<screen>&prompt.root;cp -a /media/<replaceable>PATH_TO_YOUR_DVD_DRIVE</replaceable> .</screen>
+<screen>&prompt.root;cp -a /media/<replaceable>PATH_TO_YOUR_MEDIA_DRIVE</replaceable> .</screen>
       <para>
-       Replace <replaceable>PATH_TO_YOUR_DVD_DRIVE</replaceable> with the
-       actual path under which your DVD drive is addressed. Depending on the
-       type of drive used in your system, this can be
-       <filename>cdrom</filename>, <filename>cdrecorder</filename>,
-       <filename>dvd</filename>, or <filename>dvdrecorder</filename>.
+       Replace <replaceable>PATH_TO_YOUR_MEDIA_DRIVE</replaceable> with the
+       actual path under which your installation media drive is addressed.
       </para>
      </step>
      <step>
       <para>
-       Rename the directory to the DVD number:
+       Rename the directory to the MEDIA number:
       </para>
-<screen>&prompt.root;mv <replaceable>PATH_TO_YOUR_DVD_DRIVE</replaceable> DVD<replaceable>X</replaceable></screen>
+<screen>&prompt.root;mv <replaceable>PATH_TO_YOUR_MEDIA_DRIVE</replaceable> DVD<replaceable>X</replaceable></screen>
       <para>
-       Replace <replaceable>X</replaceable> with the actual number of your DVD.
+       Replace <replaceable>X</replaceable> with the actual number of your installation media.
       </para>
      </step>
     </substeps>
@@ -626,7 +623,7 @@ description=HTTP Repository</screen>
    <step>
     <para>
      Enter the <filename>INSTALL/<replaceable>PRODUCT</replaceable></filename>
-     directory and copy each DVD to a separate directory, such as
+     directory and copy each MEDIA to a separate directory, such as
      <literal>DVD1</literal> and <literal>DVD2</literal>.
     </para>
    </step>
@@ -699,7 +696,7 @@ description=HTTP Repository</screen>
    </step>
    <step>
     <para>
-     Create subdirectories for each DVD.
+     Create subdirectories for each installation media.
     </para>
    </step>
    <step>

--- a/xml/deployment_installserver.xml
+++ b/xml/deployment_installserver.xml
@@ -237,7 +237,7 @@
     <substeps performance="required">
      <step>
       <para>
-       Copy the entire content of the installation media into the installation
+       Copy the entire content of the installation medium into the installation
        server directory:
       </para>
 <screen>&prompt.root;cp -a /media/<replaceable>PATH_TO_YOUR_MEDIA_DRIVE</replaceable> .</screen>

--- a/xml/deployment_installserver.xml
+++ b/xml/deployment_installserver.xml
@@ -248,7 +248,7 @@
      </step>
      <step>
       <para>
-       Rename the directory to the MEDIA number:
+       Rename the directory to the medium number:
       </para>
 <screen>&prompt.root;mv <replaceable>PATH_TO_YOUR_MEDIA_DRIVE</replaceable> DVD<replaceable>X</replaceable></screen>
       <para>

--- a/xml/deployment_installserver.xml
+++ b/xml/deployment_installserver.xml
@@ -623,7 +623,7 @@ description=HTTP Repository</screen>
    <step>
     <para>
      Enter the <filename>INSTALL/<replaceable>PRODUCT</replaceable></filename>
-     directory and copy each MEDIA to a separate directory, such as
+     directory and copy each media to a separate directory, such as
      <literal>DVD1</literal> and <literal>DVD2</literal>.
     </para>
    </step>

--- a/xml/deployment_installserver.xml
+++ b/xml/deployment_installserver.xml
@@ -623,7 +623,7 @@ description=HTTP Repository</screen>
    <step>
     <para>
      Enter the <filename>INSTALL/<replaceable>PRODUCT</replaceable></filename>
-     directory and copy each media to a separate directory, such as
+     directory and copy each medium to a separate directory, such as
      <literal>DVD1</literal> and <literal>DVD2</literal>.
     </para>
    </step>

--- a/xml/deployment_installserver.xml
+++ b/xml/deployment_installserver.xml
@@ -696,7 +696,7 @@ description=HTTP Repository</screen>
    </step>
    <step>
     <para>
-     Create subdirectories for each installation media.
+     Create subdirectories for each installation medium.
     </para>
    </step>
    <step>

--- a/xml/deployment_installserver.xml
+++ b/xml/deployment_installserver.xml
@@ -232,7 +232,7 @@
    </step>
    <step>
     <para>
-     For each installation media contained in the media kit execute the following commands:
+     For each installation medium contained in the media kit, execute the following commands:
     </para>
     <substeps performance="required">
      <step>

--- a/xml/deployment_installserver.xml
+++ b/xml/deployment_installserver.xml
@@ -252,7 +252,7 @@
       </para>
 <screen>&prompt.root;mv <replaceable>PATH_TO_YOUR_MEDIA_DRIVE</replaceable> DVD<replaceable>X</replaceable></screen>
       <para>
-       Replace <replaceable>X</replaceable> with the actual number of your installation media.
+       Replace <replaceable>X</replaceable> with the actual number of your installation medium.
       </para>
      </step>
     </substeps>

--- a/xml/deployment_kernelupdate.xml
+++ b/xml/deployment_kernelupdate.xml
@@ -34,23 +34,23 @@
   </para>
   <para>
    You can download the full ISO image or only the <literal>initrd</literal>
-   and <literal>linux</literal> files. The ISO usually needs to be burned to
-   a CD or DVD. The <literal>initrd</literal> and
-   <literal>linux</literal> files can be used for a PXE boot. For details about
-   booting via PXE, see <xref linkend="cha-deployment-prep-pxe" />.
+   and <literal>linux</literal> files. The ISO usually needs to be copied to a
+   &usbflashdrive;. The <literal>initrd</literal> and <literal>linux</literal>
+   files can be used for a PXE boot. For details about booting via PXE, see
+   <xref linkend="cha-deployment-prep-pxe" />.
   </para>
  </sect1>
  <sect1 xml:id="sec-kiso-boot">
   <title>Boot Kernel Update</title>
   <para>
-   To use the Kernel Update, boot from the DVD or via PXE. When the
+   To use the Kernel Update, boot from the &usbflashdrive; or via PXE. When the
    <literal>linux</literal> and the <literal>initrd</literal> are loaded,
-   you will be asked to insert the installation DVD.
+   you will be asked to insert the installation media.
   </para>
   <para>
    You can use the boot parameters described in
    <xref linkend="cha-boot-parameters" />. This allows using other
-   installation sources than the installation DVD.
+   installation sources than the installation &usbflashdrive;.
   </para>
  </sect1>
 </chapter>

--- a/xml/deployment_kernelupdate.xml
+++ b/xml/deployment_kernelupdate.xml
@@ -35,7 +35,7 @@
   <para>
    You can download the full ISO image or only the <literal>initrd</literal>
    and <literal>linux</literal> files. The ISO usually needs to be copied to a
-   &usbflashdrive;. The <literal>initrd</literal> and <literal>linux</literal>
+   &usbflashdrive; or burned to a DVD. The <literal>initrd</literal> and <literal>linux</literal>
    files can be used for a PXE boot. For details about booting via PXE, see
    <xref linkend="cha-deployment-prep-pxe" />.
   </para>

--- a/xml/deployment_kernelupdate.xml
+++ b/xml/deployment_kernelupdate.xml
@@ -45,7 +45,7 @@
   <para>
    To use the Kernel Update, boot from the &usbflashdrive; or via PXE. When the
    <literal>linux</literal> and the <literal>initrd</literal> are loaded,
-   you will be asked to insert the installation media.
+   you will be asked to insert the installation medium.
   </para>
   <para>
    You can use the boot parameters described in

--- a/xml/deployment_mksusecd.xml
+++ b/xml/deployment_mksusecd.xml
@@ -70,7 +70,7 @@ Use SUSEConnect --help for more details.</screen>
   </para>
 
   <para>
-   After you create your custom image, either burn it to a CD/DVD media using
+   After you create your custom image, either burn it to a CD/DVD medium using
    your preferred disk-writing program such as Brasero or
    <command>mybashburn</command>, or create a bootable &usbflashdrive; using
    the <command>dd</command> command. Make sure the device is not mounted, then

--- a/xml/deployment_mksusecd.xml
+++ b/xml/deployment_mksusecd.xml
@@ -4,7 +4,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<chapter version="5.0" role="General" 
+<chapter version="5.0" role="General"
   xml:id="cha-deployment-prep-mksusecd"
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
@@ -37,13 +37,13 @@
 <screen>&prompt.user;zypper search-packages mksusecd
 Following packages were found in following modules:
 
-Package               Module or Repository                                             
+Package               Module or Repository
 --------------------  -----------------------------------------------------------------
 mksusecd              Development Tools Module (sle-module-development-tools/15/x86_64)
 mksusecd-debuginfo    Development Tools Module (sle-module-development-tools/15/x86_64)
 mksusecd-debugsource  Development Tools Module (sle-module-development-tools/15/x86_64)
-mksusecd              Available                                                        
-srcpackage:mksusecd   Available                                                        
+mksusecd              Available
+srcpackage:mksusecd   Available
 
 To activate the respective module or product, use SUSEConnect --product.
 Use SUSEConnect --help for more details.</screen>
@@ -70,13 +70,11 @@ Use SUSEConnect --help for more details.</screen>
   </para>
 
   <para>
-   After you create your custom image, copy it to a CD/DVD using your preferred
-   disk-writing program such as Brasero or <command>mybashburn</command>.
-  </para>
-
-  <para>
-   Create a bootable USB drive using the <command>dd</command> command. Make
-   sure the device is not mounted, then run the following command:
+   After you create your custom image, either burn it to a CD/DVD media using
+   your preferred disk-writing program such as Brasero or
+   <command>mybashburn</command>, or create a bootable &usbflashdrive; using
+   the <command>dd</command> command. Make sure the device is not mounted, then
+   run the following command:
   </para>
 
 <screen>&prompt.root;<command>dd</command> if=<replaceable>min-install.iso</replaceable> of=/dev/<replaceable>SDB</replaceable> bs=4M</screen>
@@ -90,10 +88,10 @@ Use SUSEConnect --help for more details.</screen>
 
   <para>
    Use <command>mksusecd</command> to create a minimal boot image to start
-   client machines from a CD/DVD or USB drive, in place of starting them from a
-   PXE boot server. The minimal boot image launches the kernel and initrd, and
-   then the remaining installation files are fetched from a local NFS server
-   (see <xref linkend="sec-deployment-instserver-sles9"/>).
+   client machines from a CD/DVD or &usbflashdrive;, in place of starting them
+   from a PXE boot server. The minimal boot image launches the kernel and
+   initrd, and then the remaining installation files are fetched from a local
+   NFS server (see <xref linkend="sec-deployment-instserver-sles9"/>).
   </para>
 
   <para>

--- a/xml/deployment_prep_aarch64_media.xml
+++ b/xml/deployment_prep_aarch64_media.xml
@@ -54,7 +54,7 @@
    </para>
    <variablelist>
     <varlistentry>
-     <term>USB Flash Drive</term>
+     <term>&usbflashdrivecap;</term>
      <listitem>
       <para>
        This is the simplest way to start the installation. To create a bootable

--- a/xml/deployment_prep_x86_media.xml
+++ b/xml/deployment_prep_x86_media.xml
@@ -17,12 +17,12 @@
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
- 
+
  <!--
    taroth 2019-07-31: CAVE - same section content is used in
    deployment_prep_aarch64_media.xml
  -->
- 
+
  <para>
   This section gives an overview of the steps required for the
   complete installation of &productnamereg;.
@@ -37,7 +37,7 @@
   For a full description of how to install and configure the system with
   &yast;, refer to <xref linkend="part-deployment"/>.
  </para>
- 
+
  <important os="sles">
   <title>Hardware Support Updates</title>
    <para>
@@ -54,7 +54,7 @@
    </para>
    <variablelist>
     <varlistentry>
-     <term>USB Flash Drive</term>
+     <term>&usbflashdrivecap;</term>
      <listitem>
       <para>
        This is the simplest way to start the installation. To create a bootable
@@ -65,6 +65,7 @@
       <screen>&prompt.root;<command>dd</command> if=<replaceable>PATH_TO_ISO_IMAGE</replaceable> of=<replaceable>USB_STORAGE_DEVICE</replaceable> bs=4M</screen>
      </listitem>
     </varlistentry>
+    <!-- 2020-03-26 tbazant: Full ISO1 no longer fits on DVD
     <varlistentry>
      <term>DVD</term>
      <listitem>
@@ -79,6 +80,7 @@
       </para>
      </listitem>
     </varlistentry>
+    -->
     <varlistentry>
      <term>Network Booting</term>
      <listitem>
@@ -92,7 +94,7 @@
       </para>
       <para>It is possible to install from many common network protocols, such
        as NFS, HTTP, FTP, or SMB. For more information on how to perform such an
-       installation, refer to <xref linkend="cha-remote-installation"/>. 
+       installation, refer to <xref linkend="cha-remote-installation"/>.
       </para>
      </listitem>
     </varlistentry>

--- a/xml/deployment_prep_zseries_info_i.xml
+++ b/xml/deployment_prep_zseries_info_i.xml
@@ -378,7 +378,7 @@
     <title>Additional Information</title>
     <para>
      Consult the <filename>README</filename> file located in the root directory
-     of the first installation media of &productname; before installing
+     of the first installation medium of &productname; before installing
      &productname; on IBM &zseries;. This file complements this documentation.
     </para>
    </tip>

--- a/xml/deployment_prep_zseries_info_i.xml
+++ b/xml/deployment_prep_zseries_info_i.xml
@@ -377,9 +377,9 @@
    <tip>
     <title>Additional Information</title>
     <para>
-     Consult the <filename>README</filename> file located in the root directory of
-     DVD&nbsp;1 of your &productname; before installing &productname; on IBM
-     &zseries;. This file complements this documentation.
+     Consult the <filename>README</filename> file located in the root directory
+     of the first installation media of &productname; before installing
+     &productname; on IBM &zseries;. This file complements this documentation.
     </para>
    </tip>
   </sect3>
@@ -468,7 +468,7 @@
    </para>
    <para>
     For &productname;, there are two such files. Both are located in the root
-    directory of the file system of DVD 1:
+    directory of the first installation media:
    </para>
    <itemizedlist>
     <listitem>

--- a/xml/deployment_prep_zseries_info_i.xml
+++ b/xml/deployment_prep_zseries_info_i.xml
@@ -468,7 +468,7 @@
    </para>
    <para>
     For &productname;, there are two such files. Both are located in the root
-    directory of the first installation media:
+    directory of the first installation medium:
    </para>
    <itemizedlist>
     <listitem>

--- a/xml/deployment_prep_zseries_prep_i.xml
+++ b/xml/deployment_prep_zseries_prep_i.xml
@@ -823,7 +823,7 @@ DIRM USER WITHPASS</screen>
     </para>
     <para>
      Log in as the z/VM Linux guest to IPL. Make the content of the directory
-     <filename>/boot/s390x</filename> of the &leanos; (media 1) available
+     <filename>/boot/s390x</filename> of the &leanos; (medium 1) available
      via FTP within your network. From this directory, get the files
      <filename>linux</filename>, <filename>initrd</filename>,
      <filename>parmfile</filename>, and <filename>sles.exec</filename>.

--- a/xml/deployment_prep_zseries_prep_i.xml
+++ b/xml/deployment_prep_zseries_prep_i.xml
@@ -111,7 +111,7 @@
     <para>
      For &zseries;, IPL your LPAR/VM guest from this medium as described in
      <xref linkend="sec-prep-ipling-lpar-dvd"/>. After entering your network
-     parameters, the installation system treats the media as the source of
+     parameters, the installation system treats the medium as the source of
      installation data. Because &zseries; cannot have an X11-capable terminal
      attached directly, choose between VNC or SSH installation. SSH also
      provides a graphical installation by tunneling the X connection through

--- a/xml/deployment_prep_zseries_prep_i.xml
+++ b/xml/deployment_prep_zseries_prep_i.xml
@@ -204,7 +204,7 @@
     <para>
      Refer to the documentation provided with the third-party product that is
      enabling FTP server services on your Windows workstation. The
-     &usbflashdrive; containing the &installmedia; media must be in the
+     &usbflashdrive; containing the &installmedia; medium must be in the
      available FTP path.
     </para>
     <para>

--- a/xml/deployment_prep_zseries_prep_i.xml
+++ b/xml/deployment_prep_zseries_prep_i.xml
@@ -133,7 +133,7 @@
     <title>Using SMB</title>
     <para>
      To make the installation media available with SMB, insert the
-     &usbflashdrive; with &installmedia; into the USB slot of the Windows
+     &usbflashdrive; with &installmedia; into the USB port of the Windows
      workstation. Then create a new share using the &usbflashdrive;'s letter
      and make it available for everyone in the network.
     </para>

--- a/xml/deployment_prep_zseries_prep_i.xml
+++ b/xml/deployment_prep_zseries_prep_i.xml
@@ -96,11 +96,12 @@
    <sect4 xml:id="sec-prep-makeavail-linuxws-oncd">
     <title>&productname; on DVD</title>
     <para>
-     DVD1 of the &productname; for &zseries; contains a bootable Linux
-     image for Intel-based workstations and an image for &zseries;.
+     The first installation media of the &productname; for &zseries; contains a
+     bootable Linux image for Intel-based workstations and an image for
+     &zseries;.
     </para>
     <para>
-     For Intel-based workstations, boot from this DVD. When prompted, choose
+     For Intel-based workstations, boot from this media. When prompted, choose
      the desired answer language and keyboard layout and select <guimenu>Start
      rescue system</guimenu>. You need at least 64&nbsp;MB RAM for this. No
      disk space is needed, because the entire rescue system resides in the
@@ -108,9 +109,9 @@
      workstation manually.
     </para>
     <para>
-     For &zseries;, IPL your LPAR/VM guest from this DVD as described in
+     For &zseries;, IPL your LPAR/VM guest from this media as described in
      <xref linkend="sec-prep-ipling-lpar-dvd"/>. After entering your network
-     parameters, the installation system treats the DVD as the source of
+     parameters, the installation system treats the media as the source of
      installation data. Because &zseries; cannot have an X11-capable terminal
      attached directly, choose between VNC or SSH installation. SSH also
      provides a graphical installation by tunneling the X connection through
@@ -132,9 +133,9 @@
     <title>Using SMB</title>
     <para>
      To make the installation media available with SMB, insert the
-     &productname; DVD&nbsp;1 into the DVD drive of the Windows workstation.
-     Then create a new share using the DVD-ROM drive's letter and make it
-     available for everyone in the network.
+     &usbflashdrive; with &installmedia; into the USB slot of the Windows
+     workstation. Then create a new share using the &usbflashdrive;'s letter
+     and make it available for everyone in the network.
     </para>
 <!-- bnc#803514
          http://lists.samba.org/archive/samba-technical/2001-April/013007.html
@@ -193,16 +194,18 @@
     <title>With NFS</title>
     <para>
      Refer to the documentation provided with the third party product that
-     enables NFS server services for your Windows workstation. The DVD-ROM
-     drive containing the &productname; DVDs must be in the available NFS path.
+     enables NFS server services for your Windows workstation. The
+     &usbflashdrive; containing the &installmedia; media must be in the
+     available NFS path.
     </para>
    </sect4>
    <sect4 xml:id="sec-prep-makeavail-windowsws-ftp">
     <title>Using FTP</title>
     <para>
      Refer to the documentation provided with the third-party product that is
-     enabling FTP server services on your Windows workstation. The DVD-ROM
-     drive containing the &productname; DVDs must be in the available FTP path.
+     enabling FTP server services on your Windows workstation. The
+     &usbflashdrive; containing the &installmedia; media must be in the
+     available FTP path.
     </para>
     <para>
      The FTP server that is bundled with certain Microsoft Windows releases
@@ -258,8 +261,8 @@
     <title>Importing the Installation Data</title>
     <para>
      Importing the media requires the installation source to be available on
-     the Cobbler server&mdash;either from DVD or from a network source. Run the
-     following command to import the data:
+     the Cobbler server&mdash;either from &usbflashdrive; or from a network
+     source. Run the following command to import the data:
     </para>
 <screen>&prompt.sudo;cobbler import --path=<replaceable>PATH</replaceable><co xml:id="co-cobbler-import-path"/> --name=<replaceable>IDENTIFIER</replaceable><co xml:id="co-cobbler-import-dirname"/> --arch=s390x</screen>
     <calloutlist>
@@ -414,16 +417,15 @@ DASD=600"</screen>
    </sect4>
   </sect3>
   <sect3 xml:id="sec-prep-makeavail-dvd-usb-hmc">
-   <title>Installing from DVD or Flash Disk of the HMC</title>
+   <title>Installing from a &usbflashdrivecap; of the HMC</title>
    <para>
     Installation of &productname; on IBM &zseries; servers usually requires a
     network installation source. If this requirement cannot be fulfilled, &sls;
-    allows you to use the existing DVD or the flash disk of the Hardware
-    Management Console (HMC) as an installation source for installation on an
-    LPAR.
+    allows you to use the &usbflashdrive; of the Hardware Management Console
+    (HMC) as an installation source for installation on an LPAR.
    </para>
    <para>
-    To perform installation from the DVD media or the flash disk of the HMC, proceed
+    To perform installation from the &usbflashdrive; of the HMC, proceed
     as follows:
    </para>
    <itemizedlist>
@@ -457,7 +459,7 @@ DASD=600"</screen>
    <important>
     <title>Linux System Must Boot First</title>
     <para>
-     Before granting access to the media in the DVD or the flash disk of the
+     Before granting access to the media in the &usbflashdrive; of the
      HMC, wait until the Linux system is booted. IPLing can disrupt the
      connection between the HMC and the LPAR. If the first attempt to use the
      described method fails, you can grant the access and retry the option
@@ -467,7 +469,7 @@ DASD=600"</screen>
    <note>
     <title>Installation Repository</title>
     <para>
-     The DVD or the flash disk is not kept as an installation repository, as the
+     The &usbflashdrive; is not kept as an installation repository, as the
      installation is a one-time procedure. If you need an installation
      repository, register and use the online repository.
     </para>
@@ -821,7 +823,7 @@ DIRM USER WITHPASS</screen>
     </para>
     <para>
      Log in as the z/VM Linux guest to IPL. Make the content of the directory
-     <filename>/boot/s390x</filename> of the &leanos; media (DVD1) available
+     <filename>/boot/s390x</filename> of the &leanos; (media 1) available
      via FTP within your network. From this directory, get the files
      <filename>linux</filename>, <filename>initrd</filename>,
      <filename>parmfile</filename>, and <filename>sles.exec</filename>.

--- a/xml/deployment_prep_zseries_prep_i.xml
+++ b/xml/deployment_prep_zseries_prep_i.xml
@@ -195,7 +195,7 @@
     <para>
      Refer to the documentation provided with the third party product that
      enables NFS server services for your Windows workstation. The
-     &usbflashdrive; containing the &installmedia; media must be in the
+     &usbflashdrive; containing the &installmedia; medium must be in the
      available NFS path.
     </para>
    </sect4>

--- a/xml/deployment_prep_zseries_prep_i.xml
+++ b/xml/deployment_prep_zseries_prep_i.xml
@@ -109,7 +109,7 @@
      workstation manually.
     </para>
     <para>
-     For &zseries;, IPL your LPAR/VM guest from this media as described in
+     For &zseries;, IPL your LPAR/VM guest from this medium as described in
      <xref linkend="sec-prep-ipling-lpar-dvd"/>. After entering your network
      parameters, the installation system treats the media as the source of
      installation data. Because &zseries; cannot have an X11-capable terminal

--- a/xml/deployment_prep_zseries_prep_i.xml
+++ b/xml/deployment_prep_zseries_prep_i.xml
@@ -101,7 +101,7 @@
      &zseries;.
     </para>
     <para>
-     For Intel-based workstations, boot from this media. When prompted, choose
+     For Intel-based workstations, boot from this medium. When prompted, choose
      the desired answer language and keyboard layout and select <guimenu>Start
      rescue system</guimenu>. You need at least 64&nbsp;MB RAM for this. No
      disk space is needed, because the entire rescue system resides in the

--- a/xml/deployment_prep_zseries_prep_i.xml
+++ b/xml/deployment_prep_zseries_prep_i.xml
@@ -96,7 +96,7 @@
    <sect4 xml:id="sec-prep-makeavail-linuxws-oncd">
     <title>&productname; on DVD</title>
     <para>
-     The first installation media of the &productname; for &zseries; contains a
+     The first installation medium of the &productname; for &zseries; contains a
      bootable Linux image for Intel-based workstations and an image for
      &zseries;.
     </para>

--- a/xml/deployment_prep_zseries_requirements.xml
+++ b/xml/deployment_prep_zseries_requirements.xml
@@ -386,9 +386,9 @@
   <tip>
    <title>Additional Information</title>
    <para>
-    Consult the <filename>README</filename> file located in the root directory of
-    DVD&nbsp;1 of &productname; before installing &productname; on
-    &zseries;.
+    Consult the <filename>README</filename> file located in the root directory
+    of the first installation media of &productname; before installing
+    &productname; on &zseries;.
    </para>
   </tip>
  </sect2>

--- a/xml/deployment_prep_zseries_requirements.xml
+++ b/xml/deployment_prep_zseries_requirements.xml
@@ -387,7 +387,7 @@
    <title>Additional Information</title>
    <para>
     Consult the <filename>README</filename> file located in the root directory
-    of the first installation media of &productname; before installing
+    of the first installation medium of &productname; before installing
     &productname; on &zseries;.
    </para>
   </tip>

--- a/xml/deployment_remote.xml
+++ b/xml/deployment_remote.xml
@@ -317,7 +317,7 @@
     </step>
     <step>
      <para>
-      Boot the target system using the installation media (&usbflashdrive;) of
+      Boot the target system using the installation medium (&usbflashdrive;) of
       the &productname; media kit.
      </para>
     </step>

--- a/xml/deployment_remote.xml
+++ b/xml/deployment_remote.xml
@@ -96,7 +96,7 @@
   </para>
 
   <sect2 xml:id="sec-remote-installation-scenario-vncstat">
-   <title>Installation from DVD via VNC</title>
+   <title>Installation from Source Media via VNC</title>
    <para>
     This type of installation still requires some degree of physical access to
     the target system to boot for installation. The installation is
@@ -123,7 +123,7 @@
     </listitem>
     <listitem>
      <para>
-      Installation DVD.
+      Installation DVD or &usbflashdrive;.
      </para>
     </listitem>
    </itemizedlist>
@@ -133,7 +133,8 @@
     </para>
     <step>
      <para>
-      Boot the target system using DVD1 of the &productname; media kit.
+      Boot the target system using the installation media (&usbflashdrive;) of
+      the &productname; media kit.
      </para>
     </step>
     <step>
@@ -273,7 +274,7 @@
   </sect2>
 
   <sect2 xml:id="sec-remote-installation-scenario-sshstat">
-   <title>Installation from DVD via SSH</title>
+   <title>Installation from Source Media via SSH</title>
    <para>
     This type of installation still requires some degree of physical access to
     the target system to boot for installation and to determine the IP address
@@ -300,7 +301,7 @@
     </listitem>
     <listitem>
      <para>
-      Installation DVD.
+      Installation DVD or &usbflashdrive;.
      </para>
     </listitem>
    </itemizedlist>
@@ -316,7 +317,8 @@
     </step>
     <step>
      <para>
-      Boot the target system using DVD1 of the &productname; media kit.
+      Boot the target system using the installation media (&usbflashdrive;) of
+      the &productname; media kit.
      </para>
     </step>
     <step>

--- a/xml/deployment_remote.xml
+++ b/xml/deployment_remote.xml
@@ -133,7 +133,7 @@
     </para>
     <step>
      <para>
-      Boot the target system using the installation media (&usbflashdrive;) of
+      Boot the target system using the installation medium (&usbflashdrive;) of
       the &productname; media kit.
      </para>
     </step>

--- a/xml/deployment_troubleshooting.xml
+++ b/xml/deployment_troubleshooting.xml
@@ -49,8 +49,7 @@
  <sect1 xml:id="sec-installation-troubleshooting-dvd">
   <title>No Bootable Drive Available</title>
   <para>
-   If your computer does not contain a built-in bootable &usbflashdrive; or DVD
-   drive there are several alternatives. This is also an option if your drive
+   If your computer cannot boot from USB or DVD drive, there are several alternatives. This is also an option if your drive
    is not supported by &productname;.
   </para>
   <variablelist>

--- a/xml/deployment_troubleshooting.xml
+++ b/xml/deployment_troubleshooting.xml
@@ -111,7 +111,7 @@
    &usbflashdrive; or DVD drive set as the first entry for booting. Otherwise
    the machine would try to boot from another medium, typically the hard disk.
    Guidance for changing the firmware boot sequence can be found in the
-   documentation provided with your mainboard, or in the following paragraphs.
+   documentation provided with your main board, or in the following paragraphs.
   </para>
   <para>
    The BIOS is the software that enables the very basic functions of a

--- a/xml/deployment_troubleshooting.xml
+++ b/xml/deployment_troubleshooting.xml
@@ -110,7 +110,7 @@
    incorrect boot sequence setting in BIOS. The BIOS boot sequence must have
    &usbflashdrive; or DVD drive set as the first entry for booting. Otherwise
    the machine would try to boot from another medium, typically the hard disk.
-   Guidance for changing the BIOS boot sequence can be found in the
+   Guidance for changing the firmware boot sequence can be found in the
    documentation provided with your mainboard, or in the following paragraphs.
   </para>
   <para>

--- a/xml/deployment_troubleshooting.xml
+++ b/xml/deployment_troubleshooting.xml
@@ -61,7 +61,7 @@
       Linux supports most existing &usbflashdrive; or DVD drives. If the system
       has no &usbflashdrive; or DVD drive, it is still possible that an
       external drive, connected through USB, FireWire, or SCSI, can be used to
-      boot the system. Sometimes a BIOS update may help if you encounter
+      boot the system. Sometimes a firmware update may help if you encounter
       problems.
      </para>
     </listitem>

--- a/xml/deployment_troubleshooting.xml
+++ b/xml/deployment_troubleshooting.xml
@@ -4,7 +4,6 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-
 <chapter version="5.0" role="General" xml:id="cha-installation-troubleshooting"
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
@@ -22,9 +21,9 @@
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
-
  <sect1 xml:id="sec-installation-troubleshooting-checking-media">
   <title>Checking Media</title>
+
   <para>
    If you encounter any problems using the &productname; installation media,
    check the integrity of your installation media. Boot from the media and
@@ -33,12 +32,14 @@
    lets you choose which device to check. Select the respective device and
    confirm with <guimenu>OK</guimenu> to perform the check.
   </para>
+
   <para>
    In a running system, start &yast; and choose <menuchoice>
    <guimenu>Software</guimenu> <guimenu>Media Check</guimenu> </menuchoice>.
    Insert the medium click <guimenu>Start Check</guimenu>. Checking may take
    several minutes.
   </para>
+
   <para>
    If errors are detected during the check, do not use this medium for
    installation. Media problems may, for example, occur when having burned the
@@ -48,10 +49,13 @@
  </sect1>
  <sect1 xml:id="sec-installation-troubleshooting-dvd">
   <title>No Bootable Drive Available</title>
+
   <para>
-   If your computer cannot boot from USB or DVD drive, there are several alternatives. This is also an option if your drive
-   is not supported by &productname;.
+   If your computer cannot boot from USB or DVD drive, there are several
+   alternatives. This is also an option if your drive is not supported by
+   &productname;.
   </para>
+
   <variablelist>
    <varlistentry>
     <term>Using an External &usbflashdrivecap; or DVD Drive</term>
@@ -71,8 +75,7 @@
      <para>
       If a machine lacks both a &usbflashdrive; and DVD drive, but provides a
       working Ethernet connection, perform a completely network-based
-      installation.
-      <phrase
+      installation. <phrase
       os="sles;sled">See
       <xref
       linkend="sec-remote-installation-scenario-vncpxe"/> and
@@ -91,19 +94,23 @@
      </para>
      <itemizedlist os="sles;sled">
       <listitem>
-       <para arch="x86_64"><xref linkend="sec-x86-media"/></para>
+       <para arch="x86_64">
+        <xref linkend="sec-x86-media"/>
+       </para>
       </listitem>
       <listitem os="sles">
-       <para arch="aarch64"><xref linkend="sec-aarch64-media"/></para>
+       <para arch="aarch64">
+        <xref linkend="sec-aarch64-media"/>
+       </para>
       </listitem>
      </itemizedlist>
     </listitem>
    </varlistentry>
   </variablelist>
  </sect1>
-
  <sect1 xml:id="sec-installation-troubleshooting-bios">
   <title>Booting from Installation Media Fails</title>
+
   <para>
    One reason a machine does not boot the installation media can be an
    incorrect boot sequence setting in BIOS. The BIOS boot sequence must have
@@ -112,6 +119,7 @@
    Guidance for changing the firmware boot sequence can be found in the
    documentation provided with your main board, or in the following paragraphs.
   </para>
+
   <para>
    The BIOS is the software that enables the very basic functions of a
    computer. Motherboard vendors provide a BIOS specifically made for their
@@ -119,12 +127,13 @@
    time&mdash;when the machine is booting. During this initialization phase,
    the machine performs several diagnostic hardware tests. One of them is a
    memory check, indicated by a memory counter. When the counter appears, look
-   for a line, usually below the counter or somewhere at the bottom,
-   mentioning the key to press to access the BIOS setup. Usually the key to
-   press is one of <keycap function="delete"/>, <keycap>F1</keycap>, or
+   for a line, usually below the counter or somewhere at the bottom, mentioning
+   the key to press to access the BIOS setup. Usually the key to press is one
+   of <keycap function="delete"/>, <keycap>F1</keycap>, or
    <keycap function="escape"/>. Press this key until the BIOS setup screen
    appears.
   </para>
+
   <procedure xml:id="pro-tinstallation-troubleshooting-bios">
    <title>Changing the BIOS Boot Sequence</title>
    <step>
@@ -145,7 +154,7 @@
    <step>
     <para>
      In the screen that opens, look for a subentry called <guimenu>BOOT
-      SEQUENCE</guimenu> or <guimenu>BOOT ORDER</guimenu>. Change the settings
+     SEQUENCE</guimenu> or <guimenu>BOOT ORDER</guimenu>. Change the settings
      by pressing <keycap function="pageup"/> or <keycap function="pagedown"/>
      until the &usbflashdrive; or DVD drive is listed first.
     </para>
@@ -154,11 +163,12 @@
     <para>
      Leave the BIOS setup screen by pressing <keycap function="escape"/>. To
      save the changes, select <guimenu>SAVE &amp; EXIT SETUP</guimenu>, or
-     press <keycap>F10</keycap>. To confirm that your settings should be
-     saved, press <keycap>Y</keycap>.
+     press <keycap>F10</keycap>. To confirm that your settings should be saved,
+     press <keycap>Y</keycap>.
     </para>
    </step>
   </procedure>
+
   <procedure>
    <title>Changing the Boot Sequence in an SCSI BIOS (Adaptec Host Adapter)</title>
    <step>
@@ -190,7 +200,8 @@
    </step>
    <step>
     <para>
-     Enter the ID of the &usbflashdrive; or DVD drive and press <keycap
+     Enter the ID of the &usbflashdrive; or DVD drive and press
+     <keycap
       function="enter"/> again.
     </para>
    </step>
@@ -207,11 +218,13 @@
     </para>
    </step>
   </procedure>
+
   <para>
-   Regardless of what language and keyboard layout your final installation
-   will be using, most BIOS configurations use the US keyboard layout as
-   shown in the following figure:
+   Regardless of what language and keyboard layout your final installation will
+   be using, most BIOS configurations use the US keyboard layout as shown in
+   the following figure:
   </para>
+
   <figure xml:id="fig-trouble-install-keyboard-us">
    <title>US Keyboard Layout</title>
    <mediaobject>
@@ -224,25 +237,29 @@
    </mediaobject>
   </figure>
  </sect1>
-
  <sect1 xml:id="sec-installation-troubleshooting-noboot">
   <title>Boot Failure</title>
+
   <para>
    Some hardware types, mainly very old or very recent ones, fail to boot.
-   Reasons can be missing support for hardware in the installation kernel
-   or drivers causing problems on some specific hardware.
+   Reasons can be missing support for hardware in the installation kernel or
+   drivers causing problems on some specific hardware.
   </para>
+
   <para>
    If your system fails to install using the standard
    <guimenu>Installation</guimenu> mode from the first installation boot
    screen, try the following:
   </para>
+
   <procedure>
    <step>
     <para>
      With the installation media still in the drive, reboot the machine with
-     <keycombo> <keycap function="control"/> <keycap function="alt"/> <keycap
-       function="delete"/> </keycombo> or using the hardware reset button.
+     <keycombo> <keycap function="control"/> <keycap function="alt"/>
+     <keycap
+       function="delete"/> </keycombo> or using the hardware reset
+     button.
     </para>
    </step>
    <step>
@@ -255,15 +272,18 @@
    </step>
    <step>
     <para>
-     Proceed with the installation as described in <xref linkend="cha-install"/>.
+     Proceed with the installation as described in
+     <xref linkend="cha-install"/>.
     </para>
    </step>
   </procedure>
+
   <para>
-   If this fails, proceed as above, but choose <guimenu>Safe
-   Settings</guimenu> instead. This option disables ACPI and DMA support. Most
-   hardware will boot with this option.
+   If this fails, proceed as above, but choose <guimenu>Safe Settings</guimenu>
+   instead. This option disables ACPI and DMA support. Most hardware will boot
+   with this option.
   </para>
+
   <para>
    If both of these options fail, use the boot parameters prompt to pass any
    additional parameters needed to support this type of hardware to the
@@ -271,6 +291,7 @@
    boot parameters, refer to the kernel documentation located in
    <filename>/usr/src/linux/Documentation/kernel-parameters.txt</filename>.
   </para>
+
   <tip>
    <title>Obtaining Kernel Documentation</title>
    <para>
@@ -278,14 +299,15 @@
     package to view the kernel documentation.
    </para>
   </tip>
+
   <para>
-   There are other ACPI-related kernel parameters that can be entered
-   at the boot prompt prior to booting for installation:
+   There are other ACPI-related kernel parameters that can be entered at the
+   boot prompt prior to booting for installation:
   </para>
+
   <variablelist>
    <varlistentry>
-    <term><systemitem>acpi=off</systemitem>
-    </term>
+    <term><systemitem>acpi=off</systemitem></term>
     <listitem>
      <para>
       This parameter disables the complete ACPI subsystem on your computer.
@@ -295,19 +317,17 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><systemitem>acpi=force</systemitem>
-    </term>
+    <term><systemitem>acpi=force</systemitem></term>
     <listitem>
      <para>
-      Always enable ACPI even if your computer has an old BIOS dated before
-      the year 2000. This parameter also enables ACPI if it is set in addition
-      to <systemitem>acpi=off</systemitem>.
+      Always enable ACPI even if your computer has an old BIOS dated before the
+      year 2000. This parameter also enables ACPI if it is set in addition to
+      <systemitem>acpi=off</systemitem>.
      </para>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><systemitem>acpi=noirq</systemitem>
-    </term>
+    <term><systemitem>acpi=noirq</systemitem></term>
     <listitem>
      <para>
       Do not use ACPI for IRQ routing.
@@ -315,8 +335,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><systemitem>acpi=ht</systemitem>
-    </term>
+    <term><systemitem>acpi=ht</systemitem></term>
     <listitem>
      <para>
       Run only enough ACPI to enable hyper-threading.
@@ -324,8 +343,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><systemitem>acpi=strict</systemitem>
-    </term>
+    <term><systemitem>acpi=strict</systemitem></term>
     <listitem>
      <para>
       Be less tolerant of platforms that are not strictly ACPI specification
@@ -334,8 +352,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><systemitem>pci=noacpi</systemitem>
-    </term>
+    <term><systemitem>pci=noacpi</systemitem></term>
     <listitem>
      <para>
       Disable PCI IRQ routing of the new ACPI system.
@@ -343,8 +360,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><systemitem>pnpacpi=off</systemitem>
-    </term>
+    <term><systemitem>pnpacpi=off</systemitem></term>
     <listitem>
      <para>
       This option is for serial or parallel problems when your BIOS setup
@@ -353,20 +369,18 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><systemitem>notsc</systemitem>
-    </term>
+    <term><systemitem>notsc</systemitem></term>
     <listitem>
      <para>
       Disable the time stamp counter. This option can be used to work around
       timing problems on your systems. It is a recent feature, so if you see
-      regressions on your machine, especially time related or even total
-      hangs, this option is worth a try.
+      regressions on your machine, especially time related or even total hangs,
+      this option is worth a try.
      </para>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><systemitem>nohz=off</systemitem>
-    </term>
+    <term><systemitem>nohz=off</systemitem></term>
     <listitem>
      <para>
       Disable the nohz feature. If your machine hangs, this option may help.
@@ -375,11 +389,13 @@
     </listitem>
    </varlistentry>
   </variablelist>
+
   <para>
    When you have determined the right parameter combination, &yast;
-   automatically writes them to the boot loader configuration to make sure
-   that the system boots properly next time.
+   automatically writes them to the boot loader configuration to make sure that
+   the system boots properly next time.
   </para>
+
   <para>
    If inexplicable errors occur when the kernel is loaded or during the
    installation, select <guimenu>Memory Test</guimenu> in the boot menu to
@@ -387,17 +403,19 @@
    usually a hardware error.
   </para>
  </sect1>
-
  <sect1 xml:id="sec-installation-troubleshooting-graph">
   <title>Fails to Launch Graphical Installer</title>
+
   <para>
    After you insert the medium into your drive and reboot your machine, the
    installation screen comes up, but after you select
    <guimenu>Installation</guimenu>, the graphical installer does not start.
   </para>
+
   <para>
    There are several ways to deal with this situation:
   </para>
+
   <itemizedlist>
    <listitem>
     <para>
@@ -415,6 +433,7 @@
     </para>
    </listitem>
   </itemizedlist>
+
   <procedure xml:id="pro-installation-troubleshooting-graph">
    <title>Change Screen Resolution for Installation</title>
    <step>
@@ -435,6 +454,7 @@
     </para>
    </step>
   </procedure>
+
   <procedure xml:id="pro-installation-troubleshooting-text">
    <title>Installation in Text Mode</title>
    <step>
@@ -454,6 +474,7 @@
     </para>
    </step>
   </procedure>
+
   <procedure xml:id="pro-trouble-install-vnc">
    <title>VNC Installation</title>
    <step>
@@ -478,9 +499,9 @@
     </para>
     <para>
      Instead of starting right into the graphical installation routine, the
-     system continues to run in a text mode. The system then halts, displaying a message
-     containing the IP address and port number at which the installer can be
-     reached via a browser interface or a VNC viewer application.
+     system continues to run in a text mode. The system then halts, displaying
+     a message containing the IP address and port number at which the installer
+     can be reached via a browser interface or a VNC viewer application.
     </para>
    </step>
    <step>
@@ -510,9 +531,9 @@
    </step>
   </procedure>
  </sect1>
-
  <sect1 xml:id="sec-installation-troubleshooting-mini">
   <title>Only Minimalist Boot Screen Started</title>
+
   <para>
    You inserted the medium into the drive, the BIOS routines are finished, but
    the system does not start with the graphical boot screen. Instead it
@@ -520,10 +541,12 @@
    machine not providing sufficient graphics memory for rendering a graphical
    boot screen.
   </para>
+
   <para>
-   Although the text boot screen looks minimalist, it provides nearly the
-   same functionality as the graphical one:
+   Although the text boot screen looks minimalist, it provides nearly the same
+   functionality as the graphical one:
   </para>
+
   <variablelist>
    <varlistentry>
     <term>Boot Options</term>
@@ -532,9 +555,9 @@
       Unlike the graphical interface, the different boot parameters cannot be
       selected using the cursor keys of your keyboard. The boot menu of the
       text mode boot screen offers some keywords to enter at the boot prompt.
-      These keywords map to the options offered in the graphical version.
-      Enter your choice and press <keycap function="enter"/> to launch the
-      boot process.
+      These keywords map to the options offered in the graphical version. Enter
+      your choice and press <keycap function="enter"/> to launch the boot
+      process.
      </para>
     </listitem>
    </varlistentry>
@@ -542,10 +565,10 @@
     <term>Custom Boot Options</term>
     <listitem>
      <para>
-      After selecting a boot parameter, enter the appropriate keyword at the boot
-      prompt or enter some custom boot parameters as described in
-      <xref linkend="sec-installation-troubleshooting-noboot"/>. To launch the installation
-      process, press <keycap function="enter"/>.
+      After selecting a boot parameter, enter the appropriate keyword at the
+      boot prompt or enter some custom boot parameters as described in
+      <xref linkend="sec-installation-troubleshooting-noboot"/>. To launch the
+      installation process, press <keycap function="enter"/>.
      </para>
     </listitem>
    </varlistentry>
@@ -553,10 +576,9 @@
     <term>Screen Resolutions</term>
     <listitem>
      <para>
-      Use the function keys (<keycap>F1</keycap> ...
-      <keycap>F12</keycap>) to determine the screen resolution for
-      installation. If
-      you need to boot in text mode, choose <keycap>F3</keycap>.
+      Use the function keys (<keycap>F1</keycap> ... <keycap>F12</keycap>) to
+      determine the screen resolution for installation. If you need to boot in
+      text mode, choose <keycap>F3</keycap>.
      </para>
     </listitem>
    </varlistentry>
@@ -564,6 +586,7 @@
  </sect1>
  <sect1 xml:id="sec-installation-troubleshooting-log" os="sles">
   <title>Log Files</title>
+
   <para>
    For more information about log files that are created during installation,
    see <xref linkend="sec-admsupport-install"/>.

--- a/xml/deployment_troubleshooting.xml
+++ b/xml/deployment_troubleshooting.xml
@@ -47,21 +47,22 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-installation-troubleshooting-dvd">
-  <title>No Bootable DVD Drive Available</title>
+  <title>No Bootable Drive Available</title>
   <para>
-   If your computer does not contain a built-in bootable DVD drive
-   there are several alternatives. This is also an option if your drive
+   If your computer does not contain a built-in bootable &usbflashdrive; or DVD
+   drive there are several alternatives. This is also an option if your drive
    is not supported by &productname;.
   </para>
   <variablelist>
    <varlistentry>
-    <term>Using External DVD Device</term>
+    <term>Using an External &usbflashdrivecap; or DVD Drive</term>
     <listitem>
      <para>
-      Linux supports most existing DVD drives. If the system has no DVD drive,
-      it is still possible that an external DVD drive, connected through USB,
-      FireWire, or SCSI, can be used to boot the system. Sometimes a BIOS update
-      may help if you encounter problems.
+      Linux supports most existing &usbflashdrive; or DVD drives. If the system
+      has no &usbflashdrive; or DVD drive, it is still possible that an
+      external drive, connected through USB, FireWire, or SCSI, can be used to
+      boot the system. Sometimes a BIOS update may help if you encounter
+      problems.
      </para>
     </listitem>
    </varlistentry>
@@ -69,8 +70,9 @@
     <term>Network Boot via PXE</term>
     <listitem>
      <para>
-      If a machine lacks a DVD drive, but provides a working Ethernet
-      connection, perform a completely network-based installation.
+      If a machine lacks both a &usbflashdrive; and DVD drive, but provides a
+      working Ethernet connection, perform a completely network-based
+      installation.
       <phrase
       os="sles;sled">See
       <xref
@@ -82,10 +84,10 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>USB Flash Drive</term>
+    <term>&usbflashdrivecap;</term>
     <listitem>
      <para>
-      You can use a USB flash drive if your machine lacks a DVD drive and
+      You can use a &usbflashdrive; if your machine lacks a DVD drive and
       network connection. <phrase os="sles;sled">For details, see:</phrase>
      </para>
      <itemizedlist os="sles;sled">
@@ -106,10 +108,10 @@
   <para>
    One reason a machine does not boot the installation media can be an
    incorrect boot sequence setting in BIOS. The BIOS boot sequence must have
-   DVD drive set as the first entry for booting. Otherwise the machine would
-   try to boot from another medium, typically the hard disk. Guidance for
-   changing the BIOS boot sequence can be found in the documentation provided
-   with your mainboard, or in the following paragraphs.
+   &usbflashdrive; or DVD drive set as the first entry for booting. Otherwise
+   the machine would try to boot from another medium, typically the hard disk.
+   Guidance for changing the BIOS boot sequence can be found in the
+   documentation provided with your mainboard, or in the following paragraphs.
   </para>
   <para>
    The BIOS is the software that enables the very basic functions of a
@@ -144,9 +146,9 @@
    <step>
     <para>
      In the screen that opens, look for a subentry called <guimenu>BOOT
-     SEQUENCE</guimenu> or <guimenu>BOOT ORDER</guimenu>. Change the settings
+      SEQUENCE</guimenu> or <guimenu>BOOT ORDER</guimenu>. Change the settings
      by pressing <keycap function="pageup"/> or <keycap function="pagedown"/>
-     until the DVD drive is listed first.
+     until the &usbflashdrive; or DVD drive is listed first.
     </para>
    </step>
    <step>
@@ -172,7 +174,7 @@
      components are now displayed.
     </para>
     <para>
-     Make note of the SCSI ID of your DVD drive.
+     Make note of the SCSI ID of your &usbflashdrive; or DVD drive.
     </para>
    </step>
    <step>
@@ -189,7 +191,8 @@
    </step>
    <step>
     <para>
-     Enter the ID of the DVD drive and press <keycap function="enter"/> again.
+     Enter the ID of the &usbflashdrive; or DVD drive and press <keycap
+      function="enter"/> again.
     </para>
    </step>
    <step>
@@ -238,10 +241,9 @@
   <procedure>
    <step>
     <para>
-     With the DVD still in the drive, reboot the machine with
-     <keycombo> <keycap function="control"/>
-     <keycap function="alt"/> <keycap function="delete"/> </keycombo> or using
-     the hardware reset button.
+     With the installation media still in the drive, reboot the machine with
+     <keycombo> <keycap function="control"/> <keycap function="alt"/> <keycap
+       function="delete"/> </keycombo> or using the hardware reset button.
     </para>
    </step>
    <step>

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -158,6 +158,8 @@
 <!ENTITY leanos        "Unified Installer">
 <!ENTITY installmedia  "&slea;-&product-ga;-SP&product-sp;-Online-<replaceable xmlns='http://docbook.org/ns/docbook'>ARCH</replaceable>-GM-media1.iso">
 <!ENTITY packagemedia  "&slea;-&product-ga;-SP&product-sp;-Full-<replaceable xmlns='http://docbook.org/ns/docbook'>ARCH</replaceable>-GM-media1.iso">
+<!ENTITY usbflashdrive "USB flash drive">
+<!ENTITY usbflashdrivecap "USB Flash Drive">
 <!ENTITY sle           "SUSE Linux Enterprise">
 <!ENTITY slea          "SLE">
 <!ENTITY slereg        "SUSE&reg; Linux Enterprise">

--- a/xml/mobile.xml
+++ b/xml/mobile.xml
@@ -897,7 +897,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>USB Flash Disks</term>
+    <term>&usbflashdrivecap;s</term>
     <listitem>
      <para>
       These devices are handled by the system like external hard disks. It is

--- a/xml/opensuse_update.xml
+++ b/xml/opensuse_update.xml
@@ -60,7 +60,7 @@
    <title>Preparations</title>
    <para>
     Before upgrading, copy the old configuration files to a separate medium
-    (such as removable hard disk or USB flash drive) to secure the data.
+    (such as removable hard disk or &usbflashdrive;) to secure the data.
     This primarily applies to files stored in <filename>/etc</filename> as
     well as some of the directories and files in <filename>/var</filename>.
     You may also want to write the user data in <filename>/home</filename>

--- a/xml/planning.xml
+++ b/xml/planning.xml
@@ -118,9 +118,9 @@
     installation is called <emphasis>target system</emphasis> or
     <emphasis>installation target</emphasis>. The term
     <emphasis>repository</emphasis> (previously called <quote>installation
-    source</quote>) is used for all sources of installation data. This includes
-    physical media, such as CD and DVD, and network servers distributing the
-    installation data in your network.
+     source</quote>) is used for all sources of installation data. This
+    includes physical media, such as CD, DVD, or &usbflashdrive;, and network
+    servers distributing the installation data in your network.
    </para>
   </note>
  </sect1>
@@ -286,6 +286,14 @@
     There is an additional, second Packages medium, but this contains only source
     code and is not required for installation.
     </para>
+    <tip>
+     <title>Full Media Size</title>
+     <para>
+      The size of the full installation media &installmedia; exceeds the
+      capacity of a dual layer DVD.  Therefore you can only boot it from a USB
+      Flash Drive.
+     </para>
+    </tip>
 
   </sect2>
 

--- a/xml/x86_inst_problem.xml
+++ b/xml/x86_inst_problem.xml
@@ -119,13 +119,13 @@
  </sect2>
 
  <sect2 xml:id="sec-bootproblem-redirect">
-  <title>Redirecting the Boot Source to the Installation Media</title>
+  <title>Redirecting the Boot Source to the Installation Medium</title>
   <para>
    To simplify the installation process and avoid accidental installations, the
-   default setting on the installation media for &productname; is that your
+   default setting on the installation medium for &productname; is that your
    system is booted from the first hard disk. At this point, an installed boot
    loader normally takes over control of the system. This means that the boot
-   media can stay in the drive during the installation. To start the installation,
+   medium can stay in the drive during the installation. To start the installation,
    choose one of the installation possibilities in the boot menu of the media.
   </para>
  </sect2>

--- a/xml/x86_inst_problem.xml
+++ b/xml/x86_inst_problem.xml
@@ -119,13 +119,13 @@
  </sect2>
 
  <sect2 xml:id="sec-bootproblem-redirect">
-  <title>Redirecting the Boot Source to the Boot DVD</title>
+  <title>Redirecting the Boot Source to the Installation Media</title>
   <para>
    To simplify the installation process and avoid accidental installations, the
-   default setting on the installation DVD for &productname; is that your
+   default setting on the installation media for &productname; is that your
    system is booted from the first hard disk. At this point, an installed boot
    loader normally takes over control of the system. This means that the boot
-   DVD can stay in the drive during an installation. To start the installation,
+   media can stay in the drive during the installation. To start the installation,
    choose one of the installation possibilities in the boot menu of the media.
   </para>
  </sect2>

--- a/xml/yast2_sw_addon_osuse.xml
+++ b/xml/yast2_sw_addon_osuse.xml
@@ -23,7 +23,7 @@
     drivers). To install a new add-on, start &yast; and select <menuchoice>
     <guimenu>Software</guimenu> <guimenu>Add-On Products</guimenu>
     </menuchoice>. You can select various types of product media, like CD,
-    FTP, USB mass storage devices (such as USB flash drives or disks) or a
+    FTP, USB mass storage devices (such as &usbflashdrive;s or disks) or a
     local directory. You can also work directly with ISO files. To add an
     add-on as ISO file media, select <guimenu>Local ISO Image</guimenu> then
     enter the <guimenu>Path to ISO Image</guimenu>. The <guimenu>Repository

--- a/xml/yast2_sw_addon_osuse.xml
+++ b/xml/yast2_sw_addon_osuse.xml
@@ -25,7 +25,7 @@
     </menuchoice>. You can select various types of product media, like CD,
     FTP, USB mass storage devices (such as &usbflashdrive;s or disks) or a
     local directory. You can also work directly with ISO files. To add an
-    add-on as ISO file media, select <guimenu>Local ISO Image</guimenu> then
+    add-on as ISO file medium, select <guimenu>Local ISO Image</guimenu> then
     enter the <guimenu>Path to ISO Image</guimenu>. The <guimenu>Repository
     Name</guimenu> is arbitrary.
    </para>

--- a/xml/yast2_sw_repo.xml
+++ b/xml/yast2_sw_repo.xml
@@ -64,8 +64,8 @@
  <sect2 xml:id="sec-yast-software-instsource-add">
   <title>Adding Software Repositories</title>
   <para>
-   You can either add repositories from DVD/CD, removable mass storage devices
-   (such as flash disks), a local directory, an ISO image or a network source.
+   You can either add repositories from DVD/CD, a &usbflashdrive;, a local
+   directory, an ISO image or a network source.
   </para>
   <para>
    To add repositories from the <guimenu>Configured Software


### PR DESCRIPTION
### Description
SLE15SP2 full installation media 1 does not fit on a 2-layer DVD any more.
This update adds the &usbflashdrive; where applicable alongside the legacy DVD as an installation media.

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
