### PR TITLE
Removed invalid note about certificate paths (bsc#1176166)

### DIFF
--- a/xml/adm_wbem.xml
+++ b/xml/adm_wbem.xml
@@ -298,29 +298,13 @@
      must be in PEM format.
     </para>
     <para>
-     The default generated server certificate is in the following location:
+     By default, SFCB looks for a server certificate in the following location:
     </para>
+<screen>/etc/sfcb/server.pem</screen>
     <para>
-     <filename>/etc/sfcb/server.pem</filename>
+     To generate a new certificate, run the following command:
     </para>
-    <note>
-     <title>Paths to SSL Certificates</title>
-     <para>
-      The default generated certificate files
-      <filename>servercert.pem</filename> and <filename>
-      serverkey.pem</filename> are stored under
-      <filename>/etc/ssl/servercerts</filename> directory. Files
-      <filename>/etc/sfcb/client.pem</filename>,
-      <filename>/etc/sfcb/file.pem</filename> and
-      <filename>/etc/sfcb/server.pem</filename> are symbolic links to these
-      files.
-     </para>
-    </note>
-    <para>
-     To generate a new certificate, enter the following command as
-     &rootuser; in the command line:
-    </para>
-<screen>&prompt.user;sh /usr/share/sfcb/genSslCert.sh
+<screen>&prompt.sudo;sh /usr/share/sfcb/genSslCert.sh
 Generating SSL certificates in .
 Generating a 2048 bit RSA private key
 ...................................................................+++
@@ -332,11 +316,11 @@ writing new private key to '/var/tmp/sfcb.0Bjt69/key.pem'
      <filename>client.pem</filename> , <filename>file.pem</filename> and
      <filename>server.pem</filename> in the current working directory. If you
      want the script to generate the certificates in
-     <filename>/etc/sfcb</filename> directory, you need to append it to the
-     command. If these files already exist, a warning message is displayed and
-     the old certificates are not overwritten.
+     <filename>/etc/sfcb</filename> directory, you need to append the path to
+     the command. If these files already exist, a warning message is displayed
+     and the old certificates are not overwritten.
     </para>
-<screen>&prompt.user;sh /usr/share/sfcb/genSslCert.sh /etc/sfcb
+<screen>&prompt.sudo;sh /usr/share/sfcb/genSslCert.sh /etc/sfcb
 Generating SSL certificates in .
 WARNING: server.pem SSL Certificate file already exists.
          old file will be kept intact.


### PR DESCRIPTION
### Description

Removed invalid note about certificate paths


### Are there any relevant issues/feature requests?

* bsc#1176166


### Is this feature exclusive to SLE 15 SP3 (or Leap 15.3)?

We are currently **only merging documentation relevant for SLE 15 SP2**
(and Leap 15.2) or lower.

- [ ] This PR only applies to SLE 15 SP3 or higher
- [x] This PR applies to older releases as well.


### Are backports required?

- [x] To maintenance/SLE15SP2
- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [x] To maintenance/SLE12SP4
- [x] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP2
