### PR TITLE
Update links to documentation.suse.com

### DIFF
--- a/xml/adm_support.xml
+++ b/xml/adm_support.xml
@@ -1631,7 +1631,7 @@ setup-sca</screen>
       <step>
        <para>
         Check the &suse; Knowledge base
-        (<link xlink:href="http://www.suse.com/support/kb/"/>) for results that
+        (<link xlink:href="https://www.suse.com/support/kb/"/>) for results that
         directly relate to the problem identified by SCA. Work at resolving
         them.
        </para>
@@ -2046,7 +2046,7 @@ setup-sca</screen>
     Both the SCA appliance and the SCA tool will then run the custom patterns
     against new Supportconfig archives as part of the analysis report. For
     detailed instructions on how to create (and test) your own patterns, see
-    <link xlink:href="http://www.suse.com/communities/conversations/sca-pattern-development/"/>.
+    <link xlink:href="https://www.suse.com/c/blog/sca-pattern-development/"/>.
    </para>
   </sect2>
  </sect1>
@@ -2291,25 +2291,25 @@ setup-sca</screen>
    </listitem>
    <listitem>
     <para>
-     <link xlink:href="http://www.suse.com/communities/conversations/sca-pattern-development/"/>&mdash;Instructions
+     <link xlink:href="https://www.suse.com/c/blog/sca-pattern-development/"/>&mdash;Instructions
      on how to create (and test) your own SCA patterns.
     </para>
    </listitem>
    <listitem>
     <para>
-     <link xlink:href="http://www.suse.com/communities/conversations/basic-server-health-check-supportconfig/"/>&mdash;A
+     <link xlink:href="https://www.suse.com/c/blog/basic-server-health-check-supportconfig/"/>&mdash;A
      Basic Server Health Check with Supportconfig.
     </para>
    </listitem>
    <listitem>
     <para>
-     <link xlink:href="https://www.novell.com/communities/coolsolutions/cool_tools/create-your-own-supportconfig-plugin/"/>&mdash;Create
+     <link xlink:href="https://community.microfocus.com/t5/GroupWise-Tips-Information/Create-Your-Own-Supportconfig-Plugin/ta-p/1783289"/>&mdash;Create
      Your Own Supportconfig Plugin.
     </para>
    </listitem>
    <listitem>
     <para>
-     <link xlink:href="http://www.suse.com/communities/conversations/creating-a-central-supportconfig-repository/"/>&mdash;Creating
+     <link xlink:href="https://www.suse.com/c/blog/creating-a-central-supportconfig-repository/"/>&mdash;Creating
      a Central Supportconfig Repository.
     </para>
     <para>

--- a/xml/adm_wbem.xml
+++ b/xml/adm_wbem.xml
@@ -1914,7 +1914,7 @@ localhost:5988/root/cimv2:Linux_Ext4FileSystem FSReservedCapacity=, \
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><link xlink:href="http://sblim.sourceforge.net/wiki/index.php/Main_Page/"/>
+    <term><link xlink:href="http://sblim.sourceforge.net/wiki/index.php/Main_Page"/>
     </term>
     <listitem>
      <para>

--- a/xml/adm_wbem.xml
+++ b/xml/adm_wbem.xml
@@ -1887,7 +1887,7 @@ localhost:5988/root/cimv2:Linux_Ext4FileSystem FSReservedCapacity=, \
   <variablelist>
    <title>For more details about WBEM and SFCB, see the following sources:</title>
    <varlistentry>
-    <term><link xlink:href="http://www.dmtf.org"/>
+    <term><link xlink:href="https://www.dmtf.org"/>
     </term>
     <listitem>
      <para>
@@ -1896,7 +1896,7 @@ localhost:5988/root/cimv2:Linux_Ext4FileSystem FSReservedCapacity=, \
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><link xlink:href="http://www.dmtf.org/standards/wbem/"/>
+    <term><link xlink:href="https://www.dmtf.org/standards/wbem/"/>
     </term>
     <listitem>
      <para>
@@ -1905,7 +1905,7 @@ localhost:5988/root/cimv2:Linux_Ext4FileSystem FSReservedCapacity=, \
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><link xlink:href="http://www.dmtf.org/standards/cim/"/>
+    <term><link xlink:href="https://www.dmtf.org/standards/cim/"/>
     </term>
     <listitem>
      <para>

--- a/xml/apache2.xml
+++ b/xml/apache2.xml
@@ -2400,7 +2400,7 @@ An optional company name []:<co xml:id="co-ssl-self-optional"/></screen>
      <formalpara>
       <title>Web Page</title>
       <para>
-       <link xlink:href="http://www.suse.com/support/security/"/>
+       <link xlink:href="https://www.suse.com/support/security/"/>
       </para>
      </formalpara>
     </listitem>
@@ -2408,7 +2408,7 @@ An optional company name []:<co xml:id="co-ssl-self-optional"/></screen>
      <formalpara>
       <title>Mailing List Archive</title>
       <para>
-       <link xlink:href="http://lists.opensuse.org/opensuse-security-announce/"/>
+       <link xlink:href="https://lists.opensuse.org/opensuse-security-announce/"/>
       </para>
      </formalpara>
     </listitem>
@@ -2416,7 +2416,7 @@ An optional company name []:<co xml:id="co-ssl-self-optional"/></screen>
      <formalpara>
       <title>List of Security Announcements</title>
       <para>
-       <link xlink:href="http://www.suse.com/support/update/"/>
+       <link xlink:href="https://www.suse.com/support/update/"/>
       </para>
      </formalpara>
     </listitem>
@@ -2669,8 +2669,8 @@ An optional company name []:<co xml:id="co-ssl-self-optional"/></screen>
    <para>
     If you experience difficulties specific to Apache in &productname;, take a
     look at the Technical Information Search at
-    <link xlink:href="http://www.suse.com/support"/>. The history of Apache is
-    provided at <link xlink:href="http://httpd.apache.org/ABOUT_APACHE.html"/>.
+    <link xlink:href="https://www.suse.com/support"/>. The history of Apache is
+    provided at <link xlink:href="https://httpd.apache.org/ABOUT_APACHE.html"/>.
     This page also explains why the server is called Apache.
    </para>
   </sect2>

