### PR TITLE
rpi: Update Bluetooth instructions

### DIFF
--- a/xml/art_sles_rpi_quick.xml
+++ b/xml/art_sles_rpi_quick.xml
@@ -1177,6 +1177,28 @@ Successfully registered system</screen>
     purposes, like wireless keyboards, mice or audio devices.
    </para>
    <para>
+    If not done already, you will need to enable the
+    <emphasis role="italic">Desktop Applications Module</emphasis>.
+    Assuming you have registered the base product already,
+    as described in <xref linkend="sec-rpi-registration"/>,
+    the fastest way to enable the Module is:
+   </para>
+   <screen>&prompt.root;SUSEConnect -p sle-module-desktop-applications/&product-ga;.&product-sp;/aarch64
+Registering system to SUSE Customer Center
+
+Updating system details on https://scc.suse.com ...
+
+Activating sle-module-desktop-applications &product-ga;.&product-sp; aarch64 ...
+-> Adding service to system ...
+-> Installing release package ...
+
+Successfully registered system
+</screen>
+   <para>
+    Then you can install the <emphasis role="italic">BlueZ</emphasis> software stack:
+   </para>
+   <screen>&prompt.root;zypper install bluez</screen>
+   <para>
     To enable the &btreg; controller for use with
     <command>bluetoothctl</command> and related applications, run on Model&nbsp;B:
    </para>

--- a/xml/art_sles_rpi_quick.xml
+++ b/xml/art_sles_rpi_quick.xml
@@ -1173,7 +1173,7 @@ Successfully registered system</screen>
   <sect2 xml:id="sec-rpi-bt">
    <title>&btreg;</title>
    <para>
-    The &rpi; has a &btreg; controller on-board that can be used for various
+    &rpi3; and later have a &btreg; controller on-board that can be used for various
     purposes, like wireless keyboards, mice or audio devices.
    </para>
    <para>
@@ -1200,13 +1200,18 @@ Successfully registered system
    <screen>&prompt.root;zypper install bluez</screen>
    <para>
     To enable the &btreg; controller for use with
-    <command>bluetoothctl</command> and related applications, run on Model&nbsp;B:
+    <command>bluetoothctl</command> and related applications,
+    for example, on &rpi3; Model&nbsp;B with the default UART configuration, run:
    </para>
 <screen>&prompt.root;hciattach /dev/ttyAMA1 bcm43xx 921600
 bcm43xx_init
-Flash firmware /lib/firmware/BCM43430A1.hcd
+Flash firmware /lib/firmware/<replaceable>BCM43430A1</replaceable>.hcd
 Set Controller UART speed to 921600 bit/s
 Device setup complete</screen>
+   <para>
+    Note: The command is the same for &rpi4; Model&nbsp;B,
+    just the chipset name and thus firmware filename in the output will be different.
+   </para>
    <para>
     You can then use <command>hciconfig hci0 up</command> to bring the device
     up and use <command>hcitool scan</command> to scan the environment for


### PR DESCRIPTION

### Description
Explain how to install `bluez` (jsc#SLE-3245).
Update the section to cover Raspberry Pi 4 Model B (jsc#SLE-7276), too.

### Checklist
* Check all items that apply.

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3

SLE15-SP1 was in the same situation of not having `bluez` pre-installed. However, Raspberry Pi 4 is new in SLE15-SP2. Missing entities may complicate the backport.