### PR TITLE
vt doc: Improve libvirt network section

### DIFF
--- a/xml/libvirt_networking.xml
+++ b/xml/libvirt_networking.xml
@@ -8,12 +8,11 @@
  <title>Managing Networks</title>
  <info>
   <abstract>
-   <para>
-    This chapter introduces common networking configurations supported by
-    &libvirt;. It does not depend on the hypervisor used. It is valid for all
-    hypervisors supported by &libvirt;, such as &kvm; or &xen;. These setups
-    can be achieved using both the graphical interface of &vmm; and the command
-    line tool <command>virsh</command>.
+    <para>
+     This chapter describes common network configurations for a &vmhost;,
+     including those supported natively by the &vmhost; and &libvirt;.
+     The configurations are valid for all hypervisors supported by &productname;,
+     such as &kvm; or &xen;.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -21,61 +20,381 @@
   </dm:docmanager>
  </info>
  <para>
-  There are two common network setups to provide a &vmguest; with a network
-  connection:
+  There are two common network configurations to provide a &vmguest; with a
+  network connection:
  </para>
  <itemizedlist>
   <listitem>
    <para>
-    A <emphasis>virtual network</emphasis> for the guest
+    A <emphasis>network bridge</emphasis> acting as a Layer 2 switch
    </para>
   </listitem>
   <listitem>
    <para>
-    A <emphasis>network bridge</emphasis> over a host's physical network
-    interface that the guest can use
+    A <emphasis>virtual network</emphasis> managed by &libvirt; with Layer 3
+    forwarding enabled
    </para>
   </listitem>
  </itemizedlist>