--- a/xml/art_sle_install_quick.xml
+++ b/xml/art_sle_install_quick.xml
@@ -239,36 +239,31 @@ disk:
    <itemizedlist>
     <listitem>
      <para>
-      &sls; &productnumber; (<phrase os="sles">covered here</phrase><phrase os="sled">refer
-      to <link xlink:href="&dsc-sles;/"/> for
-      installation instructions</phrase>)
+      &sls; &productnumber; (<phrase os="sles">covered here</phrase><phrase os="sled">for
+      installation instructions, refer to <link xlink:href="https://documentation.suse.com/sles/"/></phrase>)
      </para>
     </listitem>
     <listitem>
      <para>
-      &sled; &productnumber; (<phrase os="sled">covered here</phrase><phrase os="sles">refer
-      to <link xlink:href="&dsc-sled;/"/> for
-      installation instructions</phrase>)
+      &sled; &productnumber; (<phrase os="sled">covered here</phrase><phrase os="sles">for
+      installation instructions, refer to <link xlink:href="https://documentation.suse.com/sled/"/></phrase>)
      </para>
     </listitem>
     <listitem>
      <para>
-      &slehpc; &productnumber; <!-- (refer to FIXME for
-      installation instructions) -->
+      &slehpc; &productnumber; <!-- (for installation instructions, refer to FIXME ) -->
      </para>
     </listitem>
     <listitem>
      <para>
-      &slert; &productnumber; (refer to <link
-       xlink:href="&dsc-rt;/"/> for
-      installation instructions)
+      &slert; &productnumber; (for installation instructions, refer to <link
+      xlink:href="https://documentation.suse.com/sle-rt/"/>)
      </para>
     </listitem>
     <listitem>
      <para>
-      &sles4sap; &productnumber; (refer to <link
-      xlink:href="&dsc-sap;/"/> for
-      installation instructions)
+      &sles4sap; &productnumber; (for installation instructions, refer to <link
+      xlink:href="https://documentation.suse.com/sles-sap"/>)
      </para>
     </listitem>
     <listitem>
@@ -277,8 +272,8 @@ disk:
        cwickert 2019-11-21: Omit version in name and URL once SUMA 3.2 is EOL
        all SUMA versions can be installed with the unified installer.
       </remark>
-      &susemgr; Server 4.1 (refer to <link xlink:href="&dsc-suma;/"/> for
-      installation instructions)
+      &susemgr; Server 4.1 (for installation instructions, refer to
+      <link xlink:href="https://documentation.suse.com/suma/"/>)
      </para>
     </listitem>
     <listitem>
@@ -287,8 +282,8 @@ disk:
        cwickert 2019-11-21: Omit version in name and URL once SUMA 3.2 is EOL
        all SUMA versions can be installed with the unified installer.
       </remark>
-      &susemgr; Proxy 4.1 (refer to <link xlink:href="&dsc-suma;/"/> for
-      installation instructions)
+      &susemgr; Proxy 4.1 (for installation instructions, refer to
+      <link xlink:href="https://documentation.suse.com/suma/"/>)
      </para>
     </listitem>
     <listitem>
@@ -297,8 +292,8 @@ disk:
        cwickert 2019-11-21: Omit version in name and URL once SUMA 3.2 is EOL
        all SUMA versions can be installed with the unified installer.
       </remark>
-      &susemgr; Retail Branch Server 4.1 (refer to <link
-       xlink:href="&dsc-suma-retail;/"/> for installation instructions)
+      &susemgr; Retail Branch Server 4.1 (for installation instructions, refer
+      to <link xlink:href="https://documentation.suse.com/suma-retail"/>)
      </para>
     </listitem>
    </itemizedlist>
@@ -527,7 +522,7 @@ disk:
     you have chosen in the first step of this installation. For a description
     of the modules and their lifecycles, select a module to see the
     accompanying text. More detailed information is available in the <link
-     xlink:href="&dsc-sles;/html/SLES-all/art-modules.html">&modulesquick;</link>
+    xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/art-modules.html">&modulesquick;</link>
     and the <link
      xlink:href="https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15/#Intro.Module">Release
     Notes</link>.

--- a/xml/art_sles_rpi_quick.xml
+++ b/xml/art_sles_rpi_quick.xml
@@ -1156,8 +1156,8 @@ Successfully registered system</screen>
     For detailed information about the network configuration in
     &productnamearch;, consult the respective sections of the
     <citetitle>&sls; Deployment</citetitle> and
-    <citetitle>Administration</citetitle> guides at <link
-     xlink:href="&dsc-sles;/"/>.
+    <citetitle>Administration</citetitle> guides at
+    <link xlink:href="https://documentation.suse.com/sles/15-SP2/"/>.
    </para>
   </sect2>
  </sect1>
@@ -1231,7 +1231,7 @@ Device setup complete</screen>
    <title>Product Documentation</title>
    <para>
     You can find the complete documentation for &productnamearch;
-    &productnumber; at <link xlink:href="&dsc;/"/>.
+    &productnumber; at <link xlink:href="https://documentation.suse.com/"/>.
    </para>
    <note>
     <title>Applicability of Product Documentation</title>

--- a/xml/ay_12_migrate_15.xml
+++ b/xml/ay_12_migrate_15.xml
@@ -973,8 +973,7 @@
    <itemizedlist>
     <listitem os="sles;sled">
      <para>
-      <link
-       xlink:href="&dsc-sles-12;//html/SLES-all/configuration.html#CreateProfile-firewall">&susefirewall;/&ay;
+      <link xlink:href="https://documentation.suse.com/sles-12/html/SLES-all/configuration.html#CreateProfile-firewall">&susefirewall;/&ay;
       Documentation for &slea; 12</link>
      </para>
     </listitem>

--- a/xml/common_copyright_gfdl.xml
+++ b/xml/common_copyright_gfdl.xml
@@ -34,7 +34,7 @@
  </para>
  <para>
   For &suse; trademarks, see
-  <link xlink:href="http://www.suse.com/company/legal/"/>. All other
+  <link xlink:href="https://www.suse.com/company/legal/"/>. All other
   third-party trademarks are the property of their respective owners. Trademark
   symbols (&reg;, &trade; etc.) denote trademarks of &suse; and its affiliates.
   Asterisks (*) denote third-party trademarks.

