### PR TITLE
Increased XFS filesystem max size to 16 EiB (bsc#1171801)

### DIFF
--- a/xml/storage_filesystems.xml
+++ b/xml/storage_filesystems.xml
@@ -1696,7 +1696,7 @@ inode_ratio = 8192</screen>
       </entry>
       <entry>
        <para>
-        8 EiB
+        16 EiB
        </para>
       </entry>
       <entry>


### PR DESCRIPTION
### Description

Increase XFS filesystem max size from 8 to 16 EiB

### Are there any relevant issues/feature requests?

* bsc#1171801


### Is this feature exclusive to SLE 15 SP3 (or Leap 15.3)?

We are currently **only merging documentation relevant for SLE 15 SP2**
(and Leap 15.2) or lower.

- [ ] This PR only applies to SLE 15 SP3 or higher
- [x] This PR applies to older releases as well.


### Are backports required?

- [x] To maintenance/SLE15SP2
- [x] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP2
