### PR TITLE
Auto-balooning disabled by default (jsc#SLE-4267)

### DIFF
--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -3136,81 +3136,8 @@ polkit.addRule(function(action, subject) {
     </procedure>
    </sect1>
 <!-- ============================================================== -->
-   <sect1 xml:id="sec-sec-prot-general-accounts">
-    <title>Various Account Checks</title>
-
-    <para/>
-
-    <sect2 xml:id="sec-sec-prot-general-accounts-unlocked">
-     <title>Unlocked Accounts</title>
-     <para>
-      It is important that all system and vendor accounts that are not used
-      for logins are locked. To get a list of unlocked accounts on your
-      system, you can check for accounts that do <emphasis>not</emphasis>
-      have an encrypted password string starting with <literal>!</literal>
-      or <literal>*</literal> in the <filename>/etc/shadow</filename> file.
-      If you lock an account using <command>passwd</command>
-      <option>-l</option>, it will put a <literal>!!</literal> in front of
-      the encrypted password, effectively disabling the password. If you
-      lock an account using <command>usermod</command> <option>-L</option>,
-      it will put a <literal>!</literal> in front of the encrypted password.
-      Many system and shared accounts are usually locked by default by
-      having a <literal>*</literal> or <literal>!!</literal> in the password
-      field which renders the encrypted password into an invalid string.
-      Hence, to get a list of all unlocked (encryptable) accounts, run
-      (<command>egrep</command> is used to allow use of
-      regular-expressions):
-     </para>
-<screen>&prompt.root;egrep -v ':\*|:\!' /etc/shadow | awk -F: '{print $1}'</screen>
-     <para>
-      Also make sure all accounts have a <literal>x</literal> in the
-      password field in <filename>/etc/passwd</filename>. The following
-      command lists all accounts that do not have a <literal>x</literal> in
-      the password field:
-     </para>
-<screen>&prompt.root;grep -v ':x:' /etc/passwd</screen>
-     <para>
-      An <literal>x</literal> in the password fields means that the password
-      has been shadowed, for example the encrypted password needs to be
-      looked up in the <filename>/etc/shadow</filename> file. If the
-      password field in <filename>/etc/passwd</filename> is empty, then the
-      system will not look up the shadow file and it will not prompt the user
-      for a password at the login prompt.
-     </para>
-    </sect2>
-
-    <sect2 xml:id="sec-sec-prot-general-accounts-unused">
-     <title>Unused Accounts</title>
->>>>>>> dca25a881... Unmount removable devices (bsc#1079637) (#594)
-     <para>
-      Restart <systemitem>udisks2</systemitem>:
-     </para>
-     <screen>&prompt.root;systemctl restart udisks2</screen>
-    </step>
-    <step>
-     <para>
-      Restart <systemitem>polkit</systemitem>
-     </para>
-     <screen>&prompt.root;systemctl restart polkit</screen>
-    </step>
-    <step>
-     <para>
-      In &yast;, click <menuchoice><guimenu>Security and
-      Users</guimenu><guimenu>User and Group
-      Management</guimenu><guimenu>Groups</guimenu></menuchoice> to create the
-      three groups <literal>mmedia_all</literal>,
-      <literal>mmedia_optical</literal>, and
-      <literal>mmedia_removable</literal>. Then add the users to these groups
-      as wanted.
-     </para>
-    </step>
-   </procedure>
-  </sect1>
-<!-- ============================================================== -->
   <sect1 xml:id="sec-sec-prot-general-accounts">
    <title>Various Account Checks</title>
-
-   <para/>
 
    <sect2 xml:id="sec-sec-prot-general-accounts-unlocked">
     <title>Unlocked Accounts</title>

--- a/xml/vt_best_practices.xml
+++ b/xml/vt_best_practices.xml
@@ -438,88 +438,23 @@ always madvise [never]</screen>
     <sect4 xml:id="sec-vt-best-mem-xen-dom-0">
      <title>Managing Domain-0 Memory</title>
      <para>
-      When using the &xen; hypervisor, by default a small percentage of system
-      memory is reserved for the hypervisor. All remaining memory is
-      automatically allocated to Domain-0. When virtual machines are created,
-      memory is ballooned out of Domain-0 to provide memory for the virtual
-      machine. This process is called "autoballooning".
+      In previous versions of &sls;, the default memory allocation scheme of a
+      &xen; host was to allocate all host physical memory to &dom0; and enable
+      auto-ballooning. Memory was automatically ballooned from &dom0; when
+      additional domains were started. This behavior has always been error
+      prone and disabling it was strongly encouraged. Starting in &sls; 15 SP1,
+      auto-ballooning has been disabled by default and &dom0; is given 10% of
+      host physical memory + 1GB. For example, on a host with 32GB of physical
+      memory, 4.2GB of memory is allocated for &dom0;.
      </para>
      <para>
-      Autoballooning has several limitations:
-     </para>
-     <itemizedlist>
-      <listitem>
-       <para>
-        Reduced performance while dom0 is ballooning down to free memory for
-        the new domain.
-       </para>
-      </listitem>
-      <listitem>
-       <para>
-        Memory freed by ballooning is not confined to a specific NUMA node.
-        This can result in performance problems in the new domain because of
-        using a non-optimal NUMA configuration.
-       </para>
-      </listitem>
-      <listitem>
-       <para>
-        Failure to start large domains because of delays while ballooning large
-        amounts of memory from dom0.
-       </para>
-      </listitem>
-     </itemizedlist>
-     <para>
-      For these reasons, we strongly recommend to disable autoballooning and
-      give Domain-0 the memory needed for its workload. Determining Domain-0
-      memory and vCPU sizing should follow a similar process as any other
-      virtual machine.
-     </para>
-     <para>
-      Autoballooning is controlled by the toolstack used to manage your &xen;
-      installation. For the xl/libxl toolstack, autoballooning is controlled by
+      The use of <option>dom0_mem</option> &xen; command line option in
+      <filename>/etc/default/grub</filename> is still supported and encouraged
+      (see <xref linkend="sec-vt-best-kernel-parameter"/> for more
+      information). You can restore the old behavior by setting
+      <option>dom0_mem</option> to the host physical memory size and enabling
       the <option>autoballoon</option> setting in
-      <filename>/etc/xen/xl.conf</filename>. For the libvirt+libxl toolstack,
-      autoballooning is controlled by the <option>autoballoon</option> setting
-      in <filename>/etc/libvirt/libxl.conf</filename>.
-     </para>
-     <para>
-      The amount of memory initially allocated to Domain-0 is controlled by the
-      &xen; hypervisor dom0_mem parameter. For example, to set the initial
-      memory allocation of Domain-0 to 8GB, add <option>dom0_mem=8G</option> to
-      the &xen; hypervisor parameters. The dom0_mem parameter can also be used
-      to specify the minimum and maximum memory allocations for Domain-0. For
-      example, to set the initial memory of Domain-0 to 8GB, but allow it to be
-      changed (ballooned) anywhere between 4GB and 16GB, add the following to
-      the &xen; hypervisor parameters:
-      <option>dom0_mem=8G,min:4G,max:8G</option>.
-     </para>
-     <itemizedlist>
-      <listitem>
-       <para>
-        To set dom0_mem on &slea; 11 products, modify
-        <filename>/boot/grub/menu.lst</filename>, adding
-        <option>dom0_mem=XX</option> to the &xen; hypervisor (xen.gz)
-        parameters. The change will be applied at next reboot.
-       </para>
-      </listitem>
-      <listitem>
-       <para>
-        To set dom0_mem on &slea; 12 and 15 products, modify
-        <filename>/etc/default/grub</filename>, adding
-        <option>dom0_mem=XX</option> to
-        <option>GRUB_CMDLINE_XEN_DEFAULT</option>. See
-        <xref
-        linkend="sec-vt-best-kernel-parameter"/> for more
-        information.
-       </para>
-      </listitem>
-     </itemizedlist>
-     <para>
-      Autoballooning is enabled by default since it is extremely difficult to
-      determine a predefined amount of memory required by Domain-0. Memory
-      needed by Domain-0 is heavily dependent on the number of hosted virtual
-      machines and their configuration. Users must ensure Domain-0 has
-      sufficient memory resources to accommodate virtual machine workloads.
+      <filename>/etc/xen/xl.conf</filename>.
      </para>
     </sect4>
     <sect4 xml:id="sec-vt-best-mem-xen-tmpfs">

--- a/xml/xen_virtualization_vhost.xml
+++ b/xml/xen_virtualization_vhost.xml
@@ -135,7 +135,6 @@
   <para>
    The use of <option>dom0_mem</option> &xen; command line option in
    <filename>/etc/default/grub</filename> is still supported and encouraged
-   (see <xref linkend="sec-vt-best-kernel-parameter"/> for more information).
    You can restore the old behavior by setting <option>dom0_mem</option> to the
    host physical memory size and enabling the <option>autoballoon</option>
    setting in <filename>/etc/xen/xl.conf</filename>.

--- a/xml/xen_virtualization_vhost.xml
+++ b/xml/xen_virtualization_vhost.xml
@@ -134,7 +134,7 @@
   </para>
   <para>
    The use of <option>dom0_mem</option> &xen; command line option in
-   <filename>/etc/default/grub</filename> is still supported and encouraged
+   <filename>/etc/default/grub</filename> is still supported and encouraged.
    You can restore the old behavior by setting <option>dom0_mem</option> to the
    host physical memory size and enabling the <option>autoballoon</option>
    setting in <filename>/etc/xen/xl.conf</filename>.

--- a/xml/xen_virtualization_vhost.xml
+++ b/xml/xen_virtualization_vhost.xml
@@ -123,17 +123,22 @@
   <title>Managing &dom0; Memory</title>
 
   <para>
-   In a default &xen; installation, a small percentage of system memory is
-   reserved for the hypervisor, and all remaining memory is automatically
-   allocated to &dom0;. When virtual machines are created, memory is ballooned
-   out of &dom0; to provide memory for the virtual machine. This process is
-   called "autoballooning".
+   In previous versions of &sls;, the default memory allocation scheme of a
+   &xen; host was to allocate all host physical memory to &dom0; and enable
+   auto-ballooning. Memory was automatically ballooned from &dom0; when
+   additional domains were started. This behavior has always been error prone
+   and disabling it was strongly encouraged. Starting in &sls; 15 SP1,
+   auto-ballooning has been disabled by default and &dom0; is given 10% of host
+   physical memory + 1GB. For example, on a host with 32GB of physical memory,
+   4.2GB of memory is allocated for &dom0;.
   </para>
-
   <para>
-   SUSE recommends disabling autoballooning and configuring &dom0; with
-   adequate memory. Generally 10 percent of the total system memory is
-   sufficient, with a minimum of 1 GiB and a maximum of 64 GiB.
+   The use of <option>dom0_mem</option> &xen; command line option in
+   <filename>/etc/default/grub</filename> is still supported and encouraged
+   (see <xref linkend="sec-vt-best-kernel-parameter"/> for more information).
+   You can restore the old behavior by setting <option>dom0_mem</option> to the
+   host physical memory size and enabling the <option>autoballoon</option>
+   setting in <filename>/etc/xen/xl.conf</filename>.
   </para>
 
   <warning>


### PR DESCRIPTION
### Description
This update reflects that memory auto-balooning is disabled by default since 15 SP1

### Checklist
* Check all items that apply.

*Are backports required?*

- [x] To maintenance/SLE15SP1
