### PR TITLE
Remove locale step on jeos-firstboot

### DIFF
--- a/xml/art_jeos_quickstart.xml
+++ b/xml/art_jeos_quickstart.xml
@@ -454,24 +454,8 @@
     After the system is booted, jeos-firstboot guides you through the initial system setup.
    </para>
    <procedure xml:id="pro-rpi-firstboot-jeos">
-    <step>
-     <para>
-      The &jeos; image comes with only the <literal>en_US</literal> locale. You
-      can install and select the desired system locale after the setup is
-      completed, using the provided instructions.
-     </para>
-     <informalfigure>
-      <mediaobject>
-       <imageobject>
-        <imagedata width="80%" fileref="jeos_locale.png"/>
-       </imageobject>
-       <textobject><phrase>jeos-firstboot showing information on setting locale</phrase>
-       </textobject>
-      </mediaobject>
-     </informalfigure>
-    </step>
-    <step>
-     <para>
+       <step>
+       <para>
        As the first step, you are prompted to select the appropriate keyboard layout
        using the keyboard selection dialog.
      </para>
@@ -506,7 +490,7 @@
       </para>
     </step>
    </procedure>
-       <tip>
+    <tip>
     <title>Installing Product Patches after First Boot</title>
     <para>
      After &jeos; has been successfully installed and registered, we highly
@@ -514,4 +498,39 @@
     </para>
    </tip>
 </sect1>
+<sect1 xml:id="sec-jeos-config">
+    <title>Configuring JeOS images</title>
+<sect2 xml:id="sec-jeos-locale">
+<title>Changing System Language</title>
+<para>
+    The JeOS image comes with only the English (en_US) locale. You can
+    install and select the desired system locale after the setup is
+    completed, using the instructions provided below.
+</para>
+<para>
+    Install glibc-locale:
+</para>
+<screen>
+    <command>zypper in glib-locale</command>
+</screen>
+<para>
+    Use localectl to change to the locale desired, for example, to change
+    the main system language to German use:
+</para>
+<screen>
+    <command>localectl set-locale LANG=de_DE.UTF-8</command>
+</screen>
+<para>
+    For a complete list of the locale codes available use:
+</para>
+<screen>
+<command>localectl list-locales</command>
+</screen>
+<para>
+    For more information on language settings and how to use it with YaST
+    in SLE please check <xref linkend="cha-yast-lang"/>
+</para>
+</sect2>
+</sect1>
+
 </article>


### PR DESCRIPTION
Add new section about locale configuration

### Description

Add new section for local configuration and remove the now obsolete (removed) step of jeos-firstboot warning about that

Test build ran on travis with green

### Are there any relevant issues/feature requests?

https://jira.suse.com/browse/PM-2100
(for SLE, tracked as https://jira.suse.com/browse/SLE-15348) 

### Is this feature exclusive to SLE 15 SP3 (or Leap 15.3)?

We are currently **only merging documentation relevant for SLE 15 SP2**
(and Leap 15.2) or lower.

- [ x] This PR only applies to SLE 15 SP3 or higher
- [ ] This PR applies to older releases as well.


### Are backports required?

- [ ] To maintenance/SLE15SP2
- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP2
