### PR TITLE
AutoYaST network configuration updates

### DIFF
--- a/xml/ay_introduction.xml
+++ b/xml/ay_introduction.xml
@@ -98,8 +98,9 @@
     </listitem>
     <listitem>
      <para>
-      Installation: &yast; performs the installation and configuration of the
-      basic system using the data from the &ay; profile.
+      Installation: &yast; performs the installation and basic configuration
+      (e.g. partitioning, networking, firewall) of the target system using the
+      data from the &ay; profile.
      </para>
     </listitem>
     <listitem>
@@ -107,7 +108,8 @@
       Post Configuration: After the installation and configuration of the
       basic system, the system can run a second stage in order to perform
       any aditional configuration that requires the target system to be already
-      running like post-installation scripts.
+      running like post-installation scripts, third party modules or even
+      some &yast; module.
     </para>
     </listitem>
    </itemizedlist>
@@ -118,9 +120,8 @@
      A regular installation of &productname; &productnumber; is
      performed in a single stage. The auto-installation process, however, is
      divided into two stages. After the installation and main configuration
-     of the basic system, the system can boot into a second in order to perform
+     of the basic system, it is booted into a second stage in order to perform
      a post configuration.
-     done.
     </para>
     <para>
      The packages <literal>autoyast2</literal> and
@@ -129,8 +130,8 @@
      will be shown before booting into the installed system.
     </para>
     <para>
-      The second stage will be run only if it is strictly neccesary and can be
-      turned off with the <literal>second_stage</literal> parameter:
+     The second stage runs only if it is strictly neccesary and can be turned
+     off completely with the <literal>second_stage</literal> parameter:
     </para>
 <screen>&lt;general&gt;
   &lt;mode&gt;

--- a/xml/ay_introduction.xml
+++ b/xml/ay_introduction.xml
@@ -69,8 +69,8 @@
     quickly. They need to share the same environment and similar, but not
     necessarily identical, hardware. The installation is defined by an XML
     configuration file (usually named <filename>autoinst.xml</filename>)
-    called the <quote>&ay; profile</quote>. It can initially be created
-    using existing configuration resources easily be tailored for any
+    called the <quote>&ay; profile</quote>. You can create this 
+    using existing configuration resources, and easily tailor it for any
     specific environment.
    </para>
 
@@ -91,7 +91,7 @@
     <listitem>
      <para>
       Preparation: All relevant information about the target system is
-      collected and turned into the appropriate directives of the profile.
+      collected and turned into the appropriate directives in the profile.
       The profile is transferred onto the target system where its
       directives will be parsed and fed into &yast;.
      </para>
@@ -105,10 +105,10 @@
     </listitem>
     <listitem>
      <para>
-      Post Configuration: After the installation and configuration of the
+      Post-configuration: After the installation and configuration of the
       basic system, the system can run a second stage in order to perform
       any aditional configuration that requires the target system to be already
-      running like post-installation scripts, third party modules or even
+      running, such as post-installation scripts, third party modules or even
       some &yast; module.
     </para>
     </listitem>
@@ -121,7 +121,7 @@
      performed in a single stage. The auto-installation process, however, is
      divided into two stages. After the installation and main configuration
      of the basic system, it is booted into a second stage in order to perform
-     a post configuration.
+     any post-installation configuration steps.
     </para>
     <para>
      The packages <literal>autoyast2</literal> and
@@ -130,7 +130,7 @@
      will be shown before booting into the installed system.
     </para>
     <para>
-     The second stage runs only if it is strictly neccesary and can be turned
+     The second stage runs only if it is strictly necessary, and the second stage can be turned
      off completely with the <literal>second_stage</literal> parameter:
     </para>
 <screen>&lt;general&gt;

--- a/xml/ay_introduction.xml
+++ b/xml/ay_introduction.xml
@@ -48,10 +48,9 @@
 
    <para>
     &ay; can be used where no user intervention is required or where
-    customization is required. Using an &ay; control file, &yast;
-    prepares the system for a custom installation and does not interact
-    with the user, unless specified in the file controlling the
-    installation.
+    customization is required. Using an &ay; profile, &yast; prepares
+    the system for a custom installation and does not interact with
+    the user, unless specified in the file controlling the installation.
    </para>
 
    <para>
