### PR TITLE
fix errors regarding mounting SMB1 shares

### DIFF
--- a/xml/net_samba.xml
+++ b/xml/net_samba.xml
@@ -765,7 +765,7 @@
    <para>
     However, this change only affects <command>mount</command> and
     mounting via <filename>/etc/fstab</filename>. SMB1 is still
-    available by explicitely requiring it when using the following:
+    available by explicitly requiring it. Use the following command:
    </para>
    <itemizedlist>
     <listitem>

--- a/xml/net_samba.xml
+++ b/xml/net_samba.xml
@@ -763,9 +763,9 @@
     by default, namely SMB 2.1, SMB 3.0, or SMB 3.02.
    </para>
    <para>
-    However, this change only affects <command>mount</command> and mounting via
-    <filename>/etc/fstab</filename>. SMB1 is still available by default when
-    using the following:
+    However, this change only affects <command>mount</command> and
+    mounting via <filename>/etc/fstab</filename>. SMB1 is still
+    available by explicitely requiring it when using the following:
    </para>
    <itemizedlist>
     <listitem>
@@ -822,7 +822,7 @@
     kernel, add the option <option>vers=1.0</option> to the
     <command>mount</command> command line you use:
    </para>
-   <screen>&prompt.root;mount –t smbfs <replaceable>IP_ADDRESS</replaceable>:/<replaceable>SHARE</replaceable> /<replaceable>MOUNT_POINT</replaceable> –o username=<replaceable>USER_ID</replaceable>,workgroup=<replaceable>WORKGROUP_NAME</replaceable>,<emphasis role="bold">vers=1.0</emphasis></screen>
+   <screen>&prompt.root;mount -t cifs //<replaceable>HOST</replaceable>/<replaceable>SHARE</replaceable> /<replaceable>MOUNT_POINT</replaceable> –o username=<replaceable>USER_ID</replaceable>,<emphasis role="bold">vers=1.0</emphasis></screen>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-samba-anmeld-serv">


### PR DESCRIPTION
### Description

The SLE15+ docs have errors regarding mounting SMB1 shares.


### Are there any relevant issues/feature requests?

no

### Is this feature exclusive to SLE 15 SP3 (or Leap 15.3)?

- [ ] This PR only applies to SLE 15 SP3 or higher
- [x] This PR applies to older releases as well.


### Are backports required?

- [x] To maintenance/SLE15SP2
- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP2
