### PR TITLE
SuSEFirewall2 config to firewalld for Host-Based Routing in Xen

### DIFF
--- a/xml/xen_host_network.xml
+++ b/xml/xen_host_network.xml
@@ -221,6 +221,31 @@ STARTMODE="hotplug"
      </step>
      <step>
       <para>
+       Ensure that IP forwarding is enabled:
+      </para>
+      <substeps>
+       <step>
+        <para>
+         In &yast;, go to <menuchoice><guimenu>Network
+           Settings</guimenu><guimenu>Routing</guimenu></menuchoice>.
+        </para>
+       </step>
+       <step>
+        <para>
+         Enter the <guimenu>Routing</guimenu> tab and activate <guimenu>Enable
+          IPv4 Forwarding</guimenu> and <guimenu>Enable IPv6
+          Forwarding</guimenu> options.
+        </para>
+       </step>
+       <step>
+        <para>
+         Confirm the setting and quit &yast;.
+        </para>
+       </step>
+      </substeps>
+     </step>
+     <step>
+      <para>
        Apply the following configuration to &firewalld;:
        </para>
       <itemizedlist mark="bullet" spacing="normal">
@@ -229,12 +254,6 @@ STARTMODE="hotplug"
          Add &xenguest;.0 to the devices in the public zone:
         </para>
 <screen>&prompt.sudo;firewall-cmd --zone=public --add-interface=&xenguest;.0</screen>
-       </listitem>
-       <listitem>
-        <para>
-         Switch on the routing in the firewall:
-        </para>
-<screen>&prompt.sudo;ADDME</screen>
        </listitem>
        <listitem>
         <para>

--- a/xml/xen_host_network.xml
+++ b/xml/xen_host_network.xml
@@ -221,34 +221,33 @@ STARTMODE="hotplug"
      </step>
      <step>
       <para>
-       Edit the file
-       <filename>/etc/sysconfig/&susefirewallfiles;</filename> and add
-       the following configurations:
-      </para>
+       Apply the following configuration to &firewalld;:
+       </para>
       <itemizedlist mark="bullet" spacing="normal">
        <listitem>
         <para>
-         Add &xenguest;.0 to the devices in FW_DEV_EXT:
+         Add &xenguest;.0 to the devices in the public zone:
         </para>
-<screen>FW_DEV_EXT="br0 &xenguest;.0"</screen>
+<screen>&prompt.sudo;firewall-cmd --zone=public --add-interface=&xenguest;.0</screen>
        </listitem>
        <listitem>
         <para>
          Switch on the routing in the firewall:
         </para>
-<screen>FW_ROUTE="yes"</screen>
+<screen>&prompt.sudo;ADDME</screen>
        </listitem>
        <listitem>
         <para>
          Tell the firewall which address should be forwarded:
         </para>
-<screen>FW_FORWARD="&xenguestip;/32,0/0"</screen>
+<screen>&prompt.sudo;firewall-cmd --zone=public \
+--add-forward-port=port=80:proto=tcp:toport=80:toaddr="&xenguestip;/32,0/0"</screen>
        </listitem>
        <listitem>
         <para>
-         Finally, restart the firewall with the command:
+         Make the runtime configuration changes permanent:
         </para>
-<screen>&prompt.sudo;systemctl restart &susefirewallfiles;</screen>
+<screen>&prompt.sudo;firewall-cmd --runtime-to-permanent</screen>
        </listitem>
       </itemizedlist>
      </step>


### PR DESCRIPTION
### Description
As SUSEFirewall is not among SLE15's any longer, this update tries to translate its configuration to firewalld rules

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
