### PR TITLE
AutoYaST Support for Dynamic Profiles

### DIFF
--- a/xml/ay_create_control_file.xml
+++ b/xml/ay_create_control_file.xml
@@ -340,4 +340,104 @@
     <link xlink:href="http://www.w3.org/TR/xslt">www.w3.org/TR/xslt</link>
    </para>
   </sect1>
+
+  <sect1 xml:id="check-profile">
+   <title>Checking a Control File</title>
+
+   <para>
+    Depending on the use case, creating an &ay; profile can be difficult,
+    especially if you build a dynamic one using <link
+    xlink:href="part-dynamic-profiles">rules/classes, ERB templates or
+    pre-scripts</link>. To simplify the testing and debugging process, &ay;
+    offers the <literal>check-profile</literal> command, which takes care of
+    fetching, building and, optionally, importing the profile to detect any
+    potential problem.
+   </para>
+
+   <note>
+    <para>
+     Although this command uses the same approach than the installation, the
+     results may vary depending on the differences between the current system
+     and installation media: &yast; package versions, architecture, etc.
+    </para>
+   </note>
+
+   <warning>
+    <para>
+     You must be careful when running this command because pre-installation
+     scripts and ERB code would run as the <literal>root</literal> user.
+     So, please, only use profiles that you trust.
+    </para>
+   </warning>
+
+   <sect2>
+    <title>Basic Checks</title>
+
+    <para>
+     The simplest way to use this command is just to read and validate the profile:
+    </para>
+
+<screen>&prompt.sudo; yast2 autoyast check-profile filename=autoinst.xml output=result.xml</screen>
+
+    <para>
+     The <filename>result.xml</filename> file contains the result of evaluating
+     the profile. Bear in mind that, even if you do not use any advanced
+     feature, the content of <filename>autoinst.xml</filename> and
+     <filename>result.xml</filename> may differ. The reason is that &ay; does
+     some clean-up when it processes the profile.
+    </para>
+
+    <para>
+     <literal>check-profile</literal> can deal with remote files too:
+    </para>
+
+<screen>&prompt.sudo; yast2 autoyast check-profile filename=http://192.168.1.100/autoinst.xml output=result.xml</screen>
+
+   </sect2>
+
+   <sect2>
+    <title>Running pre-scripts</title>
+
+    <para>
+     Optionally, &ay; is able to run the scripts that are included in the
+     profile, reporting any error found during the execution. This is especially
+     relevant if you are using a pre-installation script to modify the profile.
+     To enable this feature, you need to set the <literal>run-scripts</literal>
+     to <literal>true</literal>.
+    </para>
+
+<screen>&prompt.sudo; yast2 autoyast check-profile filename=http://192.168.1.100/autoinst.xml output=result.xml run-scripts=true</screen>
+
+    <warning>
+     <para>
+      Needless to say that you must be careful when enabling the
+      <literal>run-scripts</literal> option because the scripts will run as root
+      and they may affect the current system.
+     </para>
+    </warning>
+   </sect2>
+
+   <sect2>
+    <title>Importing the Profile</title>
+
+    <para>
+     It is possible to face some problems when importing a valid profile, even
+     if it is correct. The reason is that AutoYaST does not perform any logic
+     check when fetching, building and validating the profile.
+    </para>
+
+    <para>
+     To anticipate such problems, the <literal>check-profile</literal> command
+     imports the profile and reports problem that it is detected. As it may take
+     a while, you can disable this behavior setting the
+     <literal>import-all</literal> option to <literal>false</literal>.
+    </para>
+
+<screen>&prompt.sudo; yast2 autoyast check-profile filename=http://192.168.1.100/autoinst.xml output=result.xml import-all=false</screen>
+
+    <para>
+     Importing the profile is a safe operation and does not alter the underlying system in any way.
+    </para>
+   </sect2>
+  </sect1>
  </chapter>

