### PR TITLE
tuning_cgroups: Fixed references to kernel documentation

### DIFF
--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -394,7 +394,8 @@ TasksMax=16284
    <listitem>
     <para>
      Kernel documentation (package <systemitem>kernel-source</systemitem>):
-     files in <filename>/usr/src/linux/Documentation/cgroups</filename>.
+     files in <filename>/usr/src/linux/Documentation/cgroup-v1</filename> and file
+     <filename>/usr/src/linux/Documentation/cgroup-v2.txt</filename>.
     </para>
    </listitem>
    <listitem>


### PR DESCRIPTION
### Description
Sync kernel documentation references with kernel version actually used.

### Are there any relevant issues/feature requests?
n/a

### Is this feature exclusive to SLE 15 SP3 (or Leap 15.3)?

No, this fix is for SLE15SP1 and SLE12SP5.
SLE15SP2 and newer require a slightly different update.
I'll send a separate PR for this.

We are currently **only merging documentation relevant for SLE 15 SP2**
(and Leap 15.2) or lower.

- [ ] This PR only applies to SLE 15 SP3 or higher
- [X] This PR applies to older releases as well.


### Are backports required?

- [ ] To maintenance/SLE15SP2
- [X] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [X] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP2
