### PR TITLE
hardening guide: incorporate topics from SAP HANA hardening guide

### DIFF
--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -3554,7 +3554,7 @@ tty1</screen>
     <important>
      <para>
       These configuration changes will also cause root logins on serial
-      consoles like <filename>/dev/ttyS0</filename> to be denied. In case you
+      consoles such as <filename>/dev/ttyS0</filename> to be denied. In case you
       require such use cases you need to list the respective tty devices
       additionally in the <filename>/etc/securetty</filename> file.
      </para>

--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -3450,22 +3450,24 @@ Account Expires: Never</screen>
 
    <para>
     By default, the &rootuser; user is assigned a password
-    and can login via various methods like on any local terminal, in a
-    graphical session, or remotely via SSH. These methods should be restricted
-    as far as possible. Shared usage of the root account should be avoided,
-    instead individual administrators should use tools like
-    <literal>su(1)</literal> or <literal>sudo(8)</literal> to elevate
-    privileges. This allows to associate &rootuser; logins with particular
-    users. This also adds another layer of security, because not only the root
-    password but also the password of an administrator's account needs to be
-    compromised to gain full root access.  This section explains how to limit
-    direct root logins on the different levels of the system.
+    and can log in using various methods&mdash;for example, on a local
+    terminal, in a graphical session, or remotely via SSH. These methods
+    should be restricted as far as possible. Shared usage of the root account
+    should be avoided. Instead, individual administrators should use tools such as
+    <literal>su</literal> or <literal>sudo</literal> (for more information,
+    type <command>man 1 su</command> or <command>man 8 sudo</command>) to obtain elevated
+    privileges. This allows associating &rootuser; logins with particular
+    users. This also adds another layer of security; not only the &rootuser;
+    password, but both the &rootuser; <emphasis>and</emphasis> the password of
+    an an administrator's regular account would need to be compromised to gain full root
+    access. This section explains how to limit direct root logins on the different
+    levels of the system.
    </para>
    <sect2 xml:id="sec-sec-prot-restrict-root-tty">
     <title>Restricting Local Text Console Logins</title>
 
     <para>
-     TTY devices provide text mode system access via the console. For desktop
+     TTY devices provide text-mode system access via the console. For desktop
      systems these are accessed via the local keyboard or&mdash;in case of server
      systems&mdash;via input devices connected to a KVM switch or a remote
      management card (ILO, DRAC, etc).

--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -3570,7 +3570,7 @@ tty1</screen>
      not designed to be run as &rootuser; and are more likely to
      contain security issues than console programs. If you require a graphical
      login, use a non-&rootuser; login. Configure your system to disallow
-     &rootuser; login on graphical session.
+     &rootuser; from logging in to graphical sessions.
     </para>
 
     <para>

--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -3574,16 +3574,15 @@ tty1</screen>
     </para>
 
     <para>
-     To deny the &rootuser; user login to graphical sessions you
+     To prevent &rootuser; from logging in to graphical sessions, you
      can apply the same basic steps as outlined in
      <xref linkend="sec-sec-prot-restrict-root-tty"/>.
-     You only need to also add the <literal>pam_securetty</literal> module to
-     the PAM stack file belonging to the display manager, for example
-     <filename>/etc/pam.d/gdm</filename> for GDM. The graphical session also
-     runs on a TTY device, <literal>tty7</literal>, by default. Therefore,
-     when you restrict &rootuser; logins to
-     <literal>tty1</literal>, then a &rootuser; login in the
-     graphical session will be denied.
+     Just add the <literal>pam_securetty</literal> module to the PAM
+     stack file belonging to the display manager&mdash;for example,
+     <filename>/etc/pam.d/gdm</filename> for GDM. The graphical
+     session also runs on a TTY device: by default, <literal>tty7</literal>.
+     Therefore, if you restrict &rootuser; logins to <literal>tty1</literal>,
+     then &rootuser; will be denied login in the graphical session.
     </para>
    </sect2>
 

