### PR TITLE
Tuning cgroup

### DIFF
--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -401,14 +401,14 @@ TasksMax=16284
    <itemizedlist mark="bullet" spacing="normal">
     <listitem>
      <para>
-      <filename>blkio.weight</filename> (only available in older
-      kernels with legacy block layer and when using the CFQ I/O scheduler)
+      <filename>blkio.weight</filename> (only available in kernels up to version 4.20
+      with legacy block layer and when using the CFQ I/O scheduler)
      </para>
     </listitem>
     <listitem>
      <para>
-      <filename>blkio.bfq.weight</filename> (only available in newer
-      kernels with blk-mq and when using BFQ I/O scheduler)
+      <filename>blkio.bfq.weight</filename> (available in kernels starting with
+      version 5.0 with blk-mq and when using BFQ I/O scheduler)
      </para>
     </listitem>
    </itemizedlist>

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -459,7 +459,7 @@ mq-deadline kyber [bfq] none
 </screen>
    <para>
     With this settings and reader1 in background, reader2 should
-    achieve higher throughput than before:
+    have higher throughput than previously:
    </para>
 <screen>
 [reader1] /mnt/tests/io-cgroup/> sudo su -c "sync; echo 3 > /proc/sys/vm/drop_caches"

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE chapter
 [
   <!ENTITY % entities SYSTEM "entity-decl.ent">
   %entities;
-  <!ENTITY reader1 "reader1:/io-cgroup #">
+  <!-- custom prompt entities for the 'Controlling I/O with Proportional Weight Policy' section --> 
   <!ENTITY prompt.reader1 "<prompt role='root' xmlns='http://docbook.org/ns/docbook'>[reader1] host1:/io-cgroup # </prompt>">
   <!ENTITY prompt.reader2 "<prompt role='root' xmlns='http://docbook.org/ns/docbook'>[reader2] host1:/io-cgroup # </prompt>">
   <!ENTITY prompt.io-controller "<prompt role='root' xmlns='http://docbook.org/ns/docbook'>[io-controller] host1:/io-cgroup # </prompt>">
   <!ENTITY prompt.io-cgroup "<prompt role='root' xmlns='http://docbook.org/ns/docbook'>host1:/io-cgroup # </prompt>">
   <!ENTITY prompt.plain-root "<prompt role='root' xmlns='http://docbook.org/ns/docbook'>host1:~ # </prompt>">
+  <!ENTITY prompt.blkio "<prompt role='root' xmlns='http://docbook.org/ns/docbook'>[io-controller] host1:/sys/fs/cgroup/blkio/ # </prompt>">
+  <!ENTITY prompt.unified "<prompt role='root' xmlns='http://docbook.org/ns/docbook'>[io-controller] host1:/sys/fs/cgroup/unified # </prompt>">
 ]>
 
 <chapter xmlns="http://docbook.org/ns/docbook"
@@ -393,7 +394,7 @@ TasksMax=16284
   </sect2>
  </sect1>
 
- <sect1>
+  <sect1>
   <title>Controlling I/O with Proportional Weight Policy</title>
   <para>
       This section introduces using the Linux kernel's block I/O controller to 
@@ -409,15 +410,16 @@ TasksMax=16284
       provided for both cgroup-v1 and cgroup-v2.
   </para>
   <para>
-      You need a test directory containing two files for testing performance and changed settings. A quick way to create test files fully-populated
-      with text is using the <command>yes</command> command. The following example 
-      commands create a test directory, and then populate it with two 500 MB text
-      files:
+      You need a test directory containing two files for testing performance and 
+      changed settings. A quick way to create test files fully-populated
+      with text is using the <command>yes</command> command. The following 
+      example commands create a test directory, and then populate it with two 
+      537 MB text files:
       </para> 
   <screen>&prompt.plain-root;mkdir /io-cgroup
 &prompt.plain-root;cd /io-cgroup
-&prompt.plain-root;yes this is a test file | head -c 500MB > file1.txt
-&prompt.plain-root;yes this is a test file | head -c 500MB > file2.txt
+&prompt.plain-root;yes this is a test file | head -c 537MB > file1.txt
+&prompt.plain-root;yes this is a test file | head -c 537MB > file2.txt
 </screen>
   <para>
     To run the examples open three command shells. Two shells are for reader 
@@ -448,17 +450,17 @@ TasksMax=16284
     </listitem>
    </itemizedlist>
    <para>
