### PR TITLE
NM connection editor not installed by default (bsc#1169867)

### DIFF
--- a/xml/nm.xml
+++ b/xml/nm.xml
@@ -146,8 +146,8 @@ http://www.heise.de/netze/artikel/WLAN-und-LAN-sichern-mit-IEEE-802-1X-und-Radiu
    <title>&nm; Connection Editor</title>
    <para>
     In previous &productname; releases, network connections were configured
-    using the application called <emphasis>&nm; Connection Editor</emphasis>.
-    It is no longer installed by default because <emphasis>&gnome; Control
+    using an application called <emphasis>&nm; Connection Editor</emphasis>.
+    This is no longer installed by default, because <emphasis>&gnome; Control
      Center</emphasis> has fully replaced its configuration capabilities.
    </para>
    <para>

--- a/xml/nm.xml
+++ b/xml/nm.xml
@@ -142,6 +142,22 @@ http://www.heise.de/netze/artikel/WLAN-und-LAN-sichern-mit-IEEE-802-1X-und-Radiu
    connections.
   </para>
 
+  <tip>
+   <title>&nm; Connection Editor</title>
+   <para>
+    In previous &productname; releases, network connections were configured
+    using the application called <emphasis>&nm; Connection Editor</emphasis>.
+    It is no longer installed by default because <emphasis>&gnome; Control
+     Center</emphasis> has fully replaced its configuration capabilities.
+   </para>
+   <para>
+    If you still need to use &nm; Connection Editor to configure network
+    connections, install the
+    <package>NetworkManager-connection-editor</package> package manually:
+   </para>
+<screen>&prompt.sudo;zypper install NetworkManager-connection-editor</screen>
+  </tip>
+
   <para>
    To open the network configuration dialog in &gnome;, open the settings menu
    via the status menu and click the <guimenu>Network</guimenu> entry.
@@ -647,14 +663,14 @@ http://www.heise.de/netze/artikel/WLAN-und-LAN-sichern-mit-IEEE-802-1X-und-Radiu
 </para>
 <para>
     User connections require every user to authenticate in &nm;, which stores
-    the user's credentials in their local GNOME keyring so they don't have to 
+    the user's credentials in their local GNOME keyring so they don't have to
     re-enter them every time they connect.
 </para>
 <para>
     System connections are available to all users automatically. The first user
     to create the connection enters any necessary credentials, and then all other
     users have access without needing to know the credentials. The difference in
-    configuring a user or system connection is a single checkbox, <guimenu>Make  
+    configuring a user or system connection is a single checkbox, <guimenu>Make
     available to other users</guimenu>.
     For information on how to configure user or system connections with &nm;, refer
     to <xref linkend="sec-nm-configure"/>.


### PR DESCRIPTION
### Description
NM connection editor is no longer installed by default in SLE15SP2. This update includes a hint
to install it manually in case you need it.