--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -3544,9 +3544,9 @@ tty1</screen>
 
     <important>
      <para>
-      Avoid adding the <literal>pam_securetty</literal> PAM module to the
-      <filename>/etc/pam.d/common-auth</filename> file. This change would
-      break <command>su</command> and <command>sudo</command>, however,
+      Do not add the <literal>pam_securetty</literal> module to the
+      <filename>/etc/pam.d/common-auth</filename> file. This would
+      break the <command>su</command> and <command>sudo</command> commands,
       because these tools would then also reject &rootuser; authentications.
      </para>
     </important>

--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -3534,7 +3534,7 @@ tty1</screen>
       <para>
        Check whether logins to other terminals will be rejected for
        &rootuser;. A login on <literal>tty2</literal>, for example, should be
-       rejected right away without even the root password being queried.
+       rejected immediately, without even querying the account password.
        Also make sure that you can still successfully login to
        <literal>tty1</literal> and thus that &rootuser; is not locked out of
        the system completely.

--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -3491,7 +3491,7 @@ Account Expires: Never</screen>
     <note>
      <para>
       The steps shown here are tailored towards PC architectures (&x86; and
-      &x86-64;). On architectures like &power; different terminal
+      &x86-64;). On architectures such as &power;, different terminal
       device names than <literal>tty1</literal> may be used. Be careful not to
       lock yourself out completely by specifying wrong terminal device names.
       You can determine the device name of the terminal you are currently

--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -3620,7 +3620,7 @@ tty1</screen>
    <title>Setting an Inactivity Timeout for Interactive Shell Sessions</title>
    <para>
     It can be a good idea to terminate an interactive shell session after a
-    certain time of inactivity, for example to:
+    certain period of inactivity; for example, to:
    </para>
     <itemizedlist>
      <listitem>
@@ -3636,7 +3636,7 @@ tty1</screen>
     </itemizedlist>
    <para>
     By default, there is no inactivity timeout for shells. Nothing will
-    happen if a shell stays open unused for days or even years. It is possible
+    happen if a shell stays open and unused for days or even years. It is possible
     to configure most shells in a way that idle sessions terminate
     automatically after a certain amount of time. The following example
     shows how to set an inactivity timeout for a number of
@@ -3646,8 +3646,8 @@ tty1</screen>
     The inactivity timeout can be configured for login shells only or for all
     interactive shells. In the latter case the inactivity timeout is running
     individually for each shell instance. This means that timeouts will
-    accumulate. When a sub or child shell is started then the timeout runs for
-    the sub or child shell and only afterwards will the
+    accumulate. When a sub- or child-shell is started, then a new timeout begins for
+    the sub- or child-shell, and only afterwards will the
     timeout of the parent continue running.
    </para>
    <para>
@@ -3716,29 +3716,28 @@ tty1</screen>
    </informaltable>
    <para>
     Every listed shell supports an internal timeout shell variable that can be
-    set to a specific time value to activate the inactivity timeout. If you want
-    to prevent users from overriding the timeout setting you can mark the
+    set to a specific time value to cause the inactivity timeout. If you want
+    to prevent users from overriding the timeout setting, you can mark the
     corresponding shell timeout variable as readonly. The corresponding variable
     declaration syntax is also found in the table above.
    </para>
 
    <note>
     <para>
-     This feature is only a utility that can help avoiding risks if a user is
-     forgetful or follows unsafe practices. It does not protect against
-     malicious users, however. The timeout discussed here only applies to
-     certain interactive wait states of a shell. A malicious user can always
-     find ways to circumvent the timeout and keep their session open anyway.
+     This feature is only helpful for avoiding risks if a user is forgetful or follows
+     unsafe practices. It does not protect against hostile users. The timeout
+     only applies to interactive wait states of a shell. A malicious user can always
+     find ways to circumvent the timeout and keep their session open regardless.
     </para>
    </note>
 
    <para>