--- a/xml/common_copyright_opensuse.xml
+++ b/xml/common_copyright_opensuse.xml
@@ -32,7 +32,7 @@
  </para>
  <para>
   For &suse; trademarks, see
-  <link xlink:href="http://www.suse.com/company/legal/"/>. All other
+  <link xlink:href="https://www.suse.com/company/legal/"/>. All other
   third-party trademarks are the property of their respective owners. Trademark
   symbols (&reg;, &trade; etc.) denote trademarks of &suse; and its affiliates.
   Asterisks (*) denote third-party trademarks.

--- a/xml/common_copyright_quick.xml
+++ b/xml/common_copyright_quick.xml
@@ -31,7 +31,7 @@
 
  <para>
   For &suse; trademarks, see
-  <link xlink:href="http://www.suse.com/company/legal/"/>. All other
+  <link xlink:href="https://www.suse.com/company/legal/"/>. All other
   third-party trademarks are the property of their respective owners. Trademark
   symbols (&reg;, &trade; etc.) denote trademarks of &suse; and its affiliates.
   Asterisks (*) denote third-party trademarks.

--- a/xml/common_intro_available_doc_i.xml
+++ b/xml/common_intro_available_doc_i.xml
@@ -24,7 +24,7 @@
   <title>Online Documentation and Latest Updates</title>
   <para>
    Documentation for our products is available at
-   <link os="sles;sled" xlink:href="&dsc;/"/><link os="osuse" xlink:href="http://doc.opensuse.org/"/>,
+   <link os="sles;sled" xlink:href="https://documentation.suse.com/"/><link os="osuse" xlink:href="http://doc.opensuse.org/"/>,
    where you can also find the latest updates, and browse or download the documentation in various formats.
    The latest documentation updates are usually available in the English version of the documentation.
   </para>

--- a/xml/common_intro_feedback_i.xml
+++ b/xml/common_intro_feedback_i.xml
@@ -26,7 +26,7 @@
    <listitem>
     <para>
      For services and support options available for your product, refer to
-     <link xlink:href="http://www.suse.com/support/"/>.
+     <link xlink:href="https://www.suse.com/support/"/>.
     </para>
     <para>
      To open a service request, you need a subscription at &scc;. Go to

--- a/xml/deployment_customize_installation_image.xml
+++ b/xml/deployment_customize_installation_image.xml
@@ -18,9 +18,10 @@
     Add modules and extensions to create a single
     customized installation image. Then copy your
     custom image to a CD, DVD, or &usbflashdrive; to create a bootable customized
-    installation medium. See <citetitle>How to Create a Custom Installation
-    Medium for SUSE Linux Enterprise 15</citetitle>
-    <link xlink:href="https://documentation.suse.com/sbp/all/single-html/SBP-SLE15-Custom-Installation-Medium/"/>
+    installation medium. See the <link
+    xlink:href="https://documentation.suse.com/sbp/all/single-html/SBP-SLE15-Custom-Installation-Medium/">
+    the &suse; Best Practices paper on <citetitle>How to Create a Custom Installation
+    Medium for SUSE Linux Enterprise 15</citetitle></link>
     for complete instructions.
    </para>
   </abstract>

--- a/xml/deployment_prep_aarch64_raspi.xml
+++ b/xml/deployment_prep_aarch64_raspi.xml
@@ -240,7 +240,7 @@ dtoverlay=i2c-rtc,ds1307</screen>
   </para>
   <para>
    The process of writing the card image onto &microsd; media is described in the
-   <link xlink:href="&dsc-sles;/html/SLES-rpi-quick/art-rpiquick.html">&rpiquick;</link>.
+   <link xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-rpi-quick/art-rpiquick.html">&rpiquick;</link>.
   </para>
  </sect2>
 
@@ -290,9 +290,9 @@ dtoverlay=i2c-rtc,ds1307</screen>
   </para>
   <para>
    The process of setting up a PXE boot server for &x86; and &arm; is described
-   in the &suse; Best Practices document <link
-    xlink:href="&dsc-sbp;/all/html/SBP-Multi-PXE-Install/index.html"><citetitle>How
-     to Set Up a Multi-PXE Installation Server</citetitle></link>.
+   in the &suse; Best Practices document
+   <link xlink:href="https://documentation.suse.com/sbp/all/html/SBP-Multi-PXE-Install/index.html"><citetitle>How
+   to Set Up a Multi-PXE Installation Server</citetitle></link>.
   </para>
   <para>
    The &rpi; Foundation publishes information on how to PXE boot one &rpi; from
@@ -329,7 +329,7 @@ dtoverlay=i2c-rtc,ds1307</screen>
     </term>
     <listitem>
      <para>
-      <link xlink:href="&dsc-sles;/html/SLES-rpi-quick/art-rpiquick.html"/>
+      <link xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-rpi-quick/art-rpiquick.html"/>
      </para>
     </listitem>
    </varlistentry>

--- a/xml/deployment_prep_power.xml
+++ b/xml/deployment_prep_power.xml
@@ -44,10 +44,10 @@
      <para>
        Check the database of &suse;-certified hardware to make sure that
        your particular hardware configuration is supported. The database is available at <link
-       xlink:href="http://www.suse.com/yessearch/Search.jsp"/>.
+       xlink:href="https://www.suse.com/yessearch/Search.jsp"/>.
        &productname; may support additional IBM &power; systems that are not listed. For the latest
      information, refer to the IBM Information Center for Linux at <link
-     xlink:href="http://www.ibm.com/support/knowledgecenter/linuxonibm/liaam/liaamdistros.htm"/>.
+     xlink:href="https://www.ibm.com/support/knowledgecenter/linuxonibm/liaam/liaamdistros.htm"/>.
     </para>
    </listitem>
   </varlistentry>

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -481,36 +481,31 @@
   <itemizedlist os="sles;sled">
    <listitem>
     <para>
-     &sls; &productnumber; (<phrase os="sles">covered here</phrase><phrase os="sled">refer
-     to <link xlink:href="&dsc-sles;/"/> for
-     installation instructions</phrase>)
+     &sls; &productnumber; (<phrase os="sles">covered here</phrase><phrase os="sled">for
+     installation instructions, refer to <link xlink:href="https://documentation.suse.com/sles/"/></phrase>)
     </para>
    </listitem>
    <listitem>
     <para>
