### PR TITLE
Moving xen2kvm to libvirt part

### DIFF
--- a/xml/book_sle_virtualization.xml
+++ b/xml/book_sle_virtualization.xml
@@ -66,6 +66,7 @@
   <xi:include href="libvirt_configuration_gui.xml"/>
   <xi:include href="libvirt_configuration_virsh.xml"/>
   <xi:include href="libvirt_management_vagrant.xml"/>
+  <xi:include href="xen2kvm.xml"/>
  </part>
 
 <!-- ===================================================================== -->
@@ -126,7 +127,6 @@
 <!-- ===================================================================== -->
  <xi:include href="vt_glossary.xml"/>
  <xi:include os="sles;sled" href="vmdp_drivers.xml"/>
- <xi:include href="xen2kvm.xml"/>
  <xi:include href="xen_xmtoxl.xml"/>
  <!--taroth 2019-01-18: commenting docupdates for now
      as discussed in doc team meeting-->

--- a/xml/xen2kvm.xml
+++ b/xml/xen2kvm.xml
@@ -4,7 +4,7 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-<appendix xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="xen2kvm-migration">
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="xen2kvm-migration">
  <title>&xen; to &kvm; Migration Guide</title>
  <para>
   As the &kvm; virtualization solution is becoming more and more popular among
@@ -1131,4 +1131,4 @@ getty@xvc1.service -&gt; /usr/lib/systemd/system/getty@xvc1.service
    <link xlink:href="https://documentation.suse.com/"/>.
   </para>
  </sect1>
-</appendix>
+</chapter>


### PR DESCRIPTION
### Description

the xen2kvm guide was previously wrongly moved to an appendix, now targeting it to the correct place in libvirt



### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [x] 15 SP3  | (`master` only)   
| [ ] 15 SP2  | [ ] 
| [ ] 15 SP1  | [ ] 
| [ ] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