-    To test this, run a single reader process (in the examples,reading 
+    To test this, run a single reader process (in the examples, reading 
     from a SSD) without controlling its I/O, using 
     <filename>file2.txt</filename>:
    </para>
 <screen> 
 &prompt.io-controller;sync; echo 3 > /proc/sys/vm/drop_caches
 &prompt.io-controller;echo $$; dd if=file2.txt of=/dev/null bs=4k count=131072
-8967
-122070+1 records in
-122070+1 records out
-500000000 bytes (500 MB, 477 MiB) copied, 2.6367 s, 190 MB/s
+5251
+131072+0 records in
+131072+0 records out
+536870912 bytes (537 MB, 512 MiB) copied, 1.33049 s, 404 MB/s
 </screen>
    <para>
     Now run a background process reading from the same disk:
@@ -477,20 +479,21 @@ TasksMax=16284
    <para>
     Each process gets half of the throughput for I/O operations.
     Next, set up two control groups&mdash;one for each
-    process&mdash;verify that BFQ is used, and set different weights:
+    process&mdash;verify that BFQ is used, and set a different weight
+    for reader2:
    </para>
 <screen>
 &prompt.io-controller;cd /sys/fs/cgroup/blkio/
-&prompt.io-controller;mkdir reader1
-&prompt.io-controller;mkdir reader2
-&prompt.io-controller;echo 5220 > reader1/cgroup.procs
-&prompt.io-controller;echo 5251 > reader2/cgroup.procs
-&prompt.io-controller;cat /sys/block/sda/queue/scheduler
+&prompt.blkio;mkdir reader1
+&prompt.blkio;mkdir reader2
+&prompt.blkio;echo 5220 > reader1/cgroup.procs
+&prompt.blkio;echo 5251 > reader2/cgroup.procs
+&prompt.blkio;cat /sys/block/sda/queue/scheduler
 mq-deadline kyber [bfq] none
-&prompt.io-controller;cat reader1/blkio.bfq.weight
+&prompt.blkio;cat reader1/blkio.bfq.weight
 100
-&prompt.io-controller;echo 200 >reader1/blkio.bfq.weight
-&prompt.io-controller;cat reader2/blkio.bfq.weight
+&prompt.blkio;echo 200 > reader2/blkio.bfq.weight
+&prompt.blkio;cat reader2/blkio.bfq.weight
 200
 </screen>
    <para>
@@ -513,10 +516,10 @@ mq-deadline kyber [bfq] none
     Now double its weight again:
    </para>
 <screen>
-&prompt.io-controller;cat reader1/blkio.bfq.weight
+&prompt.blkio;cat reader1/blkio.bfq.weight
 100
-&prompt.io-controller;echo 400 > reader1/blkio.bfq.weight
-&prompt.io-controller;cat reader2/blkio.bfq.weight
+&prompt.blkio;echo 400 > reader2/blkio.bfq.weight
+&prompt.blkio;cat reader2/blkio.bfq.weight
 400
 </screen>
    <para>
@@ -537,62 +540,103 @@ mq-deadline kyber [bfq] none
   <sect2>
    <title>Using cgroup-v2</title>
    <para>
-    First, make sure that the Block IO controller is not active
-    under cgroup-v1. To do this, boot with kernel parameter
-    <option>cgroup_no_v1=blkio</option>. You should have a 
-    <filename>/sys/fs/cgroup/blkio/</filename> populated with
-    <filename>blkio.*</filename> files, and IO controller shows 
-    up as an option for cgroup-v2.
+    First set up your test environment as shown at the beginning of
+    this chapter.
+   </para>
+   <para>
+    Then make sure that the Block IO controller is not active,
+    as that is for cgroup-v1. To do this, boot with kernel parameter
+    <option>cgroup_no_v1=blkio</option>. Verify that this parameter
+    was used, and that the IO controller (cgroup-v2) is available:
    </para>
 <screen>
 &prompt.io-controller;cat /proc/cmdline
 BOOT_IMAGE=... cgroup_no_v1=blkio ...
-&prompt.io-controller;ls /sys/fs/cgroup/blkio/
-blkio.bfq.io_service_bytes
-blkio.bfq.io_service_bytes_recursive
-blkio.bfq.io_serviced
-[...]
 &prompt.io-controller;cat /sys/fs/cgroup/unified/cgroup.controllers
 io
 </screen>
  <para>
-   Next, enable the IO controller, create two control groups,
-   ensure that BFQ is used (the active controller is enclosed in
-   square brackets), and set weights:
+   Next, enable the IO controller:
    </para>
 <screen>
 &prompt.io-controller;cd /sys/fs/cgroup/unified/
-&prompt.io-controller;echo '+io' > cgroup.subtree_control
-&prompt.io-controller;cat cgroup.subtree_control
+&prompt.unified;echo '+io' > cgroup.subtree_control
+&prompt.unified;cat cgroup.subtree_control
 io
-&prompt.io-controller;mkdir reader1
-&prompt.io-controller;mkdir reader2
-&prompt.io-controller;echo 3712 > reader1/cgroup.procs
-&prompt.io-controller;echo 3744 > reader2/cgroup.procs
-&prompt.io-controller;cat /sys/block/sda/queue/scheduler
-mq-deadline kyber [bfq] none
-&prompt.io-controller;cat reader1/io.bfq.weight
-default 100
-&prompt.io-controller;echo 400 >reader2/io.bfq.weight
-&prompt.io-controller;cat reader2/io.bfq.weight
-default 400
+</screen>
+<para>
+    Now run all the test steps, similarly to the steps for cgroup-v1.
+    Note that some of the directories are different. Run a single reader
+    process (in the examples, reading from a SSD) without controlling its
+    I/O, using file2.txt: 
+</para>
+<screen>
+&prompt.unified;cd -
+&prompt.io-controller;sync; echo 3 > /proc/sys/vm/drop_caches
+&prompt.io-controller;echo $$; dd if=file2.txt of=/dev/null bs=4k count=131072
+5633
+[...]
 </screen>
    <para>
-    With these settings, throughput looks like the following:
+    Run a background process reading from the same disk and note your
+    throughput values:
+   </para>
+<screen>
+&prompt.reader1;sync; echo 3 > /proc/sys/vm/drop_caches
+&prompt.reader1;echo $$; dd if=file1.txt of=/dev/null bs=4k
+5633
+[...]
+&prompt.reader2;echo $$; dd if=file2.txt of=/dev/null bs=4k count=131072
+5703
+[...]
+</screen>
+<para>
+    Each process gets half of the throughput for I/O operations. Set up two control groups, one for each process, verify that BFQ is 
+    the active scheduler, and set a different weight for reader2: 
+</para>
+<screen>
+&prompt.io-controller;cd -
+&prompt.unified;mkdir reader1
+&prompt.unified;mkdir reader2
+&prompt.unified;echo 5633 > reader1/cgroup.procs
+&prompt.unified;echo 5703 > reader2/cgroup.procs
+&prompt.unified;cat /sys/block/sda/queue/scheduler
+mq-deadline kyber [bfq] none
+&prompt.unified;cat reader1/io.bfq.weight
+default 100
+&prompt.unified;echo 200 > reader2/io.bfq.weight
+&prompt.unified;cat reader2/io.bfq.weight
+default 200
+</screen>
+   <para>
+    Test your throughput with the new settings. reader2 should
+    show an increase in throughput.
    </para>
 <screen>
 &prompt.reader1;sync; echo 3 > /proc/sys/vm/drop_caches
 &prompt.reader1;echo $$; dd if=file1 of=/dev/null bs=4k
-3712
-...
+5633
+[...]
 &prompt.reader2;echo $$; dd if=file2 of=/dev/null bs=4k count=131072
-3744
-131072+0 records in
-131072+0 records out
-536870912 bytes (537 MB, 512 MiB) copied, 1.75746 s, 305 MB/s
+5703
+[...]
+</screen>
+<para>
+    Try doubling the weight again for reader2, and testing the new setting:
+</para>
+<screen>
+&prompt.reader2;echo 400 > reader1/blkio.bfq.weight
+&prompt.reader2;cat reader2/blkio.bfq.weight
+400
+&prompt.reader1;sync; echo 3 > /proc/sys/vm/drop_caches
+&prompt.reader1;echo $$; dd if=file1.txt of=/dev/null bs=4k
+[...]
+&prompt.reader2;echo $$; dd if=file2.txt of=/dev/null bs=4k count=131072
+[...]
 </screen>
   </sect2>
   </sect1>
+  
  <sect1>
   <title>For More Information</title>
 

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -515,8 +515,8 @@ $ cat /sys/fs/cgroup/unified/cgroup.controllers
 io
 </screen>
  <para>
-   Next steps are: enable IO controller, create 2 control groups,
-   ensure that BFQ is used, set weights.
+   Next, enable IO controller, create 2 control groups,
+   ensure that BFQ is used, and set weights:
    </para>
 <screen>
 [I/O controller] > cd /sys/fs/cgroup/unified/

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -439,9 +439,9 @@ TasksMax=16284
 536870912 bytes (537 MB, 512 MiB) copied, 2.61592 s, 205 MB/s
 </screen>
    <para>
-    Both processes get an equal share for I/O, halving throughput for
-    each process. Now we set up two control groups - one for each
-    process - check that BFQ is used and set different weights:
+    Each process gets half of the throughput for I/O operations.
+    Next, set up two control groups&mdash;one for each
+    process&mdash;and make sure that BFQ is used, and set different weights:
    </para>
 <screen>
 [I/O controller] > cd /sys/fs/cgroup/blkio/

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -501,7 +501,7 @@ mq-deadline kyber [bfq] none
   <sect2>
    <title>Using cgroup-v2</title>
    <para>
-    First we need to make sure that Block IO controller is not active
+    First, make sure that Block IO controller is not active
     under cgroup-v1. Thus we boot with kernel parameter
     <option>cgroup_no_v1=blkio</option>. Block IO controller is
     inactive in cgroup-v1 and IO controller shows up as an option for

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -425,7 +425,7 @@ TasksMax=16284
 536870912 bytes (537 MB, 512 MiB) copied, 1.33049 s, 404 MB/s
 </screen>
    <para>
-    Now running a background process reading from the same disk.
+    Now run a background process reading from the same disk:
    </para>
 <screen>
 [reader1] /mnt/tests/io-cgroup/> sudo su -c "sync; echo 3 > /proc/sys/vm/drop_caches"

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -413,7 +413,7 @@ TasksMax=16284
     </listitem>
    </itemizedlist>
    <para>
-    Running a single reader process (reading from SSD) without
+    Run a single reader process (reading from SSD) without
     controlling its I/O:
    </para>
 <screen>

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -394,10 +394,9 @@ TasksMax=16284
    <title>Using cgroup-v1</title>
 
    <para>
-    Assume you have a reader processes and you want to grant it a
-    higher priority for I/O operations then other reader processes
-    accessing the same disk. This can be managed with proportional
-    weight policy files:
+    The following proportional weight policy files can be used to grant a reader process a
+    higher priority for I/O operations than other reader processes
+    accessing the same disk.
    </para>
    <itemizedlist mark="bullet" spacing="normal">
     <listitem>

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -408,7 +408,7 @@ TasksMax=16284
     <listitem>
      <para>
       <filename>blkio.bfq.weight</filename> (only available in newer
-      kernels with blk-mq and using BFQ I/O scheduler)
+      kernels with blk-mq and when using BFQ I/O scheduler)
      </para>
     </listitem>
    </itemizedlist>

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -474,7 +474,7 @@ mq-deadline kyber [bfq] none
 </screen>
    <para>
     The higher proportional weight resulted in higher throughput for reader2.
