### PR TITLE
Import @joseivanlopez' Multi-device Btrfs § from PR 443 (JIRA SLE-3877)

### DIFF
--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -2566,7 +2566,7 @@ size=40G features='0' hwhandler='0' wp=rw
    </informaltable>
   </sect2>
 
-  <sect2 xml:id="ay.multidevice_btrfs">
+  <sect2 xml:id="ay-multidevice-btrfs">
    <title>Multi-device Btrfs Configuration</title>
 
    <para>

--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -2570,10 +2570,18 @@ size=40G features='0' hwhandler='0' wp=rw
    <title>Multi-device Btrfs Configuration</title>
 
    <para>
-    A <emphasis>Btrfs file system</emphasis> can be created on top of many
-    devices, offering similar features to a RAID device. With &ay;, a
-    <emphasis>multi-device Btrfs</emphasis> can be configured by specifying a
-    drive with the <literal>CT_BTRFS</literal> type. The <literal>device</literal>
+    Btrfs supports creating a single volume that spans more than one
+    storage device, offering similar features to software RAID implementations
+    such as the Linux kernel's built-in <command>mdraid</command> subsystem.
+    <emphasis>Multi-device Btrfs</emphasis> offers advantages over some other
+    RAID implementations. For example, you can dynamically migrate a
+    multi-device Btrfs volume from one RAID level to another, RAID levels can
+    be set on a per-file basis, and more. However, not all of these features are
+    fully supported yet in &productname; &product-ga; &product-sp;.
+   </para>
+    
+   <para>With &ay;, a multi-device Btrfs can be configured by specifying a drive
+    with the <literal>CT_BTRFS</literal> type. The <literal>device</literal>
     property is used as an arbitrary name to identify each multi-device Btrfs.
    </para>
 

--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -2646,7 +2646,7 @@ as per ancorgs' comment on Github-->
     system:
    </para>
 
-   <itemizedlist mark="bullet" spacing="normal">
+   <itemizedlist>
     <listitem>
      <para>
       Devices need to indicate the <literal>btrfs_name</literal> property to be

--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -2577,7 +2577,7 @@ size=40G features='0' hwhandler='0' wp=rw
     RAID implementations. For example, you can dynamically migrate a
     multi-device Btrfs volume from one RAID level to another, RAID levels can
     be set on a per-file basis, and more. However, not all of these features are
-    fully supported yet in &productname; &product-ga; &product-sp;.
+    fully supported yet in &productname; &product-ga; SP &product-sp;.
    </para>
     
    <para>With &ay;, a multi-device Btrfs can be configured by specifying a drive

--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -2566,6 +2566,104 @@ size=40G features='0' hwhandler='0' wp=rw
    </informaltable>
   </sect2>
 
+  <sect2 xml:id="ay.multidevice_btrfs">
+   <title>Multi-device Btrfs Configuration</title>
+
+   <para>
+    A <emphasis>Btrfs file system</emphasis> can be created on top of many
+    devices, offering similar features to a RAID device. With &ay;, a
+    <emphasis>multi-device Btrfs</emphasis> can be configured by specifying a
+    drive with the <literal>CT_BTRFS</literal> type. The <literal>device</literal>
+    property is used as an arbitrary name to identify each multi-device Btrfs.
+   </para>
+
+   <para>
+    As with RAID, you need to create all block devices first (e.g., partitions,
+    LVM logical volumes, etc.) and assign them to the Btrfs file system you want
+    to create over such block devices.
+   </para>
+
+   <para>
+    The following example shows a simple multi-device Btrfs configuration:
+   </para>
+
+   <example>
+    <title>Multi-device Btrfs configuration</title>
+      <screen>&lt;partitioning config:type="list"&gt;
+  &lt;drive&gt;
+    &lt;device&gt;/dev/sda&lt;/device&gt;
+    &lt;disklabel&gt;none&lt;/disklabel&gt;
+    &lt;partitions&gt;
+      &lt;partition&gt;
+        &lt;btrfs_name&gt;root_fs&lt;/btrfs_name&gt;
+      &lt;/partition&gt;
+    &lt;/partitions&gt;
+    &lt;use&gt;all&lt;/use&gt;
+  &lt;/drive&gt;
+  &lt;drive&gt;
+    &lt;device&gt;/dev/sdb&lt;/device&gt;
+    &lt;disklabel&gt;gpt&lt;/disklabel&gt;
+    &lt;partitions&gt;
+      &lt;partition&gt;
+        &lt;partition_nr&gt;1&lt;/partition_nr&gt;
+        &lt;size&gt;4gb&lt;/size&gt;
+        &lt;filesystem&gt;ext4&lt;/filesystem&gt;
+        &lt;btrfs_name&gt;root_fs&lt;/btrfs_name&gt;
+      &lt;/partition&gt;
+    &lt;/partitions&gt;
+    &lt;use&gt;all&lt;/use&gt;
+  &lt;/drive&gt;
+  &lt;drive&gt;
+    &lt;device&gt;root_fs&lt;/device&gt;
+    &lt;type config:type="symbol"&gt;CT_BTRFS&lt;/type&gt;
+    &lt;partitions&gt;
+      &lt;partition config:type="list&gt;
+        &lt;mount&gt;/&lt;/mount&gt;
+      &lt;/partition&gt;
+    &lt;/partitions&gt;
+    &lt;btrfs_options&gt;
+      &lt;raid_leve&gt;raid1&lt;/raid_level&gt;
+      &lt;metadata_raid_leve&gt;raid1&lt;/metadata_raid_level&gt;
+    &lt;/btrfs_options&gt;
+  &lt;/drive&gt;
+&lt;/partitioning&gt;</screen>
+   </example>
+
+   <para>
+    The supported data and meta-data RAID levels are: <literal>default</literal>,
+    <literal>single</literal>, <literal>dup</literal>, <literal>raid0</literal>,
+    <literal>raid1</literal>, and <literal>raid10</literal>. By default, file
+    system meta-data is mirrored across two devices and data is striped across
+    all of the devices. If only one device is present, meta-data will be
+    duplicated on that one device.
+   </para>
+   
+<!--lproven 2020-06-30: omitting raid5 & raid6 for now as unsupported in 15SP2
+as per ancorgs' comment on Github-->
+ 
+   <para>
+    Keep the following in mind when configuring a multi-device Btrfs file
+    system:
+   </para>
+
+   <itemizedlist mark="bullet" spacing="normal">
+    <listitem>
+     <para>
+      Devices need to indicate the <literal>btrfs_name</literal> property to be
+      included into a multi-device Btrfs file system.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      All Btrfs-specific options are contained in the
+      <literal>btrfs_options</literal> resource of a <literal>CT_BTRFS</literal>
+      drive.
+     </para>
+    </listitem>
+   </itemizedlist>
+  </sect2>
+
+
   <sect2 xml:id="ay-partition-nfs">
    <title>NFS Configuration</title>
 


### PR DESCRIPTION
### Description

This PR adds information about how to configure a multi-device Btrfs drive in AutoYaST.

(This is new functionality in SLE 15 SP2, which is why this change has been on hold since July 2019. It was in openSUSE long ago.)

Relevant links:

 * https://trello.com/c/FsEzGg70/975-3-multi-device-btrfs-support-in-autoyast
 * https://jira.suse.de/browse/SLE-3877

I have reformatted @joseivanlopez' text from https://github.com/SUSE/doc-sle/pull/443
Changes from PR #443:
 * inserted into the same position in the new, multi-file AutoYast guide
 * fixed indentation in the example
 * removed `raid5` and `raid6` as per @ancorgs's comment as they are not yet supported

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
