### PR TITLE
Add warning to avoid `ntpd -x` when live migrating (BSC #1173877)

### DIFF
--- a/xml/libvirt_managing.xml
+++ b/xml/libvirt_managing.xml
@@ -986,6 +986,7 @@ Metadata:       yes
    &vmguest; is constantly available.
   </para>
 
+
   <sect2 xml:id="libvirt-admin-live-migration-requirements">
    <title>Migration Requirements</title>
    <para>
@@ -1116,6 +1117,21 @@ Metadata:       yes
      </para>
     </listitem>
    </itemizedlist>
+
+   <warning>
+    <title>Avoid NTP Slew Mode When Live-Migrating</title>
+    <para>
+     Do not use the <command>ntpd</command> daemon's slew mode (invoked with
+     <command>ntpd -x</command>) when live-migrating a &vmguest; to a different
+     &vmhost;. The <command>-x</command> switch instructs <command>ntpd</command>
+     to adjust the system clock gradually, in 0.05ms/s steps, instead of making
+     a sudden large adjustment. This gradual adjustment is not reliable inside
+     VMs and can result in significant time discrepancies.
+    </para>
+    <para>
+     This setting is off by default in &productname;.
+    </para>
+   </warning>
   </sect2>
 
   <sect2 xml:id="sec-libvirt-admin-migrate-virtmanager">

--- a/xml/libvirt_managing.xml
+++ b/xml/libvirt_managing.xml
@@ -1123,7 +1123,7 @@ Metadata:       yes
     <para>
      Do not use the <systemitem class="daemon">ntpd</systemitem> daemon's slew mode (invoked with
      <command>ntpd -x</command>) when live-migrating a &vmguest; to a different
-     &vmhost;. The <command>-x</command> switch instructs <command>ntpd</command>
+     &vmhost;. The <option>-x</option> switch instructs <systemitem class="daemon">ntpd</systemitem>
      to adjust the system clock gradually, in 0.05ms/s steps, instead of making
      a sudden large adjustment. This gradual adjustment is not reliable inside
      VMs and can result in significant time discrepancies.

--- a/xml/libvirt_managing.xml
+++ b/xml/libvirt_managing.xml
@@ -1121,7 +1121,7 @@ Metadata:       yes
    <warning>
     <title>Avoid NTP Slew Mode When Live-Migrating</title>
     <para>
-     Do not use the <command>ntpd</command> daemon's slew mode (invoked with
+     Do not use the <systemitem class="daemon">ntpd</systemitem> daemon's slew mode (invoked with
      <command>ntpd -x</command>) when live-migrating a &vmguest; to a different
      &vmhost;. The <command>-x</command> switch instructs <command>ntpd</command>
      to adjust the system clock gradually, in 0.05ms/s steps, instead of making


### PR DESCRIPTION
### Description
Fixed https://bugzilla.suse.com/show_bug.cgi?id=1173887
which is due to https://bugzilla.suse.com/show_bug.cgi?id=1170728
This is an L3 customer bug report. 

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [x] To maintenance/SLE12SP3
