### PR TITLE
Btrfs zstd

### DIFF
--- a/xml/storage_filesystems.xml
+++ b/xml/storage_filesystems.xml
@@ -217,9 +217,9 @@
    <warning>
     <title>Support for Rollbacks</title>
     <para>
-     Rollbacks are only supported by the &suse; support if you do not remove
-     any of the preconfigured subvolumes. You may, however, add subvolumes
-     using the &yast; Partitioner.
+     Rollbacks are only supported by &suse; if you do not remove any of the
+     preconfigured subvolumes. You may, however, add subvolumes using the
+     &yast; Partitioner.
     </para>
    </warning>
    <sect3 xml:id="sec-filesystems-major-btrfs-compress">

--- a/xml/storage_filesystems.xml
+++ b/xml/storage_filesystems.xml
@@ -233,16 +233,22 @@
      </para>
     </note>
     <para>
-     Since &slea;12 SP1, compression for Btrfs file systems is supported. Use
-     the <option>compress</option> or <option>compress-force</option> option
-     and select the compression algorithm, <literal>lzo</literal> or
-     <literal>zlib</literal> (the default). The zlib compression has a higher
-     compression ratio while lzo is faster and takes less CPU load.
+     The Btrfs file system supports transparent compression. While enabled,
+     Btrfs compresses file data when written and uncompresses file data when
+     read.
+    </para>
+    <para>
+     Use the <option>compress</option> or <option>compress-force</option>
+     mount option and select the compression algorithm, <literal>zstd</literal>,
+     <literal>lzo</literal> or <literal>zlib</literal> (the default). zlib
+     compression has a higher compression ratio while lzo is faster and takes
+     less CPU load. The zstd algorithm offers a modern compromise, with
+     performance close to lzo and compression ratios similar to zlib.
     </para>
     <para>
      For example:
     </para>
-<screen>&prompt.root;mount -o compress /dev/sdx /mnt</screen>
+<screen>&prompt.root;mount -o compress=zstd /dev/sdx /mnt</screen>
     <para>
      In case you create a file, write to it, and the compressed result is
      greater or equal to the uncompressed size, Btrfs will skip compression for

--- a/xml/storage_filesystems.xml
+++ b/xml/storage_filesystems.xml
@@ -226,10 +226,11 @@
     <title>Mounting Compressed Btrfs File Systems</title>
     <remark>toms 2015-09-16: FATE#316463</remark>
     <note>
-     <title>&grub; and LZO Compressed Root</title>
+     <title>&grub; and Compressed Root</title>
      <para>
-      &grub; cannot read an lzo compressed root. You need a separate
-      <filename>/boot</filename> partition to use compression.
+      &grub; cannot boot from lzo or zstd compressed root file systems. Use
+      zlib compression, or create a separate <filename>/boot</filename>
+      partition if you wish to use lzo or zstd compression for root.
      </para>
     </note>
     <para>


### PR DESCRIPTION
zstd documentation is missing from the Btrfs compression section.
It can be used with SLES 15sp1+.