### PR TITLE
Add proofreading changes from Dublin to SLE Storage Guide

### DIFF
--- a/xml/common_intro_lifecycle_support_i.xml
+++ b/xml/common_intro_lifecycle_support_i.xml
@@ -124,7 +124,7 @@
   <itemizedlist>
    <listitem>
     <para>
-     Technology previews
+     Technology previews.
     </para>
    </listitem>
    <listitem>

--- a/xml/common_intro_lifecycle_support_i.xml
+++ b/xml/common_intro_lifecycle_support_i.xml
@@ -124,28 +124,28 @@
   <itemizedlist>
    <listitem>
     <para>
-     Technology previews.
+     technology previews.
     </para>
    </listitem>
    <listitem>
     <para>
-     Sound, graphics, fonts, and artwork.
+     sound, graphics, fonts, and artwork.
     </para>
    </listitem>
    <listitem>
     <para>
-     Packages that require an additional customer contract.
+     packages that require an additional customer contract.
     </para>
    </listitem>
    <listitem>
     <para>
-     Some packages shipped as part of the module <emphasis>Workstation
+     some packages shipped as part of the module <emphasis>Workstation
      Extension</emphasis> are L2-supported only.
     </para>
    </listitem>
    <listitem>
     <para>
-     Packages with names ending in <package>-devel</package> (containing header
+     packages with names ending in <package>-devel</package> (containing header
      files and similar developer resources) will only be supported together
      with their main packages.
     </para>

--- a/xml/storage_iscsi.xml
+++ b/xml/storage_iscsi.xml
@@ -369,8 +369,8 @@
     <title>Partitions</title>
     <para>
      Before you begin, choose the partitions you wish to use for back-end
-     storage. The partitions do not have to be formatted: the iSCSI client can
-     format them when connected, overwriting all existing formatting.
+     storage. The partitions do not have to be formatted&mdash;the iSCSI client
+     can format them when connected, overwriting all existing formatting.
     </para>
    </important>
    <procedure>
@@ -1203,7 +1203,7 @@ node.session.iscsi.ImmediateData = Yes
  </sect1>
 
  <sect1 xml:id="sec-iscsi-targetcli">
-  <title>Setting up Software Targets Using targetcli-fb</title>
+  <title>Setting Up Software Targets Using targetcli-fb</title>
   <para>
    <systemitem>targetcli</systemitem> is a shell for managing the configuration
    of the LinuxIO (LIO) target subsystem. The shell can be called
@@ -1298,13 +1298,13 @@ o- / ............................ [...]
     </listitem>
    </itemizedlist>
    <para>
-    To familiarize yourself with functionality of targetcli, set up a local
+    To familiarize yourself with the functionality of targetcli, set up a local
     image file as a software target using the <command>create</command> command:
    </para>
 <screen>/backstores/fileio create test-disc <replaceable>/alt</replaceable>/test.img 1G</screen>
    <para>
-    This creates the 1GB <filename>test.img</filename> image in the specified
-    location (in this case <filename>/alt</filename>). Run
+    This creates a 1&nbsp;GB <filename>test.img</filename> image in the
+    specified location (in this case <filename>/alt</filename>). Run
     <command>ls</command>, and you should see the following result:
    </para>
 <screen>/> ls
@@ -1324,10 +1324,10 @@ o- / ........................................................... [...]
   o- xen-pvscsi ......................................... [Targets: 0]
 /></screen>   
    <para>
-    The output indicates that there is now a file-based back-store, under the
+    The output indicates that there is now a file-based backstore, under the
     <filename>/backstores/fileio</filename> directory, called
     <literal>test-disc</literal>, which is linked to the created file
-    <filename>/alt/test.img</filename>. Note that the new back-store is not yet
+    <filename>/alt/test.img</filename>. Note that the new backstore is not yet
     activated.
    </para>
    <para>
@@ -1371,7 +1371,7 @@ o- / ........................................................... [...]
    </para>
 <screen>/> iscsi/ create</screen>
    <para>
-    Run the <command>ls</command> again
+    Run the <command>ls</command> command again:
    </para>
 <screen>/> ls
 o- / ............................................................... [...]
@@ -1401,7 +1401,7 @@ o- / ............................................................... [...]
     <literal>iqn.2003-01.org.linux-iscsi.e83.x8664:sn.8b35d04dd456</literal>
    </para>
    <para>
-    Note that targetcli has also created and enabled the default target portal
+    Note that <command>targetcli</command> has also created and enabled the default target portal
     group <literal>tpg1</literal>. This is done because the variables
     <literal>auto_add_default_portal</literal> and
     <literal>auto_enable_tpgt</literal> at the root level are set to
@@ -1413,11 +1413,11 @@ o- / ............................................................... [...]
     can access the configured target.
    </para>
    <para>
-    Next step is to create a LUN (Logical Unit Number) for the iSCSI
-    target. The best way to do this is to let targetcli assign its name and
+    The next step is to create a LUN (Logical Unit Number) for the iSCSI
+    target. The best way to do this is to let <command>targetcli</command> assign its name and
     number automatically. Switch to the directory of the
     iSCSI target, and then use the <command>create</command> command in the
-    <filename>lun</filename> directory to assign a LUN to the back store.
+    <filename>lun</filename> directory to assign a LUN to the backstore.
    </para>
 <screen>/> cd /iscsi/iqn.2003-01.org.linux-iscsi.e83.x8664:sn.8b35d04dd456/
 /iscsi/iqn.2003-01.org.linux-iscsi.e83.x8664:sn.8b35d04dd456> cd tpg1
@@ -1434,7 +1434,7 @@ o- tpg1 .............................................. [no-gen-acls, no-auth]
       o- portals ............................................... [Portals: 1]
         o- 0.0.0.0:3260 ................................................ [OK]</screen>
    <para>
-    There is now an iSCSI target that has a 1GB file-based back-store. The
+    There is now an iSCSI target that has a 1&nbsp;GB file-based backstore. The
     target has the
     <literal>iqn.2003-01.org.linux-iscsi.e83.x8664:sn.8b35d04dd456</literal>
     name, and it can be accessed from any network port of the system.
@@ -1482,8 +1482,8 @@ Configuration restored from /etc/target/example.json
     <para>
      To test whether the configured target is working, connect to it using the
      <package>open-iscsi</package> iSCSI initiator installed on the same
-     system (replace <replaceable>HOSTNAME</replaceable> with hostname of the
-     local machine):
+     system (replace <replaceable>HOSTNAME</replaceable> with the hostname of
+     the local machine):
     </para>
 <screen>&prompt.user;iscsiadm -m discovery -t st -p <replaceable>HOSTNAME</replaceable></screen>
    <para>

--- a/xml/storage_lvm.xml
+++ b/xml/storage_lvm.xml
@@ -1647,9 +1647,10 @@ sudo lvreduce /dev/LOCAL/DATA</screen>
     <para>
      To check the exact behavior, run the <command>lvmconfig -l | grep
      global_filter_compat</command> command. If the result shows that the
-     <literal>global_filter_compat</literal> option exists and set to
+     <literal>global_filter_compat</literal> option exists and is set to
      <literal>0</literal>, the behavior described above applies. If the option
-     does not exist or set to <literal>1</literal>, the behavior remains unchanged.
+     does not exist or is set to <literal>1</literal>, the behavior remains
+     unchanged.
     </para>
    </important>
   </sect2>

--- a/xml/storage_multipath.xml
+++ b/xml/storage_multipath.xml
@@ -63,7 +63,77 @@
     The <filename>multipath-tools</filename> package automatically detects the
     following storage arrays:
    </para>
-   <simplelist><member>3PARdata VV</member><member>AIX NVDISK</member><member>AIX VDASD</member><member>APPLE Xserve RAID</member><member>COMPELNT Compellent Vol</member><member>COMPAQ/HP HSV101, HSV111, HSV200, HSV210, HSV300, HSV400, HSV 450</member><member>COMPAQ/HP MSA, HSV</member><member>COMPAQ/HP MSA VOLUME</member><member>DataCore SANmelody</member><member>DDN SAN DataDirector</member><member>DEC HSG80</member><member>DELL MD3000</member><member>DELL MD3000i</member><member>DELL MD32xx</member><member>DELL MD32xxi</member><member>DGC</member><member>EMC Clariion</member><member>EMC Invista</member><member>EMC SYMMETRIX</member><member>EUROLOGC FC2502</member><member>FSC CentricStor</member><member>FUJITSU ETERNUS_DX, DXL, DX400, DX8000</member><member>HITACHI DF</member><member>HITACHI/HP OPEN</member><member>HP A6189A</member><member>HP HSVX700</member><member>HP LOGICAL VOLUME</member><member>HP MSA2012fc, MSA 2212fc, MSA2012i</member><member>HP MSA2012sa, MSA2312 fc/i/sa, MCA2324 fc/i/sa, MSA2000s VOLUME</member><member>HP P2000 G3 FC|P2000G3 FC/iSCSI|P2000 G3 SAS|P2000 G3 iSCSI</member><member>IBM 1722-600</member><member>IBM 1724</member><member>IBM 1726</member><member>IBM 1742</member><member>IBM 1745, 1746</member><member>IBM 1750500</member><member>IBM 1814</member><member>IBM 1815</member><member>IBM 1818</member><member>IBM 1820N00</member><member>IBM 2105800</member><member>IBM 2105F20</member><member>IBM 2107900</member><member>IBM 2145</member><member>IBM 2810XIV</member><member>IBM 3303 NVDISK</member><member>IBM 3526</member><member>IBM 3542</member><member>IBM IPR</member><member>IBM Nseries</member><member>IBM ProFibre 4000R</member><member>IBM S/390 DASD ECKD</member><member>IBM S/390 DASD FBA</member><member>Intel Multi-Flex</member><member>LSI/ENGENIO INF-01-00</member><member>NEC DISK ARRAY</member><member>NETAPP LUN</member><member>NEXENTA COMSTAR</member><member>Pillar Axiom</member><member>PIVOT3 RAIGE VOLUME</member><member>SGI IS</member><member>SGI TP9100, TP 9300</member><member>SGI TP9400, TP9500</member><member>STK FLEXLINE 380</member><member>STK OPENstorage D280</member><member>SUN CSM200_R</member><member>SUN LCSM100_[IEFS]</member><member>SUN STK6580, STK6780</member><member>SUN StorEdge 3510, T4</member><member>SUN SUN_6180</member>
+   <simplelist>
+    <member>3PARdata VV</member>
+    <member>AIX NVDISK</member>
+    <member>AIX VDASD</member>
+    <member>APPLE Xserve RAID</member>
+    <member>COMPELNT Compellent Vol</member>
+    <member>COMPAQ/HP HSV101, HSV111, HSV200, HSV210, HSV300, HSV400, HSV 450</member>
+    <member>COMPAQ/HP MSA, HSV</member>
+    <member>COMPAQ/HP MSA VOLUME</member>
+    <member>DataCore SANmelody</member>
+    <member>DDN SAN DataDirector</member>
+    <member>DEC HSG80</member>
+    <member>DELL MD3000</member>
+    <member>DELL MD3000i</member>
+    <member>DELL MD32xx</member>
+    <member>DELL MD32xxi</member>
+    <member>DGC</member>
+    <member>EMC Clariion</member>
+    <member>EMC Invista</member>
+    <member>EMC SYMMETRIX</member>
+    <member>EUROLOGC FC2502</member>
+    <member>FSC CentricStor</member>
+    <member>FUJITSU ETERNUS_DX, DXL, DX400, DX8000</member>
+    <member>HITACHI DF</member>
+    <member>HITACHI/HP OPEN</member>
+    <member>HP A6189A</member>
+    <member>HP HSVX700</member>
+    <member>HP LOGICAL VOLUME</member>
+    <member>HP MSA2012fc, MSA 2212fc, MSA2012i</member>
+    <member>HP MSA2012sa, MSA2312 fc/i/sa, MCA2324 fc/i/sa, MSA2000s VOLUME</member>
+    <member>HP P2000 G3 FC|P2000G3 FC/iSCSI|P2000 G3 SAS|P2000 G3 iSCSI</member>
+    <member>IBM 1722-600</member>
+    <member>IBM 1724</member>
+    <member>IBM 1726</member>
+    <member>IBM 1742</member>
+    <member>IBM 1745, 1746</member>
+    <member>IBM 1750500</member>
+    <member>IBM 1814</member>
+    <member>IBM 1815</member>
+    <member>IBM 1818</member>
+    <member>IBM 1820N00</member>
+    <member>IBM 2105800</member>
+    <member>IBM 2105F20</member>
+    <member>IBM 2107900</member>
+    <member>IBM 2145</member>
+    <member>IBM 2810XIV</member>
+    <member>IBM 3303 NVDISK</member>
+    <member>IBM 3526</member>
+    <member>IBM 3542</member>
+    <member>IBM IPR</member>
+    <member>IBM Nseries</member>
+    <member>IBM ProFibre 4000R</member>
+    <member>IBM S/390 DASD ECKD</member>
+    <member>IBM S/390 DASD FBA</member>
+    <member>Intel Multi-Flex</member>
+    <member>LSI/ENGENIO INF-01-00</member>
+    <member>NEC DISK ARRAY</member>
+    <member>NETAPP LUN</member>
+    <member>NEXENTA COMSTAR</member>
+    <member>Pillar Axiom</member>
+    <member>PIVOT3 RAIGE VOLUME</member>
+    <member>SGI IS</member>
+    <member>SGI TP9100, TP 9300</member>
+    <member>SGI TP9400, TP9500</member>
+    <member>STK FLEXLINE 380</member>
+    <member>STK OPENstorage D280</member>
+    <member>SUN CSM200_R</member>
+    <member>SUN LCSM100_[IEFS]</member>
+    <member>SUN STK6580, STK6780</member>
+    <member>SUN StorEdge 3510, T4</member>
+    <member>SUN SUN_6180</member>
    </simplelist>
    <para>
     In general, most other storage arrays should work. When storage arrays are
@@ -109,7 +179,13 @@
     Storage arrays from the following vendors have been tested with
     &productname;:
    </para>
-   <simplelist><member>EMC</member><member>Hitachi</member><member>Hewlett-Packard/Compaq</member><member>IBM</member><member>NetApp</member><member>SGI</member>
+   <simplelist>
+    <member>EMC</member>
+    <member>Hitachi</member>
+    <member>Hewlett-Packard/Compaq</member>
+    <member>IBM</member>
+    <member>NetApp</member>
+    <member>SGI</member>
    </simplelist>
    <para>
     Most other vendor storage arrays should also work. Consult your vendor’s
@@ -1732,14 +1808,12 @@ blacklist_exceptions {
    <para>
     Starting with &productname; 12 SP2, the multipath tools support the option
     <literal>find_multipaths</literal> in the <literal>defaults</literal>
-    section of <filename>/etc/multipath.conf</filename>. Simply put, this
-    option prevents multipath and
-    <systemitem
-     class="daemon">multipathd</systemitem> from setting up
-    multipath maps for devices with only a single path (see the <command>man 5
-    multipath.conf</command> for details). In certain configurations, this may
-    save the administrator from the effort of creating blacklist entries, for
-    example for local SATA disks.
+    section of <filename>/etc/multipath.conf</filename>. This option prevents
+    multipath and <systemitem class="daemon">multipathd</systemitem> from
+    setting up multipath maps for devices with only a single path (see 
+    <command>man 5 multipath.conf</command> for details). In certain
+    configurations, this may save the administrator from needing to create
+    blacklist entries, for example for local SATA disks.
    </para>
    <para>
     Convenient as it seems at first, using the
@@ -3833,7 +3907,11 @@ umount /mnt</screen>
     <para>
      For example:
     </para>
-    <simplelist><member><literal>Number Major Minor RaidDevice State</literal></member><member><literal>0 253 0 0 active sync /dev/dm-0</literal></member><member><literal>1 253 1 1 active sync /dev/dm-1</literal></member><member><literal>2 253 2 2 active sync /dev/dm-2</literal></member>
+    <simplelist>
+     <member><literal>Number Major Minor RaidDevice State</literal></member>
+     <member><literal>0 253 0 0 active sync /dev/dm-0</literal></member>
+     <member><literal>1 253 1 1 active sync /dev/dm-1</literal></member>
+     <member><literal>2 253 2 2 active sync /dev/dm-2</literal></member>
     </simplelist>
    </step>
   </procedure>

--- a/xml/storage_multipath.xml
+++ b/xml/storage_multipath.xml
@@ -2681,11 +2681,13 @@ prio_args "hbtl 1:.:.:. 2 4:.:.:. 4"</screen>
        <para>
         <literal>base_num</literal> is the logarithmic base number, used to
         partition different priority ranks. Valid values are integers from 2 to
-        10. The maximum average latency value is 100s, the minimum is 1&nbsp;&mu;s.
-        For example, if <literal>base_num=10</literal>, the paths will begrouped
-        in priority groups with path latency &lt;=1&nbsp;&mu;s, (1&nbsp;&mu;s,
-        10&nbsp;&mu;s], (10&nbsp;&mu;s, 100&nbsp;&mu;s), (100&nbsp;&mu;s, 1ms),
-        (1ms, 10ms), (10ms, 100ms), (100ms, 1s), (1s, 10s), (10s, 100s), >100s.
+        10. The maximum average latency value is 100s, the minimum is
+        1&nbsp;&mu;s. For example, if <literal>base_num=10</literal>, the paths
+        will begrouped in priority groups with path latency &lt;=1&nbsp;&mu;s,
+        (1&nbsp;&mu;s, 10&nbsp;&mu;s], (10&nbsp;&mu;s, 100&nbsp;&mu;s),
+        (100&nbsp;&mu;s, 1&nbsp;ms), (1&nbsp;ms, 10&nbsp;ms), (10&nbsp;ms,
+        100&nbsp;ms), (100&nbsp;ms, 1&nbsp;s), (1&nbsp;s, 10&nbsp;s),
+        (10&nbsp;s, 100&nbsp;s), >100&nbsp;s.
        </para>
       </listitem>
      </varlistentry>

--- a/xml/storage_multipath.xml
+++ b/xml/storage_multipath.xml
@@ -2757,7 +2757,7 @@ prio_args "hbtl 1:.:.:. 2 4:.:.:. 4"</screen>
         partition different priority ranks. Valid values are integers from 2 to
         10. The maximum average latency value is 100s, the minimum is
         1&nbsp;&mu;s. For example, if <literal>base_num=10</literal>, the paths
-        will begrouped in priority groups with path latency &lt;=1&nbsp;&mu;s,
+        will be grouped in priority groups with path latency &lt;=1&nbsp;&mu;s,
         (1&nbsp;&mu;s, 10&nbsp;&mu;s], (10&nbsp;&mu;s, 100&nbsp;&mu;s),
         (100&nbsp;&mu;s, 1&nbsp;ms), (1&nbsp;ms, 10&nbsp;ms), (10&nbsp;ms,
         100&nbsp;ms), (100&nbsp;ms, 1&nbsp;s), (1&nbsp;s, 10&nbsp;s),

--- a/xml/storage_multipath.xml
+++ b/xml/storage_multipath.xml
@@ -63,77 +63,7 @@
     The <filename>multipath-tools</filename> package automatically detects the
     following storage arrays:
    </para>
-   <simplelist>
-    <member>3PARdata VV</member>
-    <member>AIX NVDISK</member>
-    <member>AIX VDASD</member>
-    <member>APPLE Xserve RAID</member>
-    <member>COMPELNT Compellent Vol</member>
-    <member>COMPAQ/HP HSV101, HSV111, HSV200, HSV210, HSV300, HSV400, HSV 450</member>
-    <member>COMPAQ/HP MSA, HSV</member>
-    <member>COMPAQ/HP MSA VOLUME</member>
-    <member>DataCore SANmelody</member>
-    <member>DDN SAN DataDirector</member>
-    <member>DEC HSG80</member>
-    <member>DELL MD3000</member>
-    <member>DELL MD3000i</member>
-    <member>DELL MD32xx</member>
-    <member>DELL MD32xxi</member>
-    <member>DGC</member>
-    <member>EMC Clariion</member>
-    <member>EMC Invista</member>
-    <member>EMC SYMMETRIX</member>
-    <member>EUROLOGC FC2502</member>
-    <member>FSC CentricStor</member>
-    <member>FUJITSU ETERNUS_DX, DXL, DX400, DX8000</member>
-    <member>HITACHI DF</member>
-    <member>HITACHI/HP OPEN</member>
-    <member>HP A6189A</member>
-    <member>HP HSVX700</member>
-    <member>HP LOGICAL VOLUME</member>
-    <member>HP MSA2012fc, MSA 2212fc, MSA2012i</member>
-    <member>HP MSA2012sa, MSA2312 fc/i/sa, MCA2324 fc/i/sa, MSA2000s VOLUME</member>
-    <member>HP P2000 G3 FC|P2000G3 FC/iSCSI|P2000 G3 SAS|P2000 G3 iSCSI</member>
-    <member>IBM 1722-600</member>
-    <member>IBM 1724</member>
-    <member>IBM 1726</member>
-    <member>IBM 1742</member>
-    <member>IBM 1745, 1746</member>
-    <member>IBM 1750500</member>
-    <member>IBM 1814</member>
-    <member>IBM 1815</member>
-    <member>IBM 1818</member>
-    <member>IBM 1820N00</member>
-    <member>IBM 2105800</member>
-    <member>IBM 2105F20</member>
-    <member>IBM 2107900</member>
-    <member>IBM 2145</member>
-    <member>IBM 2810XIV</member>
-    <member>IBM 3303 NVDISK</member>
-    <member>IBM 3526</member>
-    <member>IBM 3542</member>
-    <member>IBM IPR</member>
-    <member>IBM Nseries</member>
-    <member>IBM ProFibre 4000R</member>
-    <member>IBM S/390 DASD ECKD</member>
-    <member>IBM S/390 DASD FBA</member>
-    <member>Intel Multi-Flex</member>
-    <member>LSI/ENGENIO INF-01-00</member>
-    <member>NEC DISK ARRAY</member>
-    <member>NETAPP LUN</member>
-    <member>NEXENTA COMSTAR</member>
-    <member>Pillar Axiom</member>
-    <member>PIVOT3 RAIGE VOLUME</member>
-    <member>SGI IS</member>
-    <member>SGI TP9100, TP 9300</member>
-    <member>SGI TP9400, TP9500</member>
-    <member>STK FLEXLINE 380</member>
-    <member>STK OPENstorage D280</member>
-    <member>SUN CSM200_R</member>
-    <member>SUN LCSM100_[IEFS]</member>
-    <member>SUN STK6580, STK6780</member>
-    <member>SUN StorEdge 3510, T4</member>
-    <member>SUN SUN_6180</member>
+   <simplelist><member>3PARdata VV</member><member>AIX NVDISK</member><member>AIX VDASD</member><member>APPLE Xserve RAID</member><member>COMPELNT Compellent Vol</member><member>COMPAQ/HP HSV101, HSV111, HSV200, HSV210, HSV300, HSV400, HSV 450</member><member>COMPAQ/HP MSA, HSV</member><member>COMPAQ/HP MSA VOLUME</member><member>DataCore SANmelody</member><member>DDN SAN DataDirector</member><member>DEC HSG80</member><member>DELL MD3000</member><member>DELL MD3000i</member><member>DELL MD32xx</member><member>DELL MD32xxi</member><member>DGC</member><member>EMC Clariion</member><member>EMC Invista</member><member>EMC SYMMETRIX</member><member>EUROLOGC FC2502</member><member>FSC CentricStor</member><member>FUJITSU ETERNUS_DX, DXL, DX400, DX8000</member><member>HITACHI DF</member><member>HITACHI/HP OPEN</member><member>HP A6189A</member><member>HP HSVX700</member><member>HP LOGICAL VOLUME</member><member>HP MSA2012fc, MSA 2212fc, MSA2012i</member><member>HP MSA2012sa, MSA2312 fc/i/sa, MCA2324 fc/i/sa, MSA2000s VOLUME</member><member>HP P2000 G3 FC|P2000G3 FC/iSCSI|P2000 G3 SAS|P2000 G3 iSCSI</member><member>IBM 1722-600</member><member>IBM 1724</member><member>IBM 1726</member><member>IBM 1742</member><member>IBM 1745, 1746</member><member>IBM 1750500</member><member>IBM 1814</member><member>IBM 1815</member><member>IBM 1818</member><member>IBM 1820N00</member><member>IBM 2105800</member><member>IBM 2105F20</member><member>IBM 2107900</member><member>IBM 2145</member><member>IBM 2810XIV</member><member>IBM 3303 NVDISK</member><member>IBM 3526</member><member>IBM 3542</member><member>IBM IPR</member><member>IBM Nseries</member><member>IBM ProFibre 4000R</member><member>IBM S/390 DASD ECKD</member><member>IBM S/390 DASD FBA</member><member>Intel Multi-Flex</member><member>LSI/ENGENIO INF-01-00</member><member>NEC DISK ARRAY</member><member>NETAPP LUN</member><member>NEXENTA COMSTAR</member><member>Pillar Axiom</member><member>PIVOT3 RAIGE VOLUME</member><member>SGI IS</member><member>SGI TP9100, TP 9300</member><member>SGI TP9400, TP9500</member><member>STK FLEXLINE 380</member><member>STK OPENstorage D280</member><member>SUN CSM200_R</member><member>SUN LCSM100_[IEFS]</member><member>SUN STK6580, STK6780</member><member>SUN StorEdge 3510, T4</member><member>SUN SUN_6180</member>
    </simplelist>
    <para>
     In general, most other storage arrays should work. When storage arrays are
@@ -179,13 +109,7 @@
     Storage arrays from the following vendors have been tested with
     &productname;:
    </para>
-   <simplelist>
-    <member>EMC</member>
-    <member>Hitachi</member>
-    <member>Hewlett-Packard/Compaq</member>
-    <member>IBM</member>
-    <member>NetApp</member>
-    <member>SGI</member>
+   <simplelist><member>EMC</member><member>Hitachi</member><member>Hewlett-Packard/Compaq</member><member>IBM</member><member>NetApp</member><member>SGI</member>
    </simplelist>
    <para>
     Most other vendor storage arrays should also work. Consult your vendor’s
@@ -364,7 +288,8 @@
     that the <filename>initrd</filename> and the installed system behave the
     same regarding the root file system and all other file systems required to
     boot the system. If Multipath is enabled in the system, it also needs to be
-    enabled in the <filename>initrd</filename> and vice versa. See <xref
+    enabled in the <filename>initrd</filename> and vice versa. See
+    <xref
      linkend="sec-multipath-configuration-start"/> for details.
    </para>
    <para>
@@ -1276,7 +1201,8 @@
     <step>
      <para>
       When finished, save <filename>/etc/multipath.conf</filename> and test
-      your settings as described in <xref
+      your settings as described in
+      <xref
        linkend="sec-multipath-conf-file-verify"/>.
      </para>
     </step>
@@ -1498,8 +1424,8 @@ sdf: state = 2
    <para>
     Changes to the <filename>/etc/multipath.conf</filename> file cannot take
     effect when <command>multipathd</command> is running. After you make
-    changes, save and close the file, then run the following commands 
-    to apply the changes and update the multipath maps:
+    changes, save and close the file, then run the following commands to apply
+    the changes and update the multipath maps:
    </para>
    <procedure>
     <step>
@@ -1507,7 +1433,7 @@ sdf: state = 2
       Apply your configuration changes:
      </para>
 <screen>&prompt.sudo;multipathd reconfigure</screen>
-    </step>   
+    </step>
     <step>
      <para>
       Run <command>dracut -f</command> to re-create the
@@ -1807,7 +1733,8 @@ blacklist_exceptions {
     Starting with &productname; 12 SP2, the multipath tools support the option
     <literal>find_multipaths</literal> in the <literal>defaults</literal>
     section of <filename>/etc/multipath.conf</filename>. Simply put, this
-    option prevents multipath and <systemitem
+    option prevents multipath and
+    <systemitem
      class="daemon">multipathd</systemitem> from setting up
     multipath maps for devices with only a single path (see the <command>man 5
     multipath.conf</command> for details). In certain configurations, this may
@@ -2328,9 +2255,10 @@ multipaths {
        After you have modified the <filename>/etc/multipath.conf</filename>
        file, you must run <command>dracut</command> <option>-f</option> to
        re-create the <filename>initrd</filename> on your system, then restart
-       the node for the changes to take effect. See <xref
-        linkend="sec-multipath-conf-file-apply"/> for details. This applies to
-       all affected nodes.
+       the node for the changes to take effect. See
+       <xref
+        linkend="sec-multipath-conf-file-apply"/> for details.
+       This applies to all affected nodes.
       </para>
      </step>
     </procedure>
@@ -2666,8 +2594,8 @@ prio_args ""</screen>
            </entry>
            <entry>
             <para>
-             Generates the path priority based on a latency algorithm, which
-             is configured with the <literal>prio_args</literal> keyword.
+             Generates the path priority based on a latency algorithm, which is
+             configured with the <literal>prio_args</literal> keyword.
             </para>
            </entry>
           </row>
@@ -2676,97 +2604,92 @@ prio_args ""</screen>
        </informaltable>
       </listitem>
      </varlistentry>
- </variablelist>
-
-<bridgehead><literal>prio_args</literal> arguments</bridgehead>
+    </variablelist>
+    <bridgehead><literal>prio_args</literal> arguments</bridgehead>
     <para>
-        These are the arguments for the prioritizer programs that
-        require arguments. Most <literal>prio</literal> programs do not need
-        arguments. There is no default. The values depend on the <literal>prio</literal>
-        setting and whether the prioritizer requires any of the following arguments:
-      </para>
-   <variablelist>
-       <varlistentry>
-           <term>weighted</term>
-             <listitem>
-               <para>
-              Requires a value of the form
-             <literal>[hbtl|devname|serial|wwn]</literal>
-             <replaceable>REGEX1</replaceable> <replaceable>PRIO1</replaceable>
-             <replaceable>REGEX2</replaceable>
-             <replaceable>PRIO2</replaceable>...
-                </para>
-             <para>
-             Regex must be of SCSI H:B:T:L format, for example 1:0:.:.
-             and *:0:0:., with a weight value, where H, B, T, L are the
-             host, bus, target, and LUN  IDs for a device. For example:
-             </para>
-             <screen>prio "weightedpath"
-prio_args "hbtl 1:.:.:. 2 4:.:.:. 4"</screen>            
-        </listitem>
-    </varlistentry>
-    <varlistentry>
-        <term>devname</term>
-        <listitem>
-            <para>
-                Regex is in device name format. For example: sda, sd.e
-            </para>
-        </listitem>
-    </varlistentry>
-    <varlistentry>
-        <term>serial</term>
-        <listitem>
-            <para>
-             Regex is in serial number format. For example: .*J1FR.*324. Look up your serial
-             number with the <command>multipathd show paths format %z</command> 
-             command.
-             (<command>multipathd show wildcards</command> displays all 
-             <literal>format</literal> wildcards.)
-            </para>
-        </listitem>
-    </varlistentry>
-
-    <varlistentry>
-        <term>alua</term>
-        <listitem>
-            <para>
-                If <literal>exclusive_pref_bit</literal> is set for a device 
-                (<literal>alua exclusive_pref_bit</literal>), paths with
-                the <literal>preferred path</literal> bit set will 
-                always be in their own path group.
-            </para>
-        </listitem>
-    </varlistentry>    
-
-<varlistentry>
-    <term>path_latency</term>
-     <listitem>
-          <para>
-               <literal>path_latency</literal> adjusts latencies
-                between remote and local storage arrays, if both arrays
-                use the same type of hardware. Usually the latency on 
-                the remote array will be higher, so you can tune the latency 
-                to bring them closer together. This requires a value pair of the form 
-                <literal>io_num=<replaceable>20</replaceable> 
-                base_num=<replaceable>10</replaceable></literal>.
-            </para>
-            <para>
-                <literal>io_num</literal> is the number of read IOs sent to the current path 
-                continuously, which are used to calculate the average path latency. Valid values 
-                are integers from  2 to 200.
-            </para>
-            <para>   
-              <literal>base_num</literal> is the logarithmic base number, 
-              used to partition different priority ranks. Valid values are integer from 2 - 10. The 
-              maximum average latency value is 100s, the minimum is 1us. For example,  
-              if  <literal>base_num=10</literal>, the paths will be grouped in priority groups with 
-               path  latency &lt;=1us, (1us, 10us], (10us, 100us], (100us, 1ms], 
-              (1ms, 10ms], (10ms, 100ms], (100ms, 1s], (1s, 10s], (10s, 100s], >100s
-             </para>
-        </listitem>
-    </varlistentry>
-</variablelist>
-  
+     These are the arguments for the prioritizer programs that require
+     arguments. Most <literal>prio</literal> programs do not need arguments.
+     There is no default. The values depend on the <literal>prio</literal>
+     setting and whether the prioritizer requires any of the following
+     arguments:
+    </para>
+    <variablelist>
+     <varlistentry>
+      <term>weighted</term>
+      <listitem>
+       <para>
+        Requires a value of the form
+        <literal>[hbtl|devname|serial|wwn]</literal>
+        <replaceable>REGEX1</replaceable> <replaceable>PRIO1</replaceable>
+        <replaceable>REGEX2</replaceable> <replaceable>PRIO2</replaceable>...
+       </para>
+       <para>
+        Regex must be of SCSI H:B:T:L format, for example 1:0:.:. and *:0:0:.,
+        with a weight value, where H, B, T, L are the host, bus, target, and
+        LUN IDs for a device. For example:
+       </para>
+<screen>prio "weightedpath"
+prio_args "hbtl 1:.:.:. 2 4:.:.:. 4"</screen>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>devname</term>
+      <listitem>
+       <para>
+        Regex is in device name format. For example: sda, sd.e
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>serial</term>
+      <listitem>
+       <para>
+        Regex is in serial number format. For example: .*J1FR.*324. Look up
+        your serial number with the <command>multipathd show paths format
+        %z</command> command. (<command>multipathd show wildcards</command>
+        displays all <literal>format</literal> wildcards.)
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>alua</term>
+      <listitem>
+       <para>
+        If <literal>exclusive_pref_bit</literal> is set for a device
+        (<literal>alua exclusive_pref_bit</literal>), paths with the
+        <literal>preferred path</literal> bit set will always be in their own
+        path group.
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>path_latency</term>
+      <listitem>
+       <para>
+        <literal>path_latency</literal> adjusts latencies between remote and
+        local storage arrays if both arrays use the same type of hardware.
+        Usually the latency on the remote array will be higher, so you can tune
+        the latency to bring them closer together. This requires a value pair
+        of the form <literal>io_num=<replaceable>20</replaceable>
+        base_num=<replaceable>10</replaceable></literal>.
+       </para>
+       <para>
+        <literal>io_num</literal> is the number of read IOs sent to the current
+        path continuously, which are used to calculate the average path
+        latency. Valid values are integers from 2 to 200.
+       </para>
+       <para>
+        <literal>base_num</literal> is the logarithmic base number, used to
+        partition different priority ranks. Valid values are integers from 2 to
+        10. The maximum average latency value is 100s, the minimum is 1&nbsp;&mu;s.
+        For example, if <literal>base_num=10</literal>, the paths will begrouped
+        in priority groups with path latency &lt;=1&nbsp;&mu;s, (1&nbsp;&mu;s,
+        10&nbsp;&mu;s], (10&nbsp;&mu;s, 100&nbsp;&mu;s), (100&nbsp;&mu;s, 1ms),
+        (1ms, 10ms), (10ms, 100ms), (100ms, 1s), (1s, 10s), (10s, 100s), >100s.
+       </para>
+      </listitem>
+     </varlistentry>
+    </variablelist>
     <bridgehead>Multipath Attributes</bridgehead>
     <para>
      Multipath attributes are used to control the behavior of multipath I/O for
@@ -3908,11 +3831,7 @@ umount /mnt</screen>
     <para>
      For example:
     </para>
-    <simplelist>
-     <member><literal>Number Major Minor RaidDevice State</literal></member>
-     <member><literal>0 253 0 0 active sync /dev/dm-0</literal></member>
-     <member><literal>1 253 1 1 active sync /dev/dm-1</literal></member>
-     <member><literal>2 253 2 2 active sync /dev/dm-2</literal></member>
+    <simplelist><member><literal>Number Major Minor RaidDevice State</literal></member><member><literal>0 253 0 0 active sync /dev/dm-0</literal></member><member><literal>1 253 1 1 active sync /dev/dm-1</literal></member><member><literal>2 253 2 2 active sync /dev/dm-2</literal></member>
     </simplelist>
    </step>
   </procedure>

--- a/xml/storage_nvmeof.xml
+++ b/xml/storage_nvmeof.xml
@@ -350,13 +350,13 @@ Parameter traddr is now '10.0.0.1'.</screen>
    </para>
    <screen>&prompt.user;cat /sys/module/qla2xxx/parameters/ql2xnvmeenable</screen>
    <para>
-    A resulting <literal>1</literal> suggests &nvme; is enabled, a
+    A resulting <literal>1</literal> means &nvme; is enabled, a
     <literal>0</literal> indicates it is disabled.
    </para>
 
    <para>
-    Next, ensure that the Marvell adapter firmware has at least version
-    8.08.204 by checking the output of the following commend:
+    Next, ensure that the Marvell adapter firmware is at least version
+    8.08.204 by checking the output of the following command:
    </para>
    <screen>&prompt.user;cat /sys/class/scsi_host/host0/fw_version</screen>
 

--- a/xml/storage_raid-leds.xml
+++ b/xml/storage_raid-leds.xml
@@ -821,7 +821,7 @@
    </para>
 <screen>&prompt.sudo;ledctl off={ /dev/sda /dev/sdb }</screen>
    <para>
-    To locate three block devices run one of the following commends (both are
+    To locate three block devices, run one of the following commands (both are
     equivalent):
    </para>
 <screen>&prompt.sudo;ledctl locate=/dev/sda,/dev/sdb,/dev/sdc


### PR DESCRIPTION
### Description
Incorporate Dublin's requested changes to the Storage Guide.

2 important notes:
• I found additional uses of "commend" in place of "command" and fixed them. I also fixed some missing punctuation.
• I reformatted the storage_multipath.xml file as the formatting was strange. I also fixed a set of broken ranges with mismatched parentheses: (1-10], (10-20] etc. I have also found this typo in the Debian and Ubuntu docs; I think nobody dared to question it.

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
