### PR TITLE
Re-register SMT client after changing namespace (bsc#1034676)

### DIFF
--- a/xml/smt_client.xml
+++ b/xml/smt_client.xml
@@ -598,8 +598,7 @@
   <procedure>
    <step>
     <para>
-     Delete a registration of the client host. Find more information in
-     <xref linkend="smt-registration-delete"/>
+     De-register the client from the &smt; server by running <command>SUSEConnect --de-register</command> on the client host.
     </para>
    </step>
    <step>

--- a/xml/smt_client.xml
+++ b/xml/smt_client.xml
@@ -592,12 +592,31 @@
   <title>Registering SLE12 Clients against &smt; Test Environment</title>
 
   <para>
-   To configure a client to register against the test environment instead of
-   the production environment, modify <filename>/etc/SUSEConnect</filename> on
-   the client machine by setting:
+   To register a client in the testing environment, follow these steps:
   </para>
 
+  <procedure>
+   <step>
+    <para>
+     Delete a registration of the client host. Find more information in
+     <xref linkend="smt-registration-delete"/>
+    </para>
+   </step>
+   <step>
+    <para>
+     Modify <filename>/etc/SUSEConnect</filename> on the client machine as
+     follows:
+    </para>
 <screen>namespace: testing</screen>
+   </step>
+   <step>
+    <para>
+     Re-register the client host against &smt; in order for the new
+     namespace setting to take effect. See general information about
+     registering &smt; clients in <xref linkend="smt-client"/>.
+    </para>
+   </step>
+  </procedure>
 
   <para>
    For more information about using &smt; with a test environment, see

--- a/xml/smt_mirroring.xml
+++ b/xml/smt_mirroring.xml
@@ -576,8 +576,7 @@ repo/testing/SUSE/Updates/SLE-SERVER/12/x86_64/update/
   <procedure>
    <step>
     <para>
-     Delete a registration of the client host. Find more information in
-     <xref linkend="smt-registration-delete"/>
+     De-register the client from the &smt; server by running <command>SUSEConnect --de-register</command> on the client host.
     </para>
    </step>
    <step>

--- a/xml/smt_mirroring.xml
+++ b/xml/smt_mirroring.xml
@@ -570,11 +570,31 @@ repo/testing/SUSE/Updates/SLE-SERVER/12/x86_64/update/
   </para>
 
   <para>
-   To register a client in the testing environment, modify
-   <filename>/etc/SUSEConnect</filename> on the client machine as follows:
+   To register a client in the testing environment, follow these steps:
   </para>
 
+  <procedure>
+   <step>
+    <para>
+     Delete a registration of the client host. Find more information in
+     <xref linkend="smt-registration-delete"/>
+    </para>
+   </step>
+   <step>
+    <para>
+     Modify <filename>/etc/SUSEConnect</filename> on the client machine as
+     follows:
+    </para>
 <screen>namespace: testing</screen>
+   </step>
+   <step>
+    <para>
+     Re-register the client host against &smt; in order for the new
+     namespace setting to take effect. See general information about
+     registering &smt; clients in <xref linkend="smt-client"/>.
+    </para>
+   </step>
+  </procedure>
 
   <para>
    To move the testing environment to the production environment, manually copy
@@ -783,10 +803,31 @@ sudo chmod go-rwx -R /var/lib/smt/.gnupg</screen>
     <term>Registering Clients in the Testing Environment</term>
     <listitem>
      <para>
-      To register a client in the testing environment, modify the
-      <filename>/etc/SUSEConnect</filename> file on the client machine:
+      To register a client in the testing environment, follow these steps:
      </para>
-<screen>namespace: testing</screen>
+
+     <procedure>
+      <step>
+       <para>
+        Delete a registration of the client host. Find more information in
+        <xref linkend="smt-registration-delete"/>
+       </para>
+      </step>
+      <step>
+       <para>
+        Modify <filename>/etc/SUSEConnect</filename> on the client machine as
+        follows:
+       </para>
+   <screen>namespace: testing</screen>
+      </step>
+      <step>
+       <para>
+        Re-register the client host against &smt; in order for the new
+        namespace setting to take effect. See general information about
+        registering &smt; clients in <xref linkend="smt-client"/>.
+       </para>
+      </step>
+     </procedure>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/xml/smt_mirroring.xml
+++ b/xml/smt_mirroring.xml
@@ -809,8 +809,7 @@ sudo chmod go-rwx -R /var/lib/smt/.gnupg</screen>
      <procedure>
       <step>
        <para>
-        Delete a registration of the client host. Find more information in
-        <xref linkend="smt-registration-delete"/>
+        De-register the client from the &smt; server by running <command>SUSEConnect --de-register</command> on the client host.
        </para>
       </step>
       <step>


### PR DESCRIPTION
### Description
This update describes steps to change the namespace of an SMT client

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [x] To maintenance/SLE12SP4
- [x] To maintenance/SLE12SP3