@@ -70,9 +69,9 @@
     quickly. They need to share the same environment and similar, but not
     necessarily identical, hardware. The installation is defined by an XML
     configuration file (usually named <filename>autoinst.xml</filename>)
-    called the <quote>&ay; control file</quote>. It can initially be
-    created using existing configuration resources easily be tailored for
-    any specific environment.
+    called the <quote>&ay; profile</quote>. It can initially be created
+    using existing configuration resources easily be tailored for any
+    specific environment.
    </para>
 
    <para>
@@ -92,15 +91,15 @@
     <listitem>
      <para>
       Preparation: All relevant information about the target system is
-      collected and turned into the appropriate directives of the control
-      file. The control file is transferred onto the target system where its
+      collected and turned into the appropriate directives of the profile.
+      The profile is transferred onto the target system where its
       directives will be parsed and fed into &yast;.
      </para>
     </listitem>
     <listitem>
      <para>
       Installation: &yast; performs the installation and configuration of the
-      basic system using the data from the &ay; control file.
+      basic system using the data from the &ay; profile.
      </para>
     </listitem>
     <listitem>

--- a/xml/ay_introduction.xml
+++ b/xml/ay_introduction.xml
@@ -99,17 +99,17 @@
     </listitem>
     <listitem>
      <para>
-      Installation: &yast; performs the installation of the basic system
-      using the data from the &ay; control file.
+      Installation: &yast; performs the installation and configuration of the
+      basic system using the data from the &ay; control file.
      </para>
     </listitem>
     <listitem>
      <para>
-      Configuration: After the installation of the basic system, the system
-      configuration is performed in the second stage of the installation.
-      User-defined post-installation scripts from the &ay; control file
-      will also be executed at this stage.
-     </para>
+      Post Configuration: After the installation and configuration of the
+      basic system, the system can run a second stage in order to perform
+      any aditional configuration that requires the target system to be already
+      running like post-installation scripts.
+    </para>
     </listitem>
    </itemizedlist>
 
@@ -118,8 +118,9 @@
     <para>
      A regular installation of &productname; &productnumber; is
      performed in a single stage. The auto-installation process, however, is
-     divided into two stages. After the installation of the basic system the
-     system boots into the second stage where the system configuration is
+     divided into two stages. After the installation and main configuration
+     of the basic system, the system can boot into a second in order to perform
+     a post configuration.
      done.
     </para>
     <para>
@@ -129,8 +130,8 @@
      will be shown before booting into the installed system.
     </para>
     <para>
-     The second stage can be turned off with the
-     <literal>second_stage</literal> parameter:
+      The second stage will be run only if it is strictly neccesary and can be
+      turned off with the <literal>second_stage</literal> parameter:
     </para>
 <screen>&lt;general&gt;
   &lt;mode&gt;
@@ -139,22 +140,5 @@
   &lt;/mode&gt;
 &lt;/general&gt;</screen>
    </note>
-
-   <para>
-    The complete and detailed process is illustrated in the following
-    figure:
-   </para>
-
-   <figure xml:id="process">
-    <title>Auto-installation process</title>
-    <mediaobject>
-     <imageobject role="html">
-      <imagedata fileref="autoyast-oview.png"/>
-     </imageobject>
-     <imageobject role="fo">
-      <imagedata fileref="autoyast-oview.png" width="75%"/>
-     </imageobject>
-    </mediaobject>
-   </figure>
   </sect1>
  </chapter>

--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -21,11 +21,8 @@
    <para>
     Network configuration is mainly used to connect a single workstation to an
     Ethernet-based LAN and it is commonly configured even before starting &ay;
-    in order to fetch the profile from a network location.
-   </para>
-
-   <para>
-    This network configuration is usually done through <command>linuxrc</command>
+    in order to fetch the profile from a network location. This network
+    configuration is usually done through <command>linuxrc</command>
    </para>
 
    <note>
@@ -37,25 +34,22 @@
    </note>
 
    <para>
-    By default &yast; keeps the network settings created during the installation.
-    Thus, linuxrc configured network could be considered the minimal network
-    configuration.
-   </para>
-   <para>
-    The copy of the configuration can be ommited setting the 
-    <literal>keep_install_network</literal> option to <literal>false</literal>.
+    By default &yast; copies the network settings that were used during the
+    installation to the finaly system. This configuration is merged with the
+    one defined in the &ay; profile. The copy of the configuration can be
+    ommited setting the <literal>keep_install_network</literal> option to
+    <literal>false</literal>.
    </para>
 
 <screen>&lt;keep_install_network
 config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
 
    <para>
