### PR TITLE
tuning_systemresources: ionice: Refer to BFQ for blk-mq

### DIFF
--- a/xml/tuning_systemresources.xml
+++ b/xml/tuning_systemresources.xml
@@ -372,7 +372,7 @@ Large page support
     not apply for these writes. Also be aware that the
     I/O class and priority settings are obeyed only by the
     <emphasis>CFQ</emphasis> I/O scheduler for the legacy block I/O path
-    (refer to <xref linkend="cha-tuning-io-schedulers"/>) and
+    (refer to <xref linkend="cha-tuning-io-schedulers"/>), and the
     <emphasis>BFQ</emphasis> I/O scheduler for blk-mq I/O path (refer
     to <xref linkend="cha-tuning-io-schedulers-blkmq"/>).  You can set
     the following three scheduling classes:

--- a/xml/tuning_systemresources.xml
+++ b/xml/tuning_systemresources.xml
@@ -373,7 +373,7 @@ Large page support
     I/O class and priority settings are obeyed only by the
     <emphasis>CFQ</emphasis> I/O scheduler for the legacy block I/O path
     (refer to <xref linkend="cha-tuning-io-schedulers"/>), and the
-    <emphasis>BFQ</emphasis> I/O scheduler for blk-mq I/O path (refer
+    <emphasis>BFQ</emphasis> I/O scheduler for the blk-mq I/O path (refer
     to <xref linkend="cha-tuning-io-schedulers-blkmq"/>).  You can set
     the following three scheduling classes:
    </para>

--- a/xml/tuning_systemresources.xml
+++ b/xml/tuning_systemresources.xml
@@ -369,10 +369,13 @@ Large page support
     the disk. The caveat of this feature is that standard writes are cached in
     the page cache and are written back to persistent storage only later by an
     independent kernel process. Thus the I/O priority setting generally does
-    not apply for these writes. Also be aware that I/O class and priority
-    setting is obeyed only by <emphasis>CFQ</emphasis> I/O scheduler (refer to
-    <xref linkend="cha-tuning-io-schedulers"/>). You can set the following
-    three scheduling classes:
+    not apply for these writes. Also be aware that
+    I/O class and priority setting are obeyed only by
+    <emphasis>CFQ</emphasis> I/O scheduler for legacy block I/O path
+    (refer to <xref linkend="cha-tuning-io-schedulers"/>) and
+    <emphasis>BFQ</emphasis> I/O scheduler for blk-mq I/O path (refer
+    to <xref linkend="cha-tuning-io-schedulers-blkmq"/>).  You can set
+    the following three scheduling classes:
    </para>
    <variablelist>
     <varlistentry>

--- a/xml/tuning_systemresources.xml
+++ b/xml/tuning_systemresources.xml
@@ -366,7 +366,7 @@ Large page support
     processes with heavy disk access that are not time-critical, such as backup
     jobs. <command>ionice</command> also lets you raise the I/O priority for a
     specific process to make sure this process always has immediate access to
-    the disk. The caveat of this feature is that standard writes are cached in
+    the disk. The caveat with this feature is that standard writes are cached in
     the page cache and are written back to persistent storage only later by an
     independent kernel process. Thus the I/O priority setting generally does
     not apply for these writes. Also be aware that

--- a/xml/tuning_systemresources.xml
+++ b/xml/tuning_systemresources.xml
@@ -371,7 +371,7 @@ Large page support
     independent kernel process. Thus, the I/O priority setting generally does
     not apply for these writes. Also be aware that the
     I/O class and priority settings are obeyed only by the
-    <emphasis>CFQ</emphasis> I/O scheduler for legacy block I/O path
+    <emphasis>CFQ</emphasis> I/O scheduler for the legacy block I/O path
     (refer to <xref linkend="cha-tuning-io-schedulers"/>) and
     <emphasis>BFQ</emphasis> I/O scheduler for blk-mq I/O path (refer
     to <xref linkend="cha-tuning-io-schedulers-blkmq"/>).  You can set

--- a/xml/tuning_systemresources.xml
+++ b/xml/tuning_systemresources.xml
@@ -368,7 +368,7 @@ Large page support
     specific process to make sure this process always has immediate access to
     the disk. The caveat with this feature is that standard writes are cached in
     the page cache and are written back to persistent storage only later by an
-    independent kernel process. Thus the I/O priority setting generally does
+    independent kernel process. Thus, the I/O priority setting generally does
     not apply for these writes. Also be aware that
     I/O class and priority setting are obeyed only by
     <emphasis>CFQ</emphasis> I/O scheduler for legacy block I/O path

--- a/xml/tuning_systemresources.xml
+++ b/xml/tuning_systemresources.xml
@@ -369,7 +369,7 @@ Large page support
     the disk. The caveat with this feature is that standard writes are cached in
     the page cache and are written back to persistent storage only later by an
     independent kernel process. Thus, the I/O priority setting generally does
-    not apply for these writes. Also be aware that
+    not apply for these writes. Also be aware that the
     I/O class and priority setting are obeyed only by
     <emphasis>CFQ</emphasis> I/O scheduler for legacy block I/O path
     (refer to <xref linkend="cha-tuning-io-schedulers"/>) and

--- a/xml/tuning_systemresources.xml
+++ b/xml/tuning_systemresources.xml
@@ -370,7 +370,7 @@ Large page support
     the page cache and are written back to persistent storage only later by an
     independent kernel process. Thus, the I/O priority setting generally does
     not apply for these writes. Also be aware that the
-    I/O class and priority setting are obeyed only by
+    I/O class and priority settings are obeyed only by the
     <emphasis>CFQ</emphasis> I/O scheduler for legacy block I/O path
     (refer to <xref linkend="cha-tuning-io-schedulers"/>) and
     <emphasis>BFQ</emphasis> I/O scheduler for blk-mq I/O path (refer


### PR DESCRIPTION
Signed-off-by: Andreas Herrmann <aherrmann@suse.com>

### Description
Bring tuning guide in sync with what's in maintenance/SLE12SP4 branch.
The reference to BFQ is missing in section about ionice.
This change should be applied to maintenance branches for
SLE15SP1, SLE15SP0, and SLE12SP5.

Branches SLE12SP4 and SLE15SP2 are not affected.

### Checklist
* Check all items that apply.

*Are backports required?*

- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
