### PR TITLE
'rmt-cli export repos' runs on online RMT

### DIFF
--- a/xml/rmt_rmt-cli.xml
+++ b/xml/rmt_rmt-cli.xml
@@ -319,7 +319,10 @@
     <term><command>rmt-cli export repos [path]</command></term>
     <listitem>
      <para>
-      Run this on the offline &rmt; to export RPM packages.
+      Run this regularly on the online &rmt; to mirror the set of repositories
+      specified in the <filename>repos.json</filename> at the given path. The
+      mirrored repository files will be stored in subdirectories of the same
+      path.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
### Description
The 'rmt-cli export repos' command runs on online RMT instead of offline. This update fixes that.

### Checklist
* Check all items that apply.

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