-     &sled; &productnumber; (<phrase os="sled">covered here</phrase><phrase os="sles">refer
-     to <link xlink:href="&dsc-sled;/"/> for
-     installation instructions</phrase>)
+     &sled; &productnumber; (<phrase os="sled">covered here</phrase><phrase os="sles">for
+     installation instructions, refer to <link xlink:href="https://documentation.suse.com/sled/"/></phrase>)
     </para>
    </listitem>
    <listitem>
     <para>
-     &slehpc; &productnumber; <!-- (refer to FIXME for
-     installation instructions) -->
+     &slehpc; &productnumber; <!-- (for installation instructions, refer to FIXME) -->
     </para>
    </listitem>
    <listitem>
     <para>
-     &slert; &productnumber; (refer to <link
-      xlink:href="&dsc-rt;/"/> for
-     installation instructions)
+     &slert; &productnumber; (for installation instructions, refer to <link
+     xlink:href="https://documentation.suse.com/sle-rt/"/>)
     </para>
    </listitem>
    <listitem>
     <para>
-     &sles4sap;  &productnumber; (refer to <link
-      xlink:href="&dsc-sap;/"/> for
-     installation instructions)
+     &sles4sap;  &productnumber; (for installation instructions, refer to <link
+     xlink:href="https://documentation.suse.com/sles-sap"/>)
     </para>
    </listitem>
    <listitem>
@@ -519,8 +514,8 @@
       cwickert 2019-11-21: Omit version in name and URL once SUMA 3.2 is EOL
       all SUMA versions can be installed with the unified installer.
      </remark>
-     &susemgr; Server 4.1 (refer to <link xlink:href="&dsc-suma;/"/> for
-     installation instructions)
+     &susemgr; Server 4.1 (for installation instructions, refer to
+     <link xlink:href="https://documentation.suse.com/suma/"/>)
     </para>
    </listitem>
    <listitem>
@@ -529,8 +524,8 @@
       cwickert 2019-11-21: Omit version in name and URL once SUMA 3.2 is EOL
       all SUMA versions can be installed with the unified installer.
      </remark>
-     &susemgr; Proxy 4.1 (refer to <link xlink:href="&dsc-suma;/"/> for
-     installation instructions)
+     &susemgr; Proxy 4.1 (for installation instructions, refer to
+     <link xlink:href="https://documentation.suse.com/suma/"/>)
     </para>
    </listitem>
    <listitem>
@@ -539,8 +534,8 @@
       cwickert 2019-11-21: Omit version in name and URL once SUMA 3.2 is EOL
       all SUMA versions can be installed with the unified installer.
      </remark>
-     &susemgr; Retail Branch Server 4.1 (refer to <link
-      xlink:href="&dsc-suma-retail;/"/> for installation instructions)
+     &susemgr; Retail Branch Server 4.1 (for installation instructions, refer
+     to <link xlink:href="https://documentation.suse.com/suma-retail"/>)
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -358,27 +358,6 @@ they also have a trademark policy, let's be careful here. -->
 <!ENTITY fate           "Fate #">
 <!ENTITY dc             "Doc Comment #">
 
-
-<!-- ============================================================= -->
-<!--              documentation.suse.com links                     -->
-<!-- ============================================================= -->
-
-<!ENTITY dsc            "https://documentation.suse.com">
-<!ENTITY dsc-sles       "&dsc;/sles">
-<!ENTITY dsc-sles-11    "&dsc;/sles-11">
-<!ENTITY dsc-sles-12    "&dsc;/sles-12">
-<!ENTITY dsc-sled       "&dsc;/sled">
-<!ENTITY dsc-sled-12    "&dsc;/sled-12">
-<!ENTITY dsc-ha         "&dsc;/sle-ha">
-<!ENTITY dsc-rt         "&dsc;/sle-rt">
-<!ENTITY dsc-sap        "&dsc;/sles-sap">
-<!ENTITY dsc-sbp        "&dsc;/sbp">
-<!ENTITY dsc-ses        "&dsc;/ses">
-<!ENTITY dsc-suma       "&dsc;/suma">
-<!ENTITY dsc-suma-retail "&dsc;/suma-retail">
-<!ENTITY dsc-vmdp       "&dsc;/sle-vmdp">
-
-
 <!-- ============================================================= -->
 <!--                    Book Abstracts                             -->
 <!-- ============================================================= -->
@@ -1035,7 +1014,7 @@ they also have a trademark policy, let's be careful here. -->
   &susemgr; documentation. The <citetitle>Client Migration</citetitle>
   procedure is described in the <citetitle>&susemgr; Upgrade Guide</citetitle>,
   available at <link xmlns:xlink="http://www.w3.org/1999/xlink"
-  xlink:href="&dsc-suma;/"/>.
+  xlink:href="https://documentation.suse.com/suma/"/>.
  </para>'>
 
  <!ENTITY note-upgrade-reduce-install-size

--- a/xml/grub2.xml
+++ b/xml/grub2.xml
@@ -1354,10 +1354,10 @@ password_pbkdf2 root grub.pbkdf2.sha512.10000.9CA4611006FE96BC77A...</screen>
 
   <para>
    Extensive information about &grub; is available at <link
-   xlink:href="http://www.gnu.org/software/grub/"/>. Also refer to the
+   xlink:href="https://www.gnu.org/software/grub/"/>. Also refer to the
    <command>grub</command> info page. <phrase os="sles;sled">You can also
    search for the keyword <quote>&grub;</quote> in the Technical Information
-   Search at <link xlink:href="http://www.suse.com/support"/> to get
+   Search at <link xlink:href="https://www.suse.com/support"/> to get
    information about special issues.</phrase>
   </para>
  </sect1>

--- a/xml/help_admin.xml
+++ b/xml/help_admin.xml
@@ -421,7 +421,7 @@
    all documentation available for &productname; check out your
    product-specific documentation Web page at
    <phrase os="sles;sled"><link
-   xlink:href="&dsc;/"/></phrase><phrase os="osuse"><link
+   xlink:href="https://documentation.suse.com/"/></phrase><phrase os="osuse"><link
    xlink:href="http:/doc.opensuse.org/"/></phrase>.
   </para>
 