+ <sect1 xml:id="libvirt-networks-bridged">
+  <title>Network Bridge</title>
+
+  <para>
+   The network bridge configuration provides a Layer 2 switch for &vmguest;s,
+   switching Layer 2 Ethernet packets between ports on the bridge based on MAC
+   addresses associated with the ports. This gives the &vmguest; Layer 2 access
+   to the &vmhost;'s network. This configuration is analogous to connecting the
+   &vmguest;'s virtual Ethernet cable into a hub that is shared with the host
+   and other &vmguest;s running on the host. The configuration is often referred
+   to as <emphasis>shared physical device</emphasis>.
+  </para>
+
+  <para>
+   The network bridge configuration is the default configuration of
+   &productname; when configured as a &kvm; or &xen; hypervisor. It is the
+   preferred configuration when you simply want to connect &vmguest;s to the
+   &vhhost;'s LAN.
+  </para>
+
+  <sect2 xml:id="libvirt-networks-bridged-yast">
+   <title>Managing Network Bridges with &yast;</title>
+   <para>
+    This section includes procedures to add or remove network bridges with
+    &yast;.
+   </para>
+   <sect3 xml:id="libvirt-networks-bridged-yast-add">
+    <title>Adding a Network Bridge</title>
+    <para>
+     To add a network bridge on &vmhost;, follow these steps:
+    </para>
+    <procedure>
+     <step>
+      <para>
+       Start
+       <menuchoice><guimenu>&yast;</guimenu><guimenu>System</guimenu><guimenu>Network
+       Settings</guimenu></menuchoice>.
+      </para>
+     </step>
+     <step>
+      <para>
+       Activate the <guimenu>Overview</guimenu> tab and click
+       <guimenu>Add</guimenu>.
+      </para>
+     </step>
+     <step>
+      <para>
+       Select <guimenu>Bridge</guimenu> from the <guimenu>Device Type</guimenu>
+       list and enter the bridge device interface name in the
+       <guimenu>Configuration Name</guimenu> entry. Press the
+       <guimenu>Next</guimenu> button to proceed.
+      </para>
+     </step>
+     <step>
+      <para>
+       In the <guimenu>Address</guimenu> tab, specify networking details such
+       as DHCP/static IP address, subnet mask or host name.
+      </para>
+      <para>
+       Using <guimenu>Dynamic Address</guimenu> is only useful when also
+       assigning a device to a bridge that is connected to a DHCP server.
+      </para>
+      <para>
+       If you intend to create a virtual bridge that has no connection to a
+       real Ethernet device, use <guimenu>Statically assigned IP
+       Address</guimenu>. In this case, it is a good idea to use addresses from
+       the private IP address ranges, for example,
+       <literal>192.168.0.0/16</literal>, <literal>172.16.0.0/12</literal>, or
+       <literal>10.0.0.0/8</literal>.
+      </para>
+      <para>
+       To create a bridge that should only serve as a connection between the
+       different guests without connection to the host system, set the IP
+       address to <literal>0.0.0.0</literal> and the subnet mask to
+       <literal>255.255.255.255</literal>. The network scripts handle this
+       special address as an unset IP address.
+      </para>
+     </step>
+     <step>
+      <para>
+       Activate the <guimenu>Bridged Devices</guimenu> tab and activate the
+       network devices you want to include in the network bridge.
+      </para>
+     </step>
+     <step>
+      <para>
+       Click <guimenu>Next</guimenu> to return to the
+       <guimenu>Overview</guimenu> tab and confirm with <guimenu>OK</guimenu>.
+       The new network bridge should now be active on &vmhost;.
+      </para>
+     </step>
+    </procedure>
+   </sect3>
+   <sect3 xml:id="libvirt-networks-bridged-yast-rm">
+    <title>Deleting a Network Bridge</title>
+    <para>
+     To delete an existing network bridge, follow these steps:
+    </para>
+    <procedure>
+     <step>
+      <para>
+       Start
+       <menuchoice><guimenu>&yast;</guimenu><guimenu>System</guimenu><guimenu>Network
+       Settings</guimenu></menuchoice>.
+      </para>
+     </step>
+     <step>
+      <para>
+       Select the bridge device you want to delete from the list in the
+       <guimenu>Overview</guimenu> tab.
+      </para>
+     </step>
+     <step>
+      <para>
+       Delete the bridge with <guimenu>Delete</guimenu> and confirm with
+       <guimenu>OK</guimenu>.
+      </para>
+     </step>
+    </procedure>
+   </sect3>
+  </sect2>
+
+  <sect2 xml:id="libvirt-networks-bridged-add-brctl">
+   <title>Managing Network Bridges from the Command Line</title>
+   <para>
+    This section includes procedures to add or remove network bridges using the
+    command line.
+   </para>
+   <sect3 xml:id="libvirt-networks-bridged-add-brctl-add">
+    <title>Adding a Network Bridge</title>
+    <para>
+     To add a new network bridge device on &vmhost;, follow these steps:
+    </para>
+    <procedure>
+     <step>
+      <para>
+       Log in as &rootuser; on the &vmhost; where you want to create a new
+       network bridge.
+      </para>
+     </step>
+     <step>
+      <para>
+       Choose a name for the new
+       bridge&mdash;<replaceable>virbr_test</replaceable> in our
+       example&mdash;and run
+      </para>
+<screen>&prompt.root;ip link add name <replaceable>VIRBR_TEST</replaceable> type bridge</screen>
+     </step>
+     <step>
+      <para>
+       Check if the bridge was created on &vmhost;:
+      </para>
+<screen>&prompt.root;bridge vlan
+[...]
+virbr_test  1 PVID Egress Untagged
+</screen>
+      <para>
+       <literal>virbr_test</literal> is present, but is not associated with any
+       physical network interface.
+      </para>
+     </step>
+     <step>
+      <para>
+       Bring the network bridge up and add a network interface to the bridge:
+      </para>
+<screen>
+&prompt.root;ip link set virbr_test up
+&prompt.root;ip link set eth1 master virbr_test
+</screen>
+      <important>
+       <title>Network Interface Must Be Unused</title>
+       <para>
+        You can only assign a network interface that is not yet used by other
+        network bridge.
+       </para>
+      </important>
+     </step>
+     <step>
+      <para>
+       Optionally, enable STP (see
+       <link xlink:href="https://en.wikipedia.org/wiki/Spanning_Tree_Protocol">Spanning
+       Tree Protocol</link>):
+      </para>
+<screen>&prompt.root;bridge link set dev virbr_test cost 4</screen>
+     </step>
+    </procedure>
+   </sect3>
+   <sect3 xml:id="libvirt-networks-bridged-add-brctl-del">
+    <title>Deleting a Network Bridge</title>
+    <para>
+     To delete an existing network bridge device on &vmhost; from the command
+     line, follow these steps:
+    </para>
+    <procedure>
+     <step>
+      <para>
+       Log in as &rootuser; on the &vmhost; where you want to delete an
+       existing network bridge.
+      </para>
+     </step>
+     <step>
+      <para>
+       List existing network bridges to identify the name of the bridge to
+       remove:
+      </para>
+<screen>&prompt.root;bridge vlan
+[...]
+virbr_test  1 PVID Egress Untagged
+</screen>
+     </step>
+     <step>
+      <para>
+       Delete the bridge:
+      </para>
+<screen>&prompt.root;ip link delete dev virbr_test</screen>
+     </step>
+    </procedure>
+   </sect3>
+  </sect2>
+
+  <sect2 xml:id="sec-xen-net-vlan">
+   <title>Using VLAN Interfaces</title>
+   <para>
+    Sometimes, it is necessary to create a private connection either between
+    two &vmhost;s or between &vmguest; systems. For example, to migrate
+    &vmguest; to hosts in a different network segment, or to create a private
+    bridge that only &vmguest; systems may connect to (even when running on
+    different &vmhost; systems). An easy way to build such connections is to set
+    up VLAN networks.
+   </para>
+   <para>
+    VLAN interfaces are commonly set up on the &vmhost;. They either interconnect
+    the different &vmhost; systems, or they may be set up as a physical
+    interface to an otherwise virtual-only bridge. It is even possible to
+    create a bridge with a VLAN as a physical interface that has no IP address
+    in the &vmhost;. That way, the guest systems have no possibility to access
+    the host over this network.
+   </para>
+   <para>
+    Run the &yast; module <menuchoice><guimenu>System</guimenu><guimenu>Network
+    Settings</guimenu></menuchoice>. Follow this procedure to set up the VLAN
+    device:
+   </para>
+   <procedure>
+    <title>Setting up VLAN Interfaces with &yast;</title>
+    <step>
+     <para>
+      Click <guimenu>Add</guimenu> to create a new network interface.
+     </para>
+    </step>
+    <step>
+     <para>
+      In the <guimenu>Hardware Dialog</guimenu>, select <guimenu>Device
+      Type</guimenu> <guimenu>VLAN</guimenu>.
+     </para>
+    </step>
+    <step>
+     <para>
+      Change the value of <guimenu>Configuration Name</guimenu> to the ID of
+      your VLAN. Note that VLAN ID <literal>1</literal> is commonly used for
+      management purposes.
+     </para>
+    </step>
+    <step>
+     <para>
+      Click <guimenu>Next</guimenu>.
+     </para>
+    </step>
+    <step>
+     <para>
+      Select the interface that the VLAN device should connect to below
+      <guimenu>Real Interface for VLAN</guimenu>. If the desired interface does
+      not appear in the list, first set up this interface without an IP
+      address.
+     </para>
+    </step>
+    <step>
+     <para>
+      Select the desired method for assigning an IP address to the VLAN device.
+     </para>
+    </step>
+    <step>
+     <para>
+      Click <guimenu>Next</guimenu> to finish the configuration.
+     </para>
+    </step>
+   </procedure>
+   <para>
+    It is also possible to use the VLAN interface as a physical interface of a
+    bridge. This makes it possible to connect several &vmhost;-only networks
+    and allows live migration of &vmguest; systems that are connected to such a
+    network.
+   </para>
+   <para>
+    &yast; does not always allow setting no IP address. However, this may be a
+    desired feature, especially if &vmhost;-only networks should be connected.
+    In this case, use the special address <literal>0.0.0.0</literal> with
+    netmask <literal>255.255.255.255</literal>. The system scripts handle this
+    address as no IP address set.
+   </para>
+  </sect2>
+ </sect1>
  <sect1 xml:id="libvirt-networks-virtual">
   <title>Virtual Networks</title>
 
   <para>
