### PR TITLE
docker: add notes about building in on-demand cloud instances

### DIFF
--- a/xml/docker_building_images.xml
+++ b/xml/docker_building_images.xml
@@ -171,50 +171,51 @@
   </note>
 
   <note>
-    <title>Building container imagess on on-demand &slea; instances in the public cloud</title>
+    <title>Building Container Images in On-Demand &slea; Instances in the Public Cloud</title>
 
     <para>
       When building container images on &slea; instances that were launched as
-      so-called "on-demand" or "pay as you go" instances on a Public Cloud (as
-      AWS, GCE or Azure) some additional steps have to be performed.
-      For installing packages and updates the "on-demand" public cloud
-      instance are connected to a public cloud specific update infrastructure
-      which is based around &rmt; servers operated by SUSE on the various Public
-      Cloud Providers.
-      To be able access this update infrastructure instances need to perform
-      additional steps to locate the required services and authenticate with
-      them.
-      In order to build containers on this type of instances a new service was
-      introduced, that service is called `containerbuild-regionsrv` and will
-      be available in the public cloud images provided through the
+      so-called "on-demand" or "pay as you go" instances on a Public Cloud 
+      (AWS, GCE, or Azure), some additional steps have to be performed.
+      For installing packages and updates, the "on-demand" public cloud
+      instances are connected to a public cloud-specific update infrastructure,
+      which is based around &rmt; servers operated by &suse; on the various Public
+      Cloud Providers. Some additional steps are required to locate the required 
+      services and authenticate with them.
+    </para>
+    <para>
+      A new service was introduced to enable this, called 
+      <literal>containerbuild-regionsrv</literal>. This service is available 
+      in the public cloud images provided through the
       Marketplaces of the various Public Cloud Providers. So before building
-      an image this service has to be started on the public cloud instance
-    </para>
-    <screen>&prompt.user;systemctl start containerbuild-regionsrv</screen>
+      an image, this service has to be started on the public cloud instance by
+      running the following command:
+      </para>
+    <screen>&prompt.sudo;systemctl start containerbuild-regionsrv</screen>
 
     <para>
-      In order to have it started automatically (e.g. after reboot) please use:
+      To start it automatically after system startup, enable it with
+      <command>systemctl</command>:
     </para>
 
-    <screen>&prompt.user;systemctl enable  containerbuild-regionsrv</screen>
+    <screen>&prompt.sudo;systemctl enable containerbuild-regionsrv</screen>
 
     <para>
-      The zypper plugins provided by the &slea; base images will then connect
-      to this service for getting authentication details and information about
+      The Zypper plugins provided by the &slea; base images will then connect
+      to this service for retrieving authentication details and information about
       which update server to talk to. In order for that to work the container
-      has to be built with host networking enabled. I.e. you need to call
-      `docker build` with `--network host`:
+      has to be built with host networking enabled, like the following example:
     </para>
-    <screen>&prompt.user;docker build --network host &lt;builddir&gt;</screen>
+    <screen>&prompt.user;docker build --network host <replaceable>build-directory/</replaceable></screen>
 
     <para>
       Since update infrastructure in the Public Clouds is based upon &rmt;,
-      the same restrictions with regard to building SLE images for SLE
-      versions differing from the SLE version of the host apply here as well.
-      (See above)
+      the same restrictions with regard to building &slea; images for &slea;
+      versions differing from the &slea; version of the host apply here as well
+      (see <xref linkend="build-images-different-codebase"/>).
     </para>
-
   </note>
+   
   <para>
    To obtain the list of repositories, use the following command:
   </para>

--- a/xml/docker_building_images.xml
+++ b/xml/docker_building_images.xml
@@ -170,6 +170,51 @@
    </para>
   </note>
 
+  <note>
+    <title>Building container imagess on on-demand &slea; instances in the public cloud</title>
+
+    <para>
+      When building container images on &slea; instances that were launched as
+      so-called "on-demand" or "pay as you go" instances on a Public Cloud (as
+      AWS, GCE or Azure) some additional steps have to be performed.
+      For installing packages and updates the "on-demand" public cloud
+      instance are connected to a public cloud specific update infrastructure
+      which is based around &rmt; servers operated by SUSE on the various Public
+      Cloud Providers.
+      To be able access this update infrastructure instances need to perform
+      additional steps to locate the required services and authenticate with
+      them.
+      In order to build containers on this type of instances a new service was
+      introduced, that service is called `containerbuild-regionsrv` and will
+      be available in the public cloud images provided through the
+      Marketplaces of the various Public Cloud Providers. So before building
+      an image this service has to be started on the public cloud instance
+    </para>
+    <screen>&prompt.user;systemctl start containerbuild-regionsrv</screen>
+
+    <para>
+      In order to have it started automatically (e.g. after reboot) please use:
+    </para>
+
+    <screen>&prompt.user;systemctl enable  containerbuild-regionsrv</screen>
+
+    <para>
+      The zypper plugins provided by the &slea; base images will then connect
+      to this service for getting authentication details and information about
+      which update server to talk to. In order for that to work the container
+      has to be built with host networking enabled. I.e. you need to call
+      `docker build` with `--network host`:
+    </para>
+    <screen>&prompt.user;docker build --network host &lt;builddir&gt;</screen>
+
+    <para>
+      Since update infrastructure in the Public Clouds is based upon &rmt;,
+      the same restrictions with regard to building SLE images for SLE
+      versions differing from the SLE version of the host apply here as well.
+      (See above)
+    </para>
+
+  </note>
   <para>
    To obtain the list of repositories, use the following command:
   </para>


### PR DESCRIPTION
### Description
Building in "pay-as-you-go" or "on-demand" instances will require
addtional preparations, because of some specialities in the update
infrastructure. Add a note about that.

### Checklist
*Are backports required?*

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [x] To maintenance/SLE12SP4
- [x] To maintenance/SLE12SP3
