### PR TITLE
Fix {enable,start}_firewall config types

### DIFF
--- a/xml/ay_12_migrate_15.xml
+++ b/xml/ay_12_migrate_15.xml
@@ -631,8 +631,8 @@
     configuration syntax in &ay; that has not changed:
    </para>
    <screen><![CDATA[<firewall>
- <enable_firewall>true</enable_firewall>
- <start_firewall>true</start_firewall>
+ <enable_firewall config:type="boolean">true</enable_firewall>
+ <start_firewall config:type="boolean">true</start_firewall>
  ...
 </firewall>]]></screen>
   </note>

--- a/xml/ay_firewall.xml
+++ b/xml/ay_firewall.xml
@@ -351,7 +351,7 @@
     <example>
      <title>Example firewall section</title>
      <screen>&lt;firewall&gt;
-  &lt;enable_firewall&gt;true&lt;/enable_firewall&gt;
+  &lt;enable_firewall config:type="true"&gt;true&lt;/enable_firewall&gt;
   &lt;log_denied_packets&gt;all&lt;/log_denied_packets&gt;
   &lt;default_zone&gt;external&lt;/default_zone&gt;
   &lt;zones config:type="list"&gt;


### PR DESCRIPTION
### Description

Examples regarding `start_firewall` and `enable_firewall` are wrong because the `config:type` is missing, which causes the profile to be invalid. The fix should be applied to all SLE 15 based versions documentation.

### Are there any relevant issues/feature requests?

* [bsc#1176595](https://bugzilla.suse.com/show_bug.cgi?id=1176595)

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [x] 15 SP3  | (`master` only)   
| [x] 15 SP2  | [ ] 
| [x] 15 SP1  | [ ] 
| [x] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