-    Now doubling its weight again:
+    Now double its weight again:
    </para>
 <screen>
 [I/O controller] /sys/fs/cgroup/blkio> cat reader1/blkio.bfq.weight

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -3,6 +3,12 @@
 [
   <!ENTITY % entities SYSTEM "entity-decl.ent">
   %entities;
+  <!ENTITY reader1 "reader1:/io-cgroup #">
+  <!ENTITY prompt.reader1 "<prompt role='root' xmlns='http://docbook.org/ns/docbook'>[reader1] host1:/io-cgroup # </prompt>">
+  <!ENTITY prompt.reader2 "<prompt role='root' xmlns='http://docbook.org/ns/docbook'>[reader2] host1:/io-cgroup # </prompt>">
+  <!ENTITY prompt.io-controller "<prompt role='root' xmlns='http://docbook.org/ns/docbook'>[io-controller] host1:/io-cgroup # </prompt>">
+  <!ENTITY prompt.io-cgroup "<prompt role='root' xmlns='http://docbook.org/ns/docbook'>host1:/io-cgroup # </prompt>">
+  <!ENTITY prompt.plain-root "<prompt role='root' xmlns='http://docbook.org/ns/docbook'>host1:~ # </prompt>">
 ]>
 
 <chapter xmlns="http://docbook.org/ns/docbook"
@@ -389,14 +395,43 @@ TasksMax=16284
 
  <sect1>
   <title>Controlling I/O with Proportional Weight Policy</title>
+  <para>
+      This section introduces using the Linux kernel's block I/O controller to 
+      prioritize I/O operations. The cgroup blkio subsystem controls and monitors 
+      access to I/O on block devices. State objects that contain the subsystem 
+      parameters for a cgroup are represented as pseudofiles within the cgroup 
+      virtual file system, also called a pseudo-filesystem.
+  </para>
+  <para>      
+      The examples in this section show how writing values to some of these 
+      pseudo-files limits access or bandwidth, and reading values from some of 
+      these pseudo-files provides information on I/O operations. Examples are 
+      provided for both cgroup-v1 and cgroup-v2.
+  </para>
+  <para>
+      You need a test directory containing two files for testing performance and changed settings. A quick way to create test files fully-populated
+      with text is using the <command>yes</command> command. The following example 
+      commands create a test directory, and then populate it with two 500 MB text
+      files:
+      </para> 
+  <screen>&prompt.plain-root;mkdir /io-cgroup
+&prompt.plain-root;cd /io-cgroup
+&prompt.plain-root;yes this is a test file | head -c 500MB > file1.txt
+&prompt.plain-root;yes this is a test file | head -c 500MB > file2.txt
+</screen>
+  <para>
+    To run the examples open three command shells. Two shells are for reader 
+    processes, and one shell is for running the steps that control I/O. In the 
+    examples, each command prompt is labeled to indicate if it represents 
+    one of the reader processes, or I/O.
+  </para>
 
   <sect2>
    <title>Using cgroup-v1</title>