--- a/xml/ay_create_control_file.xml
+++ b/xml/ay_create_control_file.xml
@@ -346,7 +346,7 @@
 
    <para>
     Depending on the use case, creating an &ay; profile can be difficult,
-    especially if you build a dynamic one using <link
+    especially if you build a dynamic profile using <link
     xlink:href="part-dynamic-profiles">rules/classes, ERB templates or
     pre-scripts</link>. To simplify the testing and debugging process, &ay;
     offers the <literal>check-profile</literal> command, which takes care of
@@ -356,7 +356,7 @@
 
    <note>
     <para>
-     Although this command uses the same approach than the installation, the
+     Although this command uses the same approach as the installation, the
      results may vary depending on the differences between the current system
      and installation media: &yast; package versions, architecture, etc.
     </para>
@@ -403,15 +403,15 @@
      profile, reporting any error found during the execution. This is especially
      relevant if you are using a pre-installation script to modify the profile.
      To enable this feature, you need to set the <literal>run-scripts</literal>
-     to <literal>true</literal>.
+     option to <literal>true</literal>.
     </para>
 
 <screen>&prompt.sudo; yast2 autoyast check-profile filename=http://192.168.1.100/autoinst.xml output=result.xml run-scripts=true</screen>
 
     <warning>
      <para>
-      Needless to say that you must be careful when enabling the
-      <literal>run-scripts</literal> option because the scripts will run as root
+      You must be careful when enabling the
+      <literal>run-scripts</literal> option, because the scripts will run as root
       and they may affect the current system.
      </para>
     </warning>
@@ -422,13 +422,13 @@
 
     <para>
      It is possible to face some problems when importing a valid profile, even
-     if it is correct. The reason is that AutoYaST does not perform any logic
+     if it is correct. The reason is that &ay; does not perform any logic
      check when fetching, building and validating the profile.
     </para>
 
     <para>
      To anticipate such problems, the <literal>check-profile</literal> command
-     imports the profile and reports problem that it is detected. As it may take
+     imports the profile and reports problems that it has detected. As it may take
      a while, you can disable this behavior setting the
      <literal>import-all</literal> option to <literal>false</literal>.
     </para>

--- a/xml/ay_dynamic_profiles.xml
+++ b/xml/ay_dynamic_profiles.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE chapter
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+    %entities;
+]>
+
+<chapter xmlns="http://docbook.org/ns/docbook"
+xmlns:xi="http://www.w3.org/2001/XInclude"
+xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0"
+xml:id="dynamic-profiles">
+
+ <title>Supported Approaches to Dynamic Profiles</title>
+ <info>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker></dm:bugtracker>
+   <dm:translation>yes</dm:translation>
+  </dm:docmanager>
+ </info>
+
+  <para>
+   When dealing with the installation of multiple systems, it might be useful to
+   use a single profile (or just a reduced set of them) adapts automatically to
+   each system. In this regard, &ay; offers three different mechanisms to modify
+   the profile at installation time.
+  </para>
+
+  <variablelist>
+   <varlistentry>
+    <term>Rules and Classes</term>
+    <listitem>
+     <para>
+      Rules and classes offer the possibility to configure a system by merging
+      multiple control files during installation. You can read more about this
+      feature in the <xref linkend="rulesandclass"/> section.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+     <term>ERB Templates</term>
+     <listitem>
+      <para>
+       &ay; supports Embedded Ruby (ERB) templates syntax to modify the
+       profile's content during installation. The <xref
+       linkend="erb-templates"/> section describes how to use them.
+      </para>
+     </listitem>
+   </varlistentry>
+   <varlistentry>
+     <term>Pre-installation scripts</term>
+     <listitem>
+      <para>
+       You can use a pre-installation script to modify or even create a brand
+       new profile during installation. <xref linkend="pre-install-scripts"/>
+       describes how to benefit from them.
+      </para>
+     </listitem>
+   </varlistentry>
+  </variablelist>
+ </chapter>

