### PR TITLE
issue rmt#491: updating the documentation with new option noproxy

### DIFF
--- a/xml/rmt_config_files.xml
+++ b/xml/rmt_config_files.xml
@@ -80,6 +80,14 @@
      </listitem>
     </varlistentry>
     <varlistentry>
+      <term><literal>noproxy</literal></term>
+      <listitem>
+        <para>
+          A list of domains that should NOT go through the proxy, separated by commas. Example: "localhost,.mylocaldomain"
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
      <term><literal>proxy_auth</literal></term>
      <listitem>
       <para>


### PR DESCRIPTION
### Description
This modification adds a reference describing the "noproxy" option for RMT, as discussed in https://github.com/SUSE/rmt/issues/491 .
This functionality was added by the corresponding pull request in the Typhoeus module: https://github.com/typhoeus/typhoeus/pull/642


### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
