### PR TITLE
fixed location of initrd file

### DIFF
--- a/xml/deployment_pxe.xml
+++ b/xml/deployment_pxe.xml
@@ -345,7 +345,7 @@ DHCLIENT6_CLIENT_ID=<replaceable>00:03:52:54:00:02:c2:67</replaceable></screen>
 label linux
   ipappend 2
   kernel boot/<replaceable>ARCHITECTURE</replaceable>/loader/linux
-  append initrd=boot/x86_64/<replaceable>ARCHITECTURE</replaceable>/initrd instsys=tftp://<replaceable>TFTP_SERVER</replaceable>/SLES-<replaceable>OS_VERSION</replaceable>-<replaceable>ARCHITECTURE</replaceable>/boot/<replaceable>ARCHITECTURE</replaceable>/root install=<replaceable>PROTOCOL</replaceable>://<replaceable>SERVER_IP</replaceable>:/<replaceable>PATH</replaceable>
+  append initrd=boot/<replaceable>ARCHITECTURE</replaceable>/loader/initrd instsys=tftp://<replaceable>TFTP_SERVER</replaceable>/SLES-<replaceable>OS_VERSION</replaceable>-<replaceable>ARCHITECTURE</replaceable>/boot/<replaceable>ARCHITECTURE</replaceable>/root install=<replaceable>PROTOCOL</replaceable>://<replaceable>SERVER_IP</replaceable>:/<replaceable>PATH</replaceable>
 
 display  message
 implicit 1


### PR DESCRIPTION
initrd  file sits in boot/{ARCHITECTURE}/loader  directory   not the boot/x86_64/{ARCHITECTURE} directory

in fact /boot/x86_64/{ARCHITECTURE} doesn't exist...

### Description
correcting the file location for initrd and also the typo of x86_64/{ARCHITECTURE}

- could not submit a BUG - link gave error (You don't have permission to access "http://www.microfocus.com/LAGBroker?" on this server.)

- don't know if this needs to be backported to other docs

### Checklist
* Check all items that apply.

*Are backports required?*

- [ X ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
