### PR TITLE
vCPU scheduling (jsc#SLE-10167)

### DIFF
--- a/xml/xen_config_options.xml
+++ b/xml/xen_config_options.xml
@@ -1052,14 +1052,15 @@ alice                             4     1     3   -b-       2.8 2-3</screen>
  <sect1 xml:id="sec-xen-config-scheduling">
   <title>Virtual CPU Scheduling</title>
   <para>
-   The &xen; hypervisor schedules virtual CPUs individually across physical CPUs.
-   With modern CPUs supporting multiple threads on each core, virtual CPUs can
-   run on the same core in different threads and thus influence each other.
-    The performance of a virtual CPU running in one thread can be noticeably affected
-    by what other virtual CPUs in other threads are doing. When these virtual
-   CPUs belong to different guest systems, these guests can influence each
-   other. The effect can vary, from variations in the guest CPU time accounting
-   to worse scenarios such as <emphasis>side channel attack</emphasis>.
+   The &xen; hypervisor schedules virtual CPUs individually across physical
+   CPUs.  With modern CPUs supporting multiple threads on each core, virtual
+   CPUs can run on the same core in different threads and thus influence each
+   other.  The performance of a virtual CPU running in one thread can be
+   noticeably affected by what other virtual CPUs in other threads are doing.
+   When these virtual CPUs belong to different guest systems, these guests can
+   influence each other. The effect can vary, from variations in the guest CPU
+   time accounting to worse scenarios such as <emphasis>side channel
+    attack</emphasis>.
   </para>
   <para>
    <emphasis>Scheduling granularity</emphasis> addresses this problem. You can
@@ -1084,12 +1085,16 @@ alice                             4     1     3   -b-       2.8 2-3</screen>
     <listitem>
      <para>
       Virtual CPUs of a virtual core are always scheduled together on one
-      physical core. Two or more virtual CPUs from different virtual cores
-      will never be scheduled on the same physical core.
-      Therefore, some physical cores may have some of their CPUs left idle,
-      even if there are virtual CPUs wanting to run. This may slightly impact
-      performance, but it is important to achieve the improved isolation and
-      consistency.
+      physical core. Two or more virtual CPUs from different virtual cores will
+      never be scheduled on the same physical core.  Therefore, some physical
+      cores may have some of their CPUs left idle, even if there are virtual
+      CPUs wanting to run. The impact on performance will depend on the actual
+      workload being run inside of the guest systems. In most of the analyzed
+      cases, the observed performance degradation, especially if under
+      considerable load, was smaller than disabling HyperThreading which leaves
+      all the cores with just one thread (see the <option>smt</option> boot
+      option at <link
+       xlink:href="https://xenbits.xen.org/docs/unstable/misc/xen-command-line.html#smt-x86"/>).
      </para>
     </listitem>
    </varlistentry>

--- a/xml/xen_config_options.xml
+++ b/xml/xen_config_options.xml
@@ -1049,4 +1049,58 @@ alice                             4     1     3   -b-       2.8 2-3</screen>
 <screen>extra_guest_irqs=,512</screen>
   </sect2>
  </sect1>
+ <sect1 xml:id="sec-xen-config-scheduling">
+  <title>Virtual CPU Scheduling</title>
+  <para>
+   &xen; hypervisor schedules virtual CPUs individually across physical CPUs.
+   On modern CPUs that support multiple threads on one core, virtual CPUs can
+   run on the same core in different threads and thus influence each other.
+   Such virtual CPUs can observe performance variations resulting from the
+   actions of a virtual CPU running on the other thread.  When these virtual
+   CPUs belong to different guest systems, these guests can influence each
+   other. The effect can vary, from variations in the guest CPU time accounting
+   to worse scenarios such as <emphasis>side channel attack</emphasis>.
+  </para>
+  <para>
+   <emphasis>Scheduling granularity</emphasis> addresses this problem. You can
+   specify it at boot time by using a &xen; boot parameter:
+  </para>
+  <screen>sched-gran=<replaceable>GRANULARITY</replaceable></screen>
+  <para>
+   Replace <replaceable>GRANULARITY</replaceable> with one of:
+  </para>
+  <variablelist>
+   <varlistentry>
+    <term>cpu</term>
+    <listitem>
+     <para>
+      The regular scheduling of the &xen; hypervisor. Virtual CPUs of different
+      guests can share one physical CPU core. This is the default.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>core</term>
+    <listitem>
+     <para>
+      Virtual CPUs of a virtual core are always scheduled together on one
+      physical core. It never happens that two or more virtual CPUs from
+      different virtual cores are scheduled on the same physical core.
+      Therefore, some physical cores may have some of their CPUs left idle,
+      even if there are virtual CPUs wanting to run. This may slightly impact
+      performance, but it is important to achieve the improved isolation and
+      consistency.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>socket</term>
+    <listitem>
+     <para>
+      The granularity goes even higher to a CPU socket level.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </sect1>
 </chapter>

--- a/xml/xen_config_options.xml
+++ b/xml/xen_config_options.xml
@@ -1052,11 +1052,11 @@ alice                             4     1     3   -b-       2.8 2-3</screen>
  <sect1 xml:id="sec-xen-config-scheduling">
   <title>Virtual CPU Scheduling</title>
   <para>
-   &xen; hypervisor schedules virtual CPUs individually across physical CPUs.
-   On modern CPUs that support multiple threads on one core, virtual CPUs can
+   The &xen; hypervisor schedules virtual CPUs individually across physical CPUs.
+   With modern CPUs supporting multiple threads on each core, virtual CPUs can
    run on the same core in different threads and thus influence each other.
-   Such virtual CPUs can observe performance variations resulting from the
-   actions of a virtual CPU running on the other thread.  When these virtual
+    The performance of a virtual CPU running in one thread can be noticeably affected
+    by what other virtual CPUs in other threads are doing. When these virtual
    CPUs belong to different guest systems, these guests can influence each
    other. The effect can vary, from variations in the guest CPU time accounting
    to worse scenarios such as <emphasis>side channel attack</emphasis>.
@@ -1084,8 +1084,8 @@ alice                             4     1     3   -b-       2.8 2-3</screen>
     <listitem>
      <para>
       Virtual CPUs of a virtual core are always scheduled together on one
-      physical core. It never happens that two or more virtual CPUs from
-      different virtual cores are scheduled on the same physical core.
+      physical core. Two or more virtual CPUs from different virtual cores
+      will never be scheduled on the same physical core.
       Therefore, some physical cores may have some of their CPUs left idle,
       even if there are virtual CPUs wanting to run. This may slightly impact
       performance, but it is important to achieve the improved isolation and


### PR DESCRIPTION
### Description
The granularity of vCPUs scheduling in Xen can be specified at boot time

