### PR TITLE
AutoYaST: fix the layout description of the states tarball

### DIFF
--- a/xml/ay_configuration_management.xml
+++ b/xml/ay_configuration_management.xml
@@ -272,10 +272,15 @@
 
      <para>
       The TAR archive must have the same layout that is expected under
-      <literal>/srv</literal> in a Salt server. This means that you need to place states,
-      formulas, and pillars in a <filename>salt</filename> directory. If you prefer,
-      you can distribute pillar data in a separate TAR archive by using the
-      <literal>pillar_url</literal> option.
+      <literal>/srv</literal> in a Salt server. It means that you need to place
+      your Salt states in a <filename>salt</filename> directory and your
+      formulas in a separate <filename>formulas</filename> directory.
+     </para>
+
+     <para>
+      Additionally, you can have a <filename>pillar</filename> directory
+      containing the pillar data. Alternatively, you can provide that data in a
+      separate TAR archive by using the <literal>pillar_url</literal> option.
      </para>
 
      <example xml:id="configuration-management-masterless">


### PR DESCRIPTION
### Description

Clarifies the layout of the TAR archive you can provide to AutoYaST via the `states_url` element (related to [bsc#1168080](https://bugzilla.suse.com/show_bug.cgi?id=1168080)).

Thanks!

### Checklist
* Check all items that apply.

*Are backports required?*

- [X] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