--- a/xml/ay_dynamic_profiles.xml
+++ b/xml/ay_dynamic_profiles.xml
@@ -20,7 +20,7 @@ xml:id="dynamic-profiles">
 
   <para>
    When dealing with the installation of multiple systems, it might be useful to
-   use a single profile (or just a reduced set of them) adapts automatically to
+   use a single profile (or just a reduced set of them) that adapts automatically to
    each system. In this regard, &ay; offers three different mechanisms to modify
    the profile at installation time.
   </para>

--- a/xml/ay_erb_templates.xml
+++ b/xml/ay_erb_templates.xml
@@ -1,0 +1,480 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE chapter
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+    %entities;
+]>
+
+<chapter xmlns="http://docbook.org/ns/docbook"
+xmlns:xi="http://www.w3.org/2001/XInclude"
+xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0"
+xml:id="erb-templates">
+
+ <title>ERB Templates</title>
+ <info>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker></dm:bugtracker>
+   <dm:translation>yes</dm:translation>
+  </dm:docmanager>
+ </info>
+
+  <para>
+   ERB templates allow to embed some Ruby code within the profile to modify it
+   during the installation. With this approach, you can inspect the system and
+   adjust the profile by setting values, adding or skipping sections, etc.
+  </para>
+
+  <para>
+   In order to activate the ERB processing, the profile must have the extension
+   <filename>.erb</filename> (e.g., <filename>autoyast.xml.erb</filename>). Hence,
+   it is not possible to combine rules/classes and ERB templates.
+  </para>
+
+  <sect1 xml:id="erb">
+   <title>What is <literal>ERB</literal>?</title>
+
+   <para>
+    <literal>ERB</literal> stands for <emphasis>Embedded Ruby</emphasis> and
+    allows to use the power of the Ruby programming language to generate
+    different kind of contents. Using <literal>ERB</literal> you can include
+    some Ruby code in your profiles to adapt them at runtime depending on the
+    installation system.
+   </para>
+
+   <para>
+    When using ERB, the Ruby code is enclosed between <literal>&lt;%</literal>
+    and <literal>&gt;</literal> signs. If you want the output of the command to
+    be included in the resulting profile, you simply need to add an equal
+    sign (<literal>=</literal>).
+   </para>
+
+   <example xml:id="simple-erb">
+    <title>Including a File Using ERB</title>
+    <screen>&lt;bootloader&gt;
+  &lt;% require "open-uri" %&gt;
+  &lt;%= URI.open("http://192.168.1.1/profiles/bootloader-common.xml").read %&gt;
+&lt;/bootloader&gt;</screen>
+   </example>
+
+   <para>
+     &ay; offers a small set of <emphasis>helper functions</emphasis> to
+     retrieve information from the underlying system, like
+     <literal>disks</literal> or <literal>network_cards</literal>. You can check
+     the list of helpers and their values in the <xref linkend="erb-helpers" />
+     section.
+   </para>
+  </sect1>
+
+  <sect1 xml:id="erb-helpers">
+   <title>Template Helpers</title>
+
+   <para>
+    Template helpers are basically a set of Ruby methods that can be used in the
+    profiles to retrieve information about the installation system.
+   </para>
+
+   <sect2 xml:id="erb-disks-helper">
+    <title><literal>disks</literal></title>
+
+    <para>
+     This <literal>disks</literal> returns a list of the detected disks. Each
+     element of the list contains some basic information like the device name or
+     the size.
+    </para>
+
+    <informaltable>
+     <tgroup cols="3">
+      <thead>
+       <row>
+        <entry>
+         <para>
+          Key
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Type
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Value
+         </para>
+        </entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>
+         <para>
+          <literal>:device</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          String
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Device kernel name (e.g., <literal>sda</literal>).
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>:model</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          String
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Disk model
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>:serial</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          String
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Serial number
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>:size</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Integer
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Disk size (in bytes)
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>:udev_names</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Array&lt;String&gt;
+         </para>
+        </entry>
+        <entry>
+         <para>
+          List of disk udev names. You can use any of them to refer to the device.
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>:vendor</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          String
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Disk vendor's name
+         </para>
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+
+    <para>
+     The profile in the example below installs the system in the largest disk.
+     It sorts the list of existing disks by size and takes the last one. Then it
+     uses the <literal>:device</literal> key as value for the
+     <literal>device</literal> element.
+    </para>
+
+    <example>
+     <title>Using the Largest Disk</title>
+      <screen>&lt;partitioning t="list"&gt;
+  &lt;drive&gt;
+    &lt;% disk = disks.sort_by { |d| d[:size] }.last %&gt; &lt;!-- find the largest disk --&gt;
+    &lt;device&gt;&lt;%= disk[:device] %&gt;&lt;/device&gt; &lt;!-- print the disk device name --&gt;
+    &lt;initialize t="boolean"&gt;true&lt;/initialize&gt;
+    &lt;use&gt;all&lt;/use&gt;
+  &lt;/drive&gt;
+&lt;/partitioning&gt;
+     </screen>
+    </example>
+
+   </sect2>
+
+   <sect2 xml:id="erb-network-cards-helper">
+    <title><literal>network_cards</literal></title>
+
+    <para>
+     The <literal>network_cards</literal> helper returns a list of network
+     cards, including its name, status information (e.g., if they are connected or
+     not), etc.
+    </para>
+
+    <informaltable>
+     <tgroup cols="3">
+      <thead>
+       <row>
+        <entry>
+         <para>
+          Key
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Type
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Value
+         </para>
+        </entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>
+         <para>
+          <literal>:device</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          String
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Device name (e.g., <literal>eth0</literal>, <literal>enp3s0</literal>, etc.)
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>:mac</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          String
+         </para>
+        </entry>
+        <entry>
+         <para>
+          MAC address
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>:active</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Boolean
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Whether the device is active or not
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>:link</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Boolean
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Whether the device is connected or not
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>:vendor</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          String
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Disk vendor's name
+         </para>
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+
+    <para>
+     The following example finds the first network card that it is connected
+     to the network and configures it to use DHCP.
+    </para>
+
+   <example>
+    <title>Configure the Connected Network Cards</title>
+     <screen>&lt;interfaces t="list"&gt;
+  &lt;% with_link = netword_cards.sort_by { |n| n[:name] }.find { |n| n[:link] } %&gt;
+  &lt;% if with_link %&gt;
+    &lt;interface&gt;
+      &lt;device&gt;&lt;%= with_link[:device] %&gt;&lt;/device&gt;
+      &lt;startmode&gt;auto&lt;/startmode&gt;
+      &lt;bootproto&gt;dhcp&lt;/bootproto&gt;
+      &lt;/interface&gt;
+  &lt;% end &gt;
+&lt;/interfaces&gt;
+    </screen>
+   </example>
+   </sect2>
+
+   <sect2 xml:id="erb-os-release-helper">
+    <title><literal>os_release</literal></title>
+
+    <para>
+     The <literal>os_release</literal> returns the operating system information,
+     which is included in the <filename>/etc/os-release</filename> file.
+    </para>
+
+    <informaltable>
+     <tgroup cols="3">
+      <thead>
+       <row>
+        <entry>
+         <para>
+          Key
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Type
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Value
+         </para>
+        </entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>
+         <para>
+          <literal>:id</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          String
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Distribution ID (e.g., <literal>sles</literal>,
+          <literal>opensuse-tumbleweed</literal>, etc.)
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>:name</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          String
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Distribution name (e.g., <literal>SLES</literal>, <literal>openSUSE Tumbleweed</literal>, etc.)
+         </para>
+        </entry>
+       </row>
+       <row>
+        <entry>
+         <para>
+          <literal>:version</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          String
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Distribution version (e.g, <literal>15.2</literal>)
+         </para>
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+
+    <para>
+     You might use this information to decide which product to install, using
+     pretty much the same profile for all of them (SLE or openSUSE
+     distributions).
+    </para>
+
+    <example>
+     <title>Reusing the Same Profile for Different Distributions</title>
+     <screen>&lt;products t="list"&gt;
+  &lt;% if os_release[:id] == 'sle' %&gt;
+  &lt;product&gt;SLES&lt;/product&gt;
+  &lt;% else %&lt;
+  &lt;product&gt;openSUSE&lt;/product&gt;
+  &lt;% end %&lt;
+&lt;/products&gt;</screen>
+        </example>
+    </sect2>
+   </sect1>
+ </chapter>

