### PR TITLE
Make clear that init-scripts are different from the rest

### DIFF
--- a/xml/ay_custom_user_scripts.xml
+++ b/xml/ay_custom_user_scripts.xml
@@ -185,11 +185,21 @@
      <emphasis>init-scripts</emphasis>.
     </para>
     <para>
-     The following elements must be between the
-     &lt;scripts&gt;&lt;init-scripts
-     config:type="list"&gt;&lt;script&gt; ...
-     &lt;/script&gt;&lt;/init-scripts&gt;...&lt;/scripts&gt;
-     tags
+     Init scripts elements must be placed as follows:
+    </para>
+<screen>&lt;scripts&gt;
+    &lt;init-scripts config:type="list"&gt;
+      &lt;script&gt;
+        ...
+      &lt;/script&gt;
+    &lt;/init-scripts&gt;
+&lt;/scripts&gt;</screen>
+
+    <para>
+     Init scripts are different from the rest of script types because they are
+     not executed by &yast; but after &yast; has finished. For this reason,
+     their XML representation is different from the used by the other script
+     types.
     </para>
     <table>
      <title>Init script XML representation</title>
@@ -317,9 +327,10 @@ echo "Testing the init script" &gt;
    <sect2 xml:id="scripts-syntax">
     <title>Script XML Representation</title>
     <para>
-     The XML elements described below can be used for all the script types
-     described above, except for the <literal>chrooted</literal> element,
-     which can only be used in chroot scripts.
+     Most of the XML elements described below can be used for all the script
+     types described above, except for <emphasis>init scripts</emphasis>, whose
+     definitions can contain only a subset of these elements. See <xref
+     linkend="init-scripts" /> for further information about them.
     </para>
     <table>
      <title>Script XML Representation</title>

--- a/xml/ay_custom_user_scripts.xml
+++ b/xml/ay_custom_user_scripts.xml
@@ -197,9 +197,8 @@
 
     <para>
      Init scripts are different from the rest of script types because they are
-     not executed by &yast; but after &yast; has finished. For this reason,
-     their XML representation is different from the used by the other script
-     types.
+     not executed by &yast;, but after &yast; has finished. For this reason,
+     their XML representation is different from other script types.
     </para>
     <table>
      <title>Init script XML representation</title>


### PR DESCRIPTION
### Description

Make clear that init-scripts are different from the rest of script types and, therefore, most of the elements are not supported.

### Are there any relevant issues/feature requests?

* bsc#1176991

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [x] 15 SP3  | (`master` only)   
| [x] 15 SP2  | [ ] 
| [x] 15 SP1  | [ ] 
| [x] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [x] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
