### PR TITLE
AutoYaST: prefer colon to space to separate chanids

### DIFF
--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -104,7 +104,7 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
   </net-udev>
   <s390-devices config:type="list">
     <listentry>
-      <chanids>0.0.0800 0.0.0801 0.0.0802</chanids>
+      <chanids>0.0.0800:0.0.0801:0.0.0802</chanids>
       <type>qeth</type>
     </listentry>
   </s390-devices>
@@ -1141,9 +1141,9 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
         </entry>
         <entry>
          <para>
-          channel ids separated by spaces
+          channel ids separated by a colon (preferred) or a space
          </para>
-<screen>&lt;chanids&gt;0.0.0700 0.0.0701 0.0.0702&lt;/chanids&gt;</screen>
+<screen>&lt;chanids&gt;0.0.0700:0.0.0701:0.0.0702&lt;/chanids&gt;</screen>
         </entry>
         <entry>
          <para/>


### PR DESCRIPTION
### Description

Starting in SLE 15 SP2, it is preferred to use a colon to separate channel IDs for s390 devices. The old format, using a space, is still supported. We found a problem dealing with chanids while fixing [bsc#1163149](https://bugzilla.suse.com/show_bug.cgi?id=1163149).

Thanks!

### Checklist

* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
