### PR TITLE
Added MBR Protective options section

### DIFF
--- a/xml/grub2_yast_i.xml
+++ b/xml/grub2_yast_i.xml
@@ -180,11 +180,43 @@
        <link
        xlink:href="https://github.com/Sirrix-AG/TrustedGRUB2"/>.
       </para>
+      <para>
+      The <guimenu>MBR Protective</guimenu> section includes the following
+      options:
+    </para>
+    <variablelist>
+    <varlistentry>
+     <term><guimenu>Set</guimenu>
+     </term>
+     <listitem>
+      <para>
+       This is appropriate for traditional legacy BIOS booting 
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><guimenu>Remove</guimenu>
+     </term>
+     <listitem>
+      <para>
+       This is appropriate for UEFI booting
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><guimenu>Do not change</guimenu>
+     </term>
+     <listitem>
+      <para>
+       This may be the best choice if you have an already working
+       system and are not changing how it boots
+      </para>
+      <para>
+       In most cases the Yast defaults to the appropriate choice.
+      </para>
      </listitem>
     </varlistentry>
    </variablelist>
  </sect2>
-
  <sect2 xml:id="sec-grub2-yast2-config-order">
   <title>Adjusting the Disk Order</title>
   <para>
@@ -229,7 +261,6 @@
    </step>
   </procedure>
  </sect2>
-
  <sect2 xml:id="sec-grub2-yast2-config-advanced">
   <title>Configuring Advanced Options</title>
   <para>

--- a/xml/grub2_yast_i.xml
+++ b/xml/grub2_yast_i.xml
@@ -180,42 +180,47 @@
        <link
        xlink:href="https://github.com/Sirrix-AG/TrustedGRUB2"/>.
       </para>
+       </listitem>
+    </varlistentry>    
+    </variablelist>   
       <para>
-      The <guimenu>MBR Protective</guimenu> section includes the following
+      The <guimenu>Protective MBR flag</guimenu> section includes the following
       options:
-    </para>
+      </para>
     <variablelist>
     <varlistentry>
-     <term><guimenu>Set</guimenu>
+     <term><guimenu>set</guimenu>
      </term>
      <listitem>
       <para>
-       This is appropriate for traditional legacy BIOS booting 
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><guimenu>Remove</guimenu>
-     </term>
-     <listitem>
-      <para>
-       This is appropriate for UEFI booting
+       This is appropriate for traditional legacy BIOS booting.
       </para>
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><guimenu>Do not change</guimenu>
+     <term><guimenu>remove</guimenu>
      </term>
      <listitem>
       <para>
-       This may be the best choice if you have an already working
-       system and are not changing how it boots
+       This is appropriate for UEFI booting.
       </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><guimenu>do not change</guimenu>
+     </term>
+     <listitem>
       <para>
-       In most cases the Yast defaults to the appropriate choice.
+       This is usually the best choice if you have an already working
+       system.
       </para>
      </listitem>
     </varlistentry>
    </variablelist>
+    <para>
+       In most cases &yast; defaults to the appropriate choice.
+    </para>         
+       
  </sect2>
  <sect2 xml:id="sec-grub2-yast2-config-order">
   <title>Adjusting the Disk Order</title>


### PR DESCRIPTION
Added MBR Protective options section to 12.3.1 Boot Loader Location and Boot Code Options

### Description

Adding MBR Protective options explanation to that as it's missing


### Are there any relevant issues/feature requests?
https://bugzilla.opensuse.org/show_bug.cgi?id=1175638

### Is this feature exclusive to SLE 15 SP3 (or Leap 15.3)?

We are currently **only merging documentation relevant for SLE 15 SP2**
(and Leap 15.2) or lower.

- [ ] This PR applies to older releases as well.


### Are backports required?

- [ ] To maintenance/SLE15SP2
- [ ] To maintenance/SLE15SP1