--- a/xml/help_admin.xml
+++ b/xml/help_admin.xml
@@ -422,7 +422,7 @@
    product-specific documentation Web page at
    <phrase os="sles;sled"><link
    xlink:href="https://documentation.suse.com/"/></phrase><phrase os="osuse"><link
-   xlink:href="http:/doc.opensuse.org/"/></phrase>.
+   xlink:href="https:/doc.opensuse.org/"/></phrase>.
   </para>
 
   <para>
@@ -436,7 +436,7 @@
     <listitem>
      <para>
       The &suse; Technical Support can be found at
-      <link xlink:href="http://www.suse.com/support/"/> if you have questions
+      <link xlink:href="https://www.suse.com/support/"/> if you have questions
       or need solutions for technical problems.
      </para>
     </listitem>
@@ -447,19 +447,18 @@
      <para>
       There are several forums where you can dive in on discussions about
       &suse; products. See <phrase os="sles;sled"><link
-      xlink:href="http://forums.suse.com/"/></phrase> <phrase os="osuse"><link
-      xlink:href="http://forums.opensuse.org/"/></phrase> for a
+      xlink:href="https://forums.suse.com/"/></phrase> <phrase os="osuse"><link
+      xlink:href="https://forums.opensuse.org/"/></phrase> for a
       list.
      </para>
     </listitem>
    </varlistentry>
    <varlistentry os="sles;sled">
-    <term>&suse; Conversations</term>
+    <term>&suse; Blog</term>
     <listitem>
      <para>
-      An online community, which offers articles, tips, Q and A, and free tools
-      to download:
-      <link xlink:href="http://www.suse.com/communities/conversations/"/>
+      The &suse; blog offers articles, tips, Q and A:
+      <link xlink:href="https://www.suse.com/c/blog/"/>
      </para>
     </listitem>
    </varlistentry>
@@ -468,7 +467,7 @@
     <listitem>
      <para>
       Documentation for &gnome; users, administrators and developers is
-      available at <link xlink:href="http://library.gnome.org/"/>.
+      available at <link xlink:href="https://library.gnome.org/"/>.
      </para>
     </listitem>
    </varlistentry>
@@ -478,7 +477,7 @@
      <para>
       The Linux Documentation Project (TLDP) is run by a team of volunteers who
       write Linux-related documentation (see
-      <link xlink:href="http://www.tldp.org"/>). It is probably the most
+      <link xlink:href="https://www.tldp.org"/>). It is probably the most
       comprehensive documentation resource for Linux. The set of documents
       contains tutorials for beginners, but is mainly focused on experienced
       users and professional system administrators. TLDP publishes HOWTOs,

--- a/xml/help_user.xml
+++ b/xml/help_user.xml
@@ -121,7 +121,7 @@
    also access the product-specific manuals and documentation on the Web. For
    an overview of all documentation available for &productname; check out your
    product-specific documentation Web page at <link os="sles;sled"
-   xlink:href="&dsc;/"/><link os="osuse"
+   xlink:href="https://documentation.suse.com/"/><link os="osuse"
    xlink:href="https://doc.opensuse.org/"/>.
   </para>
 

--- a/xml/help_user.xml
+++ b/xml/help_user.xml
@@ -133,7 +133,7 @@
   <itemizedlist mark="bullet" spacing="normal">
    <listitem os="sles;sled">
     <para>
-     <link xlink:href="http://www.suse.com/support/kb/">&suse;
+     <link xlink:href="https://www.suse.com/support/kb/">&suse;
      Knowledgebase</link>
     </para>
    </listitem>
@@ -160,7 +160,7 @@
    </listitem>
    <listitem>
     <para>
-     <link xlink:href="http://www.gnome.org/">&gnome; Web
+     <link xlink:href="https://www.gnome.org/">&gnome; Web
      Site</link>
     </para>
    </listitem>

--- a/xml/kvm_appendix.xml
+++ b/xml/kvm_appendix.xml
@@ -24,7 +24,7 @@
    <para os="sles">
     &suse; has developed virtio-based drivers for Windows, which are
     available in the Virtual Machine Driver Pack (VMDP). See
-    <link xlink:href="http://www.suse.com/products/vmdriverpack/"/> for more
+    <link xlink:href="https://www.suse.com/products/vmdriverpack/"/> for more
     information on the VMDP. Installation instructions are now available in
     a dedicated official documentation.
    </para>

--- a/xml/libvirt_guest_installation.xml
+++ b/xml/libvirt_guest_installation.xml
@@ -453,7 +453,7 @@ network=vnet_nated</screen>
    <para>
     While openSUSE and SLE-based guests support memory ballooning, Windows
     guests need the
-    <link xlink:href="http://www.suse.com/products/vmdriverpack/">Virtual
+    <link xlink:href="https://www.suse.com/products/vmdriverpack/">Virtual
     Machine Driver Pack (VMDP)</link> to provide ballooning. To set the maximum
     memory greater than the initial memory configured for Windows guests,
     follow these steps:

--- a/xml/libvirt_storage.xml
+++ b/xml/libvirt_storage.xml
@@ -1392,7 +1392,7 @@ I/O size (minimum/optimal): 512 bytes / 512 bytes</screen>
   <para os="sles;sled">
    For more details, refer to the &ses; <citetitle>&admin;</citetitle>, chapter
    <citetitle>Using libvirt with Ceph</citetitle>. The &ses; documentation is
-   available from <link xlink:href="&dsc-ses;/"/>.
+   available from <link xlink:href="https://documentation.suse.com/ses/"/>.
   </para>
  </sect1>
 </chapter>

--- a/xml/net_sync.xml
+++ b/xml/net_sync.xml
@@ -450,9 +450,9 @@ pid file = /var/lock/rsync.lock
     <term>Rear</term>
     <listitem>
      <para>
-      A disaster recovery framework, see the <citetitle>Administration
-      Guide</citetitle> of the &sle; &hasi;
-      <link xlink:href="https://&dsc-ha;/"/>.
+      A disaster recovery framework, see the
+      <link xlink:href="https://documentation.suse.com/sle-ha/15-SP2/html/SLE-HA-all/cha-ha-rear.html"><citetitle>Administration
+      Guide</citetitle> of the &sle; &hasi;, chapter <citetitle>Disaster Recovery with Rear (Relax-and-Recover)</citetitle></link>.
      </para>
     </listitem>
    </varlistentry>

