### PR TITLE
Integrate Dublin proofing changes to Deployment Guide

### DIFF
--- a/xml/ay_general_options.xml
+++ b/xml/ay_general_options.xml
@@ -403,7 +403,7 @@
     images of the &leanos; and Packages ISOs. If you install from the ISOs published
     as quarterly update (they can be identified by the string <literal>QU</literal>
     in the name), the installer cannot update itself, because this feature has
-    been disabled in the updated media.
+    been disabled in the update media.
    </para>
   </important>
    <para>

--- a/xml/deployment_customize_installation_image.xml
+++ b/xml/deployment_customize_installation_image.xml
@@ -12,17 +12,15 @@
  <info>
   <abstract>
    <para>
-    You may customize the standard &sle; installation images by
-    editing a file in the installation ISO image,
-    <filename>media.1/products</filename>.
-    Add modules and extensions to create a single
-    customized installation image. Then copy your
-    custom image to a CD, DVD, or &usbflashdrive; to create a bootable customized
-    installation medium. See the <link
-    xlink:href="https://documentation.suse.com/sbp/all/single-html/SBP-SLE15-Custom-Installation-Medium/">
-    the &suse; Best Practices paper on <citetitle>How to Create a Custom Installation
-    Medium for SUSE Linux Enterprise 15</citetitle></link>
-    for complete instructions.
+    You can customize the standard &sle; installation images by editing a file
+    in the installation ISO image, <filename>media.1/products</filename>.
+    Add modules and extensions to create a single customized installation image.
+    Then copy your custom image to a CD, DVD, or &usbflashdrive; to create a
+    customized bootable installation medium. See <link xlink:href=
+    "https://documentation.suse.com/sbp/all/single-html/SBP-SLE15-Custom-Installation-Medium/">
+    the &suse; Best Practices paper on <citetitle>How to Create a Custom
+    Installation Medium for SUSE Linux Enterprise 15</citetitle></link> for
+    complete instructions.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">

--- a/xml/deployment_image.xml
+++ b/xml/deployment_image.xml
@@ -56,7 +56,7 @@
    up and clones can be used immediately.
   </para>
   <para>
-   The <command>clone-master-clean-up</command> command, for example, removes:
+   For example, the <command>clone-master-clean-up</command> command removes:
   </para>
   <itemizedlist>
    <listitem>

--- a/xml/deployment_image.xml
+++ b/xml/deployment_image.xml
@@ -14,7 +14,7 @@
   <abstract>
    <para>
     This chapter describes how to use cloned images for installing &productname;.
-    This is mostly used in virtualized environments.
+    This process is mostly used in virtualized environments.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -44,7 +44,7 @@
    <para>
     Executing the following procedure permanently deletes important
     system configuration data. If the source system for the clone is
-    used in production, run the clean up script on the cloned image.
+    used in production, run the clean-up script on the cloned image.
    </para>
   </warning>
   <para>
@@ -56,7 +56,7 @@
    up and clones can be used immediately.
   </para>
   <para>
-   The <command>clone-master-clean-up</command> command for example removes:
+   The <command>clone-master-clean-up</command> command, for example, removes:
   </para>
   <itemizedlist>
    <listitem>
@@ -93,7 +93,7 @@
      Configure the behavior of <command>clone-master-clean-up</command> by
      editing <filename>/etc/sysconfig/clone-master-clean-up</filename>.
      This configuration file defines whether users with a UID larger than 1000,
-     the <filename>/etc/sudoers</filename> file, Zypper repositories and
+     the <filename>/etc/sudoers</filename> file, Zypper repositories, and
      Btrfs snapshots should be removed.
     </para>
    </step>

--- a/xml/deployment_mksusecd.xml
+++ b/xml/deployment_mksusecd.xml
@@ -29,9 +29,9 @@
   <title>Installing mksusecd</title>
 
   <para>
-   In &slea;&nbsp;15 <command>mksusecd</command> is in the <literal>Development
-   Tools Module</literal>. If you have not enabled this module you must enable
-   it. First find the exact module name with <command>zypper</command>:
+   In &slea;&nbsp;15, <command>mksusecd</command> is in the <literal>Development
+   Tools Module</literal>. If you have not enabled this module, you must enable
+   it. First, find the exact module name with <command>zypper</command>:
   </para>
 
 <screen>&prompt.user;zypper search-packages mksusecd
@@ -55,8 +55,8 @@ Use SUSEConnect --help for more details.</screen>
 <screen>&prompt.sudo;SUSEConnect -p sle-module-development-tools/15/x86_64</screen>
 
   <para>
-   In &slea;&nbsp;15.1 and later it is in the <literal>Main Update
-   Repository</literal>, which is enabled by default.
+   In &slea;&nbsp;15.1 and later, it is in the <literal>Main Update Repository
+   </literal>, which is enabled by default.
   </para>
 
   <para>
@@ -108,7 +108,7 @@ Use SUSEConnect --help for more details.</screen>
    target system architecture. Also replace
    <replaceable>OS_version</replaceable> and
    <replaceable>SP_VERSION</replaceable> (service pack) according to your paths
-   in <xref linkend="sec-deployment-instserver-sles9"/>".
+   in <xref linkend="sec-deployment-instserver-sles9"/>.
   </para>
 
 <!-- the mksusecd chapter is not included in any OSUSE build, and the example
@@ -124,8 +124,9 @@ Use SUSEConnect --help for more details.</screen>
 --net=http://download.opensuse.org/tumbleweed/repo/oss/suse \
 /srv/tftpboot/EFI/<replaceable>ARCH</replaceable>/boot</screen>
  </sect1>
+ 
  <sect1 xml:id="sec-deployment-custom-image-boot">
-  <title>Set Default Kernel Boot Parameters</title>
+  <title>Setting Default Kernel Boot Parameters</title>
 
   <para>
    Rather than waiting for a boot prompt to enter your custom kernel boot
@@ -143,7 +144,7 @@ Use SUSEConnect --help for more details.</screen>
 <screen>&prompt.user;cat /proc/cmdline</screen>
  </sect1>
  <sect1 xml:id="sec-deployment-custom-modules">
-  <title>Customize Modules, Extensions, and Repositories</title>
+  <title>Customizing Modules, Extensions, and Repositories</title>
 
   <para>
    &sle;&nbsp;15 supports Modules (not to be confused with kernel modules) and
@@ -153,7 +154,7 @@ Use SUSEConnect --help for more details.</screen>
   </para>
 
   <para>
-   With <command>mksusecd</command> you may create an installation image
+   With <command>mksusecd</command> you can create an installation image
    containing all the additional Modules and Extensions you want. Start by
    querying existing images, like this example for &sle;&nbsp;&productnumber;:
   </para>

--- a/xml/deployment_prep_aarch64_media.xml
+++ b/xml/deployment_prep_aarch64_media.xml
@@ -30,7 +30,7 @@
  <para>
   Unlike previous &slea; products, the entire &slea; &productnumber; product
   line can be installed using the &leanos;. <phrase os="sles">For details about the changes since
-  &sle; &product-ga; and which media to download for installation, see:
+  &sle; &product-ga; and which media to download for installation, see
   <xref linkend="sec-planning-leanos"/>.</phrase>
  </para>
  <para>