-
    <para>
-    The following proportional weight policy files can be used to grant a reader process a
-    higher priority for I/O operations than other reader processes
-    accessing the same disk.
+    The following proportional weight policy files can be used to grant a reader 
+    process a higher priority for I/O operations than other reader processes
+    accessing the same disk. 
    </para>
    <itemizedlist mark="bullet" spacing="normal">
     <listitem>
@@ -413,27 +448,27 @@ TasksMax=16284
     </listitem>
    </itemizedlist>
    <para>
-    Run a single reader process (reading from SSD) without
-    controlling its I/O:
+    To test this, run a single reader process (in the examples,reading 
+    from a SSD) without controlling its I/O, using 
+    <filename>file2.txt</filename>:
    </para>
-<screen>
-&prompt.user;cd /mnt/tests/io-cgroup  
-&prompt.sudo;su -c "sync; echo 3 > /proc/sys/vm/drop_caches"
-&prompt.user;echo $$; dd if=file2 of=/dev/null bs=4k count=131072
-5251
-131072+0 records in
-131072+0 records out
-536870912 bytes (537 MB, 512 MiB) copied, 1.33049 s, 404 MB/s
+<screen> 
+&prompt.io-controller;sync; echo 3 > /proc/sys/vm/drop_caches
+&prompt.io-controller;echo $$; dd if=file2.txt of=/dev/null bs=4k count=131072
+8967
+122070+1 records in
+122070+1 records out
+500000000 bytes (500 MB, 477 MiB) copied, 2.6367 s, 190 MB/s
 </screen>
    <para>
     Now run a background process reading from the same disk:
    </para>
 <screen>
-&prompt.sudo;su -c "sync; echo 3 > /proc/sys/vm/drop_caches"
-&prompt.user;echo $$; dd if=file1 of=/dev/null bs=4k
+&prompt.reader1;sync; echo 3 > /proc/sys/vm/drop_caches
+&prompt.reader1;echo $$; dd if=file1.txt of=/dev/null bs=4k
 5220
 ...
-&prompt.user;echo $$; dd if=file2 of=/dev/null bs=4k count=131072
+&prompt.reader2;echo $$; dd if=file2.txt of=/dev/null bs=4k count=131072
 5251
 131072+0 records in
 131072+0 records out
@@ -442,33 +477,32 @@ TasksMax=16284
    <para>
     Each process gets half of the throughput for I/O operations.
     Next, set up two control groups&mdash;one for each
-    process&mdash;and make sure that BFQ is used, and set different weights:
+    process&mdash;verify that BFQ is used, and set different weights:
    </para>
 <screen>
-&prompt.user;cd /sys/fs/cgroup/blkio/
-&prompt.sudo;mkdir reader1
-&prompt.sudo;mkdir reader2
-&prompt.sudo;su -c "echo 5220 > reader1/cgroup.procs"
-&prompt.sudo;su -c "echo 5251 > reader2/cgroup.procs"
-&prompt.user;cat /sys/block/sda/queue/scheduler
+&prompt.io-controller;cd /sys/fs/cgroup/blkio/
+&prompt.io-controller;mkdir reader1
+&prompt.io-controller;mkdir reader2
+&prompt.io-controller;echo 5220 > reader1/cgroup.procs
+&prompt.io-controller;echo 5251 > reader2/cgroup.procs
+&prompt.io-controller;cat /sys/block/sda/queue/scheduler
 mq-deadline kyber [bfq] none
-&prompt.user;cat reader1/blkio.bfq.weight
+&prompt.io-controller;cat reader1/blkio.bfq.weight
 100
-&prompt.sudo;su -c "echo 200 >reader1/blkio.bfq.weight"
-&prompt.user;cat reader2/blkio.bfq.weight
+&prompt.io-controller;echo 200 >reader1/blkio.bfq.weight
+&prompt.io-controller;cat reader2/blkio.bfq.weight
 200
 </screen>
    <para>
-    With this settings and reader1 in background, reader2 should
+    With these settings and reader1 in the background, reader2 should
     have higher throughput than previously:
    </para>
 <screen>
-&prompt.user;cd /mnt/tests/io-cgroup/ 
-&prompt.sudo;su -c "sync; echo 3 > /proc/sys/vm/drop_caches"
-&prompt.user;echo $$; dd if=file1 of=/dev/null bs=4k
+&prompt.reader1;sync; echo 3 > /proc/sys/vm/drop_caches
+&prompt.reader1;echo $$; dd if=file1.txt of=/dev/null bs=4k
 5220
 ...
-&prompt.user;echo $$; dd if=file2 of=/dev/null bs=4k count=131072
+&prompt.reader2;echo $$; dd if=file2.txt of=/dev/null bs=4k count=131072
 5251
 131072+0 records in
 131072+0 records out
@@ -479,23 +513,21 @@ mq-deadline kyber [bfq] none
     Now double its weight again:
    </para>
 <screen>
-&prompt.user;cd /sys/fs/cgroup/blkio 
-&prompt.user;cat reader1/blkio.bfq.weight
+&prompt.io-controller;cat reader1/blkio.bfq.weight
 100
-&prompt.sudo;su -c "echo 400 >reader1/blkio.bfq.weight"
-&prompt.user;cat reader2/blkio.bfq.weight
+&prompt.io-controller;echo 400 > reader1/blkio.bfq.weight
+&prompt.io-controller;cat reader2/blkio.bfq.weight
 400
 </screen>
    <para>
     This results in another increase in throughput for reader2:
    </para>
 <screen>
-&prompt.user;cd /mnt/tests/io-cgroup/ 
-&prompt.sudo;su -c "sync; echo 3 > /proc/sys/vm/drop_caches"
-&prompt.user;echo $$; dd if=file1 of=/dev/null bs=4k
+&prompt.reader1;sync; echo 3 > /proc/sys/vm/drop_caches
+&prompt.reader1;echo $$; dd if=file1.txt of=/dev/null bs=4k
 5220
 ...
