### PR TITLE
Fixed path for RMT repo locations (bsc#1176516)

### DIFF
--- a/xml/rmt_install.xml
+++ b/xml/rmt_install.xml
@@ -35,11 +35,9 @@
 
   <para>
    Downloaded packages are stored in<filename>
-   /usr/share/rmt/public/repo</filename>, which is a symbolic link to
-   <filename>/var/lib/rmt/public/repo/SUSE/Products/</filename>. (You may
-   change this location by changing the symbolic link, and then updating the &rmt;
-   configuration files in <filename>/etc/nginx/vhosts.d/</filename> with the
-   new symbolic link.)
+    /usr/share/rmt/public/repo</filename>, which is a symbolic link to
+   <filename>/var/lib/rmt/public/repo/</filename>. You can change this location
+   by purely changing the symbolic link.
   </para>
 
   <para>

--- a/xml/rmt_install.xml
+++ b/xml/rmt_install.xml
@@ -34,10 +34,9 @@
   <title>Storage Requirements</title>
 
   <para>
-   Downloaded packages are stored in<filename>
-    /usr/share/rmt/public/repo</filename>, which is a symbolic link to
-   <filename>/var/lib/rmt/public/repo/</filename>. You can change this location
-   by purely changing the symbolic link.
+   Downloaded packages are stored in
+   <filename>/usr/share/rmt/public/repo</filename>, which is a symbolic link to
+   <filename>/var/lib/rmt/public/repo/</filename>.
   </para>
 
   <para>

--- a/xml/rmt_migrate_from_smt.xml
+++ b/xml/rmt_migrate_from_smt.xml
@@ -638,8 +638,8 @@
      Optional: Move the mirrored repository data from &smt; to &rmt; and adjust
      the ownership of the copied data.
     </para>
-<screen>&prompt.sudo;<command>cp -r /var/www/htdocs/repo/* /var/lib/rmt/public/repo</command>
-&prompt.sudo;<command>chown -R _rmt:nginx /var/lib/rmt/public/repo</command></screen>
+<screen>&prompt.sudo;<command>cp -r /var/www/htdocs/repo/* /usr/share/rmt/public/repo/</command>
+&prompt.sudo;<command>chown -R _rmt:nginx /usr/share/rmt/public/repo</command></screen>
    </step>
    <step>
     <para>
@@ -654,7 +654,7 @@
       </para>
       <screen>&prompt.sudo;<command>rmt-cli repos custom list</command></screen>
       <para>
-       A table of all custom repositories will be shown. the first column
+       A table of all custom repositories will be shown. The first column
        contains the <literal>ID</literal> of each repository and the
        <literal>Mirror?</literal> column will show <literal>false</literal>.
       </para>


### PR DESCRIPTION
### Description

Symlinked directories for storing repo content in RMT were not accurately documented


### Are there any relevant issues/feature requests?

* bsc#1176516

### Is this feature exclusive to SLE 15 SP3 (or Leap 15.3)?

We are currently **only merging documentation relevant for SLE 15 SP2**
(and Leap 15.2) or lower.

- [z] This PR applies to older releases as well.


### Are backports required?

- [ ] To maintenance/SLE15SP2
- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
