### PR TITLE
AY: partition_alignment element is drop

### DIFF
--- a/xml/ay_general_options.xml
+++ b/xml/ay_general_options.xml
@@ -796,11 +796,6 @@
    true
    </accept_non_trusted_gpg_key>
   </signature-handling>
-  <storage>
-   <partition_alignment config:type="symbol">
-    align_cylinder
-   </partition_alignment>
-  </storage>
   <wait>
    <pre-modules config:type="list">
     <module>


### PR DESCRIPTION
### Description

The `<partition_alignment>` element [was dropped in SLE 15 GA](https://documentation.suse.com/sles/15-SP2/html/SLES-all/appendix-ay-12vs15.html#sec-ay-12vs15-partitioning-aligning). However, it is still included in an example.

### Is this feature exclusive to SLE 15 SP3 (or Leap 15.3)?

We are currently **only merging documentation relevant for SLE 15 SP2**
(and Leap 15.2) or lower.

- [ ] This PR only applies to SLE 15 SP3 or higher
- [x] This PR applies to older releases as well.


### Are backports required?

- [x] To maintenance/SLE15SP2
- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP2
