### PR TITLE
Update path of AppArmor extra profiles

### DIFF
--- a/xml/apparmor_profiles_man.xml
+++ b/xml/apparmor_profiles_man.xml
@@ -1298,8 +1298,7 @@ Adding #include &lt;abstractions/apache2-common&gt; to profile.
      Like the graphical front-end for building &aa; profiles, the
      &yast; Add Profile Wizard, <command>aa-genprof</command> also
      supports the use of the local profile repository under
-     <filename>/etc/apparmor/profiles/extras</filename>
-<!-- path will change in &aa; ;-) 3.0 -->
+     <filename>/usr/share/apparmor/extra-profiles</filename>
      and the remote &aa; profile repository.
     </para>
     <para>
@@ -1964,7 +1963,7 @@ New Mode: r
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><filename>/etc/apparmor/profiles/extras/</filename>
+    <term><filename>/usr/share/apparmor/extra-profiles</filename>
     </term>
     <listitem>
      <para>

--- a/xml/apparmor_profiles_man.xml
+++ b/xml/apparmor_profiles_man.xml
@@ -1298,8 +1298,7 @@ Adding #include &lt;abstractions/apache2-common&gt; to profile.
      Like the graphical front-end for building &aa; profiles, the
      &yast; Add Profile Wizard, <command>aa-genprof</command> also
      supports the use of the local profile repository under
-     <filename>/usr/share/apparmor/extra-profiles</filename>
-     and the remote &aa; profile repository.
+     <filename>/usr/share/apparmor/extra-profiles</filename>.
     </para>
     <para>
      To use a profile from the local repository, proceed as follows:

--- a/xml/apparmor_repositories.xml
+++ b/xml/apparmor_repositories.xml
@@ -20,7 +20,7 @@
   &productname; ships profiles for individual applications together with
   the relevant application. These profiles are not enabled by default, and
   reside under another directory than the standard &aa; profiles,
-  <filename>/etc/apparmor/profiles/extras</filename>.
+  <filename>/usr/share/apparmor/extra-profiles</filename>.
  </para>
  <!-- <sect1 xml:id="sec-apparmor-repos-local"> -->
  <!--  <title>Using the Local Repository</title> -->
@@ -31,7 +31,7 @@
    Whenever you start to create a new profile from scratch, and there
    already is an inactive profile in your local repository, you are asked
    whether you want to use the existing inactive one from
-   <filename>/etc/apparmor/profiles/extras</filename> and whether you want
+   <filename>/usr/share/apparmor/extra-profiles</filename> and whether you want
    to base your efforts on it. If you decide to use this profile, it gets
    copied over to the directory of profiles enabled by default
    (<filename>/etc/apparmor.d</filename>) and loaded whenever &aa; is


### PR DESCRIPTION
### Description

* Update path of AppArmor extra profiles. The extra profiles were moved to /usr/share/apparmor/extra-profiles/ in AppArmor 2.9 (= long ago), see boo#713647
* Drop reference to the AppArmor remote profile repository. It was switched off years ago, and is unlikely to come back.

### Checklist
* Check all items that apply.

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3

(AFAIK SLE12 still has AppArmor 2.8.x which uses the old path. However, you might want to drop the mention of the online profile repo in the SLE12 documentation.)