### PR TITLE
Unmount removable devices (bsc#1079637)

### DIFF
--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -4081,15 +4081,15 @@ drwxrwxrwt 18 root root 16384 Dec 23 22:20 /tmp</screen>
      <step>
       <para>
        Create a user group whose users will be allowed to mount and eject
-       removable devices, for example <systemitem>mmedia_all</systemitem>:
+       removable devices, for example <replaceable>mmedia_all</replaceable>:
       </para>
-<screen>&prompt.sudo;groupadd mmedia_all</screen>
+<screen>&prompt.sudo;groupadd <replaceable>mmedia_all</replaceable></screen>
      </step>
      <step>
       <para>
        Add a specific user &exampleuser; to the new group:
       </para>
-<screen>&prompt.sudo;usermod -a -G mmedia_all &exampleuser;</screen>
+<screen>&prompt.sudo;usermod -a -G <replaceable>mmedia_all</replaceable> &exampleuser;</screen>
      </step>
      <step>
       <para>
@@ -4100,14 +4100,14 @@ drwxrwxrwt 18 root root 16384 Dec 23 22:20 /tmp</screen>
 &prompt.user;cat /etc/polkit-1/rules.d/10-mount.rules
 polkit.addRule(function(action, subject) {
  if (action.id =="org.freedesktop.udisks2.eject-media"
-  &amp;&amp; subject.isInGroup("mmedia_all")) {
+  &amp;&amp; subject.isInGroup("<replaceable>mmedia_all</replaceable>")) {
    return polkit.Result.YES;
   }
 });
 
 polkit.addRule(function(action, subject) {
  if (action.id =="org.freedesktop.udisks2.filesystem-mount"
-  &amp;&amp; subject.isInGroup("mmedia_all")) {
+  &amp;&amp; subject.isInGroup("<replaceable>mmedia_all</replaceable>")) {
    return polkit.Result.YES;
   }
 });

--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -4080,48 +4080,52 @@ drwxrwxrwt 18 root root 16384 Dec 23 22:20 /tmp</screen>
     <procedure>
      <step>
       <para>
-       Create a rules file
-       <filename>/etc/polkit-1/rules.d/01-restrict-removable-media.rules</filename>
-       similar to the following:
+       Create a user group whose users will be allowed to mount and eject
+       removable devices, for example <systemitem>mmedia_all</systemitem>:
       </para>
-      <screen>// Allow users in group 'mmedia_all' to mount/unmount all type of drives
-// Allow users in group 'mmedia_removable' to mount/umount USB storage drives
-// Allow users in group 'mmedia_optical' to mount/unmount Optical drives
+<screen>&prompt.sudo;groupadd mmedia_all</screen>
+     </step>
+     <step>
+      <para>
+       Add a specific user &exampleuser; to the new group:
+      </para>
+<screen>&prompt.sudo;usermod -a -G mmedia_all &exampleuser;</screen>
+     </step>
+     <step>
+      <para>
+       Create the <filename>/etc/polkit-1/rules.d/10-mount.rules</filename>
+       file with the following content:
+      </para>
+<screen>
+&prompt.user;cat /etc/polkit-1/rules.d/10-mount.rules
 polkit.addRule(function(action, subject) {
-  if (/^org\.freedesktop\.udisks2\.filesystem-.*mount.*$/.test(action.id) &amp;&amp;
-  action.lookup("drive.removable") == "true") {
-    if (subject.isInGroup("mmedia_all")) {
-      return polkit.Result.YES;
-    } else {
-      if (/.*optical.*/.test(action.lookup("drive.removable.media"))) {
-        if (subject.isInGroup("mmedia_optical"))
-        return polkit.Result.YES;
-      } else if (/.*floppy.*/.test(action.lookup("drive.removable.media"))) {
-        return polkit.Result.NO;
-      } else if (action.lookup("drive.removable.bus") == "usb") {
-        if (subject.isInGroup("mmedia_removable"))
-        return polkit.Result.YES;
-      }
-      return polkit.Result.NO;
-    }
+ if (action.id =="org.freedesktop.udisks2.eject-media"
+  &amp;&amp; subject.isInGroup("mmedia_all")) {
+   return polkit.Result.YES;
   }
-});</screen>
+});
 
+polkit.addRule(function(action, subject) {
+ if (action.id =="org.freedesktop.udisks2.filesystem-mount"
+  &amp;&amp; subject.isInGroup("mmedia_all")) {
+   return polkit.Result.YES;
+  }
+});
+</screen>
       <important>
        <title>Naming of the Rules File</title>
        <para>
-        Rules files are processed in alphabetical order. Functions are called
-        in the order they were added until one of the functions returns a
-        value. Hence, to add an authorization rule that is processed before
-        other rules, put it in a file in /etc/polkit-1/rules.d with a name
-        that sorts before other rules files, for example
-        <filename>01-restrict-removable-media.rules</filename>. Each function
-        should return a value from <literal>polkit.Result</literal>.
-       </para>
-       <para>
-        <!-- http://doccomments.provo.novell.com/comments/29432 -->
         The name of a rules file must start with a digit, otherwise it
         will be ignored.
+       </para>
+       <para>
+        Rules files are processed in alphabetical order. Functions are called
+        in the order they were added until one of the functions returns a
+        value. Therefore, to add an authorization rule that is processed before
+        other rules, put it in a file in /etc/polkit-1/rules.d with a name
+        that sorts before other rules files, for example
+        <filename>/etc/polkit-1/rules.d/10-mount.rules</filename>. Each function
+        should return a value from <literal>polkit.Result</literal>.
        </para>
       </important>
      </step>
@@ -4136,17 +4140,6 @@ polkit.addRule(function(action, subject) {
        Restart <systemitem>polkit</systemitem>
       </para>
 <screen>&prompt.root;systemctl restart polkit</screen>
-     </step>
-     <step>
-      <para>
-       In &yast;, click <menuchoice><guimenu>Security and
-       Users</guimenu><guimenu>User and Group
-       Management</guimenu><guimenu>Groups</guimenu></menuchoice> to create
-       the three groups <literal>mmedia_all</literal>,
-       <literal>mmedia_optical</literal>, and
-       <literal>mmedia_removable</literal>. Then add the users to these
-       groups as wanted.
-      </para>
      </step>
     </procedure>
    </sect1>


### PR DESCRIPTION
This update fixes a rule to unmount removable devices without root password prompt.

- [x] To maintenance/SLE15SP2 (master)
- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [x] To maintenance/SLE12SP4
- [x] To maintenance/SLE12SP3