--- a/xml/deployment_prep_aarch64_raspi.xml
+++ b/xml/deployment_prep_aarch64_raspi.xml
@@ -70,14 +70,14 @@
    Graphics Processing Unit (GPU), not the &arm; Central Processing Unit (CPU).
    It is the GPU which starts initializing the hardware from a first-stage
    boot loader in the on-chip Boot Read-Only Memory (Boot ROM).
-   Only few configuration options can influence the Boot ROM,
+   Only a few configuration options can influence the Boot ROM,
    see <xref linkend="sec-aarch64-deprpi-otp"/>.
   </para>
   <para>
    The &rpi;&nbsp;3 hardware does not have any built-in firmware. Instead,
    its second-stage boot loader firmware <literal>bootcode.bin</literal> is
-   loaded from the boot medium every time that the machine is powered on.
-   It in turn loads the third-stage boot loader <literal>start.elf</literal>.
+   loaded from the boot medium every time the machine is powered on. It in turn
+   loads the third-stage boot loader <literal>start.elf</literal>.
   </para>
   <para>
    The &rpi;&nbsp;4 hardware has a small Electrically Erasable Programmable
@@ -92,14 +92,14 @@
     from a specially prepared &microsd; card.
    </para>
    <para>
-    Only insert boot media that you trust, and verify that
-    no <literal>recovery.bin</literal> file is unintentionally present.
+    Only insert boot media that you trust, and verify that no file called
+    <literal>recovery.bin</literal> is unintentionally present.
    </para>
   </warning>
   <para>
-   If a file <literal>armstub8.bin</literal> is present, it will be loaded
-   as fourth-stage boot loader at &aarch64; Exception Level 3 (EL3).
-   Otherwise a minimal integrated stub will be used.
+   If a file called <literal>armstub8.bin</literal> is present, it will be
+   loaded as a fourth-stage boot loader at &aarch64; Exception Level 3 (EL3).
+   Otherwise, a minimal integrated stub will be used.
   </para>
   <note>
    <title>EL3 Security Considerations</title>
@@ -186,11 +186,11 @@
      USB boot mode cannot be disabled again (<xref linkend="sec-aarch64-deprpi-otp"/>).
     </para>
     <para>
-     For more details refer to the &rpi; Foundation Web site:
+     For more details, refer to the &rpi; Foundation Web site:
      <link xlink:href="https://www.raspberrypi.org/documentation/hardware/raspberrypi/bootmodes/msd.md"/>
     </para>
     <para>
-     For the &rpi; Compute Module&nbsp;3 the needed setting is the same,
+     For the &rpi; Compute Module&nbsp;3, the setting required is the same,
      but the deployment of the modified image is a little more complicated.
     </para>
    </sect4>

--- a/xml/deployment_prep_aarch64_raspi.xml
+++ b/xml/deployment_prep_aarch64_raspi.xml
@@ -69,9 +69,9 @@
    The primary processor on the &rpi;'s System-on-Chip (SoC) is the &vc;
    Graphics Processing Unit (GPU), not the &arm; Central Processing Unit (CPU).
    It is the GPU which starts initializing the hardware from a first-stage
-   boot loader in the on-chip Boot Read-Only Memory (Boot ROM).
-   Only a few configuration options can influence the Boot ROM,
-   see <xref linkend="sec-aarch64-deprpi-otp"/>.
+   boot loader in the on-chip Boot Read-Only Memory (Boot ROM). Only a few
+   configuration options can influence the Boot ROM; see
+   <xref linkend="sec-aarch64-deprpi-otp"/>.
   </para>
   <para>
    The &rpi;&nbsp;3 hardware does not have any built-in firmware. Instead,
@@ -81,9 +81,9 @@
   </para>
   <para>
    The &rpi;&nbsp;4 hardware has a small Electrically Erasable Programmable
-   Read-Only Memory (EEPROM) for the second-stage boot loader. Otherwise it
-   boots similar to &rpi;&nbsp;3, loading the third-stage boot loader
-   <literal>start4.elf</literal> from the boot medium.
+   Read-Only Memory (EEPROM) for the second-stage boot loader. Apart from that,
+   its boot sequence is similar to that of the &rpi;&nbsp;3, loading the
+   third-stage boot loader <literal>start4.elf</literal> from the boot medium.
   </para>
   <warning>
    <title>EEPROM Update on &rpi;&nbsp;4</title>
@@ -97,9 +97,9 @@
    </para>
   </warning>
   <para>
-   If a file called <literal>armstub8.bin</literal> is present, it will be
-   loaded as a fourth-stage boot loader at &aarch64; Exception Level 3 (EL3).
-   Otherwise, a minimal integrated stub will be used.
+   If an <literal>armstub8.bin</literal> file is present, it will be loaded as
+   a fourth-stage boot loader at &aarch64; Exception Level 3 (EL3). Otherwise,
+   a minimal integrated stub will be used.
   </para>
   <note>
    <title>EL3 Security Considerations</title>
@@ -145,13 +145,13 @@
   <sect3 xml:id="sec-aarch64-deprpi-otp">
    <title>OTP Memory</title>
    <para>
-    Further, the SoC has a very small amount of One-Time Programmable Memory
+    The SoC also has a very small amount of One-Time Programmable Memory
     (OTP memory). This can be used to configure some settings, such as whether
     the Boot ROM should attempt to boot from USB devices or over Ethernet.
    </para>
    <para>
-    This OTP memory is described on the &rpi; Foundation Web site:
-    <link xlink:href="https://www.raspberrypi.org/documentation/hardware/raspberrypi/otpbits.mdd"/>
+    This OTP memory is described on the &rpi; Foundation Web site: <link
+     xlink:href="https://www.raspberrypi.org/documentation/hardware/raspberrypi/otpbits.mdd"/>
    </para>
    <warning>
     <title>One-Time Programmable Only</title>
@@ -177,9 +177,9 @@
     <screen>program_usb_boot_mode=1</screen>
     <para>
      Then continue to boot from the modified &microsd; card as usual.
-     Once you see output from U-Boot or GRUB boot loaders or the Linux kernel,
-     you can remove power and then the &microsd; card.
-     Your device should now be able to boot from USB (<xref linkend="sec-aarch64-deprpi-usb"/>).
+     Once you see output from the U-Boot or GRUB boot loaders or the Linux
+     kernel, you can remove power and then the &microsd; card. Your device
+     should now be able to boot from USB (<xref linkend="sec-aarch64-deprpi-usb"/>).
     </para>
     <para>
      Note that once USB boot mode has been enabled for &rpi3; Model&nbsp;B,

--- a/xml/deployment_prep_power.xml
+++ b/xml/deployment_prep_power.xml
@@ -170,8 +170,7 @@
       a partitioning proposal. In this case, you need to create partitions
       manually. To avoid this, we recommend to have 10&nbsp;GB reserved for the
       root partition. Increase the minimum size to 16&nbsp;GB if you plan to
-      enable Btrfs snapshots on the root volume (see
-      <xref linkend="cha-snapper"/>).
+      enable Btrfs snapshots on the root volume (see <xref linkend="cha-snapper"/>).
      </para>
     </listitem>
    </varlistentry>
@@ -179,13 +178,11 @@
 
   <para>
    Before installing &productname;, make sure that the server has the latest