--- a/xml/planning.xml
+++ b/xml/planning.xml
@@ -86,7 +86,7 @@
    and the database of certified hardware is updated regularly. Find the search
    form for certified hardware at
    <link
-    xlink:href="http://www.suse.com/yessearch/Search.jsp"/>.
+    xlink:href="https://www.suse.com/yessearch/Search.jsp"/>.
   </para>
 
   <para>

--- a/xml/printing.xml
+++ b/xml/printing.xml
@@ -986,10 +986,10 @@ cat file | netcat -w 1 IP-address port</screen>
    <para>
     In-depth information about printing on &productname; is presented in the
     openSUSE Support Database at <link
-    xlink:href="http://en.opensuse.org/Portal:Printing"/>. <phrase
+    xlink:href="https://en.opensuse.org/Portal:Printing"/>. <phrase
     os="sles;sled">Solutions to many specific problems are presented in the
     SUSE Knowledgebase (<link
-    xlink:href="http://www.suse.com/support/"/>). Locate the relevant articles
+    xlink:href="https://www.suse.com/support/"/>). Locate the relevant articles
     with a text search for <literal>CUPS</literal>.</phrase>
    </para>
   </sect2>

--- a/xml/qemu_running_vms_qemukvm.xml
+++ b/xml/qemu_running_vms_qemukvm.xml
@@ -713,10 +713,10 @@ based iSCSI:
       replication, and data consistency. You can use an RBD from your
       &kvm;-managed &vmguest;s similarly to how you use other block devices.
      </para>
-     <para os="sles;sled">
-      For more details, refer to the &ses; <citetitle>&admin;</citetitle>, chapter
-      <citetitle>Ceph as a Back-end for QEMU KVM Instance</citetitle>. The &ses; documentation is
-      available from <link xlink:href="&dsc-ses;/"/>.
+     <para os="sles;sled">For more details, refer to the <link
+      xlink:href="https://documentation.suse.com/ses/6/html/ses-all/cha-ceph-kvm.html">&ses;
+      <citetitle>&admin;</citetitle>, chapter
+      <citetitle>Ceph as a Back-end for QEMU KVM Instance</citetitle></link>.
      </para>
    </sect3>
 

--- a/xml/qemu_running_vms_qemukvm.xml
+++ b/xml/qemu_running_vms_qemukvm.xml
@@ -134,7 +134,7 @@
     SeaBIOS is the default BIOS used. You can boot USB devices, any drive
     (CD-ROM, Floppy, or a hard disk). It has USB mouse and keyboard support and
     supports multiple VGA cards. For more information about SeaBIOS, refer to
-    the <link xlink:href="http://www.seabios.org/SeaBIOS">SeaBIOS
+    the <link xlink:href="https://www.seabios.org/SeaBIOS">SeaBIOS
     Website</link>.
    </para>
   </note>

--- a/xml/rmt_overview.xml
+++ b/xml/rmt_overview.xml
@@ -85,7 +85,7 @@
   <para>
    For an overview of the documentation available for your product and the
    latest documentation updates, refer to
-   <link xlink:href="&dsc;"/>.
+   <link xlink:href="https://documentation.suse.com/"/>.
   </para>
  </sect1>
  <xi:include href="common_intro_feedback_i.xml"/>

--- a/xml/security_pcidss.xml
+++ b/xml/security_pcidss.xml
@@ -497,7 +497,7 @@
         &productnamex; and automatically enabling an evaluated configuration.
         This setup procedure can also be automated with the &susemgr;. For
         more information, see the &susemgr; documentation at
-        <link xlink:href="&dsc-suma;/"/>.
+        <link xlink:href="https://documentation.suse.com/suma/"/>.
        </para>
        <para>
         By default, &productnamex; does not create additional accounts
@@ -978,9 +978,8 @@
       </para>
       <para>
        For information about &susemgr;, see the
-       <link
-         xlink:href="&dsc-suma;/">&susemgr;
-         product page</link>.
+       <link xlink:href="https://documentation.suse.com/suma/">&susemgr;
+       documentation page</link>.
       </para>
      </listitem>
     </itemizedlist>

--- a/xml/sle_update_backporting.xml
+++ b/xml/sle_update_backporting.xml
@@ -224,7 +224,7 @@
    <listitem>
     <para>
      For security bug fixes, consult the
-     <link xlink:href="http://www.suse.com/support/security/#1">&suse; security
+     <link xlink:href="https://www.suse.com/support/security/">&suse; security
      announcements</link>. These often refer to bugs through standardized names
      like <literal>CAN-2005-2495</literal> which are maintained by the
      <link xlink:href="http://cve.mitre.org">Common Vulnerabilities and

--- a/xml/sle_update_online.xml
+++ b/xml/sle_update_online.xml
@@ -91,9 +91,8 @@
    <para>If the system to upgrade is a &susemgr; client, it cannot be
     upgraded by &yast; online migration nor <command>zypper migration</command>.
     Use the <citetitle>Client Migration</citetitle> procedure instead. It is
-    described in the <citetitle>&susemgr; Upgrade Guide</citetitle>, available
-    at <link xmlns:xlink="http://www.w3.org/1999/xlink"
-    xlink:href="&dsc-suma;/"/>.
+    described in the <link xlink:href="https://documentation.suse.com/suma/">
+    <citetitle>&susemgr; Upgrade Guide</citetitle></link>.
    </para>
   </important>
 

--- a/xml/sle_update_upgrading.xml
+++ b/xml/sle_update_upgrading.xml
@@ -109,7 +109,7 @@
       If you cannot do a fresh installation, first upgrade your installed
       &productnameshort;&nbsp;11 service pack to
       &productnameshort;&nbsp;11&nbsp;SP4. This upgrade is described in the <link
-       xlink:href="&dsc-sles-11;/">&productnameshort;&nbsp;11 &deploy;</link>.
+      xlink:href="https://documentation.suse.com/sles/11-SP4/html/SLES-all/book-sle-deployment.html">&productnameshort;&nbsp;11&nbsp;SP4&nbsp;&deploy;</link>.
      </para>
     </listitem>
    </varlistentry>
@@ -135,8 +135,9 @@
       If you cannot do a fresh installation, first upgrade your installed
       &productnameshort;&nbsp;12 service pack to
       &productnameshort;&nbsp;12&nbsp;SP3. This upgrade is described in the