-&prompt.user;echo $$; dd if=file2 of=/dev/null bs=4k count=131072
+&prompt.reader2;echo $$; dd if=file2.txt of=/dev/null bs=4k count=131072
 5251
 131072+0 records in
 131072+0 records out
@@ -505,57 +537,62 @@ mq-deadline kyber [bfq] none
   <sect2>
    <title>Using cgroup-v2</title>
    <para>
-    First, make sure that Block IO controller is not active
+    First, make sure that the Block IO controller is not active
     under cgroup-v1. To do this, boot with kernel parameter
-    <option>cgroup_no_v1=blkio</option>. Block IO controller is
-    inactive in cgroup-v1, and IO controller shows up as an option for
-    cgroup-v2.
+    <option>cgroup_no_v1=blkio</option>. You should have a 
+    <filename>/sys/fs/cgroup/blkio/</filename> populated with
+    <filename>blkio.*</filename> files, and IO controller shows 
+    up as an option for cgroup-v2.
    </para>
 <screen>
-&prompt.user;cat /proc/cmdline
+&prompt.io-controller;cat /proc/cmdline
 BOOT_IMAGE=... cgroup_no_v1=blkio ...
-&prompt.user;ls /sys/fs/cgroup/blkio/
-&prompt.user;cat /sys/fs/cgroup/unified/cgroup.controllers
+&prompt.io-controller;ls /sys/fs/cgroup/blkio/
+blkio.bfq.io_service_bytes
+blkio.bfq.io_service_bytes_recursive
+blkio.bfq.io_serviced
+[...]
+&prompt.io-controller;cat /sys/fs/cgroup/unified/cgroup.controllers
 io
 </screen>
  <para>
-   Next, enable IO controller, create 2 control groups,
-   ensure that BFQ is used, and set weights:
+   Next, enable the IO controller, create two control groups,
+   ensure that BFQ is used (the active controller is enclosed in
+   square brackets), and set weights:
    </para>
 <screen>
-&prompt.user;cd /sys/fs/cgroup/unified/
-&prompt.sudo;su -c "echo '+io' > cgroup.subtree_control"
-&prompt.user;cat cgroup.subtree_control
+&prompt.io-controller;cd /sys/fs/cgroup/unified/
+&prompt.io-controller;echo '+io' > cgroup.subtree_control
+&prompt.io-controller;cat cgroup.subtree_control
 io
-&prompt.sudo;mkdir reader1
-&prompt.sudo;mkdir reader2
-&prompt.sudo;su -c "echo 3712 > reader1/cgroup.procs"
-&prompt.sudo;su -c "echo 3744 >reader2/cgroup.procs"
-&prompt.user;cat /sys/block/sda/queue/scheduler
+&prompt.io-controller;mkdir reader1
+&prompt.io-controller;mkdir reader2
+&prompt.io-controller;echo 3712 > reader1/cgroup.procs
+&prompt.io-controller;echo 3744 > reader2/cgroup.procs
+&prompt.io-controller;cat /sys/block/sda/queue/scheduler
 mq-deadline kyber [bfq] none
-&prompt.user;cat reader1/io.bfq.weight
+&prompt.io-controller;cat reader1/io.bfq.weight
 default 100
-&prompt.sudo;su -c "echo 400 >reader2/io.bfq.weight"
-&prompt.sudo;cat reader2/io.bfq.weight
+&prompt.io-controller;echo 400 >reader2/io.bfq.weight
+&prompt.io-controller;cat reader2/io.bfq.weight
 default 400
 </screen>
    <para>
-    With these settings, throughput looks like:
+    With these settings, throughput looks like the following:
    </para>
 <screen>
-&prompt.user;cd /mnt/tests/io-cgroup/ 
-&prompt.sudo;su -c "sync; echo 3 > /proc/sys/vm/drop_caches"
-&prompt.user;echo $$; dd if=file1 of=/dev/null bs=4k
+&prompt.reader1;sync; echo 3 > /proc/sys/vm/drop_caches
+&prompt.reader1;echo $$; dd if=file1 of=/dev/null bs=4k
 3712
 ...
-&prompt.user;echo $$; dd if=file2 of=/dev/null bs=4k count=131072
+&prompt.reader2;echo $$; dd if=file2 of=/dev/null bs=4k count=131072
 3744
 131072+0 records in
 131072+0 records out
 536870912 bytes (537 MB, 512 MiB) copied, 1.75746 s, 305 MB/s
 </screen>
   </sect2>
- </sect1>
+  </sect1>
  <sect1>
   <title>For More Information</title>
 

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -402,7 +402,7 @@ TasksMax=16284
     <listitem>
      <para>
       <filename>blkio.weight</filename> (only available in older
-      kernels with legacy block layer and using the CFQ I/O scheduler)
+      kernels with legacy block layer and when using the CFQ I/O scheduler)
      </para>
     </listitem>
     <listitem>

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -504,7 +504,7 @@ mq-deadline kyber [bfq] none
     First, make sure that Block IO controller is not active
     under cgroup-v1. To do this, boot with kernel parameter
     <option>cgroup_no_v1=blkio</option>. Block IO controller is
-    inactive in cgroup-v1 and IO controller shows up as an option for
+    inactive in cgroup-v1, and IO controller shows up as an option for
     cgroup-v2.
    </para>
 <screen>

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -393,7 +393,8 @@ TasksMax=16284
    <listitem>
     <para>
      Kernel documentation (package <systemitem>kernel-source</systemitem>):
-     files in <filename>/usr/src/linux/Documentation/cgroups</filename>.
+     files in <filename>/usr/src/linux/Documentation/cgroups-v1</filename> and
+     file <filename>/usr/src/linux/Documentation/cgroups-v2.rst</filename>.
     </para>
    </listitem>
    <listitem>

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -502,7 +502,7 @@ mq-deadline kyber [bfq] none
    <title>Using cgroup-v2</title>
    <para>
     First, make sure that Block IO controller is not active