-   firmware. For the latest firmware, visit IBM FixCentral
-   (<link
-   xlink:href="http://www.ibm.com/support/fixcentral/"/>). Select
-   your system from the Product Group list. Additional software is available
-   from the IBM &powerlinux; Tools Repository. For more information on using
-   the IBM &powerlinux; Tools Repository, see
-   <link xlink:href="https://ibm.biz/Bdxn3N"/>.
+   firmware. For the latest firmware, visit IBM FixCentral: <link xlink:href=
+   "http://www.ibm.com/support/fixcentral/"/>. Select your system from the
+   Product Group list. Additional software is available from the IBM
+   &powerlinux; Tools Repository. For more information on using the IBM
+   &powerlinux; Tools Repository, see <link xlink:href="https://ibm.biz/Bdxn3N"/>.
   </para>
  </sect1>
  <sect1 version="5.0" xml:id="sec-power-install"
@@ -394,10 +391,10 @@
    </step>
    <step>
     <para>
-     To add a module or extension, select it using the arrow keys and press
-     <keycap function="space"/>. Depending on what extensions and modules you
-     select, you may be prompted to import GnuPG keys for the associated
-     repositories.
+     If you want to install any modules or extensions, select each one using the
+     arrow keys and pressing <keycap function="space"/>. Depending on what
+     extensions and modules you select, you may be prompted to import GnuPG keys
+     for the associated repositories.
     </para>
     <informalfigure>
      <mediaobject>
@@ -456,8 +453,8 @@
    </step>
    <step>
     <para>
-     The next several screen allow you to specify the appropriate time zone,
-     and create a user. If you choose not to create a user, you are prompted to
+     The next few screens allow you to specify the appropriate time zone, and
+     create a user. If you choose not to create a user, you are prompted to
      specify a root password.
     </para>
    </step>

--- a/xml/deployment_prep_power.xml
+++ b/xml/deployment_prep_power.xml
@@ -12,8 +12,8 @@
  <info>
   <abstract>
    <para>
-    This chapter describes the installation procedure of
-    &productname; on IBM &power; systems.
+    This chapter describes the installation procedure of &productname; on IBM
+    &power; systems.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -21,513 +21,533 @@
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
- 
  <sect1 version="5.0" xml:id="sec-power-requirements"
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Hardware Requirements</title>
+  <title>Hardware Requirements</title>
 
- <info>
-  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:bugtracker></dm:bugtracker>
-   <dm:translation>yes</dm:translation>
-  </dm:docmanager>
- </info>
- <para>
-   To run &sls; on &power;, your hardware must meet the minimum requirements listed below.
- </para>
- <variablelist>
-  <varlistentry>
-   <term>Supported Servers</term>
-   <listitem>
+  <info>
+   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+    <dm:bugtracker></dm:bugtracker>
+    <dm:translation>yes</dm:translation>
+   </dm:docmanager>
+  </info>
+
+  <para>
+   To run &sls; on &power;, your hardware must meet the minimum requirements
+   listed below.
+  </para>
+
+  <variablelist>
+   <varlistentry>
+    <term>Supported Servers</term>
+    <listitem>
      <para>
-       Check the database of &suse;-certified hardware to make sure that
-       your particular hardware configuration is supported. The database is available at <link
-       xlink:href="https://www.suse.com/yessearch/Search.jsp"/>.
-       &productname; may support additional IBM &power; systems that are not listed. For the latest
-     information, refer to the IBM Information Center for Linux at <link
-     xlink:href="https://www.ibm.com/support/knowledgecenter/linuxonibm/liaam/liaamdistros.htm"/>.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-   <term>Memory Requirements</term>
-   <listitem>
-    <para>
-     A minimum of 1024 MB of RAM is required for a minimal installation. For
-     remote installations via HTTP or FTP add another 150 MB. Note that these
-     values are only valid for the installation of the operating
-     system&mdash;the actual amount of RAM depends on the
-     system's workload.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-   <term>Hard Disk Requirements</term>
-   <listitem>
-    <para>
-      The disk requirements depend on the selected type of installation selected and usage scenario.
-      Normally, a properly working system  requires more space than the installation itself. Minimum
-     requirements are as follows.
-    </para>
-    <informaltable>
-     <tgroup cols="2">
-     <colspec colnum="1" colname="col1"/>
-     <colspec colnum="2" colname="col2"/>
-     <thead>
-      <row>
-       <entry>
-         <para>
-          Installation Scope
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Minimum Hard Disk Requirements
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          Text Mode
-         </para>
-        </entry>
-        <entry>
-         <para>
-          1.5 GB
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          Minimal System
-         </para>
-        </entry>
-        <entry>
-         <para>
-          2.5 GB
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          &gnome; Desktop
-         </para>
-        </entry>
-        <entry>
-         <para>
-          3 GB
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          All patterns
-         </para>
-        </entry>
-        <entry>
-         <para>
-          4 GB
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry namest="col1" nameend="col2">
-         <para>
-          Recommended Minimum (no Btrfs snapshots): 10 GB
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry namest="col1" nameend="col2">
-         <para>
-          Required Minimum (with Btrfs snapshots): 16 GB
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry namest="col1" nameend="col2">
-         <para>
-          Recommended Minimum (with Btrfs snapshots): 32 GB
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-    <para>
-     If the root partition is smaller than 10 GB, the installer does not offer
-     a partitioning proposal. In this case you need to create
-     partitions manually. To avoid this, we recommend to have 10 GB reserved
-     for the root partition. Increase the minimum size to 16 GB if you plan
-     to enable Btrfs snapshots on the root volume (see <xref linkend="cha-snapper"/>).
-    </para>
-   </listitem>
-  </varlistentry>
- </variablelist>
- <para>
-   Before installing &productname;, make sure that the server has the latest
-   firmware. For latest firmware, visit at IBM FixCentral (<link
-  xlink:href="http://www.ibm.com/support/fixcentral/"/>). Select your system
-  from the Product Group list. Additional software is available from the IBM
-  &powerlinux; Tools Repository.  For more information on using the IBM &powerlinux; Tools
-  Repository, see <link xlink:href="https://ibm.biz/Bdxn3N"/>.
- </para>
-</sect1>
+      Check the database of &suse;-certified hardware to make sure that your
+      particular hardware configuration is supported. The database is available
+      at <link xlink:href="https://www.suse.com/yessearch/Search.jsp"/>.
+      &productname; may support additional IBM &power; systems that are not
+      listed. For the latest information, refer to the IBM Information Center
+      for Linux at
+      <link 
+       xlink:href="https://www.ibm.com/support/knowledgecenter/linuxonibm/liaam/liaamdistros.htm"/>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Memory Requirements</term>
+    <listitem>
+     <para>
+      A minimum of 1024&nbsp;MB of RAM is required for a minimal installation.
+      For remote installations via HTTP or FTP, add another 150&nbsp;MB. Note
+      that these values are only valid for the installation of the operating
+      system&mdash;the actual amount of RAM depends on the system's workload.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Hard Disk Requirements</term>
+    <listitem>
+     <para>
+      The disk requirements depend on the type of installation selected and the
+      usage scenario. Normally, a properly working system requires more space
+      than the installation itself. The minimum requirements are as follows.
+     </para>
+     <informaltable>
+      <tgroup cols="2">
+       <colspec colnum="1" colname="col1"/>
+       <colspec colnum="2" colname="col2"/>
+       <thead>
+        <row>
+         <entry>
+          <para>
+           Installation Scope
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Minimum Hard Disk Requirements
+          </para>
+         </entry>
+        </row>
+       </thead>
+       <tbody>
+        <row>
+         <entry>
+          <para>
+           Text Mode
+          </para>
+         </entry>
+         <entry>
+          <para>
+           1.5 GB
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           Minimal System
+          </para>
+         </entry>
+         <entry>
+          <para>
+           2.5 GB
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           &gnome; Desktop
+          </para>
+         </entry>
+         <entry>
+          <para>
+           3 GB
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           All patterns
+          </para>
+         </entry>
+         <entry>
+          <para>
+           4 GB
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry namest="col1" nameend="col2">
+          <para>
+           Recommended Minimum (no Btrfs snapshots): 10 GB
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry namest="col1" nameend="col2">
+          <para>
+           Required Minimum (with Btrfs snapshots): 16 GB
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry namest="col1" nameend="col2">
+          <para>
+           Recommended Minimum (with Btrfs snapshots): 32 GB
+          </para>
+         </entry>
+        </row>
+       </tbody>
+      </tgroup>
+     </informaltable>
+     <para>
+      If the root partition is smaller than 10 GB, the installer does not offer
+      a partitioning proposal. In this case, you need to create partitions
+      manually. To avoid this, we recommend to have 10&nbsp;GB reserved for the
+      root partition. Increase the minimum size to 16&nbsp;GB if you plan to
+      enable Btrfs snapshots on the root volume (see
+      <xref linkend="cha-snapper"/>).
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
 