--- a/xml/ay_erb_templates.xml
+++ b/xml/ay_erb_templates.xml
@@ -19,7 +19,7 @@ xml:id="erb-templates">
  </info>
 
   <para>
-   ERB templates allow to embed some Ruby code within the profile to modify it
+   ERB templates allow embedding some Ruby code within the profile to modify it
    during the installation. With this approach, you can inspect the system and
    adjust the profile by setting values, adding or skipping sections, etc.
   </para>
@@ -35,8 +35,8 @@ xml:id="erb-templates">
 
    <para>
     <literal>ERB</literal> stands for <emphasis>Embedded Ruby</emphasis> and
-    allows to use the power of the Ruby programming language to generate
-    different kind of contents. Using <literal>ERB</literal> you can include
+    allows using the power of the Ruby programming language to generate
+    different kind of contents. With <literal>ERB</literal>, you can include
     some Ruby code in your profiles to adapt them at runtime depending on the
     installation system.
    </para>
@@ -77,8 +77,8 @@ xml:id="erb-templates">
     <title><literal>disks</literal></title>
 
     <para>
-     This <literal>disks</literal> returns a list of the detected disks. Each
-     element of the list contains some basic information like the device name or
+     The <literal>disks</literal> helper returns a list of the detected disks. 
+     Each element of the list contains some basic information like the device name or
      the size.
     </para>
 
