### PR TITLE
Described accessing / partition from emergency shell (bsc#1171581)

### DIFF
--- a/xml/storage_multipath.xml
+++ b/xml/storage_multipath.xml
@@ -4643,6 +4643,32 @@ Give root password for maintenance
      </para>
     </listitem>
    </itemizedlist>
+   <important>
+    <para>
+     At this stage, you are working in a <command>dracut</command> emergency
+     shell inside initrd. All modification resulting from the following
+     procedures will be lost at the next reboot. To make them persistent, you
+     need to either:
+    </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+       <command>chroot</command> to the system root <filename>/</filename> file
+       system from the dracut emergency shell. You may need to mount the
+       <filename>/proc</filename>, <filename>/sys</filename>, and
+       <filename>/dev</filename> partitions as well if dracut needs access to
+       them.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       Use the rescue mode and <command>chroot</command> to the system root
+       <filename>/</filename> file system from there. Find more information
+       about rescue mode in <xref linkend="sec-trouble-data-recover-rescue"/>.
+      </para>
+     </listitem>
+    </itemizedlist>
+   </important>
    <procedure xml:id="pro-multipath-trouble-root-blacklist">
     <title>Emergency Shell: Blacklist File Systems</title>
     <para>

--- a/xml/storage_multipath.xml
+++ b/xml/storage_multipath.xml
@@ -4617,58 +4617,91 @@ Timed out waiting for device dev-disk-by\x2duuid-c4a...cfef77d.device.
 Welcome to emergency shell
 Give root password for maintenance
 (or press Control-D to continue):</screen>
-   <para>
-    This issue occurs in the following situations:
-   </para>
-   <itemizedlist>
-    <listitem>
-     <para>
-      A non-multipath root file system is not blacklisted when multipath is
-      enabled. See
-      <xref linkend="pro-multipath-trouble-root-blacklist"
-       xrefstyle="HeadingOnPage"/>.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      On a system with a multipath root file system, multipath has been
-      enabled/disabled without rebuilding the <filename>initrd</filename>. See
-      <xref linkend="pro-multipath-trouble-root-initrd"/>.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      Network-storage drivers are missing in the <filename>initrd</filename> on
-      a system with network-attached storage and multipath enabled.
-     </para>
-    </listitem>
-   </itemizedlist>
-   <important>
     <para>
-     At this stage, you are working in a <command>dracut</command> emergency
-     shell from the initrd environment. All modification resulting from the following
-     procedures will be lost at the next reboot. To make them persistent, you
-     need to either:
+     At this stage, you are working in a temporary <command>dracut</command>
+     emergency shell from the initrd environment. To make the configuration
+     changes described below persistent, you need to perform them in the
+     in the environment of the installed system.
     </para>
-    <itemizedlist>
-     <listitem>
+    <important>
+     <para>
+      As a general rule, rebuild <filename>initrd</filename> whenever
+      you make changes to <filename>multipath.conf</filename>.
+     </para>
+    </important>
+    <procedure>
+     <step>
       <para>
-       Mount the system root (<filename>/</filename>) file system and
-       <command>chroot</command> to it from the <command>dracut</command> emergency shell. You may
-       need to mount the <filename>/proc</filename>, <filename>/sys</filename>,
-       and <filename>/dev</filename> partitions as well if dracut needs access
-       to them.
+       Identify what the system root (<filename>/</filename>) file system is.
+       For help, see devices under <filename>/dev/disk/by-uuid</filename>,
+       <filename>/dev/disk/by-id</filename>, or
+       <filename>/dev/disk/by-path</filename>.
       </para>
-     </listitem>
-     <listitem>
+     </step>
+     <step>
       <para>
-       Use the rescue mode and <command>chroot</command> to the system root
-       (<filename>/</filename>) file system from there. Find more information
-       about rescue mode in <xref linkend="sec-trouble-data-recover-rescue"/>.
+       Verify whether the root file system is mounted by using the
+       <command>mount</command> command's output and mount it if needed.
       </para>
-     </listitem>
-    </itemizedlist>
-   </important>
+      <tip>
+       <para>
+        <command>dracut</command> mounts the root file system under
+        <filename>/sysroot</filename> by default.
+       </para>
+      </tip>
+      <para>
+       From now on, let us assume that the root file system is mounted under
+       <filename>/sysroot</filename>.
+      </para>
+     </step>
+     <step>
+      <para>
+       <command>chroot</command> into the <filename>/sysroot</filename>
+       mount point to access the installed system properly. Refer to
+       <xref linkend="sec-trouble-data-recover-rescue-access"/> for more
+       details.
+      </para>
+     </step>
+     <step>
+      <para>
+       Select the right scenario why the system escaped to the emergency shell
+       and follow the related procedure:
+      </para>
+      <itemizedlist>
+       <listitem>
+        <para>
+         A non-multipath root file system is not blacklisted when multipath is
+         enabled. See
+         <xref linkend="pro-multipath-trouble-root-blacklist"
+          xrefstyle="HeadingOnPage"/>.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         On a system with a multipath root file system, multipath has been
+         enabled/disabled without rebuilding the <filename>initrd</filename>. See
+         <xref linkend="pro-multipath-trouble-root-initrd"/>.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
+         Network-storage drivers are missing in the <filename>initrd</filename> on
+         a system with network-attached storage and multipath enabled. See
+         <xref linkend="pro-multipath-trouble-root-drivers"/>.
+        </para>
+       </listitem>
+      </itemizedlist>
+     </step>
+     <step>
+      <para>
+       Exit the <command>chroot</command> environment by entering the
+       <command>exit</command> command, then exit the emergency shell and
+       reboot the server by pressing <keycombo><keycap function="control"/>
+       <keycap>D</keycap></keycombo>.
+      </para>
+     </step>
+    </procedure>
+
    <procedure xml:id="pro-multipath-trouble-root-blacklist">
     <title>Emergency Shell: Blacklist File Systems</title>
     <para>
@@ -4705,12 +4738,6 @@ Dec 18 10:10:03 | 3600508b1001030343841423043300400: ignoring map</screen>
       <xref linkend="sec-multipath-blacklist"/>.
      </para>
     </step>
-    <step>
-     <para>
-      Exit the emergency shell and reboot the server by pressing <keycombo>
-      <keycap function="control"/> <keycap>D</keycap> </keycombo>.
-     </para>
-    </step>
    </procedure>
    <procedure xml:id="pro-multipath-trouble-root-initrd">
     <title>Emergency Shell: Rebuild the <filename>initrd</filename></title>
@@ -4730,12 +4757,6 @@ Dec 18 10:10:03 | 3600508b1001030343841423043300400: ignoring map</screen>
       rebuild the initrd with Multipath support with this command:
      </para>
 <screen>&prompt.user;dracut --force -o multipath</screen>
-    </step>
-    <step>
-     <para>
-      Exit the emergency shell and reboot the server by pressing <keycombo>
-      <keycap function="control"/> <keycap>D</keycap> </keycombo>.
-     </para>
     </step>
    </procedure>
    <procedure xml:id="pro-multipath-trouble-root-drivers">
@@ -4769,12 +4790,6 @@ Dec 18 10:10:03 | 3600508b1001030343841423043300400: ignoring map</screen>
       network storage fails, it is recommended to add the mount option
       <literal>_netdev</literal> to the respective entries in
       <filename>/etc/fstab</filename>.
-     </para>
-    </step>
-    <step>
-     <para>
-      Exit the emergency shell and reboot the server by pressing <keycombo>
-      <keycap function="control"/> <keycap>D</keycap> </keycombo>.
      </para>
     </step>
    </procedure>

--- a/xml/storage_multipath.xml
+++ b/xml/storage_multipath.xml
@@ -4646,7 +4646,7 @@ Give root password for maintenance
    <important>
     <para>
      At this stage, you are working in a <command>dracut</command> emergency
-     shell inside initrd. All modification resulting from the following
+     shell from the initrd environment. All modification resulting from the following
      procedures will be lost at the next reboot. To make them persistent, you
      need to either:
     </para>

--- a/xml/storage_multipath.xml
+++ b/xml/storage_multipath.xml
@@ -4623,26 +4623,19 @@ Give root password for maintenance
      changes described below persistent, you need to perform them in the
      in the environment of the installed system.
     </para>
-    <important>
-     <para>
-      As a general rule, rebuild <filename>initrd</filename> whenever
-      you make changes to <filename>multipath.conf</filename>.
-     </para>
-    </important>
     <procedure>
      <step>
       <para>
        Identify what the system root (<filename>/</filename>) file system is.
-       For help, see devices under <filename>/dev/disk/by-uuid</filename>,
-       <filename>/dev/disk/by-id</filename>, or
-       <filename>/dev/disk/by-path</filename>.
+       Inspect the content of the <filename>/proc/cmdline</filename> and
+       look for the <option>root=</option> parameter.
       </para>
      </step>
      <step>
       <para>
-       Verify whether the root file system is mounted by using the
-       <command>mount</command> command's output and mount it if needed.
+       Verify whether the root file system is mounted:
       </para>
+<screen>&prompt.sudo;systemctl status sysroot.mount</screen>
       <tip>
        <para>
         <command>dracut</command> mounts the root file system under
@@ -4656,41 +4649,26 @@ Give root password for maintenance
      </step>
      <step>
       <para>
-       <command>chroot</command> into the <filename>/sysroot</filename>
-       mount point to access the installed system properly. Refer to
-       <xref linkend="sec-trouble-data-recover-rescue-access"/> for more
-       details.
+       Mount system-required file systems under <filename>/sysroot</filename>,
+       <command>chroot</command> into it, then mount all file systems.
+       For example:
+      </para>
+<screen>
+&prompt.sudo;for x in proc sys dev run; do mount --bind /$x /sysroot/$x; done
+&prompt.sudo;chroot /sysroot /bin/bash
+&prompt.sudo;mount -a
+</screen>
+      <para>
+       Refer to <xref linkend="sec-trouble-data-recover-rescue-access"/> for
+       more details.
       </para>
      </step>
      <step>
       <para>
-       Select the right scenario why the system escaped to the emergency shell
-       and follow the related procedure:
+       Make changes to the multipath or dracut configuration as suggested
+       in the procedures below. Remember to rebuild <filename>initrd</filename>
+       to include the modifications.
       </para>
-      <itemizedlist>
-       <listitem>
-        <para>
-         A non-multipath root file system is not blacklisted when multipath is
-         enabled. See
-         <xref linkend="pro-multipath-trouble-root-blacklist"
-          xrefstyle="HeadingOnPage"/>.
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         On a system with a multipath root file system, multipath has been
-         enabled/disabled without rebuilding the <filename>initrd</filename>. See
-         <xref linkend="pro-multipath-trouble-root-initrd"/>.
-        </para>
-       </listitem>
-       <listitem>
-        <para>
-         Network-storage drivers are missing in the <filename>initrd</filename> on
-         a system with network-attached storage and multipath enabled. See
-         <xref linkend="pro-multipath-trouble-root-drivers"/>.
-        </para>
-       </listitem>
-      </itemizedlist>
      </step>
      <step>
       <para>
@@ -4737,6 +4715,12 @@ Dec 18 10:10:03 | 3600508b1001030343841423043300400: ignoring map</screen>
       previous step. For more information see
       <xref linkend="sec-multipath-blacklist"/>.
      </para>
+    </step>
+    <step>
+     <para>
+      Rebuild the <systemitem>initrd</systemitem> using the following command:
+     </para>
+<screen>&prompt.user;dracut -f --add-multipath</screen>
     </step>
    </procedure>
    <procedure xml:id="pro-multipath-trouble-root-initrd">

--- a/xml/storage_multipath.xml
+++ b/xml/storage_multipath.xml
@@ -4653,8 +4653,8 @@ Give root password for maintenance
     <itemizedlist>
      <listitem>
       <para>
-       Mount the system root <filename>/</filename> file system and
-       <command>chroot</command> to it from the dracut emergency shell. You may
+       Mount the system root (<filename>/</filename>) file system and
+       <command>chroot</command> to it from the <command>dracut</command> emergency shell. You may
        need to mount the <filename>/proc</filename>, <filename>/sys</filename>,
        and <filename>/dev</filename> partitions as well if dracut needs access
        to them.
@@ -4663,7 +4663,7 @@ Give root password for maintenance
      <listitem>
       <para>
        Use the rescue mode and <command>chroot</command> to the system root
-       <filename>/</filename> file system from there. Find more information
+       (<filename>/</filename>) file system from there. Find more information
        about rescue mode in <xref linkend="sec-trouble-data-recover-rescue"/>.
       </para>
      </listitem>

--- a/xml/storage_multipath.xml
+++ b/xml/storage_multipath.xml
@@ -4653,11 +4653,11 @@ Give root password for maintenance
     <itemizedlist>
      <listitem>
       <para>
-       <command>chroot</command> to the system root <filename>/</filename> file
-       system from the dracut emergency shell. You may need to mount the
-       <filename>/proc</filename>, <filename>/sys</filename>, and
-       <filename>/dev</filename> partitions as well if dracut needs access to
-       them.
+       Mount the system root <filename>/</filename> file system and
+       <command>chroot</command> to it from the dracut emergency shell. You may
+       need to mount the <filename>/proc</filename>, <filename>/sys</filename>,
+       and <filename>/dev</filename> partitions as well if dracut needs access
+       to them.
       </para>
      </listitem>
      <listitem>


### PR DESCRIPTION
### Description

To not lose changes made from dracut emergency shell, you need to mount and chroot the system root file system.

Rendered version attached (section 17.15.2)
[sec-multipath-trouble_color_en.pdf](https://github.com/SUSE/doc-sle/files/5465239/sec-multipath-trouble_color_en.pdf)



### Are there any relevant issues/feature requests?

* bsc#1171581

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [x] 15 SP3  | (`master` only)   
| [x] 15 SP2  | [ ] 
| [x] 15 SP1  | [ ] 
| [x] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [x] 12 SP5  | [ ] 
| [x] 12 SP4  | [ ] 
| [x] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