-<sect1 version="5.0" xml:id="sec-power-install"
+  <para>
+   Before installing &productname;, make sure that the server has the latest
+   firmware. For the latest firmware, visit IBM FixCentral
+   (<link
+   xlink:href="http://www.ibm.com/support/fixcentral/"/>). Select
+   your system from the Product Group list. Additional software is available
+   from the IBM &powerlinux; Tools Repository. For more information on using
+   the IBM &powerlinux; Tools Repository, see
+   <link xlink:href="https://ibm.biz/Bdxn3N"/>.
+  </para>
+ </sect1>
+ <sect1 version="5.0" xml:id="sec-power-install"
        xmlns="http://docbook.org/ns/docbook"
        xmlns:xi="http://www.w3.org/2001/XInclude"
        xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Installing &sls; for &power;</title>
-  <para>
-    The following procedure describes how to set up an installation environment.
-    You can skip it if you already have an installation environment ready.
-  </para>
-  <procedure>
-    <title>Preparing an Installation Environment</title>
-    <step>
-      <para>
-	Start an SSH session to your HMC and run the <command>vtmenu</command> command.
-      </para>
-    </step>
-    <step>
-      <para>
-	Select the desired &power; server and the LPAR. If a serial console session for the
-	chosen LPAR already exists, you need to close it first using the following command:
-      </para>
-      <screen>rmvterm -m <replaceable>SERVER</replaceable> -p <replaceable>LPAR</replaceable></screen>
-    </step>
-    <step>
-      <para>
-	Reboot the LPAR by creating a new SSH session to the HMC
-	and running the following command:
-      </para>
-<screen>chsysstate -r lpar -m <replaceable>SERVER</replaceable> -o shutdown -n <replaceable>LPAR</replaceable> --immed --restart</screen>
-      <para>
-	Note that this command causes a hard reboot of the LPAR. To perform a soft reboot
-	and allow the running tasks to shut down properly,
-	omit the <option>--immed</option> flag on the command above.
-      </para>
-    </step>
-    <step>
-      <para>
-	When prompted, press <literal>1</literal> in the serial console to open the SMS Menu.
-      </para>
-      <informalfigure>
-      <mediaobject>
-       <imageobject>
-        <imagedata width="80%" fileref="install_power_sms_menu.png"/>
-       </imageobject>
-       <textobject><phrase>Choose SMS Menu</phrase>
-       </textobject>
-      </mediaobject>
-     </informalfigure>
-    </step>
-    <step>
-      <para>
-	Select <literal>Setup Remote IPL (Initial Program Load)</literal> by pressing <literal>2</literal> and <keycap function="enter"/>.
-      </para>
-      <informalfigure>
-      <mediaobject>
-       <imageobject>
-        <imagedata width="80%" fileref="install_power_remote_ipl.png"/>
-       </imageobject>
-       <textobject><phrase>Choose Setup Remote IPL</phrase>
-       </textobject>
-      </mediaobject>
-     </informalfigure>
-    </step>
-    <step>
-      <para>
-	Select the NIC Adapter for accessing your TFTP server.
-      </para>
-    </step>
-    <step>
-      <para>
-	Select the IP version to be used (for example, IPv4).
-      </para>
-    </step>
-    <step>
-      <para>
-	Select the protocol used to access the TFTP server (for example, <literal>1</literal> for BOOTP).
-      </para>
-    </step>
-    <step>
-      <para>
-	Select <literal>IP Parameters</literal> by pressing <literal>1</literal> and <keycap function="enter"/>.
-      </para>
-    </step>
-    <step>
-      <para>
-	Configure the required network parameters of the LPAR, including the IP address, the network gateway,
-	and the network mask. In the <literal>Server IP Address</literal>, specify the IP address of your TFTP server.
-      </para>
-      <informalfigure>
-      <mediaobject>
-       <imageobject>
-        <imagedata width="80%" fileref="install_power_network_params.png"/>
-       </imageobject>
-       <textobject><phrase>Configure network parameters</phrase>
-       </textobject>
-      </mediaobject>
-     </informalfigure>
-    </step>
-    <step>
-      <para>
-	Use the <keycap>Esc</keycap> key to return to the first screen. Select the
-	following entries in the specified order:
-      </para>
-	<itemizedlist>
-	  <listitem>
-	    <para>
-	      <literal>Select Boot Options</literal>
-	    </para>
-	  </listitem>
-	  <listitem>
-	    <para>
-	      <literal>Select Install/Boot Device</literal>
-	    </para>
-	  </listitem>
-	  <listitem>
-	    <para>
-	      <literal>Network</literal>
-	    </para>
-	  </listitem>
-	  <listitem>
-	    <para>
-	      <literal>BOOTP</literal>
-	    </para>
-	  </listitem>
-	</itemizedlist>
-    </step>
-    <step>
-      <para>
-	Select the NIC adapter specified earlier, then choose:
-      </para>
-	<itemizedlist>
-	  <listitem>
-	    <para>
-	      <literal>Normal Mode Boot</literal>
-	    </para>
-	  </listitem>
-	  <listitem>
-	    <para>
-	      <literal>Yes</literal>
-	    </para>
-	  </listitem>
-	</itemizedlist>
-    </step>
-    <step>
-      <para>
-	When the  process starts, you should see a GRUB menu containing a
-	list of images available on the TFTP server.
-      </para>
-      <informalfigure>
-      <mediaobject>
-       <imageobject>
-        <imagedata width="80%" fileref="install_power_grub.png"/>
-       </imageobject>
-       <textobject><phrase>GRUB menu</phrase>
-       </textobject>
-      </mediaobject>
-     </informalfigure>
-    </step>
-  </procedure>
-</sect1>
 
