### PR TITLE
Update info on SUSE Registry UI

### DIFF
--- a/xml/containers-get.xml
+++ b/xml/containers-get.xml
@@ -471,9 +471,9 @@
    updated with the latest security fixes. While the &suse; Registry can be
    used free of charge, if offers additional functionality through a customer
    subscription on the container host. A subscription is required for the
-   container images to receive updates. Currently, the &suse; Registry does not
-   have a UI or a list of images. However, all available images are listed in
-   the examples in the <xref linkend="Building-Pre-build-Images"/>.
+   container images to receive updates. The &suse; Registry has a UI with a
+   subset of images. However, all available images are listed in the examples
+   in the <xref linkend="Building-Pre-build-Images"/>.
   </para>
  </sect1>
  <sect1 xml:id="comparing-containers">


### PR DESCRIPTION
# Description

There is a frontend on registry.suse.com now which lists some of the available docker images.
This PR updated the guide with the new information.

### Is this feature exclusive to SLE 15 SP3 (or Leap 15.3)?

We are currently **only merging documentation relevant for SLE 15 SP2**
(and Leap 15.2) or lower.

- [ ] This PR only applies to SLE 15 SP3 or higher
- [x] This PR applies to older releases as well.


### Are backports required?

- [x] To maintenance/SLE15SP2
- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP2