@@ -377,7 +377,7 @@ xml:id="erb-templates">
     <title><literal>os_release</literal></title>
 
     <para>
-     The <literal>os_release</literal> returns the operating system information,
+     The <literal>os_release</literal> helper returns the operating system information,
      which is included in the <filename>/etc/os-release</filename> file.
     </para>
 

--- a/xml/ay_pre_scripts.xml
+++ b/xml/ay_pre_scripts.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE chapter
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+    %entities;
+]>
+
+<chapter xmlns="http://docbook.org/ns/docbook"
+xmlns:xi="http://www.w3.org/2001/XInclude"
+xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0"
+xml:id="pre-scripts">
+
+ <title>Combining ERB templates and scripts</title>
+ <info>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker></dm:bugtracker>
+   <dm:translation>yes</dm:translation>
+  </dm:docmanager>
+ </info>
+
+  <para>
+    Section <xref linkend="pre-install-scripts"/> already describes how to use a
+    pre-script to modify the current profile. In a nutshell, if the script
+    creates a <filename>/tmp/profile/modified.xml</filename> file, &ay; imports
+    that profile and forgets about the initial one.
+  </para>
+
+  <para>
+    This is a pretty flexible approach and the only limitation is that you need
+    to rely on the languages and libraries that are available in the installation
+    media.
+  </para>
+
+  <sect1 xml:id="erb-and-scripts">
+   <title>Embedding ERB in Your Scripts</title>
+
+   <para>
+    Unlike with <emphasis>rules</emphasis>, it is possible to combine ERB
+    templates with scripts. &ay; will evaluate any ERB tag that you include in
+    your script before running it. This behavior only applies to the scripts
+    defined inside the profile and not to the external ones.
+   </para>
+
+   <para>
+    The script in the example below downloads a profile which name is based on
+    the MAC address. Saving the file as
+    <filename>/tmp/profile/modified.xml</filename> will cause &ay; to load and
+    use the just downloaded profile.
+   </para>
+
+   <example xml:id="combining-erb-and-scripts">
+    <title>Using the MAC Address to Get the Profile</title>
+    <screen>&lt;scripts&gt;
+  &lt;pre-scripts config:type="list"&gt;
+    &lt;script&gt;
+      &lt;interpreter&gt;shell&lt;/interpreter&gt;
+      &lt;filename&gt;load_profile.sh&lt;/filename&gt;
+      &lt;% mac = network_cards.first &gt;
+      &lt;source&gt;&lt;![CDATA[#!/bin/bash
+wget -O /tmp/profile/modified.xml http://myserver/&lt;%= network_cards.first[:mac] %&gt;.xml
+]]&gt;&lt;/source&gt;
+    &lt;/script&gt;
+  &lt;/pre-scripts&gt;
+&lt;/scripts&gt;</screen>
+   </example>
+  </sect1>
+
+  <sect1 xml:id="erb-helpers-in-scripts">
+   <title>Accessing ERB Helpers from Ruby Scripts</title>
+
+   <para>
+    It is possible to use the ERB helpers in Ruby scripts. To use those helpers,
+    you need to <emphasis>require</emphasis> the <filename>yast</filename> and
+    <filename>autoinstall/y2erb</filename> libraries and use the
+    <literal>Y2Autoinstall::Y2ERB::TemplateEnvironment</literal> class to access
+    them.
+   </para>
+
+   <example xml:id="ruby-script-erb-helpers">
+    <title>Accessing ERB helpers from a Ruby script</title>
+
+    <screen>
+&lt;scripts&gt;
+  &lt;pre-scripts config:type="list"&gt;
+    &lt;script&gt;
+      &lt;interpreter&gt;/usr/bin/ruby&lt;/interpreter&gt;
+      &lt;filename&gt;load_profile.sh&lt;/filename&gt;
+      &lt;source&gt;&lt;![CDATA[#!/bin/bash
+require "yast"
+require "autoinstall/y2erb"
+helpers = Y2Autoinstallation::Y2ERB::TemplateEnvironment.new
+# Now you can use the TemplateEnvironment instance to call the helpers
+disk_devices = helpers.disks.map { |d| d[:device] }
+File.write("/root/disks.txt", disk_devices.join("\n"))
+]]&gt;&lt;/source&gt;
+    &lt;/script&gt;
+  &lt;/pre-scripts&gt;
+&lt;/scripts&gt;</screen>
+   </example>
+  </sect1>
+ </chapter>

