### PR TITLE
Add a warning about profile permissions

### DIFF
--- a/xml/ay_create_control_file.xml
+++ b/xml/ay_create_control_file.xml
@@ -107,6 +107,7 @@
       the complete system configuration by running <command>sudo yast
       clone_system</command> from the command line.
      </para>
+
      <para>
       Both methods will create the file
       <filename>/root/autoinst.xml</filename>. The version created on the
@@ -116,6 +117,13 @@
       similar, but not identical. This can be done by adjusting the profile
       using your favorite text/XML editor.
      </para>
+
+     <warning>
+      <para>
+       Beware that the profile might contain sensitive information.
+      </para>
+     </warning>
+
     <para>
      With some exceptions, almost all resources of the control file can be
      configured using the configuration management system. The system offers

--- a/xml/ay_create_control_file.xml
+++ b/xml/ay_create_control_file.xml
@@ -119,8 +119,14 @@
      </para>
 
      <warning>
+     <title>Sensitive Data in Profiles</title>
       <para>
-       Beware that the profile might contain sensitive information.
+       Beware that the profile might contain sensitive information such as
+       password hashes and registration keys.
+      </para>
+      <para>
+       Carefully review the exported profiles and make sure to keep file permissions
+       restrictive.
       </para>
      </warning>
 


### PR DESCRIPTION
### Description

Just a warning about having sensitive information in the `autoinst.xml` file.


### Are there any relevant issues/feature requests?

* [bsc#1174202](https://bugzilla.suse.com/show_bug.cgi?id=1174202)

### Is this feature exclusive to SLE 15 SP3 (or Leap 15.3)?

We are currently **only merging documentation relevant for SLE 15 SP2**
(and Leap 15.2) or lower.

- [x] This PR only applies to SLE 15 SP3 or higher
- [x] This PR applies to older releases as well.


### Are backports required?

- [x] To maintenance/SLE15SP2
- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP2