-      <link os="sles" xlink:href="&dsc-sles-12;/">&productnameshort;&nbsp;12 &deploy;</link>
-      <link os="sled" xlink:href="&dsc-sled-12;/">&productnameshort;&nbsp;12 &deploy;</link>.
+      <link os="sles"
+      xlink:href="https://documentation.suse.com/sles/12-SP3/html/SLES-all/book-sle-deployment.html">&productnameshort;&nbsp;12&nbsp;SP3&nbsp;&deploy;</link><link
+      os="sled" xlink:href="https://documentation.suse.com/sled/12-SP3/html/SLED-all/book-sle-deployment.html">&productnameshort;&nbsp;12&nbsp;SP3&nbsp;&deploy;</link>.
      </para>
     </listitem>
    </varlistentry>
@@ -154,8 +155,9 @@
     <term>Upgrading &sle; Public Cloud Guests</term>
     <listitem>
      <para>
-      See <link xlink:href="https://&dsc;/suse-distribution-migration-system/1.0/single-html/distribution-migration-system/"/>
-      for instructions on upgrading &slea; guests in public clouds.
+      For instructions on upgrading &slea; guests in public clouds, see
+      <link xlink:href="https://documentation.suse.com/suse-distribution-migration-system/1.0/single-html/distribution-migration-system/"><citetitle>Using
+      the SUSE Distribution Migration System</citetitle></link>.
      </para>
     </listitem>
    </varlistentry>   

--- a/xml/sled_planning.xml
+++ b/xml/sled_planning.xml
@@ -68,7 +68,7 @@
     <para>
      &suse; provides training, support, and consulting for all topics
      pertaining to &sled;. Find more information about this at
-     <link xlink:href="http://www.suse.com/products/desktop/"/>.
+     <link xlink:href="https://www.suse.com/products/desktop/"/>.
     </para>
    </listitem>
   </varlistentry>

--- a/xml/storage_filesystems.xml
+++ b/xml/storage_filesystems.xml
@@ -38,8 +38,8 @@
   &productname; includes OCFS2 (Oracle Cluster File System 2) and the
   Distributed Replicated Block Device (DRBD) in the &hasi; add-on. These
   advanced storage systems are not covered in this guide. For information, see
-  the <citetitle>&sle; &hasi; &haguide;</citetitle> at
-  <link xlink:href="&dsc;/"/>.
+  the <link xlink:href="https://documentation.suse.com/sle-ha/15-SP2/html/SLE-HA-all/book-sleha-guide.html">
+  <citetitle>&haguide; for the &sle; &hasi;</citetitle></link>.
  </para>
  <para>
   It is very important to remember that no file system best suits all kinds of

--- a/xml/storage_filesystems.xml
+++ b/xml/storage_filesystems.xml
@@ -17,8 +17,7 @@
     including Btrfs, Ext4, Ext3, Ext2 and XFS. Each file system has its own
     advantages and disadvantages. For a side-by-side feature comparison of the
     major file systems in &productname;, see
-    <link
-    xlink:href="http://www.suse.com/products/server/technical-information/#FileSystem"/>
+    <link xlink:href="https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15-SP1/#TechInfo.Filesystems"/>
     (File System Support and Sizes). This chapter contains an overview of how
     these file systems work and what advantages they offer.
    </para>
@@ -1337,7 +1336,7 @@ inode_ratio = 8192</screen>
    </itemizedlist>
    <para>
     For information, see
-    <link xlink:href="http://www.suse.com/support/kb/doc.php?id=7009075"/>
+    <link xlink:href="https://www.suse.com/support/kb/doc.php?id=7009075"/>
     (<citetitle>SLES11 ext3 partitions can only store 50% of the files that can
     be stored on SLES10</citetitle> [Technical Information Document 7009075]).
    </para>

--- a/xml/storage_multipath.xml
+++ b/xml/storage_multipath.xml
@@ -4825,13 +4825,13 @@ prio_args "hbtl [1,3]:.:.+:.+ 260 [0,2]:.:.+:.+ 20"</screen>
    <itemizedlist mark="bullet" spacing="normal">
     <listitem>
      <para>
-      <link xlink:href="http://www.suse.com/support/kb/doc.php?id=3617600"><citetitle>Using
+      <link xlink:href="https://www.suse.com/support/kb/doc.php?id=3617600"><citetitle>Using
       LVM on local and SAN attached devices</citetitle></link>
      </para>
     </listitem>
     <listitem>
      <para>
-      <link xlink:href="http://www.suse.com/support/kb/doc.php?id=7007498"><citetitle>Using
+      <link xlink:href="https://www.suse.com/support/kb/doc.php?id=7007498"><citetitle>Using
       LVM on Multipath (DM MPIO) Devices</citetitle></link>
      </para>
     </listitem>

--- a/xml/storage_raid.xml
+++ b/xml/storage_raid.xml
@@ -29,9 +29,9 @@
   <title>RAID on Cluster File Systems</title>
   <para>
    Software RAID underneath clustered file systems needs to be set up using a
-   cluster multi-device (Cluster MD). Refer to the &haguide; for &hasi; at
-   <link
-     xlink:href="&dsc-ha;/"/>.
+   cluster multi-device (Cluster MD). Refer to the
+   <link xlink:href="https://documentation.suse.com/sle-ha/15-SP2/html/SLE-HA-all/cha-ha-cluster-md.html">
+   <citetitle>&haguide; for the &sle; &hasi;</citetitle></link>.
   </para>
  </important>
  <para>

--- a/xml/uefi.xml
+++ b/xml/uefi.xml
@@ -693,7 +693,7 @@ media that will boot on both legacy architectures and UEFI platforms.
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     <link xlink:href="http://www.uefi.org"/> &mdash;UEFI home page where you
+     <link xlink:href="https://www.uefi.org"/> &mdash;UEFI home page where you
      can find the current UEFI specifications.
     </para>
    </listitem>
@@ -705,24 +705,24 @@ media that will boot on both legacy architectures and UEFI platforms.
     <itemizedlist mark="bullet" spacing="normal">
      <listitem>
       <para>