-    In case of kept, the settings will be merged with the network settings
-    from the &ay; control file. &ay; settings have higher priority than any
-    configuration files already present. &yast; will write ifcfg-* files based
-    on the entries in the control file without removing old ones. If there is
-    an empty or absent DNS and routing section, &yast; will keep any pre-existing
-    values. Otherwise, settings from the control file will be applied.
+    &ay; settings have higher priority than any configuration files already
+    present. &yast; will write ifcfg-* files based on the entries in the profile
+    without removing old ones. If there is an empty or absent DNS and routing
+    section, &yast; will keep any pre-existing values. Otherwise, settings from
+    the profile file will be applied.
    </para>
 
    <note>
@@ -63,22 +57,23 @@ config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
 
     <para>
       Since &productname; 15.3, the write of the configuration based on the
-      control file will happen at the end of the first stage by default.
+      profile happens at the end of the first stage.
     </para>
     <para>
-      However, if the &ay; network settings are needed during the installation
-      it can be forced to be written and applied before the registration takes
+      However, if the network settings are needed during the installation you
+      can force &ay; to write and apply them before the registration takes
       place defining the <literal>setup_before_proposal</literal> option as
       <literal>true</literal>.
-      It is also very useful when the installation network is complex to define
-      through linuxrc kernel options (see <xref linkend="autoinstall-singlesystem"/>)
+      Asking &ay; to setup the network in the early stages is useful when the
+      installation network is needed and the configuration is too complex to
+      define it using linuxrc (see <xref linkend="autoinstall-singlesystem"/>)
     </para>
 
 <screen>&lt;setup_before_proposal
   config:type="boolean"&gt;true&lt;/setup_before_proposal&gt;</screen>
 
     <para>
-      If the configuration is written at the end of the installation it will
+      If the configuration is written at the end of the installation it is
       not be applied until the system is rebooted.
     </para>
    </note>
@@ -1335,8 +1330,8 @@ config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
    <sect2 xml:id="Configuration-Network-Inetd">
     <title>(X)Inetd</title>
     <para>
-     The control file has elements to specify which superserver should be
-     used (netd_service), whether it should be enabled (netd_status) and how
+     The profilehas elements to specify which superserver should be used
+     (netd_service), whether it should be enabled (netd_status) and how
      the services should be configured (netd_conf).
     </para>
     <para>

--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -20,7 +20,7 @@
 
    <para>
     Network configuration is mainly used to connect a single workstation to an
-    Ethernet-based LAN and it is commonly configured even before starting &ay;
+    Ethernet-based LAN. It is commonly configured before &ay; even starts,
     in order to fetch the profile from a network location. This network
     configuration is usually done through <command>linuxrc</command>
    </para>
@@ -35,37 +35,36 @@
 
    <para>
     By default &yast; copies the network settings that were used during the
-    installation to the finaly system. This configuration is merged with the
-    one defined in the &ay; profile. The copy of the configuration can be
-    ommited setting the <literal>keep_install_network</literal> option to
-    <literal>false</literal>.
+    installation into the final, installed system. This configuration is merged with the
+    one defined in the &ay; profile. To skip copying the network configuration,
+    set the <literal>keep_install_network</literal> option to <literal>false</literal>.
    </para>
 
 <screen>&lt;keep_install_network
 config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
 
    <para>
-    &ay; settings have higher priority than any configuration files already
-    present. &yast; will write ifcfg-* files based on the entries in the profile
-    without removing old ones. If there is an empty or absent DNS and routing
-    section, &yast; will keep any pre-existing values. Otherwise, settings from
-    the profile file will be applied.
+    &ay; settings have higher priority than any existing configuration files.
+    &yast; will write <filename>ifcfg-*</filename> files based on the entries in the profile
+    without removing old ones. If the DNS and routing section is empty or missing,
+    &yast; will keep any pre-existing values. Otherwise, it applies the settings from
+    the profile file.
    </para>
 
    <note>
      <title>Use &ay; network settings during installation</title>
 
     <para>
-      Since &productname; 15.3, the write of the configuration based on the
+      Since &productname; 15.3, writing the configuration based on the
       profile happens at the end of the first stage.
     </para>
     <para>
