### PR TITLE
"is_lvm_vg" must be replaced by using "type"

### DIFF
--- a/xml/ay_12_migrate_15.xml
+++ b/xml/ay_12_migrate_15.xml
@@ -462,6 +462,17 @@
     optimal way.
    </para>
   </sect2>
+
+  <sect2 xml:id="sec-ay-12vs15-partitioning-lvm">
+    <title>
+     Using the <literal>type</literal> to Define an Volume Group
+    </title>
+    <para>
+     The <literal>is_lvm_vg</literal> element has been dropped in favor of
+     setting the <literal>type</literal> to the <literal>CT_LVM</literal>
+     value. Refer to the <xref linkend="ay-partition-lvm"/> for further details.
+    </para>
+   </sect2>
  </sect1>
 
  <sect1 xml:id="sec-ay-12vs15-firewall">

--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -1177,7 +1177,7 @@
          <entry>
           <para>
            If this partition is on a logical volume in a volume group, specify
-           the logical volume name here (see the <literal>is_lvm_vg</literal>
+           the logical volume name here (see the <literal>type</literal>
            parameter in the drive configuration).
           </para>
           <screen>&lt;lv_name&gt;opt_lv&lt;/lv_name&gt;</screen>
@@ -1891,7 +1891,7 @@
   &lt;/drive&gt;
   &lt;drive&gt;
     &lt;device&gt;/dev/system&lt;/device&gt;
-      &lt;is_lvm_vg config:type="boolean"&gt;true&lt;/is_lvm_vg&gt;
+      &lt;type config:type="symbol"&gt;CT_LVM&lt;/type&gt;
       &lt;partitions config:type="list"&gt;
         &lt;partition&gt;
           &lt;filesystem config:type="symbol"&gt;ext4&lt;/filesystem&gt;


### PR DESCRIPTION
### Description

The `is_lvm_vg` element was dropped in SLE 15 but we did not mention this fact in the documentation.

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [x] 15 SP3  | (`master` only)   
| [x] 15 SP2  | [ ] 
| [x] 15 SP1  | [ ] 
| [x] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
