### PR TITLE
tuning_cgroups: Fixed references to kernel documentation

### DIFF
--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -645,7 +645,8 @@ default 200
    <listitem>
     <para>
      Kernel documentation (package <systemitem>kernel-source</systemitem>):
-     files in <filename>/usr/src/linux/Documentation/cgroups</filename>.
+     files in <filename>/usr/src/linux/Documentation/admin-guide/cgroup-v1</filename> and file
+     <filename>/usr/src/linux/Documentation/admin-guide/cgroup-v2.rst</filename>.
     </para>
    </listitem>
    <listitem>


### PR DESCRIPTION
### Description
tuning_cgroups: Sync kernel documentation references with newer kernel versions.

### Are there any relevant issues/feature requests?
n/a

### Is this feature exclusive to SLE 15 SP3 (or Leap 15.3)?
No.

We are currently **only merging documentation relevant for SLE 15 SP2**
(and Leap 15.2) or lower.

- [ ] This PR only applies to SLE 15 SP3 or higher
- [ ] This PR applies to older releases as well.

### Are backports required?
Yes.

- [X] To maintenance/SLE15SP2
- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP2