-    under cgroup-v1. Thus we boot with kernel parameter
+    under cgroup-v1. To do this, boot with kernel parameter
     <option>cgroup_no_v1=blkio</option>. Block IO controller is
     inactive in cgroup-v1 and IO controller shows up as an option for
     cgroup-v2.

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -387,14 +387,180 @@ TasksMax=16284
  </sect1>
 
  <sect1>
+  <title>Controlling I/O with Proportional Weight Policy</title>
+
+  <sect2>
+   <title>Using cgroup-v1</title>
+
+   <para>
+    Assume you have a reader processes and you want to grant it a
+    higher priority for I/O operations then other reader processes
+    accessing the same disk. This can be managed with proportional
+    weight policy files:
+   </para>
+   <itemizedlist mark="bullet" spacing="normal">
+    <listitem>
+     <para>
+      <filename>blkio.weight</filename> (only available in older
+      kernels with legacy block layer and using the CFQ I/O scheduler)
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <filename>blkio.bfq.weight</filename> (only available in newer
+      kernels with blk-mq and using BFQ I/O scheduler)
+     </para>
+    </listitem>
+   </itemizedlist>
+   <para>
+    Running a single reader process (reading from SSD) without
+    controlling its I/O:
+   </para>
+<screen>
+/mnt/tests/io-cgroup/> sudo su -c "sync; echo 3 > /proc/sys/vm/drop_caches"
+/mnt/tests/io-cgroup/> echo $$; dd if=file2 of=/dev/null bs=4k count=131072
+5251
+131072+0 records in
+131072+0 records out
+536870912 bytes (537 MB, 512 MiB) copied, 1.33049 s, 404 MB/s
+</screen>
+   <para>
+    Now running a background process reading from the same disk.
+   </para>
+<screen>
+[reader1] /mnt/tests/io-cgroup/> sudo su -c "sync; echo 3 > /proc/sys/vm/drop_caches"
+[reader1] /mnt/tests/io-cgroup/> echo $$; dd if=file1 of=/dev/null bs=4k
+5220
+...
+[reader2] /mnt/tests/io-cgroup/> echo $$; dd if=file2 of=/dev/null bs=4k count=131072
+5251
+131072+0 records in
+131072+0 records out
+536870912 bytes (537 MB, 512 MiB) copied, 2.61592 s, 205 MB/s
+</screen>
+   <para>
+    Both processes get an equal share for I/O, halving throughput for
+    each process. Now we set up two control groups - one for each
+    process - check that BFQ is used and set different weights:
+   </para>
+<screen>
+[I/O controller] > cd /sys/fs/cgroup/blkio/
+[I/O controller] /sys/fs/cgroup/blkio> sudo mkdir reader1
+[I/O controller] /sys/fs/cgroup/blkio> sudo mkdir reader2
+[I/O controller] /sys/fs/cgroup/blkio> sudo su -c "echo 5220 > reader1/cgroup.procs"
+[I/O controller] /sys/fs/cgroup/blkio> sudo su -c "echo 5251 > reader2/cgroup.procs"
+[I/O controller] /sys/fs/cgroup/blkio> cat /sys/block/sda/queue/scheduler
+mq-deadline kyber [bfq] none
+[I/O controller] /sys/fs/cgroup/blkio> cat reader1/blkio.bfq.weight
+100
+[I/O controller] /sys/fs/cgroup/blkio> sudo su -c "echo 200 >reader1/blkio.bfq.weight"
+[I/O controller] /sys/fs/cgroup/blkio> cat reader2/blkio.bfq.weight
+200
+</screen>
+   <para>
+    With this settings and reader1 in background, reader2 should
+    achieve higher throughput than before:
+   </para>
+<screen>
+[reader1] /mnt/tests/io-cgroup/> sudo su -c "sync; echo 3 > /proc/sys/vm/drop_caches"
+[reader1] /mnt/tests/io-cgroup/> echo $$; dd if=file1 of=/dev/null bs=4k
+5220
+...
+[reader2] /mnt/tests/io-cgroup/> echo $$; dd if=file2 of=/dev/null bs=4k count=131072
+5251
+131072+0 records in
+131072+0 records out
+536870912 bytes (537 MB, 512 MiB) copied, 2.06604 s, 260 MB/s
+</screen>
+   <para>
+    The higher proportional weight resulted in higher throughput for reader2.
+    Now doubling its weight again:
+   </para>
+<screen>
+[I/O controller] /sys/fs/cgroup/blkio> cat reader1/blkio.bfq.weight
+100
+[I/O controller] /sys/fs/cgroup/blkio> sudo su -c "echo 400 >reader1/blkio.bfq.weight"
+[I/O controller] /sys/fs/cgroup/blkio> cat reader2/blkio.bfq.weight
+400
+</screen>
+   <para>
+    This results in another increase in throughput for reader2:
+   </para>
+<screen>
+[reader1] /mnt/tests/io-cgroup/> sudo su -c "sync; echo 3 > /proc/sys/vm/drop_caches"
+[reader1] /mnt/tests/io-cgroup/> echo $$; dd if=file1 of=/dev/null bs=4k
+5220
+...
+[reader2] /mnt/tests/io-cgroup/> echo $$; echo $$; dd if=file2 of=/dev/null bs=4k count=131072
+5251
+131072+0 records in
+131072+0 records out
+536870912 bytes (537 MB, 512 MiB) copied, 1.69026 s, 318 MB/s
+</screen>
+  </sect2>
+  <sect2>
+   <title>Using cgroup-v2</title>
+   <para>
+    First we need to make sure that Block IO controller is not active
+    under cgroup-v1. Thus we boot with kernel parameter
+    <option>cgroup_no_v1=blkio</option>. Block IO controller is
+    inactive in cgroup-v1 and IO controller shows up as an option for
+    cgroup-v2.
+   </para>
+<screen>
+$ cat /proc/cmdline
+BOOT_IMAGE=... cgroup_no_v1=blkio ...
+$ ls /sys/fs/cgroup/blkio/
+$ cat /sys/fs/cgroup/unified/cgroup.controllers
+io
+</screen>
+ <para>
+   Next steps are: enable IO controller, create 2 control groups,
+   ensure that BFQ is used, set weights.
+   </para>
+<screen>
+[I/O controller] > cd /sys/fs/cgroup/unified/
+[I/O controller] > sudo su -c "echo '+io' > cgroup.subtree_control"
+[I/O controller] > cat cgroup.subtree_control
+io
+[I/O controller] /sys/fs/cgroup/unified> sudo mkdir reader1
+[I/O controller] /sys/fs/cgroup/unified> sudo mkdir reader2
+[I/O controller] /sys/fs/cgroup/unified> sudo su -c "echo 3712 >reader1/cgroup.procs"
+[I/O controller] /sys/fs/cgroup/unified> sudo su -c "echo 3744 >reader2/cgroup.procs"
+[I/O controller] /sys/fs/cgroup/unified> cat /sys/block/sda/queue/scheduler
+mq-deadline kyber [bfq] none
+[I/O controller] /sys/fs/cgroup/unified> cat reader1/io.bfq.weight
+default 100
+[I/O controller] /sys/fs/cgroup/unified> sudo su -c "echo 400 >reader2/io.bfq.weight"
+[I/O controller] /sys/fs/cgroup/unified> cat reader2/io.bfq.weight
+default 400
+</screen>
+   <para>
+    With this setting throughput looks like:
+   </para>
+<screen>
+[reader1] /mnt/tests/io-cgroup/> sudo su -c "sync; echo 3 > /proc/sys/vm/drop_caches"
+[reader1] /mnt/tests/io-cgroup/> echo $$; dd if=file1 of=/dev/null bs=4k
+3712
+...
+[reader2] /mnt/tests/io-cgroup/> echo $$; dd if=file2 of=/dev/null bs=4k count=131072
+3744
+131072+0 records in
+131072+0 records out
+536870912 bytes (537 MB, 512 MiB) copied, 1.75746 s, 305 MB/s
+</screen>
+  </sect2>
+ </sect1>
+ <sect1>
   <title>For More Information</title>
 
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
      Kernel documentation (package <systemitem>kernel-source</systemitem>):