-      However, if the network settings are needed during the installation you
-      can force &ay; to write and apply them before the registration takes
-      place defining the <literal>setup_before_proposal</literal> option as
+      However, if network settings are needed during the installation, you
+      can force &ay; to write and apply them before registration takes
+      place by setting the <literal>setup_before_proposal</literal> option to
       <literal>true</literal>.
-      Asking &ay; to setup the network in the early stages is useful when the
-      installation network is needed and the configuration is too complex to
+      Asking &ay; to setup the network in the early stages is useful when
+      installation on a network is needed, but the configuration is too complex to
       define it using linuxrc (see <xref linkend="autoinstall-singlesystem"/>)
     </para>
 
@@ -73,14 +72,14 @@ config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
   config:type="boolean"&gt;true&lt;/setup_before_proposal&gt;</screen>
 
     <para>
-      If the configuration is written at the end of the installation it is
+      If the configuration is written at the end of installation, it will
       not be applied until the system is rebooted.
     </para>
    </note>
 
    <para>
     Network settings and service activation are defined under the <literal>profile</literal>
-    <literal>networking</literal> global resource
+    <literal>networking</literal> global resource.
    </para>
 
    <example xml:id="ex-ay-network-config-general">
@@ -1330,7 +1329,7 @@ config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
    <sect2 xml:id="Configuration-Network-Inetd">
     <title>(X)Inetd</title>
     <para>
-     The profilehas elements to specify which superserver should be used
+     The profile has elements to specify which superserver should be used
      (netd_service), whether it should be enabled (netd_status) and how
      the services should be configured (netd_conf).
     </para>

--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -19,18 +19,15 @@
  </info>
 
    <para>
-    Network configuration is used to connect a single workstation to an
-    Ethernet-based LAN or to configure a dial-up connection. More complex
-    configurations (multiple network cards, routing, etc.) are also
-    provided.
+    Network configuration is mainly used to connect a single workstation to an
+    Ethernet-based LAN and it is commonly configured even before starting &ay;
+    in order to fetch the profile from a network location.
    </para>
 
    <para>
-    If the following setting is set to <literal>true</literal>, &yast;
-    will keep network settings created during the installation (via
-    <command>linuxrc</command>) and/or merge it with network settings from the
-    &ay; control file (if defined).
+    This network configuration is usually done through <command>linuxrc</command>
    </para>
+
    <note>
     <title>The <command>linuxrc</command> program</title>
     <para>
@@ -38,32 +35,57 @@
      keywords, see <xref linkend="appendix-linuxrc"/>.
     </para>
    </note>
+
    <para>
-    &ay; settings have higher priority than any configuration files already
-    present. &yast; will write ifcfg-* files based on the entries in the control
-    file without removing old ones. If there is an empty or absent DNS and
-    routing section, &yast; will keep any pre-existing values. Otherwise,
-    settings from the control file will be applied.
+    By default &yast; keeps the network settings created during the installation.
+    Thus, linuxrc configured network could be considered the minimal network
+    configuration.
+   </para>
+   <para>
+    The copy of the configuration can be ommited setting the 
+    <literal>keep_install_network</literal> option to <literal>false</literal>.
    </para>
 
 <screen>&lt;keep_install_network
-config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
+config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
 
    <para>
-    During the second stage, installation of additional packages will take
-    place before the network, as described in the profile, is configured.
-    <literal>keep_install_network</literal> is set by default to
-    <literal>true</literal> to ensure that a network is available
-    in case it is needed to install those packages. If all packages
-    are installed during the first stage and the network is not needed early
-    during the second one, setting <literal>keep_install_network</literal>
-    to <literal>false</literal> will avoid copying the configuration.
+    In case of kept, the settings will be merged with the network settings
+    from the &ay; control file. &ay; settings have higher priority than any
+    configuration files already present. &yast; will write ifcfg-* files based
+    on the entries in the control file without removing old ones. If there is
+    an empty or absent DNS and routing section, &yast; will keep any pre-existing
+    values. Otherwise, settings from the control file will be applied.
    </para>
 
