### PR TITLE
Automatic Assignment of PR-Reviews

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,20 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+# addAssignees: true
+
+# Set to author to set pr creator as assignee
+addAssignees: author
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers: 
+  - lproven
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it 
+skipKeywords:
+  - wip
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0


### PR DESCRIPTION
Add auto_assign.yml. As some PRs probably need a review by a second person, not sure if we really should handle it this way. 

@fsundermeyer @sknorr @tomschr : What do you think? 