-   A virtual network is a computer network which does not consist of a physical
-   network link, but rather uses a virtual network link. Each host can have
-   several virtual networks defined. Virtual networks are based on virtual
-   devices that connect virtual machines inside a hypervisor. They allow
-   outgoing traffic translated to the LAN and are provided with DHCP and DNS
-   services. Virtual networks can be either <emphasis>isolated</emphasis>, or
-   <emphasis>forwarded</emphasis> to a physical network.
+   &libvirt;-managed virtual networks are similar to bridged networks, but
+   typically have no Layer 2 connection to the &vmhost;. Connectivity to
+   the &vmhost;'s physical network is accomplished with Layer 3 forwarding,
+   which introduces additional packet processing on the &vmhost; as compared
+   to a Layer 2 bridged network. Virtual networks also provide DHCP and DNS
+   services for &vmguest;s. For more information on &libvirt;s virtual networks
+   see the <citetitle>Network XML format</citetitle> documentation at
+   <link xlink:href="https://libvirt.org/formatnetwork.html"/>.
   </para>
 
   <para>
-   Guests inside an <emphasis>isolated</emphasis> virtual network can
-   communicate with each other, but cannot communicate with guests outside the
-   virtual network. Also, guests not belonging to the isolated virtual network
-   cannot communicate with guests inside.
+   A standard &libvirt; installation on &productname; already comes with a
+   predefined virtual network named <literal>default</literal> that provides
+   DHCP and DNS services for the network, along with connectivity to the
+   &vmhost;'s physical network using the network address translation (NAT)
+   forwarding mode. Although it is predefined, the <literal>default</literal>
+   virtual network must be explicitly enabled by the administrator. For more
+   information on the forwarding modes supported by &libvirt; see the
+   <citetitle>Connectivity</citetitle> section of the
+   <citetitle>Network XML format</citetitle> documentation at
+   <link xlink:href="https://libvirt.org/formatnetwork.html#elementsConnect"/>.
   </para>
 
   <para>
