### PR TITLE
AY: document the new behaviour during validation

### DIFF
--- a/xml/ay_create_control_file.xml
+++ b/xml/ay_create_control_file.xml
@@ -187,6 +187,34 @@
     describes the syntax and classes of an &ay; profile.
    </para>
 
+   <note>
+    <title>Schema Extensions</title>
+
+    <para>
+     &ay; can be extended by other products and modules, but the schema does not
+     contain the specification for those extensions. As a consequence, &ay;
+     a profile that use one of those extensions might be reported as invalid.
+    </para>
+
+    <para>
+     Thus, starting in &productname; <phrase os="osuse">15.3</phrase><phrase
+     os="sles;sled">SP3</phrase>, &ay; does not validate top-level unknown
+     sections. For example, in the example below, the
+     <literal>&lt;sap-inst&gt;</literal> is not validated. The rest is validated
+     as usual.
+    </para>
+
+    <screen>&lt;general&gt;
+  &lt;mode&gt;
+    &lt;confirm config:type="boolean"&gt;true&lt;/confirm&gt;
+  &lt;/mode&gt;
+&lt;/general&gt;
+
+&lt;sap-inst&gt;
+  &lt;!-- this section is not validated -->&gt;
+&lt;/sap-inst&gt;
+</screen>
+   </note>
 
    <para>
     Before going on with the autoinstallation, fix any errors resulting from

--- a/xml/ay_create_control_file.xml
+++ b/xml/ay_create_control_file.xml
@@ -192,14 +192,15 @@
 
     <para>
      &ay; can be extended by other products and modules, but the schema does not
-     contain the specification for those extensions. As a consequence, &ay;
-     a profile that use one of those extensions might be reported as invalid.
+     contain the specification for those extensions. As a consequence, when &ay; 
+     is given a profile that uses one of those extensions, it might report the 
+     profile as invalid.
     </para>
 
     <para>
      Thus, starting in &productname; <phrase os="osuse">15.3</phrase><phrase
      os="sles;sled">SP3</phrase>, &ay; does not validate top-level unknown
-     sections. For example, in the example below, the
+     sections, and ignores them. For example, in the example below, the
      <literal>&lt;sap-inst&gt;</literal> is not validated. The rest is validated
      as usual.
     </para>


### PR DESCRIPTION
### Description

During validation, now AutoYaST ignores unknown top-level sections. See [bsc#1177173](https://bugzilla.suse.com/show_bug.cgi?id=1177173) for the rationale.

### Are there any relevant issues/feature requests?

* bsc#1177173

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [x] 15 SP3  | (`master` only)   
| [ ] 15 SP2  | [ ] 
| [ ] 15 SP1  | [ ] 
| [ ] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