-<sect1 version="5.0" xml:id="sec-power-install-procedure"
+  <para>
+   The following procedure describes how to set up an installation environment.
+   You can skip it if you already have an installation environment ready.
+  </para>
+
+  <procedure>
+   <title>Preparing an Installation Environment</title>
+   <step>
+    <para>
+     Start an SSH session to your HMC and run the <command>vtmenu</command>
+     command.
+    </para>
+   </step>
+   <step>
+    <para>
+     Select the desired &power; server and the LPAR. If a serial console
+     session for the chosen LPAR already exists, you need to close it first
+     using the following command:
+    </para>
+<screen>rmvterm -m <replaceable>SERVER</replaceable> -p <replaceable>LPAR</replaceable></screen>
+   </step>
+   <step>
+    <para>
+     Reboot the LPAR by creating a new SSH session to the HMC and running the
+     following command:
+    </para>
+<screen>chsysstate -r lpar -m <replaceable>SERVER</replaceable> -o shutdown -n <replaceable>LPAR</replaceable> --immed --restart</screen>
+    <para>
+     Note that this command causes a hard reboot of the LPAR. To perform a soft
+     reboot and allow the running tasks to shut down properly, omit the
+     <option>--immed</option> flag on the command above.
+    </para>
+   </step>
+   <step>
+    <para>
+     When prompted, press <literal>1</literal> in the serial console to open
+     the SMS Menu.
+    </para>
+    <informalfigure>
+     <mediaobject>
+      <imageobject>
+       <imagedata width="80%" fileref="install_power_sms_menu.png"/>
+      </imageobject>
+      <textobject><phrase>Choose SMS Menu</phrase>
+      </textobject>
+     </mediaobject>
+    </informalfigure>
+   </step>
+   <step>
+    <para>
+     Select <literal>Setup Remote IPL (Initial Program Load)</literal> by
+     pressing <literal>2</literal> and <keycap function="enter"/>.
+    </para>
+    <informalfigure>
+     <mediaobject>
+      <imageobject>
+       <imagedata width="80%" fileref="install_power_remote_ipl.png"/>
+      </imageobject>
+      <textobject><phrase>Choose Setup Remote IPL</phrase>
+      </textobject>
+     </mediaobject>
+    </informalfigure>
+   </step>
+   <step>
+    <para>
+     Select the NIC Adapter for accessing your TFTP server.
+    </para>
+   </step>
+   <step>
+    <para>
+     Select the IP version to be used (for example, IPv4).
+    </para>
+   </step>
+   <step>
+    <para>
+     Select the protocol used to access the TFTP server (for example,
+     <literal>1</literal> for BOOTP).
+    </para>
+   </step>
+   <step>
+    <para>
+     Select <literal>IP Parameters</literal> by pressing <literal>1</literal>
+     and <keycap function="enter"/>.
+    </para>
+   </step>
+   <step>
+    <para>
+     Configure the required network parameters of the LPAR, including the IP
+     address, the network gateway, and the network mask. In the <literal>Server
+     IP Address</literal>, specify the IP address of your TFTP server.
+    </para>
+    <informalfigure>
+     <mediaobject>
+      <imageobject>
+       <imagedata width="80%" fileref="install_power_network_params.png"/>
+      </imageobject>
+      <textobject><phrase>Configure network parameters</phrase>
+      </textobject>
+     </mediaobject>
+    </informalfigure>
+   </step>
+   <step>
+    <para>
+     Use the <keycap>Esc</keycap> key to return to the first screen. Select the
+     following entries in the specified order:
+    </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+       <literal>Select Boot Options</literal>
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       <literal>Select Install/Boot Device</literal>
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       <literal>Network</literal>
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       <literal>BOOTP</literal>
+      </para>
+     </listitem>
+    </itemizedlist>
+   </step>
+   <step>
+    <para>
+     Select the NIC adapter specified earlier, then choose:
+    </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+       <literal>Normal Mode Boot</literal>
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       <literal>Yes</literal>
+      </para>
+     </listitem>
+    </itemizedlist>
+   </step>
+   <step>
+    <para>
+     When the process starts, you should see a GRUB menu containing a list of
+     images available on the TFTP server.
+    </para>
+    <informalfigure>
+     <mediaobject>
+      <imageobject>
+       <imagedata width="80%" fileref="install_power_grub.png"/>
+      </imageobject>
+      <textobject><phrase>GRUB menu</phrase>
+      </textobject>
+     </mediaobject>
+    </informalfigure>
+   </step>
+  </procedure>
+ </sect1>
+ <sect1 version="5.0" xml:id="sec-power-install-procedure"
        xmlns="http://docbook.org/ns/docbook"
        xmlns:xi="http://www.w3.org/2001/XInclude"
        xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Installing  &sls;</title>
-  <para>
-    In general installing &sls; on &power; is similar to a regular installation procedure.
-  </para>
-  <procedure>
-    <title>&sls; Installation</title>
-    <step>
-      <para>
-In the first two steps, you are prompted to choose the desired language and keyboard
-and to read and agree to the product's license agreement.
-      </para>
-    </step>
-    <step>
-      <para>
-	Next, choose the desired product registration method and complete registration.
-	If you register the system using the &scc;, you are prompted to enable
-	update repositories. Press <literal>Yes</literal>.
-      </para>
-      <informalfigure>
-      <mediaobject>
-       <imageobject>
-        <imagedata width="80%" fileref="install_sle_power_reg.png"/>
-       </imageobject>
-       <textobject><phrase>Registering the product</phrase>
-       </textobject>
-      </mediaobject>
-     </informalfigure>
-    </step>
-    <step>
-      <para>
-	a module or extensions, select it  using the arrow keys and press <keycap function="space"/>.
-	Depending on what extensions and  modules you select, you may be prompted to import
-	GnuPG keys for the associated repositories. 
-      </para>
-      <informalfigure>
-      <mediaobject>
-       <imageobject>
-        <imagedata width="80%" fileref="install_sle_power_ext.png"/>
-       </imageobject>
-       <textobject><phrase>Selecting extensions and modules</phrase>
-       </textobject>
-      </mediaobject>
-     </informalfigure>
-    </step>
-    <step>
-      <para>
-	Install the desired add-on products. If you choose to install an add-on,
-	you need to specify the installation source for it.
-      </para>
-      <informalfigure>
-      <mediaobject>
-       <imageobject>
-        <imagedata width="80%" fileref="install_sle_power_addon.png"/>
-       </imageobject>
-       <textobject><phrase>Installing add-on products</phrase>
-       </textobject>
-      </mediaobject>
-     </informalfigure>
-    </step>
-    <step>
-      <para>
-	Specify a partition scheme for your installation. To accept the default proposal,
-	press <literal>Next</literal> or press <keycombo><keycap function="alt"/><keycap>N</keycap></keycombo>.
-      </para>
-      <informalfigure>
-      <mediaobject>
-       <imageobject>
-        <imagedata width="80%" fileref="install_sle_power_part.png"/>
-       </imageobject>
-       <textobject><phrase>Specifying a partition scheme</phrase>
-       </textobject>
-      </mediaobject>
-     </informalfigure>
-    </step>
-    <step>
-      <para>
-	Choose the system role suitable for your particular scenario.
-      </para>
-      <informalfigure>
-      <mediaobject>
-       <imageobject>
-        <imagedata width="80%" fileref="install_sle_power_sysrole.png"/>
-       </imageobject>
-       <textobject><phrase>Choosing a system role</phrase>
-       </textobject>
-      </mediaobject>
-     </informalfigure>
-    </step>
-    <step>
-      <para>
-	The next several screen allow you to specify the appropriate
-	time zone, and create a user. If you choose not to create a user,
-	you are prompted to specify a root password.
-      </para>
-    </step>
-    <step>
-      <para>
-	In the installation summary screen, make sure the SSH service
-	is enabled and open an SSH port. To do this, press <literal>Change</literal>,
-	go to the <literal>Basic Firewall and SSH Configuration</literal> screen,
-	and enable the appropriate options. Press <literal>OK</literal>.
-      </para>
-      <informalfigure>
-      <mediaobject>
-       <imageobject>
-        <imagedata width="80%" fileref="install_sle_power_ssh.png"/>
-       </imageobject>
-       <textobject><phrase>Configuring SSH settings</phrase>
-       </textobject>
-      </mediaobject>
-     </informalfigure>
-    </step>
-    <step>
-      <para>
-	Confirm the installation configuration, and press <literal>Install</literal>
-	to start the installation process.
-      </para>
-    </step>
-  </procedure>
-</sect1>
+  <title>Installing &sls;</title>
 