-   On the other hand, guests inside a <emphasis>forwarded</emphasis> (NAT,
-   network address translation) virtual network can make any outgoing network
-   connection they request. Incoming connections are allowed from &vmhost;, and
-   from other guests connected to the same virtual network. All other incoming
-   connections are blocked by <systemitem>iptables</systemitem> rules.
+   &libvirt;-managed virtual networks can be used to satisfy a wide range
+   of use-cases, but are commonly used on &vmhost;s that have a wireless
+   connection or dynamic/sporadic network connectivity such as laptops.
+   Virtual networks are also useful when the &vmhost;'s network has limited
+   IP addresses, allowing forwarding of packets between the virtual network
+   and the &vmhost;'s network. However, most server use-cases are better
+   suited for the network bridge configuration, where &vmguest;s are connected
+   to the &vmhost;'s LAN.
   </para>
 
-  <para>
-   A standard libvirt installation on &productname; already comes with a
-   predefined virtual network providing DHCP server and network address
-   translation (NAT) named "default".
-  </para>
+  <warning>
+   <title>Enabling Forwarding Mode</title>
+   <para>
+    Enabling forwarding mode in a &libvirt; virtual network enables forwarding
+    in the &vmhost; by setting <filename>/proc/sys/net/ipv4/ip_forward</filename>
+    and <filename>/proc/sys/net/ipv6/conf/all/forwarding</filename> to 1, which
+    essentially turns the &vmhost; into a router. Restarting the &vmhost;'s
+    network may reset the values and disable forwarding. To avoid this behavior,
+    explicitly enable forwarding in the &vmhost; by editing the
+    <filename>/etc/sysctl.conf</filename> file and adding:
+   </para>
+   <screen>net.ipv4.ip_forward = 1</screen>
+   <screen>net.ipv6.conf.all.forwarding = 1</screen>
+  </warning>
 
   <sect2 xml:id="libvirt-networks-virtual-vmm">
    <title>Managing Virtual Networks with &vmm;</title>
    <para>
-    You can define, configure, and operate both isolated and forwarded virtual
-    networks with &vmm;.
+    You can define, configure, and operate virtual networks with &vmm;.
    </para>
    <sect3 xml:id="libvirt-networks-virtual-vmm-define">
     <title>Defining Virtual Networks</title>
@@ -179,7 +498,7 @@
      </step>
      <step>
       <para>
-       Select whether you want isolated or forwarded virtual network.
+       Select whether you want an isolated or forwarded virtual network.
       </para>
       <figure>
        <title>Create virtual network</title>
@@ -197,13 +516,13 @@
        requests will be forwarded, and one of the forwarding modes: While
        <guimenu>NAT</guimenu> (network address translation) remaps the virtual
        network address space and allows sharing a single IP address,
-       <guimenu>Routed</guimenu> connects the virtual switch to the physical
-       host LAN with no network translation.
+       <guimenu>Routed</guimenu> forwards packets from the virtual network to
+       the &vmhost;'s physical network with no translation.
       </para>
      </step>
      <step>
       <para>
-       If you did not specify IPv6 network address space definition earlier,
+       If you did not specify an IPv6 network address space definition earlier,
        you can enable IPv6 internal routing between virtual machines.
       </para>
      </step>
@@ -217,7 +536,7 @@
        Click <guimenu>Finish</guimenu> to create the new virtual network. On
        the &vmhost;, a new virtual network bridge
        <literal>virbr<replaceable>X</replaceable></literal> is available, which
-       corresponds to the newly created virtual network. You can check with
+       corresponds to the newly-created virtual network. You can check with
        <command>bridge link</command>. &libvirt; automatically adds iptables
        rules to allow traffic to/from guests attached to the new
        <emphasis>virbr<replaceable>X</replaceable></emphasis> device.