-    To configure the inactivity timeout you need to add the matching timeout
-    variable declaration to a shell startup script. Use either the path for
-    login shells only, or the one for all shells as listed in the table. The
+    To configure the inactivity timeout, you need to add the matching timeout
+    variable declaration to each shell's startup script. Use either the path for
+    login shells only, or the one for all shells, as listed in the table. The
     following example uses paths and settings that are suitable for
     <command>bash</command> and <command>ksh</command>
-    to setup a readonly login shell timeout that cannot be overriden by users.
+    to setup a read-only login shell timeout that cannot be overridden by users.
     Create the file <filename>/etc/profile.d/timeout.sh</filename> with the
     following content:
    </para>
@@ -3751,10 +3750,10 @@ readonly TMOUT=86400</screen>
 
    <tip>
     <para>
-     We recommend to use the <command>screen</command> tool in order to
-     detach sessions before logging out. Screen sessions are not terminated
-     and can be re-attached whenever it is required. Active session can be
-     locked without logging out (read about
+     We recommend using the <command>screen</command> tool in order to
+     detach sessions before logging out. <command>screen</command> sessions
+     are not terminated and can be re-attached whenever required. An active
+     session can be locked without logging out (read about
      <keycombo action="seq">
      <keycombo action="press"><keycap function="control"/><keycap>a</keycap></keycombo>
      <keycap>x</keycap>

--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -65,7 +65,7 @@
   policies consist of the following concepts (fairly generic and incomplete
   list):
  </para>
- <itemizedlist mark="bullet" spacing="normal">
+ <itemizedlist>
   <listitem>
    <para>
     DAC (Discretionary Access Control): File and directory permissions, as set
@@ -198,7 +198,7 @@
    information is available here:
   </para>
 
-  <itemizedlist mark="bullet" spacing="normal">
+  <itemizedlist>
    <listitem>
     <para>
      <link xlink:href="https://www.netiq.com/products/privileged-user-manager/"/>
@@ -386,7 +386,7 @@
     through 7:
    </para>
 
-   <itemizedlist mark="bullet" spacing="normal">
+   <itemizedlist>
     <listitem>
      <para>
       EAL1: Functionally tested
@@ -689,7 +689,7 @@
    find more details and explanations in this chapter. Selected general topics
    are:
   </para>
-  <itemizedlist mark="bullet" spacing="normal">
+  <itemizedlist>
    <listitem>
     <para>
      Physical Security – Protection of the server from environmental threats
@@ -783,7 +783,7 @@
     Additionally, consider questions like:
    </para>
 
-   <itemizedlist mark="bullet" spacing="normal">
+   <itemizedlist>
     <listitem>
      <para>
       Who has direct physical access to the host?
@@ -1565,7 +1565,7 @@
     file system hierarchy. A number of interesting mount options are:
    </para>
 
-   <itemizedlist mark="bullet" spacing="normal">
+   <itemizedlist>
     <listitem>
      <para>
       <literal>noexec</literal>: prevents execution of files.
@@ -1826,7 +1826,7 @@
      <emphasis>No-eXecute</emphasis> (NX bit) for mitigation of buffer
      overflow attacks. For more information, see:
     </para>
-    <itemizedlist mark="bullet" spacing="normal">
+    <itemizedlist>
      <listitem>
       <para>
        <link xlink:href="http://searchenterpriselinux.techtarget.com/tip/Linux-virtual-address-randomization-and-impacting-buffer-overflows"/>
@@ -1965,7 +1965,7 @@
     &aa; consists of:
    </para>
 
-   <itemizedlist mark="bullet" spacing="normal">
+   <itemizedlist>
     <listitem>
      <para>
       A kernel extension which enforces the security profiles.
@@ -1975,7 +1975,7 @@
      <para>
       A collection of RPMs, also shipped with &productname; that provides:
      </para>
-     <itemizedlist mark="bullet" spacing="normal">
+     <itemizedlist>
       <listitem>
        <para>
         A set of &aa; profiles for numerous programs that ship with
@@ -2326,7 +2326,7 @@
     <para>
      In a nutshell, the &rmtool; for &sle; provides customers with:
     </para>
-    <itemizedlist mark="bullet" spacing="normal">
+    <itemizedlist>
      <listitem>
       <para>
        Assurance of firewall and regulatory compliance
@@ -2606,7 +2606,7 @@ telnet &lt;remote_host&gt; 25</screen>
     Here are some basic rules:
    </para>
 
-   <itemizedlist mark="bullet" spacing="normal">
+   <itemizedlist>
     <listitem>
      <para>
       NFS should not be enabled if not needed.
@@ -3445,6 +3445,325 @@ Account Expires: Never</screen>
    </para>
   </sect1>
   <xi:include href="hardening_pam_stack.xml"/>
+  <sect1 xml:id="sec-sec-prot-restrict-root">
+   <title>Restricting &rootuser; Logins</title>
+
+   <para>
+    By default, the &rootuser; user is assigned a password
+    and can login via various methods like on any local terminal, in a
+    graphical session, or remotely via SSH. These methods should be restricted
+    as far as possible. Shared usage of the root account should be avoided,
+    instead individual administrators should use tools like
+    <literal>su(1)</literal> or <literal>sudo(8)</literal> to elevate
+    privileges. This allows to associate &rootuser; logins with particular
+    users. This also adds another layer of security, because not only the root
+    password but also the password of an administrator's account needs to be
+    compromised to gain full root access.  This section explains how to limit
+    direct root logins on the different levels of the system.
+   </para>
+   <sect2 xml:id="sec-sec-prot-restrict-root-tty">
+    <title>Restricting Local Text Console Logins</title>
+
+    <para>
+     TTY devices provide text mode system access via the console. For desktop
+     systems these are accessed via the local keyboard or&mdash;in case of server
+     systems&mdash;via input devices connected to a KVM switch or a remote
+     management card (ILO, DRAC, etc).
+     By default, Linux offers 6 different consoles, that can be switched to
+     via the key combinations
+     <keycombo><keycap function="alt"/><keycap>F1</keycap></keycombo> to
+     <keycombo><keycap function="alt"/><keycap>F6</keycap></keycombo>, when
+     running in text mode, or
+     <keycombo><keycap function="control"/><keycap function="alt"/><keycap>F1</keycap></keycombo> to
+     <keycombo><keycap function="control"/><keycap function="alt"/><keycap>F6</keycap></keycombo>
+      when running in a graphical session. The
+      associated terminal devices are named <literal>tty1</literal> .. <literal>tty6</literal> accordingly.
+    </para>
+
+    <para>
+     The following steps restrict root access to the first TTY. Even this
+     access method is only meant for emergency access to the system and should
+     never be used for everyday system administration tasks.
+    </para>
+
+    <note>
+     <para>
+      The steps shown here are tailored towards PC architectures (&x86; and
+      &x86-64;). On architectures like &power; different terminal
+      device names than <literal>tty1</literal> may be used. Be careful not to
+      lock yourself out completely by specifying wrong terminal device names.
+      You can determine the device name of the terminal you are currently
+      logged into by running the <literal>tty</literal> command. Be careful
+      not to do this in a virtual terminal like via SSH or in a graphical
+      session (device names <filename>/dev/pts/<replaceable>N</replaceable></filename>)
+      but only from an actual login terminal reachable via
+      <keycombo><keycap function="alt"/><keycap>F<replaceable>N</replaceable></keycap></keycombo>.
+     </para>
+    </note>
+
+    <procedure>
+     <title>Restricting root logins on local TTYs</title>
+     <step>
+      <para>
+       Ensure that the PAM stack configuration file <filename>/etc/pam.d/login</filename>
+       contains the <literal>pam_securetty</literal> module in the <literal>auth</literal> block:
+      </para>
+      <screen>auth     requisite      pam_nologin.so
+ auth     [user_unknown=ignore success=ok ignore=ignore auth_err=die default=bad] pam_securetty.so noconsole
+ auth     include        common-auth</screen>
+      <para>
+        This will include the <literal>pam_securetty</literal> PAM module during the
+        authentication process on local consoles to allow root only to login on
+        tty devices that are listed in the file <filename>/etc/securetty</filename>.
+      </para>
+     </step>
+     <step>
+      <para>
+       Remove all entries from <filename>/etc/securetty</filename> except one.
+       This limits the access to TTY devices for root.
+      </para>
+     <screen>#
+# This file contains the device names of tty lines (one per line,
+# without leading /dev/) on which root is allowed to login.
+#
+tty1</screen>
+     </step>
+     <step>
+      <para>
+       Check whether logins to other terminals will be rejected for
+       &rootuser;. A login on <literal>tty2</literal>, for example, should be
+       rejected right away without even the root password being queried.
+       Also make sure that you can still successfully login to
+       <literal>tty1</literal> and thus that &rootuser; is not locked out of
+       the system completely.
+      </para>
+     </step>
+    </procedure>
+
+    <important>
+     <para>
+      Avoid adding the <literal>pam_securetty</literal> PAM module to the
+      <filename>/etc/pam.d/common-auth</filename> file. This change would
+      break <command>su</command> and <command>sudo</command>, however,
+      because these tools would then also reject &rootuser; authentications.
+     </para>
+    </important>
+
+    <important>
+     <para>
+      These configuration changes will also cause root logins on serial
+      consoles like <filename>/dev/ttyS0</filename> to be denied. In case you
+      require such use cases you need to list the respective tty devices
+      additionally in the <filename>/etc/securetty</filename> file.
+     </para>
+    </important>
+   </sect2>
+
+   <sect2 xml:id="sec-sec-prot-retrict-root-graphical">
+    <title>Restricting Graphical Session Logins</title>
+
+    <para>
+     To improve security on your server, avoid to use graphical user
+     environments at all. Graphical programs are often
+     not designed to be run as &rootuser; and are more likely to
+     contain security issues than console programs. If you require a graphical
+     login, use a non-&rootuser; login. Configure your system to disallow
+     &rootuser; login on graphical session.
+    </para>
+
+    <para>
+     To deny the &rootuser; user login to graphical sessions you
+     can apply the same basic steps as outlined in
+     <xref linkend="sec-sec-prot-restrict-root-tty"/>.
+     You only need to also add the <literal>pam_securetty</literal> module to
+     the PAM stack file belonging to the display manager, for example
+     <filename>/etc/pam.d/gdm</filename> for GDM. The graphical session also
+     runs on a TTY device, <literal>tty7</literal>, by default. Therefore,
+     when you restrict &rootuser; logins to
+     <literal>tty1</literal>, then a &rootuser; login in the
+     graphical session will be denied.
+    </para>
+   </sect2>
+
+   <sect2 xml:id="sec-sec-prot-restrict-root-ssh">
+    <title>Restricting SSH Logins</title>
+    <para>
+     By default the &rootuser; user is also allowed to login
+     into a machine remotely via the SSH network protocol (if the SSH port is
+     not blocked by the firewall). To restrict this possibility the following
+     change of the OpenSSH configuration needs to be performed:
+    </para>
+    <procedure>
+     <step>
+      <para>Edit <filename>/etc/ssh/sshd_config</filename> and adjust the following parameter:</para>
+      <screen>PermitRootLogin no</screen>
+     </step>
+     <step>
+      <para>Restart the <systemitem class="service">sshd</systemitem> service to make the changes effective:</para>
+      <screen>systemctl restart sshd.service</screen>
+     </step>
+    </procedure>
+    <note>
+     <para>
+      Using the PAM module <literal>pam_securetty</literal> is not suitable in
+      case of OpenSSH, because SSH logins not necessarily go through the PAM
+      stack during the auth phase (e.g. when using SSH public key authentication).
+      Also an attacker could be able to differentiate between a wrong password
+      and a successful login that was only rejected later on by policy.
+     </para>
+    </note>
+   </sect2>
+
+  </sect1>
+  <sect1 xml:id="sec-sec-prot-inactivity-logout">
+   <title>Setting an Inactivity Timeout for Interactive Shell Sessions</title>
+   <para>
+    It can be a good idea to terminate an interactive shell session after a
+    certain time of inactivity, for example to:
+   </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+      prevent open, unguarded sessions.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       avoid waste of system resources.
+      </para>
+     </listitem>
+    </itemizedlist>
+   <para>
+    By default, there is no inactivity timeout for shells. Nothing will
+    happen if a shell stays open unused for days or even years. It is possible
+    to configure most shells in a way that idle sessions terminate
+    automatically after a certain amount of time. The following example
+    shows how to set an inactivity timeout for a number of
+    common types of shells.
+   </para>
+   <para>
+    The inactivity timeout can be configured for login shells only or for all
+    interactive shells. In the latter case the inactivity timeout is running
+    individually for each shell instance. This means that timeouts will
+    accumulate. When a sub or child shell is started then the timeout runs for
+    the sub or child shell and only afterwards will the
+    timeout of the parent continue running.
+   </para>
+   <para>
+    The following table contains configuration details for a selection of
+    common shells shipped with SLE:
+   </para>
+   <informaltable frame="all" rowsep="1" colsep="1">
+    <tgroup cols="7">
+     <colspec colname="col_1" colwidth="14.2857*"/>
+     <colspec colname="col_2" colwidth="14.2857*"/>
+     <colspec colname="col_3" colwidth="14.2857*"/>
+     <colspec colname="col_4" colwidth="14.2857*"/>
+     <colspec colname="col_5" colwidth="14.2857*"/>
+     <colspec colname="col_6" colwidth="14.2857*"/>
+     <colspec colname="col_7" colwidth="14.2858*"/>
+     <thead>
+      <row>
+       <entry>package</entry>
+       <entry>shell personalities</entry>
+       <entry align="center">shell variable</entry>
+       <entry align="center">time unit</entry>
+       <entry>readonly setting</entry>
+       <entry align="center">config path (only login shell)</entry>
+       <entry align="center">config path (all shells)</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><para><literal>bash</literal></para></entry>
+       <entry><para><literal>bash, sh</literal></para></entry>
+       <entry align="center"><para><literal>TMOUT</literal></para></entry>
+       <entry align="center"><para>seconds</para></entry>
+       <entry><para><literal>readonly TMOUT=</literal></para></entry>
+       <entry><para><filename>/etc/profile.local</filename>, <filename>/etc/profile.d/</filename></para></entry>
+       <entry><para><filename>/etc/bash.bashrc</filename></para></entry>
+      </row>
+      <row>
+       <entry><para><literal>mksh</literal></para></entry>
+       <entry><para><literal>ksh, lksh, mksh, pdksh</literal></para></entry>
+       <entry align="center"><para><literal>TMOUT</literal></para></entry>
+       <entry align="center"><para>seconds</para></entry>
+       <entry><para><literal>readonly TMOUT=</literal></para></entry>
+       <entry><para><filename>/etc/profile.local</filename>, <filename>/etc/profile.d/</filename></para></entry>
+       <entry><para><filename>/etc/ksh.kshrc.local</filename></para></entry>
+      </row>
+      <row>
+       <entry><para><literal>tcsh</literal></para></entry>
+       <entry><para><literal>csh, tcsh</literal></para></entry>
+       <entry align="center"><para><literal>autologout</literal></para></entry>
+       <entry align="center"><para>minutes</para></entry>
+       <entry><para><literal>set -r autologout=</literal></para></entry>
+       <entry><para><filename>/etc/csh.login.local</filename></para></entry>
+       <entry><para><filename>/etc/csh.cshrc.local</filename></para></entry>
+      </row>
+      <row>
+       <entry><para><literal>zsh</literal></para></entry>
+       <entry><para><literal>zsh</literal></para></entry>
+       <entry align="center"><para><literal>TMOUT</literal></para></entry>
+       <entry align="center"><para>seconds</para></entry>
+       <entry><para><literal>readonly TMOUT=</literal></para></entry>
+       <entry><para><filename>/etc/profile.local</filename>, <filename>/etc/profile.d/</filename></para></entry>
+       <entry><para><filename>/etc/zsh.zshrc.local</filename></para></entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
+   <para>
+    Every listed shell supports an internal timeout shell variable that can be
+    set to a specific time value to activate the inactivity timeout. If you want
+    to prevent users from overriding the timeout setting you can mark the
+    corresponding shell timeout variable as readonly. The corresponding variable
+    declaration syntax is also found in the table above.
+   </para>
+
+   <note>
+    <para>
+     This feature is only a utility that can help avoiding risks if a user is
+     forgetful or follows unsafe practices. It does not protect against
+     malicious users, however. The timeout discussed here only applies to
+     certain interactive wait states of a shell. A malicious user can always
+     find ways to circumvent the timeout and keep their session open anyway.
+    </para>
+   </note>
+
+   <para>
+    To configure the inactivity timeout you need to add the matching timeout
+    variable declaration to a shell startup script. Use either the path for
+    login shells only, or the one for all shells as listed in the table. The
+    following example uses paths and settings that are suitable for
+    <command>bash</command> and <command>ksh</command>
+    to setup a readonly login shell timeout that cannot be overriden by users.
+    Create the file <filename>/etc/profile.d/timeout.sh</filename> with the
+    following content:
+   </para>
+   <screen># /etc/profile.d/timeout.sh for SUSE Linux
+#
+# Timeout in seconds until the bash/ksh session is terminated
+# in case of inactivity.
+# 24h = 86400 sec
+readonly TMOUT=86400</screen>
+
+   <tip>
+    <para>
+     We recommend to use the <command>screen</command> tool in order to
+     detach sessions before logging out. Screen sessions are not terminated
+     and can be re-attached whenever it is required. Active session can be
+     locked without logging out (read about
+     <keycombo action="seq">
+     <keycombo action="press"><keycap function="control"/><keycap>a</keycap></keycombo>
+     <keycap>x</keycap>
+     </keycombo>
+     /
+     <command>lockscreen</command> in <command>man screen</command> for details).
+    </para>
+   </tip>
+
+  </sect1>
   <sect1 xml:id="sec-sec-prot-dos">
    <title>Preventing Accidental Denial of Service</title>
 
@@ -3769,7 +4088,7 @@ fi</screen>
      Finally, the following items are relevant to the system security as well,
      and misconfiguration can cause many problems – and should be reviewed:
     </para>
-    <itemizedlist mark="bullet" spacing="normal">
+    <itemizedlist>
      <listitem>
       <para>
        Resolver (<filename>/etc/hosts</filename>,

--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -3496,7 +3496,7 @@ Account Expires: Never</screen>
       lock yourself out completely by specifying wrong terminal device names.
       You can determine the device name of the terminal you are currently
       logged into by running the <literal>tty</literal> command. Be careful
-      not to do this in a virtual terminal like via SSH or in a graphical
+      not to do this in a virtual terminal, such as via SSH or in a graphical
       session (device names <filename>/dev/pts/<replaceable>N</replaceable></filename>)
       but only from an actual login terminal reachable via
       <keycombo><keycap function="alt"/><keycap>F<replaceable>N</replaceable></keycap></keycombo>.

--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -3514,7 +3514,7 @@ Account Expires: Never</screen>
  auth     [user_unknown=ignore success=ok ignore=ignore auth_err=die default=bad] pam_securetty.so noconsole
  auth     include        common-auth</screen>
       <para>
-        This will include the <literal>pam_securetty</literal> PAM module during the
+        This will include the <literal>pam_securetty</literal> module during the
         authentication process on local consoles to allow root only to login on
         tty devices that are listed in the file <filename>/etc/securetty</filename>.
       </para>

--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -3565,7 +3565,7 @@ tty1</screen>
     <title>Restricting Graphical Session Logins</title>
 
     <para>
-     To improve security on your server, avoid to use graphical user
+     To improve security on your server, avoid using graphical
      environments at all. Graphical programs are often
      not designed to be run as &rootuser; and are more likely to
      contain security issues than console programs. If you require a graphical

--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -3497,7 +3497,7 @@ Account Expires: Never</screen>
       You can determine the device name of the terminal you are currently
       logged into by running the <literal>tty</literal> command. Be careful
       not to do this in a virtual terminal, such as via SSH or in a graphical
-      session (device names <filename>/dev/pts/<replaceable>N</replaceable></filename>)
+      session (device names <filename>/dev/pts/<replaceable>N</replaceable></filename>),
       but only from an actual login terminal reachable via
       <keycombo><keycap function="alt"/><keycap>F<replaceable>N</replaceable></keycap></keycombo>.
      </para>

--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -3589,10 +3589,10 @@ tty1</screen>
    <sect2 xml:id="sec-sec-prot-restrict-root-ssh">
     <title>Restricting SSH Logins</title>
     <para>
-     By default the &rootuser; user is also allowed to login
+     By default, the &rootuser; user is also allowed to log
      into a machine remotely via the SSH network protocol (if the SSH port is
-     not blocked by the firewall). To restrict this possibility the following
-     change of the OpenSSH configuration needs to be performed:
+     not blocked by the firewall). To restrict this, make the following
+     change to the OpenSSH configuration:
     </para>
     <procedure>
      <step>
@@ -3606,10 +3606,10 @@ tty1</screen>
     </procedure>
     <note>
      <para>
-      Using the PAM module <literal>pam_securetty</literal> is not suitable in
-      case of OpenSSH, because SSH logins not necessarily go through the PAM
-      stack during the auth phase (e.g. when using SSH public key authentication).
-      Also an attacker could be able to differentiate between a wrong password
+      Using the PAM <literal>pam_securetty</literal> module is not suitable in
+      case of OpenSSH, because not all SSH logins go through the PAM
+      stack during authorization (for example, when using SSH public-key authentication).
+      In addition, an attacker could differentiate between a wrong password
       and a successful login that was only rejected later on by policy.
      </para>
     </note>

--- a/xml/hardening.xml
+++ b/xml/hardening.xml
@@ -3515,8 +3515,8 @@ Account Expires: Never</screen>
  auth     include        common-auth</screen>
       <para>
         This will include the <literal>pam_securetty</literal> module during the
-        authentication process on local consoles to allow root only to login on
-        tty devices that are listed in the file <filename>/etc/securetty</filename>.
+        authentication process on local consoles, which restricts &rootuser; to logging-in
+        only on TTY devices that are listed in the file <filename>/etc/securetty</filename>.
       </para>
      </step>
      <step>


### PR DESCRIPTION
### Description

This adds two new sections to the SLE hardening guide that originate from the SAP HANA hardening guide. The topics aren't specific to SAP. A customer complained about lacking aspects in these two sections. The concerns have been addressed and the content updated and adjusted to the more general audience of the SLE hardening guide.


### Are there any relevant issues/feature requests?

* bsc#1174501


### Is this feature exclusive to SLE 15 SP3 (or Leap 15.3)?

No

- [ ] This PR only applies to SLE 15 SP3 or higher
- [X] This PR applies to older releases as well.


### Are backports required?

- [ ] To maintenance/SLE15SP2
- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [X] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP2