-     files in <filename>/usr/src/linux/Documentation/cgroups-v1</filename> and
-     file <filename>/usr/src/linux/Documentation/cgroups-v2.rst</filename>.
+     files in <filename>/usr/src/linux/Documentation/cgroups-v1</filename>,
+     file <filename>/usr/src/linux/Documentation/cgroups-v2.rst</filename>, and
+     <filename>/usr/src/linux/Documentation/block/bfq-iosched.rst</filename>.
     </para>
    </listitem>
    <listitem>

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -25,6 +25,7 @@
   </dm:docmanager>
  </info>
 
+  
  <sect1 xml:id="sec-tuning-cgroups-overview">
   <title>Overview</title>
   <para>

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -536,7 +536,7 @@ default 100
 default 400
 </screen>
    <para>
-    With this setting throughput looks like:
+    With these settings, throughput looks like:
    </para>
 <screen>
 [reader1] /mnt/tests/io-cgroup/> sudo su -c "sync; echo 3 > /proc/sys/vm/drop_caches"

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -417,8 +417,9 @@ TasksMax=16284
     controlling its I/O:
    </para>
 <screen>
-/mnt/tests/io-cgroup/> sudo su -c "sync; echo 3 > /proc/sys/vm/drop_caches"
-/mnt/tests/io-cgroup/> echo $$; dd if=file2 of=/dev/null bs=4k count=131072
+&prompt.user;cd /mnt/tests/io-cgroup  
+&prompt.sudo;su -c "sync; echo 3 > /proc/sys/vm/drop_caches"
+&prompt.user;echo $$; dd if=file2 of=/dev/null bs=4k count=131072
 5251
 131072+0 records in
 131072+0 records out
@@ -428,11 +429,11 @@ TasksMax=16284
     Now run a background process reading from the same disk:
    </para>
 <screen>
-[reader1] /mnt/tests/io-cgroup/> sudo su -c "sync; echo 3 > /proc/sys/vm/drop_caches"
-[reader1] /mnt/tests/io-cgroup/> echo $$; dd if=file1 of=/dev/null bs=4k
+&prompt.sudo;su -c "sync; echo 3 > /proc/sys/vm/drop_caches"
+&prompt.user;echo $$; dd if=file1 of=/dev/null bs=4k
 5220
 ...
-[reader2] /mnt/tests/io-cgroup/> echo $$; dd if=file2 of=/dev/null bs=4k count=131072
+&prompt.user;echo $$; dd if=file2 of=/dev/null bs=4k count=131072
 5251
 131072+0 records in
 131072+0 records out
@@ -444,17 +445,17 @@ TasksMax=16284
     process&mdash;and make sure that BFQ is used, and set different weights:
    </para>
 <screen>
-[I/O controller] > cd /sys/fs/cgroup/blkio/
-[I/O controller] /sys/fs/cgroup/blkio> sudo mkdir reader1
-[I/O controller] /sys/fs/cgroup/blkio> sudo mkdir reader2
-[I/O controller] /sys/fs/cgroup/blkio> sudo su -c "echo 5220 > reader1/cgroup.procs"
-[I/O controller] /sys/fs/cgroup/blkio> sudo su -c "echo 5251 > reader2/cgroup.procs"
-[I/O controller] /sys/fs/cgroup/blkio> cat /sys/block/sda/queue/scheduler
+&prompt.user;cd /sys/fs/cgroup/blkio/
+&prompt.sudo;mkdir reader1
+&prompt.sudo;mkdir reader2
+&prompt.sudo;su -c "echo 5220 > reader1/cgroup.procs"
+&prompt.sudo;su -c "echo 5251 > reader2/cgroup.procs"
+&prompt.user;cat /sys/block/sda/queue/scheduler
 mq-deadline kyber [bfq] none
-[I/O controller] /sys/fs/cgroup/blkio> cat reader1/blkio.bfq.weight
+&prompt.user;cat reader1/blkio.bfq.weight
 100
-[I/O controller] /sys/fs/cgroup/blkio> sudo su -c "echo 200 >reader1/blkio.bfq.weight"
-[I/O controller] /sys/fs/cgroup/blkio> cat reader2/blkio.bfq.weight
+&prompt.sudo;su -c "echo 200 >reader1/blkio.bfq.weight"
+&prompt.user;cat reader2/blkio.bfq.weight
 200
 </screen>
    <para>
@@ -462,11 +463,12 @@ mq-deadline kyber [bfq] none
     have higher throughput than previously:
    </para>
 <screen>