@@ -425,22 +744,22 @@ Networking (help keyword 'network'):
       allows guests to talk directly to each other.
      </para>
 <screen>
-&lt;network>
-&lt;name>vnet_nated&lt;/name><co xml:id="vnet-xml-name"/>
-&lt;bridge name="virbr1" /><co xml:id="vnet-xml-bridge"/>
- &lt;forward mode="nat"/><co xml:id="vnet-xml-forward"/>
- &lt;ip address="192.168.122.1" netmask="255.255.255.0"><co xml:id="vnet-xml-ip"/>
-  &lt;dhcp>
-   &lt;range start="192.168.122.2" end="192.168.122.254" /><co xml:id="vnet-xml-dhcp"/>
+&lt;network&gt;
+&lt;name&gt;vnet_nated&lt;/name&gt;<co xml:id="vnet-xml-name"/>
+&lt;bridge name="virbr1"/&gt;<co xml:id="vnet-xml-bridge"/>
+ &lt;forward mode="nat"/&gt;<co xml:id="vnet-xml-forward"/>
+ &lt;ip address="192.168.122.1" netmask="255.255.255.0"&gt;<co xml:id="vnet-xml-ip"/>
+  &lt;dhcp&gt;
+   &lt;range start="192.168.122.2" end="192.168.122.254"/&gt;<co xml:id="vnet-xml-dhcp"/>
    &lt;host mac="52:54:00:c7:92:da" name="host1.testing.com" \
-    ip="192.168.1.23.101" /><co xml:id="vnet-xml-dhcp-host"/>
+    ip="192.168.1.23.101"/&gt;<co xml:id="vnet-xml-dhcp-host"/>
    &lt;host mac="52:54:00:c7:92:db" name="host2.testing.com" \
-    ip="192.168.1.23.102" />
+    ip="192.168.1.23.102"/&gt;
    &lt;host mac="52:54:00:c7:92:dc" name="host3.testing.com" \
-    ip="192.168.1.23.103" />
-  &lt;/dhcp>
- &lt;/ip>
-&lt;/network>
+    ip="192.168.1.23.103"/&gt;
+  &lt;/dhcp&gt;
+ &lt;/ip&gt;
+&lt;/network&gt;
 </screen>
      <calloutlist>
       <callout arearefs="vnet-xml-name">
@@ -451,21 +770,21 @@ Networking (help keyword 'network'):
       <callout arearefs="vnet-xml-bridge">
        <para>
         The name of the bridge device used to construct the virtual network.
-        When defining a new network with a &lt;forward> mode of "nat" or
-        "route" (or an isolated network with no &lt;forward> element),
+        When defining a new network with a &lt;forward&gt; mode of "nat" or
+        "route" (or an isolated network with no &lt;forward&gt; element),
         &libvirt; will automatically generate a unique name for the bridge
         device if none is given.
        </para>
       </callout>
       <callout arearefs="vnet-xml-forward">
        <para>
-        Inclusion of the &lt;forward> element indicates that the virtual
+        Inclusion of the &lt;forward&gt; element indicates that the virtual
         network will be connected to the physical LAN. The
         <literal>mode</literal> attribute specifies the forwarding method. The
         most common modes are "nat" (default, network address translation),
         "route" (direct forwarding to the physical network, no address
         translation), and "bridge" (network bridge configured outside of
-        &libvirt;). If the &lt;forward> element is not specified, the virtual
+        &libvirt;). If the &lt;forward&gt; element is not specified, the virtual
         network will be isolated from other networks. For a complete list of
         forwarding modes, see
         <link xlink:href="http://libvirt.org/formatnetwork.html#elementsConnect"/>.
@@ -485,7 +804,7 @@ Networking (help keyword 'network'):
       </callout>
       <callout arearefs="vnet-xml-dhcp-host">
        <para>
-        The optional &lt;host> elements specify hosts that will be given names
+        The optional &lt;host&gt; elements specify hosts that will be given names
         and predefined IP addresses by the built-in DHCP server. Any IPv4 host
         element must specify the following: the MAC address of the host to be assigned a given
         name, the IP to be assigned to that host, and the name to be given to
@@ -510,16 +829,16 @@ Networking (help keyword 'network'):
       network.
      </para>
 <screen>