-<sect1 version="5.0" xml:id="sec-power-info"
+  <para>
+   In general, installing &sls; on &power; is similar to a regular installation
+   procedure.
+  </para>
+
+  <procedure>
+   <title>&sls; Installation</title>
+   <step>
+    <para>
+     In the first two steps, you are prompted to choose the desired language
+     and keyboard and to read and agree to the product's license agreement.
+    </para>
+   </step>
+   <step>
+    <para>
+     Next, choose the desired product registration method and complete the
+     registration. If you register the system using the &scc;, you are prompted
+     to enable update repositories. Press <literal>Yes</literal>.
+    </para>
+    <informalfigure>
+     <mediaobject>
+      <imageobject>
+       <imagedata width="80%" fileref="install_sle_power_reg.png"/>
+      </imageobject>
+      <textobject><phrase>Registering the product</phrase>
+      </textobject>
+     </mediaobject>
+    </informalfigure>
+   </step>
+   <step>
+    <para>
+     To add a module or extension, select it using the arrow keys and press
+     <keycap function="space"/>. Depending on what extensions and modules you
+     select, you may be prompted to import GnuPG keys for the associated
+     repositories.
+    </para>
+    <informalfigure>
+     <mediaobject>
+      <imageobject>
+       <imagedata width="80%" fileref="install_sle_power_ext.png"/>
+      </imageobject>
+      <textobject><phrase>Selecting extensions and modules</phrase>
+      </textobject>
+     </mediaobject>
+    </informalfigure>
+   </step>
+   <step>
+    <para>
+     Install the desired add-on products. If you choose to install an add-on,
+     you need to specify the installation source for it.
+    </para>
+    <informalfigure>
+     <mediaobject>
+      <imageobject>
+       <imagedata width="80%" fileref="install_sle_power_addon.png"/>
+      </imageobject>
+      <textobject><phrase>Installing add-on products</phrase>
+      </textobject>
+     </mediaobject>
+    </informalfigure>
+   </step>
+   <step>
+    <para>
+     Specify a partition scheme for your installation. To accept the default
+     proposal, press <literal>Next</literal> or press
+     <keycombo><keycap function="alt"/><keycap>N</keycap></keycombo>.
+    </para>
+    <informalfigure>
+     <mediaobject>
+      <imageobject>
+       <imagedata width="80%" fileref="install_sle_power_part.png"/>
+      </imageobject>
+      <textobject><phrase>Specifying a partition scheme</phrase>
+      </textobject>
+     </mediaobject>
+    </informalfigure>
+   </step>
+   <step>
+    <para>
+     Choose the system role suitable for your particular scenario.
+    </para>
+    <informalfigure>
+     <mediaobject>
+      <imageobject>
+       <imagedata width="80%" fileref="install_sle_power_sysrole.png"/>
+      </imageobject>
+      <textobject><phrase>Choosing a system role</phrase>
+      </textobject>
+     </mediaobject>
+    </informalfigure>
+   </step>
+   <step>
+    <para>
+     The next several screen allow you to specify the appropriate time zone,
+     and create a user. If you choose not to create a user, you are prompted to
+     specify a root password.
+    </para>
+   </step>
+   <step>
+    <para>
+     In the installation summary screen, make sure the SSH service is enabled
+     and open an SSH port. To do this, press <literal>Change</literal>, go to
+     the <literal>Basic Firewall and SSH Configuration</literal> screen, and
+     enable the appropriate options. Press <literal>OK</literal>.
+    </para>
+    <informalfigure>
+     <mediaobject>
+      <imageobject>
+       <imagedata width="80%" fileref="install_sle_power_ssh.png"/>
+      </imageobject>
+      <textobject><phrase>Configuring SSH settings</phrase>
+      </textobject>
+     </mediaobject>
+    </informalfigure>
+   </step>
+   <step>
+    <para>
+     Confirm the installation configuration, and press
+     <literal>Install</literal> to start the installation process.
+    </para>
+   </step>
+  </procedure>
+ </sect1>
+ <sect1 version="5.0" xml:id="sec-power-info"
        xmlns="http://docbook.org/ns/docbook"
        xmlns:xi="http://www.w3.org/2001/XInclude"
        xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Further Information</title>
+
   <para>
-    Further information on IBM &powerlinux; is available from &suse; and IBM:
+   Further information on IBM &powerlinux; is available from &suse; and IBM:
   </para>
-  
+
   <itemizedlist>
-    <listitem>
-      <para>
-	The SUSE Support Knowledge Base at <link
-	xlink:href="https://www.suse.com/support/kb/"/> is a  help tool
-	for assisting customers in solving problems. Search the knowledge base on
-	&productname; using relevant search terms.
-      </para>
-    </listitem>
-    <listitem>
-   <para>
+   <listitem>
+    <para>
+     The SUSE Support Knowledge Base at
+     <link
+	xlink:href="https://www.suse.com/support/kb/"/> is a help tool for
+     assisting customers in solving problems. Search the knowledge base on
+     &productname; using relevant search terms.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      Find security alerts at
      <link xlink:href="https://www.suse.com/support/security/"/>. &suse; also
      maintains two security-related mailing lists:
-   </para>
-   <itemizedlist>
+    </para>
+    <itemizedlist>
      <listitem>
-       <para>
-	 <literal>suse-security</literal> &mdash; General discussion of security
-	 topics related to Linux and &suse;. All security alerts for &sls; are sent to
-	 this list.
-       </para>
-     </listitem>
-     <listitem>
-       <para>
-	 <literal>suse-security-announce</literal> &mdash; The &suse; mailing list
-	 exclusively for security alerts.
-       </para>
-     </listitem>
-   </itemizedlist>
-    </listitem>
-    <listitem>
       <para>
-	In case of hardware errors, check the control panel for any codes.
-	You can look up codes at the IBM
-	Power Systems Hardware Information Center at <link
+       <literal>suse-security</literal> &mdash; General discussion of security
+       topics related to Linux and &suse;. All security alerts for &sls; are
+       sent to this list.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       <literal>suse-security-announce</literal> &mdash; The &suse; mailing
+       list exclusively for security alerts.
+      </para>
+     </listitem>
+    </itemizedlist>
+   </listitem>
+   <listitem>
+    <para>
+     In case of hardware errors, check the control panel for any codes. You can
+     look up codes at the IBM Power Systems Hardware Information Center at
+     <link
 	xlink:href="https://ibm.biz/Bdxn3T"/>.
