### PR TITLE
LDAP: how to check 389-ds instance name

### DIFF
--- a/xml/security_ldap.xml
+++ b/xml/security_ldap.xml
@@ -411,6 +411,9 @@ objectclass (2.16.840.1.113730.3.2.333 NAME 'nsPerson' <co xml:id="co-ldap-schem
        If not specified otherwise, the default instance name is
        <literal>localhost</literal>. The instance name cannot
        be changed after the instance has been created.</para>
+     <para>
+      To check the name of an instance you have not created yourself, use
+      the <command>dsctl -l</command> command.</para>
     </note>
     <para>
      <xref linkend="ex-ldap-389-ds-inf" xrefstyle="select:label"/> shows an


### PR DESCRIPTION
### Description

Add useful piece of info from a mail thread with William.


### Is this feature exclusive to SLE 15 SP3 (or Leap 15.3)?

We are currently **only merging documentation relevant for SLE 15 SP2**
(and Leap 15.2) or lower.

- [ ] This PR only applies to SLE 15 SP3 or higher
- [x] This PR applies to older releases as well.


### Are backports required?

- [x] To maintenance/SLE15SP2
- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP2
