### PR TITLE
Duplicated note about restarting kdump service (bsc#1176838)

### DIFF
--- a/xml/tuning_kexec.xml
+++ b/xml/tuning_kexec.xml
@@ -734,7 +734,7 @@ cio_ignore=all,!da5d,!f500-f502</screen>
      <para>
       After making changes to the <filename>/etc/sysconfig/kdump</filename>
       file, you need to run <command>systemctl restart kdump.service</command>.
-      Otherwise, these changes will take effect next time you reboot the
+      Otherwise, the changes will only take effect next time you reboot the
       system.
      </para>
     </important>

--- a/xml/tuning_kexec.xml
+++ b/xml/tuning_kexec.xml
@@ -5,7 +5,7 @@
     %entities;
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-tuning-kexec">
- <title>Kexec and Kdump</title>
+ <title>&kexec; and &kdump;</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -729,6 +729,15 @@ cio_ignore=all,!da5d,!f500-f502</screen>
      <envar>KDUMP_COMMANDLINE_APPEND</envar> variable in
      <filename>/etc/sysconfig/kdump</filename>.
     </para>
+    <important>
+     <title>Changes to the &kdump; Configuration File</title>
+     <para>
+      After you make changes to the <filename>/etc/sysconfig/kdump</filename>
+      file, you need to run <command>systemctl restart kdump.service</command>.
+      Otherwise, these changes will take effect next time you reboot the
+      system.
+     </para>
+    </important>
     <example>
      <title>&kdump;: Example Configuration Using a Static IP Setup</title>
      <para>
@@ -1316,8 +1325,8 @@ PID: 9446   TASK: ffff88003a57c3c0  CPU: 1   COMMAND: "bash"
   <important>
    <title>Changes to the &kdump; Configuration File</title>
    <para>
-    You always need to execute <command>systemctl restart kdump</command> after
-    you make manual changes to <filename>/etc/sysconfig/kdump</filename>.
+    After you make changes to the <filename>/etc/sysconfig/kdump</filename>
+    file, you need to run <command>systemctl restart kdump.service</command>.
     Otherwise, these changes will take effect next time you reboot the system.
    </para>
   </important>

--- a/xml/tuning_kexec.xml
+++ b/xml/tuning_kexec.xml
@@ -732,7 +732,7 @@ cio_ignore=all,!da5d,!f500-f502</screen>
     <important>
      <title>Changes to the &kdump; Configuration File</title>
      <para>
-      After you make changes to the <filename>/etc/sysconfig/kdump</filename>
+      After making changes to the <filename>/etc/sysconfig/kdump</filename>
       file, you need to run <command>systemctl restart kdump.service</command>.
       Otherwise, these changes will take effect next time you reboot the
       system.

--- a/xml/tuning_kexec.xml
+++ b/xml/tuning_kexec.xml
@@ -1327,7 +1327,7 @@ PID: 9446   TASK: ffff88003a57c3c0  CPU: 1   COMMAND: "bash"
    <para>
     After making changes to the <filename>/etc/sysconfig/kdump</filename>
     file, you need to run <command>systemctl restart kdump.service</command>.
-    Otherwise, these changes will take effect next time you reboot the system.
+    Otherwise, the changes will only take effect next time you reboot the
    </para>
   </important>
  </sect1>

--- a/xml/tuning_kexec.xml
+++ b/xml/tuning_kexec.xml
@@ -1325,7 +1325,7 @@ PID: 9446   TASK: ffff88003a57c3c0  CPU: 1   COMMAND: "bash"
   <important>
    <title>Changes to the &kdump; Configuration File</title>
    <para>
-    After you make changes to the <filename>/etc/sysconfig/kdump</filename>
+    After making changes to the <filename>/etc/sysconfig/kdump</filename>
     file, you need to run <command>systemctl restart kdump.service</command>.
     Otherwise, these changes will take effect next time you reboot the system.
    </para>


### PR DESCRIPTION
### Description

kdump service needs to be restarted after doing manual changes to the documentation. this update duplicates that information to be abvailable where manual changes to config file is mentioned

### Are there any relevant issues/feature requests?

* bsc#1176838

### Is this feature exclusive to SLE 15 SP3 (or Leap 15.3)?

We are currently **only merging documentation relevant for SLE 15 SP2**
(and Leap 15.2) or lower.

- [ ] This PR only applies to SLE 15 SP3 or higher
- [x] This PR applies to older releases as well.


### Are backports required?

- [x] To maintenance/SLE15SP2
- [x] To maintenance/SLE15SP1
- [x] To maintenance/SLE15SP0
- [x] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
- [ ] To maintenance/SLE12SP2