-      </para>
-    </listitem>
-    <listitem>
-      <para>
-	For troubleshooting tips, see the IBM &powerlinux; FAQ topic in the
-	Information Center at <link xlink:href="https://ibm.biz/Bdxn35"/>.
-      </para>
-    </listitem>
-    <listitem>
-      <para>
-	To participate in the linuxppc-dev mailing list, register using the forms
-	at <link xlink:href="http://lists.ozlabs.org/listinfo/linuxppc-dev/"/>.
-      </para>
-    </listitem>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     For troubleshooting tips, see the IBM &powerlinux; FAQ topic in the
+     Information Center at <link xlink:href="https://ibm.biz/Bdxn35"/>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     To participate in the linuxppc-dev mailing list, register using the forms
+     at <link xlink:href="http://lists.ozlabs.org/listinfo/linuxppc-dev/"/>.
+    </para>
+   </listitem>
   </itemizedlist>
-</sect1>
+ </sect1>
 </chapter>

--- a/xml/deployment_prep_x86_media.xml
+++ b/xml/deployment_prep_x86_media.xml
@@ -30,7 +30,7 @@
  <para>
   Unlike previous &slea; products, the entire &slea; &productnumber; product
   line can be installed using the &leanos;. <phrase os="sles">For details about the changes since
-  &sle; &product-ga; and which media to download for installation, see:
+  &sle; &product-ga; and which media to download for installation, see
   <xref linkend="sec-planning-leanos"/>.</phrase>
  </para>
  <para>

--- a/xml/deployment_prep_zseries_info_i.xml
+++ b/xml/deployment_prep_zseries_info_i.xml
@@ -31,8 +31,8 @@
   This section provides basic information about the system requirements, level
   of MicroCode, and software. It also covers the different installation types
   and how to do an IPL for the first installation.  For detailed technical
-  information about &zseries; on &productname; refer to <link
-  xlink:href="https://www.ibm.com/developerworks/linux/linux390/documentation_suse.html"/>.
+  information about &zseries; on &productname;, refer to <link xlink:href=
+  "https://www.ibm.com/developerworks/linux/linux390/documentation_suse.html"/>.
  </para>
  <sect2 xml:id="sec-info-sysreq-sysreq">
   <title>System Requirements</title>
@@ -132,7 +132,7 @@
     <note>
      <title>Memory Requirements with Remote Installation Sources</title>
      <para>
-      Minimum of 512 MB of memory is required for installation from NFS, FTP,
+      A minimum of 512 MB of memory is required for installation from NFS, FTP,
       and SMB installation sources, or when VNC is used. Keep in mind that the
       number of devices visible to the z/VM guest or LPAR image affects memory
       requirements. Installation with many accessible devices
@@ -195,7 +195,7 @@
         </entry>
         <entry>
          <para>
-          Recommended (this is with graphical desktop, development packages and
+          Recommended (this is with graphical desktop, development packages, and
           Java).
          </para>
         </entry>
@@ -207,9 +207,9 @@
    <sect4 xml:id="sec-info-sysreq-sysreq-hw-network">
     <title>Network Connection</title>
     <para>
-     A network connection is required to communicate with your &productname;
-     system. This can be one or several of the following connections or network
-     cards:
+     A network connection is required in order to communicate with your
+     &productname; system. This can be one or several of the following 
+     connections or network cards:
     </para>
     <itemizedlist>
      <listitem>
@@ -304,7 +304,7 @@
     <itemizedlist>
      <listitem>
       <para>
-       z/VM 6.3, we strongly suggest installing the APAR VM65419 (or higher) to
+       z/VM 6.3: we strongly suggest installing the APAR VM65419 (or higher) to
        improve the output of qclib.
       </para>
      </listitem>

--- a/xml/deployment_prep_zseries_prep_i.xml
+++ b/xml/deployment_prep_zseries_prep_i.xml
@@ -481,7 +481,7 @@ DASD=600"</screen>
   <title>Installation Types</title>
   <para>
    This section describes &productname; installation steps for each
-   installation modes. When the preparation steps described in the previous
+   installation mode. When the preparation steps described in the previous
    chapters have been completed, follow the overview of the desired
    installation mode.
   </para>
@@ -724,7 +724,7 @@ DIRM USER WITHPASS</screen>
     <title>Write a Domain XML File</title>
     <para>
      A domain XML file is used to define the &vmguest;. To create the domain
-     XML file open an empty file <filename>s15-1.xml</filename> with an editor
+     XML file, open an empty file <filename>s15-1.xml</filename> with an editor
      and create a file like in the following example.
     </para>
     <example>
@@ -790,9 +790,9 @@ DIRM USER WITHPASS</screen>
      Mark the LPAR to install and select <guimenu>Load from CD-ROM or
      server</guimenu>. Leave the field for the file location blank or enter the
      path to the root directory of the first DVD-ROM and select
-     <guimenu>Continue</guimenu>. Keep the default selection in the appeared
-     list of options. <guimenu>Operating system messages</guimenu> should now
-     show the kernel boot messages.
+     <guimenu>Continue</guimenu>. Keep the default selection in the list of
+     options that appears. <guimenu>Operating system messages</guimenu> should
+     now show the kernel boot messages.
     </para>
    </sect4>
    <sect4 xml:id="sec-prep-ipling-lpar-dvd">
@@ -1093,7 +1093,7 @@ Retry?
   </para>
   <para>
    First, choose <guimenu>Start Installation</guimenu> in the
-   <filename>linuxrc</filename> main menu. Choose then <guimenu>Start
+   <filename>linuxrc</filename> main menu. Then choose <guimenu>Start
    Installation or Update</guimenu> to start the installation process. Select
    <guimenu>Network</guimenu> as the installation medium, then select the type
    of network protocol to use for the installation. <xref
@@ -1353,8 +1353,8 @@ ter '+++' to abort).
     <para>
      The direct installation with the X Window System relies on an
      authentication mechanism based on host names. This mechanism is disabled
-     in current &productname; versions. We recommend to perform the
-     installation using SSH or VNC.
+     in current &productname; versions. We recommend performing the installation
+     using SSH or VNC.
     </para>
    </important>
    <para>

--- a/xml/deployment_prep_zseries_requirements.xml
+++ b/xml/deployment_prep_zseries_requirements.xml
@@ -8,7 +8,7 @@
 <!--
    fs 02/28/2006:
      Do not change the following words/phrases (except in URLs,
-     packagenames etc.)in all zSeries documents, because they are trademarks:
+     packagenames etc.) in all zSeries documents, because they are trademarks:
       - Redbook, Redpiece, Redpaper
       - developerWorks
       - ESCON
@@ -31,7 +31,7 @@
   This section provides basic information about the system requirements, level
   of MicroCode, and software. It also covers the different installation types
   and how to do an IPL for the first installation.  For detailed technical
-  information about &zseries; on &productname; refer to <link
+  information about &zseries; on &productname;, refer to <link
   xlink:href="https://www.ibm.com/developerworks/linux/linux390/documentation_suse.html"/>.
  </para>
  <sect2 xml:id="sec-zseries-requirements-hw">
