### PR TITLE
version/architecuture of an extension is not mandatory

### DIFF
--- a/xml/ay_registration_extensions.xml
+++ b/xml/ay_registration_extensions.xml
@@ -421,6 +421,10 @@ x509 -noout -fingerprint -sha256</screen>
    be specified in the profile, including the registration key. Otherwise the
    registration would fail.
  </para>
+  <para>
+   Architecture and version of an extension is not mandatory. The registration
+   workflow will evaluate the right one.
+ </para> 
 </note>
 
     <para>

--- a/xml/ay_registration_extensions.xml
+++ b/xml/ay_registration_extensions.xml
@@ -422,7 +422,7 @@ x509 -noout -fingerprint -sha256</screen>
    registration would fail.
  </para>
   <para>
-   Architecture and version of an extension is not mandatory. The registration
+   Architecture and version of an extension are not mandatory. The registration
    workflow will evaluate the right one.
  </para> 
 </note>


### PR DESCRIPTION
### Description

Describe the overall goals of this pull request.
AY registration section: version/architecture of an extension is not mandatory.

### Are there any relevant issues/feature requests?

* jsc#SLE-16225


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [ ] 15 SP3  | (`master` only)   

