### PR TITLE
Reword para about BTT to clarify meaning of rolling back a write op

### DIFF
--- a/xml/hardware_nvdimm.xml
+++ b/xml/hardware_nvdimm.xml
@@ -238,10 +238,12 @@
             mechanism batches accesses into sector-sized units.
            </para>
            <para>
-            The advantage of BTT is data protection: the storage subsystem ensures 
-            that each sector is completely written to the underlying medium, and if
-            a write fails for some reason, it will be unrolled. Thus a given
-            sector cannot be partially written. 
+            The advantage of BTT is data protection. The storage subsystem
+            ensures that each sector is completely written to the underlying
+            medium. If a sector cannot be completely written (that is, if the
+            write operation fails for some reason), then the whole sector will
+            be rolled back to its previous state. Thus a given sector cannot be
+            partially written. 
            </para>
            <para>
             Additionally, access to BTT namespaces is cached by the kernel.


### PR DESCRIPTION
### Description
The translation team have queried what "will be unrolled" means referring to a sector write. I have reworded the paragraph, shortened a long sentence, to clarify the meaning and bring it closer to the common "roll back" (or "rollback") usage.

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
