### PR TITLE
Update art_opensuse_install_quick.xml

### DIFF
--- a/xml/art_opensuse_install_quick.xml
+++ b/xml/art_opensuse_install_quick.xml
@@ -51,7 +51,7 @@
     </listitem>
     <listitem>
      <para>
-      1 GB physical RAM (4 GB or more strongly recommended)
+      1 GB physical RAM (at least 1.5 GB when using online repos, 4 GB or more strongly recommended)
      </para>
     </listitem>
     <listitem>


### PR DESCRIPTION
I consistently ran into OOM errors during 15.2 install on virtual machines with only 1 GB of RAM. Using 2 GB, install worked fine. According to https://de.opensuse.org/Hardware-Anforderungen_15.2, 1.5 GB will suffice; I have already copied that info into https://en.opensuse.org/Hardware_requirements (https://en.opensuse.org/index.php?title=Hardware_requirements&oldid=146170).

### Description

Describe the overall goals of this pull request.


### Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...


### Is this feature exclusive to SLE 15 SP3 (or Leap 15.3)?

We are currently **only merging documentation relevant for SLE 15 SP2**
(and Leap 15.2) or lower.

- [ ] This PR only applies to SLE 15 SP3 or higher
- [X] This PR applies to older releases as well.


### Are backports required?

- [X] To maintenance/SLE15SP2
- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP2
