### PR TITLE
Removed section on lvmetad (bsc#1177006)

### DIFF
--- a/xml/storage_lvm.xml
+++ b/xml/storage_lvm.xml
@@ -1581,7 +1581,7 @@ sudo lvreduce /dev/LOCAL/DATA</screen>
     </para>
    </tip>
   </sect2>
-
+  <!-- 2020-11-04 tbazant: lvmetad removed since 15SP2 (bsc#1177006)
   <sect2 xml:id="sec-lvm-cli-lvmetad">
    <title>Dynamic Aggregation of LVM Metadata via <systemitem class="daemon">lvmetad</systemitem></title>
    <para>
@@ -1639,7 +1639,7 @@ sudo lvreduce /dev/LOCAL/DATA</screen>
      With the <systemitem>lvmetad</systemitem> daemon running, the
      <literal>filter =</literal> setting in the
      <filename>/etc/lvm/lvm.conf</filename> file does not apply when the
-     <command>pvscan --cache device</command> command is executed. To filter
+     <command>pvscan \-\-cache device</command> command is executed. To filter
      devices, it is necessary to use the <literal>the global_filter =</literal>
      setting. Devices that are skipped by the global filter are not opened by
      LVM and are never scanned.
@@ -1654,6 +1654,7 @@ sudo lvreduce /dev/LOCAL/DATA</screen>
     </para>
    </important>
   </sect2>
+-->
 
   <sect2 xml:id="sec-lvm-cli-lvmcache">
    <title>Using LVM Cache Volumes</title>


### PR DESCRIPTION
### Description

`lvmetad` was removed from SLE, therefore it needs to be removed from the Storage Guide as well


### Are there any relevant issues/feature requests?

* bsc#1177006


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [x] 15 SP3  | (`master` only)   
| [x] 15 SP2  | [ ] 
| [ ] 15 SP1  | [ ] 
| [ ] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