--- a/xml/book_autoyast.xml
+++ b/xml/book_autoyast.xml
@@ -56,10 +56,12 @@
 <!-- ===================================================================== -->
 <!-- Part: Rules and Classes                                               -->
 <!-- ===================================================================== -->
- <part xml:id="part-rules-classes">
-     <title>Managing Mass Installations with Rules and Classes</title>
- 
- <xi:include href="ay_rules_classes.xml"/>
+ <part xml:id="part-dynamic-profiles">
+     <title>Managing Mass Installations with Dynamic Profiles</title>
+<xi:include href="ay_dynamic_profiles.xml"/>
+<xi:include href="ay_rules_classes.xml"/>
+<xi:include href="ay_erb_templates.xml"/>
+<xi:include href="ay_pre_scripts.xml"/>
 </part>
  
 <!-- ===================================================================== -->


### PR DESCRIPTION
### Description

This PR adds some sections about AutoYaST capabilities to generate dynamic profiles. In SP3 we have added support for "ERB Templates" and a new command to check whether a profile is correct or not (`check-profile`).

As usually, I am open to any change, as I am not even sure about the organization of the contents.

### Are there any relevant issues/feature requests?

* [bsc#1175735](https://bugzilla.suse.com/show_bug.cgi?id=1175735)

### Is this feature exclusive to SLE 15 SP3 (or Leap 15.3)?

We are currently **only merging documentation relevant for SLE 15 SP2**
(and Leap 15.2) or lower.

- [x] This PR only applies to SLE 15 SP3 or higher
- [ ] This PR applies to older releases as well.


### Are backports required?

- [ ] To maintenance/SLE15SP2
- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP2