-[reader1] /mnt/tests/io-cgroup/> sudo su -c "sync; echo 3 > /proc/sys/vm/drop_caches"
-[reader1] /mnt/tests/io-cgroup/> echo $$; dd if=file1 of=/dev/null bs=4k
+&prompt.user;cd /mnt/tests/io-cgroup/ 
+&prompt.sudo;su -c "sync; echo 3 > /proc/sys/vm/drop_caches"
+&prompt.user;echo $$; dd if=file1 of=/dev/null bs=4k
 5220
 ...
-[reader2] /mnt/tests/io-cgroup/> echo $$; dd if=file2 of=/dev/null bs=4k count=131072
+&prompt.user;echo $$; dd if=file2 of=/dev/null bs=4k count=131072
 5251
 131072+0 records in
 131072+0 records out
@@ -477,21 +479,23 @@ mq-deadline kyber [bfq] none
     Now double its weight again:
    </para>
 <screen>
-[I/O controller] /sys/fs/cgroup/blkio> cat reader1/blkio.bfq.weight
+&prompt.user;cd /sys/fs/cgroup/blkio 
+&prompt.user;cat reader1/blkio.bfq.weight
 100
-[I/O controller] /sys/fs/cgroup/blkio> sudo su -c "echo 400 >reader1/blkio.bfq.weight"
-[I/O controller] /sys/fs/cgroup/blkio> cat reader2/blkio.bfq.weight
+&prompt.sudo;su -c "echo 400 >reader1/blkio.bfq.weight"
+&prompt.user;cat reader2/blkio.bfq.weight
 400
 </screen>
    <para>
     This results in another increase in throughput for reader2:
    </para>
 <screen>
-[reader1] /mnt/tests/io-cgroup/> sudo su -c "sync; echo 3 > /proc/sys/vm/drop_caches"
-[reader1] /mnt/tests/io-cgroup/> echo $$; dd if=file1 of=/dev/null bs=4k
+&prompt.user;cd /mnt/tests/io-cgroup/ 
+&prompt.sudo;su -c "sync; echo 3 > /proc/sys/vm/drop_caches"
+&prompt.user;echo $$; dd if=file1 of=/dev/null bs=4k
 5220
 ...
-[reader2] /mnt/tests/io-cgroup/> echo $$; echo $$; dd if=file2 of=/dev/null bs=4k count=131072
+&prompt.user;echo $$; dd if=file2 of=/dev/null bs=4k count=131072
 5251
 131072+0 records in
 131072+0 records out
@@ -508,10 +512,10 @@ mq-deadline kyber [bfq] none
     cgroup-v2.
    </para>
 <screen>
-$ cat /proc/cmdline
+&prompt.user;cat /proc/cmdline
 BOOT_IMAGE=... cgroup_no_v1=blkio ...
-$ ls /sys/fs/cgroup/blkio/
-$ cat /sys/fs/cgroup/unified/cgroup.controllers
+&prompt.user;ls /sys/fs/cgroup/blkio/
+&prompt.user;cat /sys/fs/cgroup/unified/cgroup.controllers
 io
 </screen>
  <para>
@@ -519,31 +523,32 @@ io
    ensure that BFQ is used, and set weights:
    </para>
 <screen>
-[I/O controller] > cd /sys/fs/cgroup/unified/
-[I/O controller] > sudo su -c "echo '+io' > cgroup.subtree_control"
-[I/O controller] > cat cgroup.subtree_control
+&prompt.user;cd /sys/fs/cgroup/unified/
+&prompt.sudo;su -c "echo '+io' > cgroup.subtree_control"
+&prompt.user;cat cgroup.subtree_control
 io
-[I/O controller] /sys/fs/cgroup/unified> sudo mkdir reader1
-[I/O controller] /sys/fs/cgroup/unified> sudo mkdir reader2
-[I/O controller] /sys/fs/cgroup/unified> sudo su -c "echo 3712 >reader1/cgroup.procs"
-[I/O controller] /sys/fs/cgroup/unified> sudo su -c "echo 3744 >reader2/cgroup.procs"
-[I/O controller] /sys/fs/cgroup/unified> cat /sys/block/sda/queue/scheduler
+&prompt.sudo;mkdir reader1
+&prompt.sudo;mkdir reader2
+&prompt.sudo;su -c "echo 3712 > reader1/cgroup.procs"
+&prompt.sudo;su -c "echo 3744 >reader2/cgroup.procs"
+&prompt.user;cat /sys/block/sda/queue/scheduler
 mq-deadline kyber [bfq] none
-[I/O controller] /sys/fs/cgroup/unified> cat reader1/io.bfq.weight
+&prompt.user;cat reader1/io.bfq.weight
 default 100
-[I/O controller] /sys/fs/cgroup/unified> sudo su -c "echo 400 >reader2/io.bfq.weight"
-[I/O controller] /sys/fs/cgroup/unified> cat reader2/io.bfq.weight
+&prompt.sudo;su -c "echo 400 >reader2/io.bfq.weight"
+&prompt.sudo;cat reader2/io.bfq.weight
 default 400
 </screen>
    <para>
     With these settings, throughput looks like:
    </para>
 <screen>
-[reader1] /mnt/tests/io-cgroup/> sudo su -c "sync; echo 3 > /proc/sys/vm/drop_caches"
-[reader1] /mnt/tests/io-cgroup/> echo $$; dd if=file1 of=/dev/null bs=4k
+&prompt.user;cd /mnt/tests/io-cgroup/ 
+&prompt.sudo;su -c "sync; echo 3 > /proc/sys/vm/drop_caches"
+&prompt.user;echo $$; dd if=file1 of=/dev/null bs=4k
 3712
 ...
-[reader2] /mnt/tests/io-cgroup/> echo $$; dd if=file2 of=/dev/null bs=4k count=131072
+&prompt.user;echo $$; dd if=file2 of=/dev/null bs=4k count=131072
 3744
 131072+0 records in
 131072+0 records out


### PR DESCRIPTION
### Description
Describe (blk)io controller when using BFQ and cgroups.
Currently there is no description at all about this.

A somehow related bug report is
[Bug 1170566] L3: IO accounting/scheduler does not work

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
