### PR TITLE
Remove rc<service> controls of systemd services (jsc#SLE-11624)

### DIFF
--- a/xml/apparmor_support.xml
+++ b/xml/apparmor_support.xml
@@ -592,7 +592,7 @@ sock_type="raw" pid=30251 comm="ping"
   </sect2>
 
   <sect2 xml:id="sec-apparmor-support-trouble-syntax">
-   <title>How to Spot and Fix &aa; Syntax Errors?</title>
+   <title>How to Spot and Fix &aa; Syntax Errors</title>
    <para>
     Manually editing &aa; profiles can introduce syntax errors. If you
     attempt to start or restart &aa; with syntax errors in your profiles,

--- a/xml/apparmor_support.xml
+++ b/xml/apparmor_support.xml
@@ -592,7 +592,7 @@ sock_type="raw" pid=30251 comm="ping"
   </sect2>
 
   <sect2 xml:id="sec-apparmor-support-trouble-syntax">
-   <title>How to Spot and fix &aa; Syntax Errors?</title>
+   <title>How to Spot and Fix &aa; Syntax Errors?</title>
    <para>
     Manually editing &aa; profiles can introduce syntax errors. If you
     attempt to start or restart &aa; with syntax errors in your profiles,
@@ -600,9 +600,10 @@ sock_type="raw" pid=30251 comm="ping"
     parser error.
    </para>
 <screen>
-localhost:~ # rcapparmor start
-Loading AppArmor profiles AppArmor parser error in /etc/apparmor.d/usr.sbin.squid at line 410: syntax error, unexpected TOK_ID, expecting TOK_MODE
- Profile /etc/apparmor.d/usr.sbin.squid failed to load
+&prompt.root; systemctl start apparmor.service
+Loading AppArmor profiles AppArmor parser error in /etc/apparmor.d/usr.sbin.squid \
+ at line 410: syntax error, unexpected TOK_ID, expecting TOK_MODE
+Profile /etc/apparmor.d/usr.sbin.squid failed to load
 </screen>
    <para>
     Using the &aa; &yast; tools, a graphical error message indicates

--- a/xml/tuning_tracing.xml
+++ b/xml/tuning_tracing.xml
@@ -172,33 +172,32 @@ sendto(50, "\24\0\0\0\26\0\1\3~p\315K\0\0\0\0\0\0\0\0", 20, 0,
    To trace all child processes of a process, use <option>-f</option>:
   </para>
 
-<screen>&prompt.user;strace -f rcapache2 status
-execve("/usr/sbin/rcapache2", ["rcapache2", "status"], [/* 81 vars */]) = 0
-brk(0)                                  = 0x69e000
-mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) \
-= 0x7f3bb553b000
-mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) \
-= 0x7f3bb553a000
+<screen>
+&prompt.user;strace -f systemctl status apache2.service
+execve("/usr/bin/systemctl", ["systemctl", "status", "apache2.service"], \
+ 0x7ffea44a3318 /* 56 vars */) = 0
+brk(NULL)                               = 0x5560f664a000
 [...]
-[pid  4823] rt_sigprocmask(SIG_SETMASK, [],  &lt;unfinished ...&gt;
-[pid  4822] close(4 &lt;unfinished ...&gt;
-[pid  4823] &lt;... rt_sigprocmask resumed&gt; NULL, 8) = 0
-[pid  4822] &lt;... close resumed&gt; )       = 0
+mmap(NULL, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7f98c58a5000
+mmap(NULL, 4420544, PROT_READ|PROT_EXEC, MAP_PRIVATE|MAP_DENYWRITE, 3, 0) = 0x7f98c524a000
+mprotect(0x7f98c53f4000, 2097152, PROT_NONE) = 0
 [...]
-[pid  4825] mprotect(0x7fc42cbbd000, 16384, PROT_READ) = 0
-[pid  4825] mprotect(0x60a000, 4096, PROT_READ) = 0
-[pid  4825] mprotect(0x7fc42cde4000, 4096, PROT_READ) = 0
-[pid  4825] munmap(0x7fc42cda2000, 261953) = 0
-[...]
-[pid  4830] munmap(0x7fb1fff10000, 261953) = 0
-[pid  4830] rt_sigprocmask(SIG_BLOCK, NULL, [], 8) = 0
-[pid  4830] open("/dev/tty", O_RDWR|O_NONBLOCK) = 3
-[pid  4830] close(3)
-[...]
-read(255, "\n\n# Inform the caller not only v"..., 8192) = 73
-rt_sigprocmask(SIG_BLOCK, NULL, [], 8)  = 0
-rt_sigprocmask(SIG_BLOCK, NULL, [], 8)  = 0
-exit_group(0)</screen>
+[pid  9130] read(0, "\342\227\217 apache2.service - The Apache"..., 8192) = 165
+[pid  9130] read(0, "", 8027)           = 0
+● apache2.service - The Apache Webserver227\217 apache2.service - Th"..., 193
+   Loaded: loaded (/usr/lib/systemd/system/apache2.service; disabled; vendor preset: disabled)
+   Active: inactive (dead)
+) = 193
+[pid  9130] ioctl(3, SNDCTL_TMR_STOP or TCSETSW, {B38400 opost isig icanon echo ...}) = 0
+[pid  9130] exit_group(0)               = ?
+[pid  9130] +++ exited with 0 +++
+&lt;... waitid resumed>{si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=9130, \
+ si_uid=0, si_status=0, si_utime=0, si_stime=0}, WEXITED, NULL) = 0
+--- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=9130, si_uid=0, \
+  si_status=0, si_utime=0, si_stime=0} ---
+exit_group(3)                           = ?
++++ exited with 3 +++
+</screen>
 
   <para>
    If you need to analyze the output of <command>strace</command> and the
@@ -611,11 +610,11 @@ clock_gettime(1, 0x7fff4b5c34c0, 0xffffffffff600180, -1, 0) = 0
       by the current process PID:
      </para>
 <screen>&prompt.user;valgrind -v --tool=memcheck --trace-children=yes \
---log-file=valgrind_pid_%p.log rcapache2 restart</screen>
+--log-file=valgrind_pid_%p.log systemctl restart apache2.service</screen>
      <para>
       This process created 52 log files in the testing system, and took 75
       seconds instead of the usual 7 seconds needed to run <command>sudo
-      systemctl restart apache2</command> without Valgrind, which is
+       systemctl restart apache2.service</command> without Valgrind, which is
       approximately 10 times more.
      </para>
 <screen>&prompt.user;ls -1 valgrind_pid_*log


### PR DESCRIPTION
### Description
This update removes remains of rc<service> scripts that SUSE products used to control systemd services

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
