### PR TITLE
Added a note about certificate location for RMT

### DIFF
--- a/xml/rmt_install.xml
+++ b/xml/rmt_install.xml
@@ -136,6 +136,32 @@
     <para>
      When all common names are entered, select <guimenu>Next</guimenu>.
     </para>
+    <tip>
+     <title>Certificate Locations for RMT</title>
+
+     <itemizedlist>
+      <listitem>
+       <para>
+        <filename>/etc/rmt/ssl/rmt-ca.crt</filename>
+       </para>
+       <para>
+        This is the CA certificate bundle that <command>yast2 rmt</command> uses to
+        certify the &rmt; server certificate. <command>yast2 rmt</command> will only
+        create this file if it doesn't already exist.
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        <filename>/etc/rmt/ssl/rmt-server.crt</filename> and <filename>/etc/rmt/ssl/rmt-server.key</filename>
+       </para>
+       <para>
+        <command>yast2 rmt</command> will only generate a new server certificate and
+        private key if one doesn't already exist. To regenerate this certificate, please
+        reference <xref linkend="cha-manage-certificates-https" />.
+       </para>
+      </listitem>
+     </itemizedlist>
+    </tip>
    </step>
    <step>
     <para>


### PR DESCRIPTION
### Description

Some customers would like to use a custom CA certificate to set up their RMT servers. With this note, we can help point them in the right direction without detailing a process for custom certificates.

### Checklist

* Check all items that apply.

*Are backports required?*

No
