### PR TITLE
Update L3 support info

### DIFF
--- a/xml/art_sle_modules_quick.xml
+++ b/xml/art_sle_modules_quick.xml
@@ -98,6 +98,12 @@
     life cycle, release frequency, and the overlay support period, see
     <link xlink:href="https://www.suse.com/lifecycle"/>.
    </para>
+   <note>
+   <title>L3 support</title>
+   <para>
+   L3 support is generally provided for packages in modules. However, this excludes PackageHub and third-party modules. Use the <command>zypper info <replaceable>PACKAGE</replaceable></command> command to check the support level for a specific package.
+   </para>
+   </note>
    <informaltable>
     <tgroup cols="4">
      <colspec colnum="1" colname="name" colwidth="30*"/>
@@ -161,9 +167,6 @@
           <emphasis role="bold">Extended:</emphasis> 3 yrs
           LTSS<superscript>1</superscript>
          </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
-         </member>
         </simplelist>
        </entry>
       </row>
@@ -214,9 +217,6 @@
          <member>
           <emphasis role="bold">Extended:</emphasis> No
          </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
-         </member>
         </simplelist>
        </entry>
       </row>
@@ -251,9 +251,6 @@
          </member>
          <member>
           <emphasis role="bold">Extended:</emphasis> No
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
          </member>
         </simplelist>
        </entry>
@@ -293,9 +290,6 @@
           <emphasis role="bold">Extended:</emphasis> 3 yrs
           LTSS<superscript>1</superscript>
          </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
-         </member>
         </simplelist>
        </entry>
       </row>
@@ -332,9 +326,6 @@
          <member>
           <emphasis role="bold">Extended:</emphasis> 3 yrs
           LTSS<superscript>1</superscript>
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
          </member>
         </simplelist>
        </entry>
@@ -377,9 +368,6 @@
           <emphasis role="bold">Extended:</emphasis> 3 yrs
           LTSS<superscript>1</superscript>, 1 yr
           ESPOS<superscript>2</superscript>
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
          </member>
         </simplelist>
        </entry>
@@ -606,9 +594,6 @@
           LTSS<superscript>1</superscript>, 1.5 yr
           ESPOS<superscript>2</superscript>
          </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
-         </member>
         </simplelist>
        </entry>
       </row>
@@ -643,9 +628,6 @@
          <member>
           <emphasis role="bold">Extended:</emphasis> 3 yrs
           LTSS<superscript>1</superscript>
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
          </member>
         </simplelist>
        </entry>
@@ -763,8 +745,8 @@
        </entry>
        <entry>
         <para/>
-        <simplelist>
-         <!--
+        <!--<simplelist>
+         
          <member>
           <emphasis role="bold">Life cycle:</emphasis> ??? <remark
           condition="clarity">2019-01-31 - cwickert: missing</remark>
@@ -773,11 +755,8 @@
           <emphasis role="bold">Extended:</emphasis>  ??? <remark
           condition="clarity">2019-01-031 - cwickert: missing</remark>
          </member>
-         -->
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
-         </member>
-        </simplelist>
+         
+        </simplelist> -->
        </entry>
       </row>
       <row>


### PR DESCRIPTION
Fixes bsc-1171085

### Description

Better description of L3 support for packages in modules


### Are there any relevant issues/feature requests?

* bsc#1171085


### Is this feature exclusive to SLE 15 SP3 (or Leap 15.3)?

We are currently **only merging documentation relevant for SLE 15 SP2**
(and Leap 15.2) or lower.

- [x] This PR only applies to SLE 15 SP3 or higher
- [x] This PR applies to older releases as well.


### Are backports required?

- [x] To maintenance/SLE15SP2
- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP2
