### PR TITLE
Adding "systemd-coredump disabled"

### DIFF
--- a/xml/art_jeos_quickstart.xml
+++ b/xml/art_jeos_quickstart.xml
@@ -227,13 +227,12 @@
        <itemizedlist>
         <listitem>
          <para>
-	  Install the <package>systemd-coredump</package> package
+	  Install the <package>systemd-coredump</package> package which contains /usr/lib/sysctl.d/50-coredump.conf
          </para>
         </listitem>
         <listitem>
          <para>
-         Set <link xlink:href="https://www.freedesktop.org/software/systemd/man/systemd-coredump.html">kernel.core_pattern</link>
-         in <link xlink:href="https://www.suse.com/support/kb/doc/?id=000018634">sysctl</link>
+         To apply the configuration changes to your system, please reboot or use "sysctl --system",
          </para>
         </listitem>
         <listitem>

--- a/xml/art_jeos_quickstart.xml
+++ b/xml/art_jeos_quickstart.xml
@@ -222,12 +222,11 @@
       <para>
        Because of the small amount of memory and disk space available by default on JeOS images,
        systemd-coredump is disabled by default on JeOS images.
-       If your usage scenario requires to collect kernel core dumps for analyzing application
-       crashes:
+       If your usage scenario requires to collect application core dumps for analyzing crashes:
        <itemizedlist>
         <listitem>
          <para>
-	  Install the <package>systemd-coredump</packages> package,
+	  Install the <package>systemd-coredump</packages> package
          </para>
         </listitem>
         <listitem>
@@ -238,7 +237,7 @@
         </listitem>
         <listitem>
          <para>
-          Check out our <link xlink:href="https://documentation.suse.com/sles/15-SP3/single-html/SLES-tuning/#cha-tuning-systemd-coredump">systemd-coredump documentation</link>.
+          Check out our <link xlink:href="https://documentation.suse.com/sles/15-SP3/single-html/SLES-tuning/#cha-tuning-systemd-coredump">systemd-coredump usage and configuration documentation</link>.
          </para>
         </listitem>
        </itemizedlist>

--- a/xml/art_jeos_quickstart.xml
+++ b/xml/art_jeos_quickstart.xml
@@ -226,7 +226,7 @@
        <itemizedlist>
         <listitem>
          <para>
-	  Install the <package>systemd-coredump</packages> package
+	  Install the <package>systemd-coredump</package> package
          </para>
         </listitem>
         <listitem>

--- a/xml/art_jeos_quickstart.xml
+++ b/xml/art_jeos_quickstart.xml
@@ -232,15 +232,13 @@
         </listitem>
         <listitem>
          <para>
-         To apply the configuration changes to your system, please reboot or use "sysctl --system",
-         </para>
-        </listitem>
-        <listitem>
-         <para>
-          Check out our <link xlink:href="https://documentation.suse.com/sles/15-SP3/single-html/SLES-tuning/#cha-tuning-systemd-coredump">systemd-coredump usage and configuration documentation</link>.
+         To apply the configuration changes to your system, please reboot or use the <command>sysctl --system</command> command.
          </para>
         </listitem>
        </itemizedlist>
+       <para>
+          For further information, refer to <link xlink:href="https://documentation.suse.com/sles/15-SP3/single-html/SLES-tuning/#cha-tuning-systemd-coredump" />.
+         </para>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/xml/art_jeos_quickstart.xml
+++ b/xml/art_jeos_quickstart.xml
@@ -223,6 +223,7 @@
        Because of the small amount of memory and disk space available by default on JeOS images,
        systemd-coredump is disabled by default on JeOS images.
        If your usage scenario requires to collect application core dumps for analyzing crashes:
+      </para>
        <itemizedlist>
         <listitem>
          <para>
@@ -241,7 +242,6 @@
          </para>
         </listitem>
        </itemizedlist>
-      </para>
      </listitem>
     </varlistentry>
    </variablelist>

--- a/xml/art_jeos_quickstart.xml
+++ b/xml/art_jeos_quickstart.xml
@@ -216,6 +216,35 @@
     </para>
      </listitem>
     </varlistentry>
+    <varlistentry>
+     <term>systemd-coredump disabled</term>
+     <listitem>
+      <para>
+       Because of the small amount of memory and disk space available by default on JeOS images,
+       systemd-coredump is disabled by default on JeOS images.
+       If your usage scenario requires to collect kernel core dumps for analyzing application
+       crashes:
+       <itemizedlist>
+        <listitem>
+         <para>
+	  Install the <package>systemd-coredump</packages> package,
+         </para>
+        </listitem>
+        <listitem>
+         <para>
+         Set <link xlink:href="https://www.freedesktop.org/software/systemd/man/systemd-coredump.html">kernel.core_pattern</link>
+         in <link xlink:href="https://www.suse.com/support/kb/doc/?id=000018634">sysctl</link>
+         </para>
+        </listitem>
+        <listitem>
+         <para>
+          Check out our <link xlink:href="https://documentation.suse.com/sles/15-SP3/single-html/SLES-tuning/#cha-tuning-systemd-coredump">systemd-coredump documentation</link>.
+         </para>
+        </listitem>
+       </itemizedlist>
+      </para>
+     </listitem>
+    </varlistentry>
    </variablelist>
   </sect2>
  </sect1>

--- a/xml/art_jeos_quickstart.xml
+++ b/xml/art_jeos_quickstart.xml
@@ -220,9 +220,9 @@
      <term>systemd-coredump disabled</term>
      <listitem>
       <para>
-       Because of the small amount of memory and disk space available by default on JeOS images,
+       Due to the limited amount of memory and disk space available by default on JeOS images,
        systemd-coredump is disabled by default on JeOS images.
-       If your usage scenario requires to collect application core dumps for analyzing crashes:
+       To collect application core dumps necessary for troubleshooting, follow these steps:
       </para>
        <itemizedlist>
         <listitem>


### PR DESCRIPTION
Adding "systemd-coredump disabled" in https://susedoc.github.io/doc-sle/master/single-html/SLES-jeos/#sec-jeos-sles-diff

### Description

Describe the overall goals of this pull request.


### Are there any relevant issues/feature requests?

* bsc#1158546


### Is this feature exclusive to SLE 15 SP3 (or Leap 15.3)?
affect all JeOS 15 SPx