-&lt;network>
- &lt;name>vnet_routed&lt;/name>
- &lt;bridge name="virbr1" />
- &lt;forward mode="route" dev="eth1"/><co xml:id="vnet-xml-route"/>
- &lt;ip address="192.168.122.1" netmask="255.255.255.0">
-  &lt;dhcp>
-   &lt;range start="192.168.122.2" end="192.168.122.254" />
-  &lt;/dhcp>
- &lt;/ip>
-&lt;/network>
+&lt;network&gt;
+ &lt;name&gt;vnet_routed&lt;/name&gt;
+ &lt;bridge name="virbr1"/&gt;
+ &lt;forward mode="route" dev="eth1"/&gt;<co xml:id="vnet-xml-route"/>
+ &lt;ip address="192.168.122.1" netmask="255.255.255.0"&gt;
+  &lt;dhcp&gt;
+   &lt;range start="192.168.122.2" end="192.168.122.254"/&gt;
+  &lt;/dhcp&gt;
+ &lt;/ip&gt;
+&lt;/network&gt;
 </screen>
      <calloutlist>
       <callout arearefs="vnet-xml-route">
@@ -535,18 +854,18 @@ Networking (help keyword 'network'):
      <para>
       This configuration provides a completely isolated private network. The
       guests can talk to each other, and to &vmhost;, but cannot reach any
-      other machines on the LAN, as the &lt;forward> element is missing in the
+      other machines on the LAN, as the &lt;forward&gt; element is missing in the
       XML description.
      </para>
-<screen>&lt;network>
- &lt;name>vnet_isolated&lt;/name>
- &lt;bridge name="virbr3" />
- &lt;ip address="192.168.152.1" netmask="255.255.255.0">
-  &lt;dhcp>
-   &lt;range start="192.168.152.2" end="192.168.152.254" />
-  &lt;/dhcp>
- &lt;/ip>
- &lt;/network>
+<screen>&lt;network&gt;
+ &lt;name&gt;vnet_isolated&lt;/name&gt;
+ &lt;bridge name="virbr3"/&gt;
+ &lt;ip address="192.168.152.1" netmask="255.255.255.0"&gt;
+  &lt;dhcp&gt;
+   &lt;range start="192.168.152.2" end="192.168.152.254"/&gt;
+  &lt;/dhcp&gt;
+ &lt;/ip&gt;
+ &lt;/network&gt;
 </screen>
     </example>
     <example>
@@ -558,11 +877,11 @@ Networking (help keyword 'network'):
       network, and there will be no restrictions on incoming or outgoing
       connections.
      </para>
-<screen>&lt;network>
-        &lt;name>host-bridge&lt;/name>
-        &lt;forward mode="bridge"/>
-        &lt;bridge name="br0"/>
-&lt;/network>
+<screen>&lt;network&gt;
+        &lt;name&gt;host-bridge&lt;/name&gt;
+        &lt;forward mode="bridge"/&gt;
+        &lt;bridge name="br0"/&gt;
+&lt;/network&gt;
 </screen>
     </example>
    </sect3>
@@ -663,303 +982,6 @@ Network vnet_isolated destroyed</screen>
 <screen>&prompt.sudo;virsh net-undefine vnet_isolated
 Network vnet_isolated has been undefined</screen>
    </sect3>