@@ -112,12 +112,11 @@
    <note>
     <title>Memory Requirements with Remote Installation Sources</title>
     <para>
-     Minimum of 512 MB of memory is required for installation from NFS, FTP,
-     and SMB installation sources, or when VNC is used. Keep in mind that
+     A minimum of 512&nbsp;MB of memory is required for installation from NFS,
+     FTP, and SMB installation sources, or when VNC is used. Keep in mind that
      memory requirements also depend on the number of devices visible to the
-     z/VM guest or the LPAR image. Installation with many
-     accessible devices (even if unused for the installation) may require more
-     memory.
+     z/VM guest or the LPAR image. Installation with many accessible devices
+     (even if unused for the installation) may require more memory.
     </para>
    </note>
   </sect3>
@@ -282,8 +281,8 @@
     </listitem>
     <listitem>
      <para>
-      The host network interface is connected to a network in which the
-      virtual server will join.
+      The host network interface is connected to a network that the virtual
+      server will join.
      </para>
     </listitem>
     <listitem>
@@ -316,7 +315,7 @@
    We recommend to use the highest service level available.  Contact IBM
    support for minimum requirements.
   </para>
-  <para>For z/VM the following versions are supported:</para>
+  <para>For z/VM, the following versions are supported:</para>
   <itemizedlist>
    <listitem>
     <para>

--- a/xml/deployment_pxe.xml
+++ b/xml/deployment_pxe.xml
@@ -210,8 +210,8 @@ DHCLIENT6_CLIENT_ID=<replaceable>00:03:52:54:00:02:c2:67</replaceable></screen>
     <literal>client-id</literal>. It starts with the
     <literal>0xff</literal> prefix, instead of the hardware type, followed by the
     DHCPv6 IAID (the interface-address association ID that describes the
-    interface on the machine), followed by the DHCPv6 DHCP Unique
-    Identifier (DUID), which uniquely identifies the machine.
+    interface on the machine), followed by the DHCPv6 Unique Identifier (DUID),
+    which uniquely identifies the machine.
    </para>
    <para>
     Using the above hardware type-based and hardware address-based DUID, the new
@@ -232,9 +232,9 @@ DHCLIENT6_CLIENT_ID=<replaceable>00:03:52:54:00:02:c2:67</replaceable></screen>
     </listitem>
    </itemizedlist>
    <para>
-    The <replaceable>xx:xx:xx:xx</replaceable> fields in the DUID-Link-Layer Timestamp
-    (DUID-LLT) is a creation timestamp. A DUID-Link-Layer (DUID-LL) (<literal>00:03:00:01:$MAC</literal>)
-    does not have a timestamp.
+    The <replaceable>xx:xx:xx:xx</replaceable> field in the DUID-Link-Layer 
+    Timestamp (DUID-LLT) is a creation time stamp. A DUID-Link-Layer (DUID-LL)
+    (<literal>00:03:00:01:$MAC</literal>) does not have a time stamp.
    </para>
    <para>
     For more information on using <literal>linuxrc</literal>, see the &ayguide;.
@@ -327,7 +327,7 @@ DHCLIENT6_CLIENT_ID=<replaceable>00:03:52:54:00:02:c2:67</replaceable></screen>
     <replaceable>SLE-15-SP2-x86_64</replaceable>, and replace
     <replaceable>ARCHITECTURE</replaceable> with the architecture of your
     system, for example <literal>x86_64</literal>.  So the resulting text would
-    look like this: <package>tftpboot-installation-SLE-15-SP2-x86_64</package>
+    look like this: <package>tftpboot-installation-SLE-15-SP2-x86_64</package>.
     Run <command>zypper se tftpboot</command> to search for all available
     versions and architectures.
    </para>

--- a/xml/deployment_troubleshooting.xml
+++ b/xml/deployment_troubleshooting.xml
@@ -36,7 +36,7 @@
   <para>
    In a running system, start &yast; and choose <menuchoice>
    <guimenu>Software</guimenu> <guimenu>Media Check</guimenu> </menuchoice>.
-   Insert the medium click <guimenu>Start Check</guimenu>. Checking may take
+   Insert the medium and click <guimenu>Start Check</guimenu>. Checking may take
    several minutes.
   </para>
 
@@ -61,8 +61,8 @@
     <term>Using an External &usbflashdrivecap; or DVD Drive</term>
     <listitem>
      <para>
-      Linux supports most existing &usbflashdrive; or DVD drives. If the system
-      has no &usbflashdrive; or DVD drive, it is still possible that an
+      Linux supports most existing &usbflashdrive;s and DVD drives. If the
+      system has no &usbflashdrive; or DVD drive, it is still possible that an
       external drive, connected through USB, FireWire, or SCSI, can be used to
       boot the system. Sometimes a firmware update may help if you encounter
       problems.

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -2368,9 +2368,9 @@ sle-live-patching 8c541494</screen>
   <sect2 xml:id="sec-yast-install-proposal-network">
    <title><guimenu>Network Configuration</guimenu></title>
    <para>
-    This category displays the current network settings (as automatically
-    configured after booting into the installation, see <xref
-     linkend="sec-yast-install-network" xrefstyle="select:label"/>) or as manually
+    This category displays the current network settings, as automatically
+    configured after booting into the installation (see <xref
+    linkend="sec-yast-install-network" xrefstyle="select:label"/>) or as manually
     configured from the <guimenu>Registration</guimenu> or
     <guimenu>Add-On Product</guimenu> dialog during the respective steps of
     the installation process. If you want to check or adjust the network settings

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -196,7 +196,7 @@
     images of the &leanos; and Packages ISOs. If you install from the ISOs published
     as quarterly update (they can be identified by the string <literal>QU</literal>
     in the name), the installer cannot update itself, because this feature has
-    been disabled in the updated media.
+    been disabled in the update media.
    </para>
   </important>
 

--- a/xml/planning.xml
+++ b/xml/planning.xml
@@ -194,7 +194,7 @@
  <sect2 xml:id="sec-planning-leanos-products">
  <title>&leanos; for &sle;-based Products</title>
   <para>
-   As of &productname; 15 SP1, this includes the following base products.
+   As of &productname; 15 SP1, this includes the following base products:
   </para>
 
   <informaltable>
@@ -291,7 +291,7 @@
      <para>
       The size of the full installation media &installmedia; exceeds the
       capacity of a dual layer DVD.  Therefore you can only boot it from a USB
-      Flash Drive.
+      flash drive.
      </para>
     </tip>
 

--- a/xml/updater_gnome.xml
+++ b/xml/updater_gnome.xml
@@ -33,7 +33,7 @@
   repositories, but also new versions of packages that are already
   installed. (Patches fix security issues or malfunctions; the functionality
   and version number is usually not changed. New versions of a package increase
-  the version number and usually add functionality or introduce major changes).
+  the version number and usually add functionality or introduce major changes.)
  </para>
 
  <para>


### PR DESCRIPTION
### Description
Integrate all the changes requested by Dublin proofreading of the DepGuide.

One is possibly controversial: we are not sure if "DHCPv6 DHCP Unique Identifier" is necessary. It seems tautological. As requested, I have removed the 2nd occurrence to leave it as "DHCPv6 Unique Identifier". If the longer version is required because it is formally correct, it is trivial to reverse.

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