-       <link xlink:href="http://www.suse.com/blogs/uefi-secure-boot-plan/"/>
+       <link xlink:href="https://www.suse.com/c/uefi-secure-boot-plan/"/>
       </para>
      </listitem>
      <listitem>
       <para>
-       <link xlink:href="http://www.suse.com/blogs/uefi-secure-boot-overview/"/>
+       <link xlink:href="https://www.suse.com/c/uefi-secure-boot-overview/"/>
       </para>
      </listitem>
      <listitem>
       <para>
-       <link xlink:href="http://www.suse.com/blogs/uefi-secure-boot-details/"/>
+       <link xlink:href="https://www.suse.com/c/uefi-secure-boot-details/"/>
       </para>
      </listitem>
     </itemizedlist>
    </listitem>
    <listitem>
     <para>
-     <link xlink:href="http://en.opensuse.org/openSUSE:UEFI"/> &mdash;UEFI with
+     <link xlink:href="https://en.opensuse.org/openSUSE:UEFI"/> &mdash;UEFI with
      openSUSE.
     </para>
    </listitem>

--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -16,7 +16,7 @@
  </info>
  <para os="sles;sled">
   Supported architectures and virtualization limits for &xen; and &kvm; are
-  outlined in the <link xlink:href="http://www.suse.com/releasenotes/">Release
+  outlined in the <link xlink:href="https://www.suse.com/releasenotes/">Release
   Notes</link>.
  </para>
  <sect1 xml:id="virt-support-guests">
@@ -605,7 +605,7 @@
        &suse; has developed virtio-based drivers for Windows, which are
        available in the Virtual Machine Driver Pack (VMDP).
        For more information, see
-       <link xlink:href="http://www.suse.com/products/vmdriverpack/"/>.
+       <link xlink:href="https://www.suse.com/products/vmdriverpack/"/>.
       </para>
      </listitem>
     </varlistentry>

--- a/xml/vmdp_drivers.xml
+++ b/xml/vmdp_drivers.xml
@@ -41,7 +41,7 @@
  <para>
   The &slereg; Virtual Machine Driver Pack is available as an add-on
   product for &productname;. For detailed information refer to
-  <link xlink:href="http://www.suse.com/products/vmdriverpack/"/>.
+  <link xlink:href="https://www.suse.com/products/vmdriverpack/"/>.
  </para>
  <para>
   For more information, refer to the

--- a/xml/vmdp_drivers.xml
+++ b/xml/vmdp_drivers.xml
@@ -44,8 +44,9 @@
   <link xlink:href="http://www.suse.com/products/vmdriverpack/"/>.
  </para>
  <para>
-  Refer to the Official VMDP Installation Guide at
-  <link xlink:href="&dsc-vmdp;/"/> for
-  more information.
+  For more information, refer to the
+  <link xlink:href="https://documentation.suse.com/sle-vmdp/2.5/html/vmdp/index.html">
+  Official VMDP <citetitle>Installation Guide</citetitle>
+  </link>.
  </para>
 </appendix>

--- a/xml/xen2kvm_quick.xml
+++ b/xml/xen2kvm_quick.xml
@@ -59,9 +59,9 @@
     Windows guests using <command>virt-v2v</command> is the same as
     converting Linux guests, except in regards to handling the Virtual
     Machine Driver Pack (VMDP). Additional details on converting Windows
-    guests with the VMDP can be found in the separate Virtual Machine Driver
-    Pack documentation at <link
-     xlink:href="&dsc-vmdp;/"/>.
+    guests with the VMDP can be found in the separate at <link
+     xlink:href="https://documentation.suse.com/sle-vmdp/">Virtual Machine Driver
+     Pack documentation</link>.
    </para>
   </tip>
 
@@ -1176,7 +1176,7 @@ getty@xvc1.service -&gt; /usr/lib/systemd/system/getty@xvc1.service
   <para>
    For more information on virtualization with &xen; and &kvm;, see
    the &productname; documentation at
-   <link xlink:href="&dsc;/"/>.
+   <link xlink:href="https://documentation.suse.com/"/>.
   </para>
  </sect1>
  <!--

--- a/xml/xen_administrating.xml
+++ b/xml/xen_administrating.xml
@@ -266,7 +266,7 @@
       data is mirrored over the network. <phrase os="sles;sled">For more information, see the
       <citetitle>SUSE Linux Enterprise High Availability Extension
       &productnumber;</citetitle> documentation at
-      <link xlink:href="&dsc-ha;/"/></phrase>.
+      <link xlink:href="https://documentation.suse.com/sle-ha/15-SP2/"/></phrase>.
      </para>
     </listitem>
     <listitem>

--- a/xml/yast2_sw_addon.xml
+++ b/xml/yast2_sw_addon.xml
@@ -58,7 +58,7 @@
   information about availability of binary drivers for your system. The
   release notes are available from
   <phrase os="sles;sled"><link
-  xlink:href="http://www.suse.com/releasenotes/"/></phrase><phrase
+  xlink:href="https://www.suse.com/releasenotes/"/></phrase><phrase
   os="osuse"><link
   xlink:href="https://doc.opensuse.org/release-notes/"/></phrase>,
   from &yast; or from <filename>/usr/share/doc/release-notes/</filename> in


### PR DESCRIPTION
Based on the following guidelines:

*  avoid entities for URLs (entities for parts of the URL make it harder to
    copy/paste/replace complete URLs, plus they will be resolved during
    translation anyway)
-> this way the URLs are the same in the English versions and translation
    branches and can replaced the same way if needed
 *  using upcoming 15-SP2 URLs 
    (they will only work after FCS, but it prevents us from updating them
     in the translation branches after FCS)
 * use links to html instead of single-html (shorter download times, SEO)
 * use descriptive text for links to mention book name
    (in case deeplink is broken, plus better accessibility)
based on the following guidelines:

*  avoid entities for URLs (entities for parts of the URL make it harder to
    copy/paste/replace complete URLs, plus they will be resolved during
    translation anyway)
-> this way the URLs are the same in the English versions and translation
    branches and can replaced the same way if needed
 *  using upcoming 15-SP2 URLs 
    (they will only work after FCS, but it prevents us from updating them
     in the translation branches after FCS)
 * use links to html instead of single-html (shorter download times, SEO)
 * use descriptive text for links to mention book name
    (in case deeplink is broken, plus better accessibility)