-  </sect2>
- </sect1>
- <sect1 xml:id="libvirt-networks-bridged">
-  <title>Bridged Networking</title>
-
-  <para>
-   A network bridge is used to connect two or more network segments. It behaves
-   like a virtual network switch, and guest machines treat it transparently as
-   a physical network interface. Any physical or virtual device can be
-   connected to the bridge.
-  </para>
-
-  <para>
-   If there is a network bridge present on &vmhost;, you can connect a
-   &vmguest; to it directly. This provides the &vmguest; with full incoming and
-   outgoing network access.
-  </para>
-
-  <sect2 xml:id="libvirt-networks-bridged-yast">
-   <title>Managing Network Bridges with &yast;</title>
-   <para>
-    This section includes procedures to add or remove network bridges with
-    &yast;.
-   </para>
-   <sect3 xml:id="libvirt-networks-bridged-yast-add">
-    <title>Adding a Network Bridge</title>
-    <para>
-     To add a network bridge on &vmhost;, follow these steps:
-    </para>
-    <procedure>
-     <step>
-      <para>
-       Start
-       <menuchoice><guimenu>&yast;</guimenu><guimenu>System</guimenu><guimenu>Network
-       Settings</guimenu></menuchoice>.
-      </para>
-     </step>
-     <step>
-      <para>
-       Activate the <guimenu>Overview</guimenu> tab and click
-       <guimenu>Add</guimenu>.
-      </para>
-     </step>
-     <step>
-      <para>
-       Select <guimenu>Bridge</guimenu> from the <guimenu>Device Type</guimenu>
-       list and enter the bridge device interface name in the
-       <guimenu>Configuration Name</guimenu> entry. Proceed with
-       <guimenu>Next</guimenu>.
-      </para>
-     </step>
-     <step>
-      <para>
-       In the <guimenu>Address</guimenu> tab, specify networking details such
-       as DHCP/static IP address, subnet mask or host name.
-      </para>
-      <para>
-       Using <guimenu>Dynamic Address</guimenu> is only useful when also
-       assigning a device to a bridge that is connected to some DHCP server.
-      </para>
-      <para>
-       If you intend to create a virtual bridge that has no connection to a
-       real Ethernet device, use <guimenu>Statically assigned IP
-       Address</guimenu>. In this case, it is a good idea to use addresses from
-       the private IP address ranges, for example,
-       <literal>192.168.x.x</literal> or <literal>10.x.x.x</literal>.
-      </para>
-      <para>
-       To create a bridge that should only serve as a connection between the
-       different guests without connection to the host system, set the IP
-       address to <literal>0.0.0.0</literal> and the subnet mask to
-       <literal>255.255.255.255</literal>. The network scripts handle this
-       special address as an unset IP address.
-      </para>
-     </step>
-     <step>
-      <para>
-       Activate the <guimenu>Bridged Devices</guimenu> tab and activate the
-       network devices you want to include in the network bridge.
-      </para>
-     </step>
-     <step>
-      <para>
-       Click <guimenu>Next</guimenu> to return to the
-       <guimenu>Overview</guimenu> tab and confirm with <guimenu>OK</guimenu>.
-       The new network bridge should be active on &vmhost; now.
-      </para>
-     </step>
-    </procedure>
-   </sect3>
-   <sect3 xml:id="libvirt-networks-bridged-yast-rm">
-    <title>Deleting a Network Bridge</title>
-    <para>
-     To delete an existing network bridge, follow these steps:
-    </para>
-    <procedure>
-     <step>
-      <para>
-       Start
-       <menuchoice><guimenu>&yast;</guimenu><guimenu>System</guimenu><guimenu>Network
-       Settings</guimenu></menuchoice>.
-      </para>
-     </step>
-     <step>
-      <para>
-       Select the bridge device you want to delete from the list in the
-       <guimenu>Overview</guimenu> tab.
-      </para>
-     </step>
-     <step>
-      <para>
-       Delete the bridge with <guimenu>Delete</guimenu> and confirm with
-       <guimenu>OK</guimenu>.
-      </para>
-     </step>
-    </procedure>
-   </sect3>
-  </sect2>
-
-  <sect2 xml:id="libvirt-networks-bridged-add-brctl">
-   <title>Managing Network Bridges from the Command Line</title>
-   <para>
-    This section includes procedures to add or remove network bridges using the
-    command line.
-   </para>
-   <sect3 xml:id="libvirt-networks-bridged-add-brctl-add">
-    <title>Adding a Network Bridge</title>
-    <para>
-     To add a new network bridge device on &vmhost;, follow these steps:
-    </para>
-    <procedure>
-     <step>
-      <para>
-       Log in as &rootuser; on the &vmhost; where you want to create a new
-       network bridge.
-      </para>
-     </step>
-     <step>
-      <para>
-       Choose a name for the new
-       bridge&mdash;<replaceable>virbr_test</replaceable> in our
-       example&mdash;and run
-      </para>
-<screen>&prompt.root;ip link add name <replaceable>VIRBR_TEST</replaceable> type bridge</screen>
-     </step>
-     <step>
-      <para>
-       Check if the bridge was created on &vmhost;:
-      </para>
-<screen>&prompt.root;bridge vlan
-[...]
-virbr_test  1 PVID Egress Untagged
-</screen>
-      <para>
-       <literal>virbr_test</literal> is present, but is not associated with any
-       physical network interface.
-      </para>
-     </step>
-     <step>
-      <para>
-       Bring the network bridge up and add a network interface to the bridge:
-      </para>
-<screen>
-&prompt.root;ip link set virbr_test up
-&prompt.root;ip link set eth1 master virbr_test
-</screen>
-      <important>
-       <title>Network Interface Must Be Unused</title>
-       <para>
-        You can only enslave a network interface that is not yet used by other
-        network bridge.
-       </para>
-      </important>
-     </step>
-     <step>
-      <para>
-       Optionally, enable STP (see
-       <link xlink:href="https://en.wikipedia.org/wiki/Spanning_Tree_Protocol">Spanning
-       Tree Protocol</link>):
-      </para>
-<screen>&prompt.root;bridge link set dev virbr_test cost 4</screen>
-     </step>
-    </procedure>
-   </sect3>
-   <sect3 xml:id="libvirt-networks-bridged-add-brctl-del">
-    <title>Deleting a Network Bridge</title>
-    <para>
-     To delete an existing network bridge device on &vmhost; from the command
-     line, follow these steps:
-    </para>
-    <procedure>
-     <step>
-      <para>
-       Log in as &rootuser; on the &vmhost; where you want to delete an
-       existing network bridge.
-      </para>
-     </step>
-     <step>
-      <para>
-       List existing network bridges to identify the name of the bridge to
-       remove:
-      </para>
-<screen>&prompt.root;bridge vlan
-[...]
-virbr_test  1 PVID Egress Untagged
-</screen>
-     </step>
-     <step>
-      <para>
-       Delete the bridge:
-      </para>
-<screen>&prompt.root;ip link delete dev virbr_test</screen>
-     </step>
-    </procedure>
-   </sect3>
-  </sect2>
-
-  <sect2 xml:id="sec-xen-net-vlan">
-   <title>Using VLAN Interfaces</title>
-   <para>
-    Sometimes, it is necessary to create a private connection either between
-    two &vmhost;s or between &vmguest; systems. For example, to migrate
-    &vmguest; to hosts in a different network segment, or to create a private
-    bridge that only &vmguest; systems may connect to (even when running on
-    different &vmhost; systems). An easy way to build such connections is to set
-    up VLAN networks.
-   </para>
-   <para>
-    VLAN interfaces are commonly set up on the &vmhost;. They either interconnect
-    the different &vmhost; systems, or they may be set up as a physical
-    interface to an otherwise virtual-only bridge. It is even possible to
-    create a bridge with a VLAN as a physical interface that has no IP address
-    in the &vmhost;. That way, the guest systems have no possibility to access
-    the host over this network.
-   </para>
-   <para>
-    Run the &yast; module <menuchoice><guimenu>System</guimenu><guimenu>Network
-    Settings</guimenu></menuchoice>. Follow this procedure to set up the VLAN
-    device:
-   </para>
-   <procedure>
-    <title>Setting up VLAN Interfaces with &yast;</title>
-    <step>
-     <para>
-      Click <guimenu>Add</guimenu> to create a new network interface.
-     </para>
-    </step>
-    <step>
-     <para>
-      In the <guimenu>Hardware Dialog</guimenu>, select <guimenu>Device
-      Type</guimenu> <guimenu>VLAN</guimenu>.
-     </para>
-    </step>
-    <step>
-     <para>
-      Change the value of <guimenu>Configuration Name</guimenu> to the ID of
-      your VLAN. Note that VLAN ID <literal>1</literal> is commonly used for
-      management purposes.
-     </para>
-    </step>
-    <step>
-     <para>
-      Click <guimenu>Next</guimenu>.
-     </para>
-    </step>
-    <step>
-     <para>
-      Select the interface that the VLAN device should connect to below
-      <guimenu>Real Interface for VLAN</guimenu>. If the desired interface does
-      not appear in the list, first set up this interface without an IP
-      Address.
-     </para>
-    </step>
-    <step>
-     <para>
-      Select the desired method for assigning an IP address to the VLAN device.
-     </para>
-    </step>
-    <step>
-     <para>
-      Click <guimenu>Next</guimenu> to finish the configuration.
-     </para>
-    </step>
-   </procedure>
-   <para>
-    It is also possible to use the VLAN interface as a physical interface of a
-    bridge. This makes it possible to connect several &vmhost;-only networks
-    and allows to live-migrate &vmguest; systems that are connected to such a
-    network.
-   </para>
-   <para>
-    &yast; does not always allow to set no IP address. However, this may be a
-    desired feature especially if &vmhost;-only networks should be connected.
-    In this case, use the special address <literal>0.0.0.0</literal> with
-    netmask <literal>255.255.255.255</literal>. The system scripts handle this
-    address as no IP address set.
-   </para>
   </sect2>
  </sect1>
 </chapter>


### PR DESCRIPTION
Add a warning about enabling forwarding in the VM host when enabling
a libvirt virtual network. While at it, make some small improvements
in the description of libvirt's virtual networks.

*Are backports required?*

- [x ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [x ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
