### PR TITLE
Custom repositories translate differently with RMT (bsc#1176528)

### DIFF
--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -191,6 +191,7 @@
 <!ENTITY productnameshort "<phrase xmlns='http://docbook.org/ns/docbook' role='productname'><phrase os='osuse'>&opensuse; Leap</phrase><phrase os='sles'>&slsa;</phrase><phrase os='sled'>&sleda;</phrase></phrase>">
 <!ENTITY product-ga    "15">
 <!ENTITY product-sp    "2">
+<!ENTITY productnumbershort "&product-ga;.&product-sp;">
 <!ENTITY productnumber "<phrase xmlns='http://docbook.org/ns/docbook' role='productnumber'><phrase os='osuse'>15.2</phrase><phrase os='sles;sled'>&product-ga; SP&product-sp;</phrase></phrase>">
 <!ENTITY sdk           "SUSE Software Development Kit">
 <!ENTITY hasi          "High Availability Extension">

--- a/xml/rmt_migrate_from_smt.xml
+++ b/xml/rmt_migrate_from_smt.xml
@@ -640,13 +640,19 @@
     </para>
 <screen>&prompt.sudo;<command>cp -r /var/www/htdocs/repo/* /usr/share/rmt/public/repo/</command>
 &prompt.sudo;<command>chown -R _rmt:nginx /usr/share/rmt/public/repo</command></screen>
-<tip>
- <para>
-  The path for storing custom repositories' data on the &rmt; server is different
-  from that of &smt;. With &rmt;, it replicates the directory structure of the
-  source server's URL into a top level directory. For example TBD
- </para>
-</tip>
+   <tip>
+    <para>
+     The path for storing custom repositories' data on the &rmt; server is different
+     from that of &smt;. With &rmt;, it replicates the directory structure of the
+     source server's URL into a top level directory. For example, the custom repository's
+     URL is
+    </para>
+<screen>http://download.opensuse.org/debug/distribution/leap/&productnumbershort;/repo/oss </screen>
+    <para>
+     its URL on the &rmt; server will be
+    </para>
+<screen>http://<replaceable>RMT_HOST</replaceable>/repo/debug/distribution/leap/&productnumbershort;/repo/oss</screen>
+   </tip>
    </step>
    <step>
     <para>

--- a/xml/rmt_migrate_from_smt.xml
+++ b/xml/rmt_migrate_from_smt.xml
@@ -642,10 +642,10 @@
 &prompt.sudo;<command>chown -R _rmt:nginx /usr/share/rmt/public/repo</command></screen>
    <tip>
     <para>
-     The path for storing custom repositories' data on the &rmt; server is different
-     from that of &smt;. With &rmt;, it replicates the directory structure of the
-     source server's URL into a top level directory. For example, the custom repository's
-     URL is
+     The path for storing custom repositories' data on the &rmt; server is
+     different from that of &smt;. With &rmt;, it replicates the directory
+     structure of the source server's URL into a top level directory. For
+     example, if the custom repository's URL is
     </para>
 <screen>http://download.opensuse.org/debug/distribution/leap/&productnumbershort;/repo/oss </screen>
     <para>

--- a/xml/rmt_migrate_from_smt.xml
+++ b/xml/rmt_migrate_from_smt.xml
@@ -587,7 +587,7 @@
    <step>
     <para>
      Copy the exported <literal>.tar.gz</literal> file to an empty directory
-     and unpack it. The enter the new directory:
+     and unpack it. Then enter the new directory:
     </para>
 <screen>&prompt.user;<command>mkdir <replaceable>EMPTY_DIR</replaceable></command>
 &prompt.user;<command>cd <replaceable>EMPTY_DIR</replaceable></command>
@@ -645,20 +645,19 @@
      The path for storing custom repositories' data on the &rmt; server is
      different from that of &smt;. With &rmt;, it replicates the directory
      structure of the source server's URL into a top level directory. For
-     example, if the custom repository's URL is
+     example, if the URL of the custom repository is
     </para>
 <screen>http://download.opensuse.org/debug/distribution/leap/&productnumbershort;/repo/oss </screen>
     <para>
-     its URL on the &rmt; server will be
+     its path on the &rmt; server will be
     </para>
-<screen>http://<replaceable>RMT_HOST</replaceable>/repo/debug/distribution/leap/&productnumbershort;/repo/oss</screen>
+<screen>/usr/share/rmt/public/repo/debug/distribution/leap/&productnumbershort;/repo/oss</screen>
    </tip>
    </step>
    <step>
     <para>
-     In case your &smt; server contains custom repositories that you would like
-     to mirror to the &rmt; server, activate them before mirroring (they are
-     disabled by default).
+     Custom repositories on the &smt; server are disabled be default. If you
+     want to mirror them to the &rmt; enable them before mirroring.
     </para>
     <substeps>
      <step>

--- a/xml/rmt_migrate_from_smt.xml
+++ b/xml/rmt_migrate_from_smt.xml
@@ -591,7 +591,7 @@
     </para>
 <screen>&prompt.user;<command>mkdir <replaceable>EMPTY_DIR</replaceable></command>
 &prompt.user;<command>cd <replaceable>EMPTY_DIR</replaceable></command>
-&prompt.user;<command>tar xf <replaceable>/PATH/TO/</replaceable>smt-export.<replaceable>XXXXXX</replaceable>.tar.gz</command>
+&prompt.user;<command>tar xf <replaceable>/PATH/TO/</replaceable>smt-export.<replaceable>TIMESTAMP</replaceable>.tar.gz</command>
 &prompt.user;<command>cd smt-export</command>
 </screen>
    </step>

--- a/xml/rmt_migrate_from_smt.xml
+++ b/xml/rmt_migrate_from_smt.xml
@@ -26,7 +26,7 @@
     <term>Use New Host</term>
     <listitem>
      <para>
-      We recommend that you install &rmt; on a newly installed &slsa;
+      We recommend that you install &rmt; on a newly-installed &slsa;
       15 host. &rmt; is not a complete replacement for &smt;. It has a
       different workflow than &smt; and only supports registering &sls; 12
       systems and newer.
@@ -569,8 +569,8 @@
    <step>
     <para>
      The exported configuration is now saved to
-     <filename>smt-export.<replaceable>XXXXXX</replaceable>.tar.gz</filename>. Copy the file to a
-     location that can be accessed by the new &rmt; server.
+     <filename>smt-export.<replaceable>XXXXXX</replaceable>.tar.gz</filename>.
+     Copy the file to a location that can be accessed by the new &rmt; server.
     </para>
    </step>
   </procedure>
@@ -586,8 +586,8 @@
    </step>
    <step>
     <para>
-     Copy the exported <literal>.tar.gz</literal> file to an empty
-     directory, unpack it, then enter it:
+     Copy the exported <literal>.tar.gz</literal> file to an empty directory
+     and unpack it. The enter the new directory:
     </para>
 <screen>&prompt.user;<command>mkdir <replaceable>EMPTY_DIR</replaceable></command>
 &prompt.user;<command>cd <replaceable>EMPTY_DIR</replaceable></command>
@@ -627,16 +627,16 @@
    </step>
    <step>
     <para>
-     Optional: If the URL of the &rmt; server changed, change the URL
-     parameter of clients in <filename>/etc/SUSEConnect</filename> to point to the new
-     &rmt; server. Alternatively, change the DNS records to
-     re-assign the host name to the &rmt; server.
+     Optional: If the URL of the &rmt; server changed, change the URL parameter
+     of clients in <filename>/etc/SUSEConnect</filename> to point to the new
+     &rmt; server. Alternatively, change the DNS records to re-assign the host
+     name to the &rmt; server.
     </para>
    </step>
    <step>
     <para>
-     Optional: Move the mirrored repository data from &smt; to &rmt; and adjust
-     the ownership of the copied data.
+     Optional: Move the mirrored repository data from &smt; to &rmt;, and
+     adjust the ownership of the copied data.
     </para>
 <screen>&prompt.sudo;<command>cp -r /var/www/htdocs/repo/* /usr/share/rmt/public/repo/</command>
 &prompt.sudo;<command>chown -R _rmt:nginx /usr/share/rmt/public/repo</command></screen>
@@ -656,9 +656,9 @@
    </step>
    <step>
     <para>
-     In case your &smt; server contains custom repositories that you would
-     like to mirror to the &rmt; server: Activate them before
-     mirroring (they are disabled by default).
+     In case your &smt; server contains custom repositories that you would like
+     to mirror to the &rmt; server, activate them before mirroring (they are
+     disabled by default).
     </para>
     <substeps>
      <step>

--- a/xml/rmt_migrate_from_smt.xml
+++ b/xml/rmt_migrate_from_smt.xml
@@ -640,6 +640,13 @@
     </para>
 <screen>&prompt.sudo;<command>cp -r /var/www/htdocs/repo/* /usr/share/rmt/public/repo/</command>
 &prompt.sudo;<command>chown -R _rmt:nginx /usr/share/rmt/public/repo</command></screen>
+<tip>
+ <para>
+  The path for storing custom repositories' data on the &rmt; server is different
+  from that of &smt;. With &rmt;, it replicates the directory structure of the
+  source server's URL into a top level directory. For example TBD
+ </para>
+</tip>
    </step>
    <step>
     <para>

--- a/xml/rmt_migrate_from_smt.xml
+++ b/xml/rmt_migrate_from_smt.xml
@@ -569,7 +569,7 @@
    <step>
     <para>
      The exported configuration is now saved to
-     <filename>smt-export.<replaceable>XXXXXX</replaceable>.tar.gz</filename>.
+     <filename>smt-export.<replaceable>TIMESTAMP</replaceable>.tar.gz</filename>.
      Copy the file to a location that can be accessed by the new &rmt; server.
     </para>
    </step>


### PR DESCRIPTION
### Description

Added a tip and example of URL translation for custom repositories on RMT server

### Are there any relevant issues/feature requests?

* bsc#1176528

### Is this feature exclusive to SLE 15 SP3 (or Leap 15.3)?

We are currently **only merging documentation relevant for SLE 15 SP2**
(and Leap 15.2) or lower.

- [ ] This PR only applies to SLE 15 SP3 or higher
- [x] This PR applies to older releases as well.


### Are backports required?

- [x] To maintenance/SLE15SP2
- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP2