+   <note>
+     <title>Use &ay; network settings during installation</title>
+
+    <para>
+      Since &productname; 15.3, the write of the configuration based on the
+      control file will happen at the end of the first stage by default.
+    </para>
+    <para>
+      However, if the &ay; network settings are needed during the installation
+      it can be forced to be written and applied before the registration takes
+      place defining the <literal>setup_before_proposal</literal> option as
+      <literal>true</literal>.
+      It is also very useful when the installation network is complex to define
+      through linuxrc kernel options (see <xref linkend="autoinstall-singlesystem"/>)
+    </para>
+
+<screen>&lt;setup_before_proposal
+  config:type="boolean"&gt;true&lt;/setup_before_proposal&gt;</screen>
+
+    <para>
+      If the configuration is written at the end of the installation it will
+      not be applied until the system is rebooted.
+    </para>
+   </note>
+
    <para>
-    To configure network settings and activate networking automatically, one
-    global resource, <literal>&lt;networking&gt;</literal> is used to store the
-    whole network configuration.
+    Network settings and service activation are defined under the <literal>profile</literal>
+    <literal>networking</literal> global resource
    </para>
 
    <example xml:id="ex-ay-network-config-general">
@@ -136,8 +158,56 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
 </networking>]]></screen>
    </example>
 
+   <example xml:id="ex-ay-network-config-bond">
+     <title>Bonding Interface Configuration</title>
+<screen>
+&lt;networking&gt;
+  &lt;setup_before_proposal config:type="boolean"&gt;false&lt;/setup_before_proposal&gt;
+  &lt;keep_install_network config:type="boolean"&gt;false&lt;/keep_install_network&gt;
+  &lt;interfaces config:type="list"&gt;
+    &lt;interface&gt;
+      &lt;bonding_master&gt;yes&lt;/bonding_master&gt;
+      &lt;bonding_module_opts&gt;mode=active-backup miimon=100&lt;/bonding_module_opts&gt;
+      &lt;bonding_slave0&gt;eth1&lt;/bonding_slave0&gt;
+      &lt;bonding_slave0&gt;eth2&lt;/bonding_slave0&gt;
+      &lt;bondoption&gt;mode=balance-rr miimon=100&lt;/bondoption&gt;
+      &lt;bootproto&gt;static&lt;/bootproto&gt;
+      &lt;device&gt;bond0&lt;/device&gt;
+      &lt;ipaddr&gt;192.168.122.61&lt;/ipaddr&gt;
+      &lt;netmask&gt;255.255.255.0&lt;/netmask&gt;
+      &lt;network&gt;192.168.122.0&lt;/network&gt;
+      &lt;prefixlen&gt;24&lt;/prefixlen&gt;
+      &lt;startmode&gt;auto&lt;/startmode&gt;
+    &lt;/interface&gt;
+    &lt;interface&gt;
+      &lt;bootproto&gt;none&lt;/bootproto&gt;
+      &lt;device&gt;eth1&lt;/device&gt;
+      &lt;startmode&gt;auto&lt;/startmode&gt;
+    &lt;/interface&gt;
+    &lt;interface&gt;
+      &lt;bootproto&gt;none&lt;/bootproto&gt;
+      &lt;device&gt;eth2&lt;/device&gt;
+      &lt;startmode&gt;auto&lt;/startmode&gt;
+    &lt;/interface&gt;
+  &lt;/interfaces&gt;
+  &lt;net-udev config:type="list"&gt;
+    &lt;rule&gt;
+      &lt;name&gt;eth1&lt;/name&gt;
+      &lt;rule&gt;ATTR{address}&lt;/rule&gt;
+      &lt;value&gt;dc:e4:cc:27:94:c7&lt;/value&gt;
+    &lt;/rule&gt;
+    &lt;rule&gt;
+      &lt;name&gt;eth2&lt;/name&gt;
+      &lt;rule&gt;ATTR{address}&lt;/rule&gt;
+      &lt;value&gt;dc:e4:cc:27:94:c8&lt;/value&gt;
+    &lt;/rule&gt;
+  &lt;/net-udev&gt;
+&lt;/networking&gt;
+</screen>
+   </example>
+
    <para>
-    As shown in the example above, the <literal>&lt;networking&gt;</literal> section can be
+    As shown in the examples above, the <literal>&lt;networking&gt;</literal> section can be
     composed of a few subsections:
    </para>
 
@@ -162,37 +232,6 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
      persistent names.</para>
     </listitem>
    </itemizedlist>
-
-   <example xml:id="ex-ay-network-config-bridge">
-     <title>Bridge Interface Configuration</title>
-<screen>
-&lt;interfaces config:type="list"&gt;
-  &lt;interface&gt;
-    &lt;device&gt;br0&lt;/device&gt;
-    &lt;bootproto&gt;static&lt;/bootproto&gt;
-    &lt;bridge&gt;yes&lt;/bridge&gt;
-    &lt;bridge_forwarddelay&gt;0&lt;/bridge_forwarddelay&gt;
-    &lt;bridge_ports&gt;eth0 eth1&lt;/bridge_ports&gt;
-    &lt;bridge_stp&gt;off&lt;/bridge_stp&gt;
-    &lt;ipaddr&gt;192.168.122.100&lt;/ipaddr&gt;
-    &lt;netmask&gt;255.255.255.0&lt;/netmask&gt;
-    &lt;network&gt;192.168.122.0&lt;/network&gt;
-    &lt;prefixlen&gt;24&lt;/prefixlen&gt;
-    &lt;startmode&gt;auto&lt;/startmode&gt;
-  &lt;/interface&gt;
-  &lt;interface&gt;
-    &lt;device&gt;eth0&lt;/device&gt;
-    &lt;bootproto&gt;none&lt;/bootproto&gt;
-    &lt;startmode&gt;hotplug&lt;/startmode&gt;
-  &lt;/interface&gt;
-  &lt;interface&gt;
-    &lt;device&gt;eth1&lt;/device&gt;
-    &lt;bootproto&gt;none&lt;/bootproto&gt;
-    &lt;startmode&gt;hotplug&lt;/startmode&gt;
-  &lt;/interface&gt;
-&lt;/interfaces&gt;
-</screen>
-   </example>
 
    <tip>
     <title>IPv6 Address Support</title>
@@ -711,8 +750,39 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
        <!-- TODO: all wireless attributes, but not so many users configure wireless with autoyast -->
       </tbody>
      </tgroup>
-    </informaltable>
-   </sect2>
+   </informaltable>
+
+   <example xml:id="ex-ay-network-config-bridge">
+     <title>Bridge Interface Configuration</title>
+<screen>
+&lt;interfaces config:type="list"&gt;
+  &lt;interface&gt;
+    &lt;device&gt;br0&lt;/device&gt;
+    &lt;bootproto&gt;static&lt;/bootproto&gt;
+    &lt;bridge&gt;yes&lt;/bridge&gt;
+    &lt;bridge_forwarddelay&gt;0&lt;/bridge_forwarddelay&gt;
+    &lt;bridge_ports&gt;eth0 eth1&lt;/bridge_ports&gt;
+    &lt;bridge_stp&gt;off&lt;/bridge_stp&gt;
+    &lt;ipaddr&gt;192.168.122.100&lt;/ipaddr&gt;
+    &lt;netmask&gt;255.255.255.0&lt;/netmask&gt;
+    &lt;network&gt;192.168.122.0&lt;/network&gt;
+    &lt;prefixlen&gt;24&lt;/prefixlen&gt;
+    &lt;startmode&gt;auto&lt;/startmode&gt;
+  &lt;/interface&gt;
+  &lt;interface&gt;
+    &lt;device&gt;eth0&lt;/device&gt;
+    &lt;bootproto&gt;none&lt;/bootproto&gt;
+    &lt;startmode&gt;hotplug&lt;/startmode&gt;
+  &lt;/interface&gt;
+  &lt;interface&gt;
+    &lt;device&gt;eth1&lt;/device&gt;
+    &lt;bootproto&gt;none&lt;/bootproto&gt;
+    &lt;startmode&gt;hotplug&lt;/startmode&gt;
+  &lt;/interface&gt;
+&lt;/interfaces&gt;
+</screen>
+   </example>
+  </sect2>
 
    <sect2 xml:id="CreateProfile-Network-names">
     <title>Persistent Names of Network Interfaces</title>


### PR DESCRIPTION
### Description

A regular installation of SUSE Linux Enterprise Server 15 SP2 is performed in a single stage. The auto-installation process, however, has been historically divided in two stages. 

The idea is, that, since SLE-15-SP3, the AutoYaST network configuration, by default, will be done during the `first stage`. This PBI tries to update and extend the current documentation according to the new behavior.

- https://github.com/yast/yast-network/blob/master/doc/autoinstallation.md
- https://bugzilla.suse.com/show_bug.cgi?id=1171922

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
