### PR TITLE
Create sections on setting up a testing instance for 389ds

### DIFF
--- a/xml/security_ldap.xml
+++ b/xml/security_ldap.xml
@@ -553,7 +553,7 @@ binddn = cn=Directory Manager
       <para>
         <literal>ldapi</literal> detects the UID and GID of the user attempting 
         to log in to the server. If the UID/GID are <literal>0/0</literal> or
-        <literal>dirsrv:dirsv</literal>, <literal>ldapi</literal> binds the user 
+        <literal>dirsrv:dirsrv</literal>, <literal>ldapi</literal> binds the user 
         as the directory server root dn, which is 
         <literal>cn=Directory Manager</literal>.
       </para>

--- a/xml/security_ldap.xml
+++ b/xml/security_ldap.xml
@@ -307,20 +307,21 @@ objectclass (2.16.840.1.113730.3.2.333 NAME 'nsPerson' <co xml:id="co-ldap-schem
     </para>
     <screen>&prompt.sudo;zypper install 389-ds</screen>
     <para>
-     After installation, you can set up the server either manually
-     <phrase os="sles;osuse">(as described in <xref linkend="sec-security-ldap-server"
-      xrefstyle="select:label"/>)</phrase> or create a
+     After installation, you can set up the server 
+     <phrase os="sles;osuse">as described in <xref linkend="sec-security-ldap-server"
+      xrefstyle="select:label"/>.</phrase>      
+     <!--or create a
      very basic setup with &yast; <phrase os="sles;osuse">(as described in
       <xref linkend="sec-security-ldap-server-yast"
-      xrefstyle="select:label"/>)</phrase>.
+     xrefstyle="select:label"/>)</phrase>.-->
     </para>
  </sect1>
 
  <sect1 xml:id="sec-security-ldap-server">
-  <title>Setting up a &ds389; Test Instance</title>
+  <title>Setting up a &ds389; Testing and Development Instance</title>
   <para>
-   Follow these steps to set up a simple test instance, populated with a small
-   set of sample entries.
+   Follow these steps to set up a simple instance for testing and development, 
+   populated with a small set of sample entries.
   </para>
   <procedure>
    <step>
@@ -331,10 +332,10 @@ objectclass (2.16.840.1.113730.3.2.333 NAME 'nsPerson' <co xml:id="co-ldap-schem
    </step>
     <!-- <step>
   <para>
-     Using CA Certificates for TSL Connections
+     Using CA Certificates for TLS Connections
       <xref linkend="sec-security-ldap-server-ca" xrefstyle="select:title"/>
     </para>
-    </step>-->
+    </step> -->
    <step>
     <para>
      <!--Configuring Admin Credentials for Local Access-->
@@ -398,14 +399,14 @@ objectclass (2.16.840.1.113730.3.2.333 NAME 'nsPerson' <co xml:id="co-ldap-schem
     </varlistentry>
   </variablelist>
 
-  <sect2 xml:id="sec-security-ldap-server-instance" >
-  <title>Creating a &ds389; Instance with an .inf File</title>
+  <sect2 xml:id="sec-security-ldap-server-instance">
+  <title>Creating a &ds389; Instance with a Custom Configuration File</title>
     <para>
      Use the <command>dscreate</command> command to create a new &ds389; instance.
      There are several ways to create a new instance: interactively, from a 
-     template file, using &yast;, and using a custom configuration file.
+     template file, and using a custom configuration file.
      In this section you will learn how to use a custom configuration file. This 
-     file must have an <filename>.inf</filename> extension. 
+     file must be in the INF format. You may name it anything you like.
     </para>
     <para>
        The default instance name is <literal>localhost</literal>. The instance 
@@ -429,7 +430,7 @@ objectclass (2.16.840.1.113730.3.2.333 NAME 'nsPerson' <co xml:id="co-ldap-schem
       <screen># <replaceable>389ds-test.inf</replaceable>
           
 [general]
-config_version = 2 <co xml:id="co-ldap-389-ds-config_version"/>
+config_version = 2 <co xml:id="co-ldap-389-ds-config-version"/>
 
 [slapd]
 root_password = <replaceable>password</replaceable><co xml:id="co-ldap-389-ds-rootpasswd"/>
@@ -441,24 +442,23 @@ sample_entries = yes <co xml:id="co-ldap-389-ds-sample-entries"/>
 suffix = <replaceable>dc=test1,dc=com</replaceable></screen>
 
       <calloutlist>
-       <callout arearefs="co-ldap-389-ds-config_version">
+       <callout arearefs="co-ldap-389-ds-config-version">
         <para>
-         This line is required, indicating that this is a version 2 setup .inf
+         This line is required, indicating that this is a version 2 setup INF
          file.
         </para>
        </callout>
        <callout arearefs="co-ldap-389-ds-rootpasswd">
         <para>
          Create a <varname>root_password</varname> for
-         the directory server &rootuser; user, <literal>dirsrv</literal>. 
-         The <literal>dirsrv</literal> user has no login or shell privileges, 
-         and is used for LDAP server administration only.
+         the ldap user <literal>cn=Directory Manager</literal>. This user is for
+         connecting (binding) to the directory.
         </para>
        </callout>
        <callout arearefs="co-ldap-389-ds-cert">
         <para>
          Create self-signed server certificates in 
-         <filename>/etc/dirsrv</filename>.
+         <filename>/etc/dirsrv/slapd-<replaceable>instance-name</replaceable></filename>.
         </para>
        </callout>
        <callout arearefs="co-ldap-389-ds-sample-entries">
@@ -471,8 +471,7 @@ suffix = <replaceable>dc=test1,dc=com</replaceable></screen>
    </step>
    <step>
     <para>
-     To create the &ds389; instance from <xref linkend="ex-ldap-389-ds-inf"
-     xrefstyle="select:label"/>, run the following command:
+     To create the &ds389; instance from <xref linkend="ex-ldap-389-ds-inf" xrefstyle="select:label"/>, run the following command:
     </para>
     <screen>&prompt.sudo;dscreate -v from-file 389ds-test.inf | tee 389ds-test-output.txt</screen>
     <para>
@@ -486,7 +485,9 @@ suffix = <replaceable>dc=test1,dc=com</replaceable></screen>
    <step>
     <para>
      If the <command>dscreate</command> command should fail, the messages will 
-     tell you why. After correcting any issues, re-run the command.    
+     tell you why. After correcting any issues remove the instance 
+     (see <xref linkend="sec-security-ldap-server-remove"/>) and create a
+     new instance.    
     </para>
    </step>
    <step>
@@ -497,14 +498,20 @@ suffix = <replaceable>dc=test1,dc=com</replaceable></screen>
     <screen>&prompt.sudo;dsctl 389ds-test status
 Instance "389ds-test" is running</screen>
    </step>
-   <step>
+   <step xml:id="sec-security-ldap-server-remove">
     <para>
-     The following command cleanly removes the instance. You may reliably create 
-     and remove instances as much as you want:
+     The following commands are for cleanly removing the instance. The first 
+     command performs a dry-run and does not remove the instance. When are you 
+     sure you want to remove it, use the second command with the
+     <command>--do-it</command> option:
     </para>
-    <screen>&prompt.sudo;dsctl 389ds-test remove --do-it</screen>
+    <screen>&prompt.sudo;dsctl 389ds-test remove
+Not removing: if you are sure, add --do-it
+
+&prompt.sudo;dsctl 389ds-test remove --do-it</screen>
     <para>
-     This command also removes partially-installed or corrupted instances.
+     This command also removes partially-installed or corrupted instances. You 
+     may reliably create and remove instances as much as you want.
     </para>
    </step>
   </procedure>
@@ -523,7 +530,7 @@ Instance "389ds-test" is running</screen>
    <para>
      After creating your <filename>/root/.dsrc</filename> file, try a few
      administration commands, such as creating new users (see 
-     <xref linkend="sec-security-ldap-server-users"/>.
+     <xref linkend="sec-security-ldap-server-users"/>).
    </para>
    <example xml:id="ex-security-ldap-server-credentials-local">
     <title>A <filename>.dsrc</filename> File for Local Administration</title>
@@ -539,22 +546,16 @@ binddn = cn=Directory Manager
     <callout arearefs="co-ldap-server-dsrc-instance-name">
       <para>
         This must specify the instance name that you created in your
-        <filename>.inf</filename> file.
+        INF file.
       </para>
     </callout>       
     <callout arearefs="co-ldap-server-dsrc-remote-ldapi">
       <para>
         <literal>ldapi</literal> detects the UID and GID of the user attempting 
-        to log in to the server. If the UID/GID are <literal>0/0</literal>,
-        <literal>ldapi</literal> binds the system root user (or sudo user) as 
-        the directory server root dn, which is 
-        <literal>cn=Directory Manager</literal>. If the UID/GID are not 
-        <literal>0/0</literal> then the user is not allowed to log into the server.
-      </para>
-      <para>
-        This has the benefit of protecting the ldap root password; the root user
-        can create the password, and then sudo users never need to know the 
-        password.
+        to log in to the server. If the UID/GID are <literal>0/0</literal> or
+        <literal>dirsrv:dirsv</literal>, <literal>ldapi</literal> binds the user 
+        as the directory server root dn, which is 
+        <literal>cn=Directory Manager</literal>.
       </para>
       <para>
         In the URI the slashes are replaced with <literal>%%2f</literal>, so
@@ -564,7 +565,7 @@ binddn = cn=Directory Manager
     </callout>
    </calloutlist>
   </example>
-        <para>
+ <!-- WIP, need to address privileges more completely cschroder 23-11-2020      <para>
         You may also copy <filename>.dsrc</filename> to your home directory, for
         running commands that do not need root privileges, such as listing 
         users and groups:
@@ -574,9 +575,9 @@ demo_user
 &prompt.user;dsidm 389ds-test group list
 demo_group</screen>
      <para>
-       If you run a command that requires root privileges, such as creating
+       If you run a command that requires elevated privileges, such as creating
        new users, you will see an "Error: Insufficient access" message.
-     </para>
+  </para> -->
  </sect2>
 
  <sect2 xml:id="sec-security-ldap-server-users">
@@ -790,7 +791,7 @@ systemctl start sssd</screen>
 
 <!-- default installation uses self-signed cert -->
  <sect1 xml:id="sec-security-ldap-server-ca">
- <title>Using CA Certificates for TSL</title>
+ <title>Using CA Certificates for TLS</title>
  <para>
   You can manage the CA certificates for &ds389; with the following command
   line tools: <command>certutil</command>, <command>openssl</command>, and
@@ -810,7 +811,7 @@ systemctl start sssd</screen>
  <itemizedlist>
   <listitem>
    <para>
-    You have a server certificate and a private key to use for the TSL connection.
+    You have a server certificate and a private key to use for the TLS connection.
    </para>
   </listitem>
   <listitem>
@@ -886,6 +887,7 @@ systemctl start sssd</screen>
   <para>
    You can use &yast; to quickly create a very basic setup of the &ds389;.
   </para>
+  
  <sect2 xml:id="sec-security-ldap-server-yast-create">
   <title>Creating a &ds389; Instance with &yast;</title>
   <procedure>
@@ -987,20 +989,20 @@ systemctl start sssd</screen>
     to find the log files.
    </para>
   </step>
-  </procedure>
+ </procedure>
 
  <!--taroth 2020-01-28: disabling reference to commented section-->
  <!--
  <para>
   After you have created the instance, you can configure LDAP users and groups
   as shown in <xref linkend="sec-security-ldap-yast-usergr" xrefstyle="select:label"/>.
- </para>-->
+ </para>
  <para>
   The setup with &yast; provides only a very basic configuration of the &ds389;.
   To fine-tune more settings, see <xref linkend="sec-security-ldap-server"/>
   or the documentation mentioned in <xref linkend="sec-security-ldap-info"/>.
  </para>
-</sect2>
+</sect2> -->
 
 <!--taroth 2020-01-27: commenting this section for now as agreed with firstyear-->
 <!--<sect2 xml:id="sec-security-ldap-yast-usergr">
@@ -1098,9 +1100,9 @@ systemctl start sssd</screen>
    set of available users. Alternatively open the module for configuring
    LDAP users and groups by selecting <guimenu>LDAP User and Group
    Configuration</guimenu>.
-  </para>
- </sect2>
--->
+  </para>-->
+ </sect2> 
+
 <sect2 xml:id="sec-security-ldap-yast-client">
   <title>Configuring an LDAP Client with &yast;</title>
   <para>
@@ -1155,12 +1157,12 @@ systemctl start sssd</screen>
     </informalfigure>
    </step>
    <step>
-    <para>
+ <para> -->
      <!--
       wbrown 2019-02-25: URLs or hostnames only. IP address would break TLS
       cn/san checking.
      -->
-     Specify one or more LDAP server URLs or host names under
+  Specify one or more LDAP server URLs or host names under
      <guimenu>Enter LDAP server locations</guimenu>. For security reasons, we
      recommend to use <literal>LDAPS://</literal> URLs only. When specifying
      multiple addresses, separate them with spaces.
@@ -1257,13 +1259,13 @@ systemctl start sssd</screen>
        <para>
         When using authentication without enabling transport encryption
         using TLS or StartTLS, the password will be transmitted in the clear.
-       </para>
+        </para>
        <!--for the records:
         sknorr, 2017-03-01: Is the YaST dialog compatible with SASL in any way?
         wbrown 2019-02-26: SASL is too complicated for a setup like this,
         not worth including.
        -->
-      </warning>
+     </warning>
      </listitem>
     </itemizedlist>
     <para>
@@ -1287,7 +1289,7 @@ systemctl start sssd</screen>
     </para>
    </step>
   </procedure>
- </sect2>
+  </sect2> 
 </sect1>
 
  <sect1 xml:id="sec-security-ldap-data" os="sles;osuse">

--- a/xml/security_ldap.xml
+++ b/xml/security_ldap.xml
@@ -303,8 +303,8 @@ objectclass (2.16.840.1.113730.3.2.333 NAME 'nsPerson' <co xml:id="co-ldap-schem
   <title>Installing the Software for &ds389;</title>
    <para>
     The <systemitem>389-ds</systemitem> package contains the &ds389; and the
-    administration tools. If the package is not installed yet, install it with
-    the following command:</para>
+    administration tools. Install it with the following command:
+    </para>
     <screen>&prompt.sudo;zypper install 389-ds</screen>
     <para>
      After installation, you can set up the server either manually
@@ -316,10 +316,11 @@ objectclass (2.16.840.1.113730.3.2.333 NAME 'nsPerson' <co xml:id="co-ldap-schem
     </para>
  </sect1>
 
- <sect1 xml:id="sec-security-ldap-server" os="sles;osuse">
-  <title>Manually Configuring a &ds389;</title>
+ <sect1 xml:id="sec-security-ldap-server">
+  <title>Setting up a &ds389; Test Instance</title>
   <para>
-   Setting up the &ds389; takes the following basic steps:
+   Follow these steps to set up a simple test instance, populated with a small
+   set of sample entries.
   </para>
   <procedure>
    <step>
@@ -328,15 +329,15 @@ objectclass (2.16.840.1.113730.3.2.333 NAME 'nsPerson' <co xml:id="co-ldap-schem
      <xref linkend="sec-security-ldap-server-instance" xrefstyle="select:title"/>
     </para>
    </step>
-   <step>
-    <para>
-     <!--Using CA Certificates for TSL Connections-->
+    <!-- <step>
+  <para>
+     Using CA Certificates for TSL Connections
       <xref linkend="sec-security-ldap-server-ca" xrefstyle="select:title"/>
     </para>
-   </step>
+    </step>-->
    <step>
     <para>
-     <!--Configuring Admin Credentials for Remote/Local Access-->
+     <!--Configuring Admin Credentials for Local Access-->
       <xref linkend="sec-security-ldap-server-credentials" xrefstyle="select:title"/>
     </para>
    </step>
@@ -398,266 +399,195 @@ objectclass (2.16.840.1.113730.3.2.333 NAME 'nsPerson' <co xml:id="co-ldap-schem
   </variablelist>
 
   <sect2 xml:id="sec-security-ldap-server-instance" >
-  <title>Creating the &ds389; Instance</title>
+  <title>Creating a &ds389; Instance with an .inf File</title>
     <para>
-     You create the instance with the <command>dscreate</command> command.
-     It can take a configuration file (<filename>*.inf</filename>) which
-     defines the instance configuration settings. Alternatively, the command can
-     be run interactively.
+     Use the <command>dscreate</command> command to create a new &ds389; instance.
+     There are several ways to create a new instance: interactively, from a 
+     template file, using &yast;, and using a custom configuration file.
+     In this section you will learn how to use a custom configuration file. This 
+     file must have an <filename>.inf</filename> extension. 
     </para>
-    <note>
-     <title>Instance Name</title>
-      <para>
-       If not specified otherwise, the default instance name is
-       <literal>localhost</literal>. The instance name cannot
-       be changed after the instance has been created.</para>
-     <para>
-      To check the name of an instance you have not created yourself, use
-      the <command>dsctl -l</command> command.</para>
-    </note>
+    <para>
+       The default instance name is <literal>localhost</literal>. The instance 
+       name cannot be changed after it has been created. It is better
+       to create your own instance name, rather than using the default, to avoid 
+       confusion and to enable a better understanding of how it all works.
+    </para>
     <para>
      <xref linkend="ex-ldap-389-ds-inf" xrefstyle="select:label"/> shows an
-     example configuration file that you can use as a starting point. Alternatively,
-     use <command>dscreate create-template</command> to create a template
-     <filename>*.inf</filename> file. The template is commented and pre-filled,
-     so you can adjust its variables to your needs. For more details, see the
-     man page of <command>dscreate</command>.
+     example configuration file that you can use to create a new &ds389; instance.
+     You may copy and use this file, though be sure to create your own password.
     </para>
    <procedure>
     <step>
      <para>
-      If you want to set up a trial instance, start an editor and save the
-      following as <filename>/tmp/instance.inf</filename>:
+      Copy the following example file, <filename>389ds-test.inf</filename>, to 
+      your home directory:
      </para>
      <example xml:id="ex-ldap-389-ds-inf">
-      <title>Basic Instance Configuration File</title>
-      <screen># /tmp/instance.inf
+      <title>Minimal &ds389; Instance Configuration File</title>
+      <screen># <replaceable>389ds-test.inf</replaceable>
+          
 [general]
-config_version = 2
+config_version = 2 <co xml:id="co-ldap-389-ds-config_version"/>
 
 [slapd]
-root_password = <replaceable>YOUR_PASSWORD_FOR_CN=DIRECTORY_MANAGER</replaceable><co xml:id="co-ldap-389-ds-rootpasswd"/>
+root_password = <replaceable>password</replaceable><co xml:id="co-ldap-389-ds-rootpasswd"/>
+self_sign_cert = True <co xml:id="co-ldap-389-ds-cert"/>
+instance_name = <replaceable>389ds-test</replaceable>
 
 [backend-userroot]
-sample_entries = yes
-suffix = dc=example,dc=com</screen>
+sample_entries = yes <co xml:id="co-ldap-389-ds-sample-entries"/>
+suffix = <replaceable>dc=test1,dc=com</replaceable></screen>
+
       <calloutlist>
-       <callout arearefs="co-ldap-389-ds-rootpasswd">
+       <callout arearefs="co-ldap-389-ds-config_version">
         <para>
-         Set the <varname>root_password</varname> to the password for
-         the directory server &rootuser; user. The password is used for LDAP
-         server administration only.
+         This line is required, indicating that this is a version 2 setup .inf
+         file.
         </para>
        </callout>
+       <callout arearefs="co-ldap-389-ds-rootpasswd">
+        <para>
+         Create a <varname>root_password</varname> for
+         the directory server &rootuser; user, <literal>dirsrv</literal>. 
+         The <literal>dirsrv</literal> user has no login or shell privileges, 
+         and is used for LDAP server administration only.
+        </para>
+       </callout>
+       <callout arearefs="co-ldap-389-ds-cert">
+        <para>
+         Create self-signed server certificates in 
+         <filename>/etc/dirsrv</filename>.
+        </para>
+       </callout>
+       <callout arearefs="co-ldap-389-ds-sample-entries">
+        <para>
+         Populate the new instance with sample user and group entries.
+        </para>
+       </callout>       
       </calloutlist>
      </example>
    </step>
    <step>
     <para>
      To create the &ds389; instance from <xref linkend="ex-ldap-389-ds-inf"
-     xrefstyle="select:label"/>, run:
+     xrefstyle="select:label"/>, run the following command:
     </para>
-    <screen>&prompt.sudo;dscreate from-file /tmp/instance.inf</screen>
+    <screen>&prompt.sudo;dscreate -v from-file 389ds-test.inf | tee 389ds-test-output.txt</screen>
     <para>
-     This creates a working LDAP server.
+     This shows all activity during the instance creation, stores all the messages in
+     <filename>389ds-test-output.txt</filename>, and creates a working 
+     LDAP server in about a minute. The verbose output contains a lot of useful
+     information. If you don't want to save it then delete the 
+     <literal>| tee 389ds-test-output.txt</literal> portion of the command.
     </para>
    </step>
    <step>
     <para>
-     If <command>dscreate</command> should fail, the messages will tell you why.
-     For more details, repeat the command with the <option>-v</option> option:
+     If the <command>dscreate</command> command should fail, the messages will 
+     tell you why. After correcting any issues, re-run the command.    
     </para>
-    <screen>&prompt.sudo;dscreate -v from-file /tmp/instance.inf</screen>
    </step>
    <step>
     <para>
-     Check the status of the server with:
+     A successful installation reports "<literal>Completed installation for 
+     389ds-test</literal>". Check the status of your new server:
     </para>
-    <screen>&prompt.sudo;dsctl localhost status
-instance 'Localhost' is running</screen>
+    <screen>&prompt.sudo;dsctl 389ds-test status
+Instance "389ds-test" is running</screen>
    </step>
    <step>
     <para>
-     In case you want to delete the instance later on:
+     The following command cleanly removes the instance. You may reliably create 
+     and remove instances as much as you want:
     </para>
-    <screen>&prompt.sudo;dsctl localhost remove --do-it</screen>
+    <screen>&prompt.sudo;dsctl 389ds-test remove --do-it</screen>
     <para>
-     With this command, you can also remove partially installed or corrupted
-     instances.
+     This command also removes partially-installed or corrupted instances.
     </para>
    </step>
   </procedure>
  </sect2>
-
-<sect2 xml:id="sec-security-ldap-server-ca">
- <title>Using CA Certificates for TSL</title>
- <para>
-  You can manage the CA certificates for &ds389; with the following command
-  line tools: <command>certutil</command>, <command>openssl</command>, and
-  <command>pk12util</command>.
- </para>
- <para>
-  For testing purposes, you can create a self-signed certificate with
-  <command>dscreate</command>. Find the certificate at
-  <filename>/etc/dirsrv/slapd-localhost/ca.crt</filename>. For remote administration,
-  copy the certificate to a readable location. For production environments,
-  contact a CA authority of your organization's choice and request a server
-  certificate, a client certificate, and a root certificate.
- </para>
- <para>
- Make sure to meet the following requirements before executing the procedure below:
- </para>
- <itemizedlist>
-  <listitem>
-   <para>
-    You have a server certificate and a private key to use for the TSL connection.
-   </para>
-  </listitem>
-  <listitem>
-   <para>
-    You have set up an NSS (Network Security Services) database (for example,
-    with the <command>certutil</command> command).
-   </para>
-  </listitem>
- </itemizedlist>
-
- <procedure>
-  <para>
-  Before you can import an existing private key and certificate into the NSS
-  (Network Security Services) database, you need to create a bundle of the
-  private key and the server certificate. This results in a <filename>*.p12</filename>
-  file.
-  </para>
-  <important>
-  <title><filename>*.p12</filename> File and Friendly Name</title>
-  <para>
-   When creating the PKCS12 bundle, you must encode a friendly name
-   in the <filename>*.p12</filename> file.
-  </para>
-  <para>
-   Make sure to use <literal>Server-Cert</literal> as the friendly name. Otherwise
-   the TLS connection will fail, because the &ds389; searches for this exact string.
-  </para>
-  <para>
-    Keep in mind that the friendly name cannot be changed after you
-    import the <filename>*.p12</filename> file into the NSS
-    database.
-  </para>
- </important>
- <step>
-  <para>
-   Use the following command to create the PKCS12 bundle with the required friendly name:
-  </para>
- <screen>&prompt.root;openssl pkcs12 -export -in <replaceable>SERVER.crt</replaceable> \
-  -inkey <replaceable>SERVER.key</replaceable> -out <replaceable>SERVER.p12</replaceable> \
-  -name Server-Cert</screen>
-  <para>
-   Replace <replaceable>SERVER.crt</replaceable> with the server certificate
-   and <replaceable>SERVER.key</replaceable> with the private key to be bundled.
-   With <option>-out</option>, specify the name of the <filename>*.p12</filename>
-   file. Use <option>-name</option> to set the friendly name to use:
-   <literal>Server-Cert</literal>.
-  </para>
- </step>
- <step>
-   <para>
-     Before you can import the file into the NSS database, you need to
-     obtain its password. To do this, use the following command:
-   </para>
-<screen>pk12util -i <replaceable>PATH_TO_SERVER.p12</replaceable> -d sql:PATH_TO_NSS_DB -n Server-cert -W <replaceable>SERVER.p12_PASSWORD</replaceable></screen>
-   <para>
-     You can then find the password in the
-     <filename>pwdfile.txt</filename> file in the
-     <replaceable>PATH_TO_NSS_DB</replaceable> directory.
-   </para>
- </step>
- <step>
-  <para>
-   Now import the <replaceable>SERVER.p12</replaceable> file
-   into your NSS database:
-  </para>
-  <screen>pk12util -i <replaceable>SERVER.p12</replaceable> -d <replaceable>PATH_TO_NSS_DB</replaceable></screen>
- </step>
- </procedure>
-</sect2>
-
+ 
  <sect2 xml:id="sec-security-ldap-server-credentials">
-  <title>Configuring Admin Credentials for Remote/Local Access</title>
+  <title>Configuring Admin Credentials for Local Administration</title>
    <para>
-    For remote or local administration of the &ds389;, you can create a
-    <filename>.dsrc</filename> configuration file in your home directory. This
-    saves you typing your user name and connection details with every command.
-    <xref linkend="ex-security-ldap-server-credentials-remote"
-    xrefstyle="select:label"/> shows an example  configuration file for remote
-    administration, whereas <xref linkend="ex-security-ldap-server-credentials-local"
-    xrefstyle="select:label"/> shows one for local administration.
+    For local administration of the &ds389;, you can create a
+    <filename>.dsrc</filename> configuration file in the <filename>/root</filename>
+    directory, allowing root and sudo users to administer the server without
+    typing connection details with every command. 
+    <xref linkend="ex-security-ldap-server-credentials-local" xrefstyle="select:label"/> 
+    shows an example for local administration on the server.
    </para>
-  <example xml:id="ex-security-ldap-server-credentials-remote">
-   <title>A <filename>.dsrc</filename> File for Remote Administration</title>
-   <screen># cat ~/.dsrc
-[localhost]
-uri = ldaps://<replaceable>REMOTE_URI</replaceable> <co xml:id="co-ldap-server-dsrc-remote-localhost"/>
-basedn = dc=example,dc=com
-binddn = cn=Directory Manager
-tls_cacertdir = PATH_TO_CERTDIR <co xml:id="co-ldap-server-dsrc-remote-cert"/></screen>
-   <calloutlist>
-    <callout arearefs="co-ldap-server-dsrc-remote-localhost">
-     <para>
-      Needs to point to the LDAP server instance. If not specified otherwise,
-      the default instance name is <literal>localhost</literal>.
-     </para>
-    </callout>
-    <callout arearefs="co-ldap-server-dsrc-remote-cert">
-     <para>
-      Path to the certificate, at a readable location or on the client machine, from
-      which you use the <command>ds*</command> commands.
-     </para>
-    </callout>
-   </calloutlist>
-  </example>
-  <para>
-   If you want to administer the instance on the same host where the &ds389; runs,
-   use the configuration file in <xref linkend="ex-security-ldap-server-credentials-local"
-   xrefstyle="select:label"/>.
-  </para>
-  <example xml:id="ex-security-ldap-server-credentials-local">
-   <title>A <filename>.dsrc</filename> File for Local Administration</title>
-   <screen># cat ~/.dsrc
-[localhost]
-# Note that '/' is replaced with '%%2f'.
-uri = ldapi://%%2fvar%%2frun%%2fslapd-localhost.socket <co xml:id="co-ldap-server-dsrc-remote-ldapi"/>
-basedn = dc=example,dc=com
+   <para>
+     After creating your <filename>/root/.dsrc</filename> file, try a few
+     administration commands, such as creating new users (see 
+     <xref linkend="sec-security-ldap-server-users"/>.
+   </para>
+   <example xml:id="ex-security-ldap-server-credentials-local">
+    <title>A <filename>.dsrc</filename> File for Local Administration</title>
+     <screen># /root/.dsrc file for administering 389ds-test
+         
+[<replaceable>389ds-test</replaceable>] <co xml:id="co-ldap-server-dsrc-instance-name"/>
+
+uri = ldapi://<replaceable>%%2fvar%%2frun%%2fslapd-389ds-test.socket</replaceable> <co xml:id="co-ldap-server-dsrc-remote-ldapi"/>
+basedn = <replaceable>dc=test1,dc=com</replaceable>
 binddn = cn=Directory Manager
 </screen>
    <calloutlist>
+    <callout arearefs="co-ldap-server-dsrc-instance-name">
+      <para>
+        This must specify the instance name that you created in your
+        <filename>.inf</filename> file.
+      </para>
+    </callout>       
     <callout arearefs="co-ldap-server-dsrc-remote-ldapi">
       <para>
-       <!--Question: “When I use ldapi on the server that has the DS instance,
-       why don’t I need to provide my password?”--> When using <literal>ldapi</literal>
-       on the server where the &ds389; instance is running, your UID/GID will be
-       detected. If it is <literal>0/0</literal> (which means you are logged
-       in as &rootuser; user), the <literal>ldapi</literal> binds the local
-       &rootuser; as the directory server root dn (<literal>cn=Directory Manager</literal>)
-       of the instance. This allows local administration of the server, but also
-       allows you to set a machine-generated password for <literal>cn=Directory
-       Manager</literal> that no human knows. Whoever has administrator rights
-       on the server hosting the &ds389; instance can access the instance as
-       <literal>cn=Directory Manager</literal>.
+        <literal>ldapi</literal> detects the UID and GID of the user attempting 
+        to log in to the server. If the UID/GID are <literal>0/0</literal>,
+        <literal>ldapi</literal> binds the system root user (or sudo user) as 
+        the directory server root dn, which is 
+        <literal>cn=Directory Manager</literal>. If the UID/GID are not 
+        <literal>0/0</literal> then the user is not allowed to log into the server.
       </para>
+      <para>
+        This has the benefit of protecting the ldap root password; the root user
+        can create the password, and then sudo users never need to know the 
+        password.
+      </para>
+      <para>
+        In the URI the slashes are replaced with <literal>%%2f</literal>, so
+        in this example the path is 
+        <filename>/var/run/slapd-389/slapd-389ds-test.socket</filename>.
+      </para> 
     </callout>
    </calloutlist>
   </example>
+        <para>
+        You may also copy <filename>.dsrc</filename> to your home directory, for
+        running commands that do not need root privileges, such as listing 
+        users and groups:
+      </para>
+      <screen>&prompt.user;dsidm 389ds-test user list
+demo_user
+&prompt.user;dsidm 389ds-test group list
+demo_group</screen>
+     <para>
+       If you run a command that requires root privileges, such as creating
+       new users, you will see an "Error: Insufficient access" message.
+     </para>
  </sect2>
 
  <sect2 xml:id="sec-security-ldap-server-users">
   <title>Configuring LDAP Users and Groups</title>
    <para>
     Users and groups can be created and managed with the <command>dsidm</command>
-    command. It either runs interactively or you can use it with arguments from
-    the command line.
+    command. It runs interactively, or you can run it on the command line, and
+    list all options in a single command. 
    </para>
   <para>
-   In the following example, we add two users, &exampleuserII; and &exampleuserIII;,
+   In the following example we add two users, &exampleuserII; and &exampleuserIII;,
    by specifying their data via command-line arguments.
   </para>
   <procedure xml:id="pro-security-ldap-server-users">
@@ -678,11 +608,6 @@ binddn = cn=Directory Manager
     <screen>&prompt.sudo;dsidm localhost user get &exampleuserII;
 dn: uid=&exampleuserII;,ou=people,dc=example,dc=com
 [...]</screen>
-    <para>
-     The system prompts you for the directory server &rootuser; user password
-     (unless you configured remote or local access as described in <xref
-     linkend="sec-security-ldap-server-credentials"/>).
-    </para>
     <para>
      You need the distinguished name for actions such as changing the password
      for a user.
@@ -717,7 +642,9 @@ dn: uid=&exampleuserII;,ou=people,dc=example,dc=com
     <para>Create the user &exampleuserIII;:</para>
     <screen>&prompt.sudo;<command>dsidm</command> localhost user create --uid \
   --cn &exampleuserIII; --displayName '&exampleuserIIIfull;' \
-  --uidNumber 1001 --gidNumber 1001 --homeDirectory /home/&exampleuserIII;</screen>
+  --uidNumber 1001 --gidNumber 1001 --homeDirectory /home/&exampleuserIII;
+&prompt.sudo;reset password for uid=&exampleuserII;,ou=people,dc=example,dc=com
+  </screen>
    </step>
   </procedure>
   <procedure xml:id="pro-security-ldap-server-groups">
@@ -860,6 +787,99 @@ systemctl start sssd</screen>
   </procedure>
  </sect2>
 </sect1>
+
+<!-- default installation uses self-signed cert -->
+ <sect1 xml:id="sec-security-ldap-server-ca">
+ <title>Using CA Certificates for TSL</title>
+ <para>
+  You can manage the CA certificates for &ds389; with the following command
+  line tools: <command>certutil</command>, <command>openssl</command>, and
+  <command>pk12util</command>.
+ </para>
+ <para>
+  For testing purposes, you can create a self-signed certificate with
+  <command>dscreate</command>. Find the certificate at
+  <filename>/etc/dirsrv/slapd-localhost/ca.crt</filename>. For remote administration,
+  copy the certificate to a readable location. For production environments,
+  contact a CA authority of your organization's choice and request a server
+  certificate, a client certificate, and a root certificate.
+ </para>
+ <para>
+ Make sure to meet the following requirements before executing the procedure below:
+ </para>
+ <itemizedlist>
+  <listitem>
+   <para>
+    You have a server certificate and a private key to use for the TSL connection.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    You have set up an NSS (Network Security Services) database (for example,
+    with the <command>certutil</command> command).
+   </para>
+  </listitem>
+ </itemizedlist>
+
+ <procedure>
+  <para>
+  Before you can import an existing private key and certificate into the NSS
+  (Network Security Services) database, you need to create a bundle of the
+  private key and the server certificate. This results in a <filename>*.p12</filename>
+  file.
+  </para>
+  <important>
+  <title><filename>*.p12</filename> File and Friendly Name</title>
+  <para>
+   When creating the PKCS12 bundle, you must encode a friendly name
+   in the <filename>*.p12</filename> file.
+  </para>
+  <para>
+   Make sure to use <literal>Server-Cert</literal> as the friendly name. Otherwise
+   the TLS connection will fail, because the &ds389; searches for this exact string.
+  </para>
+  <para>
+    Keep in mind that the friendly name cannot be changed after you
+    import the <filename>*.p12</filename> file into the NSS
+    database.
+  </para>
+ </important>
+ <step>
+  <para>
+   Use the following command to create the PKCS12 bundle with the required friendly name:
+  </para>
+ <screen>&prompt.root;openssl pkcs12 -export -in <replaceable>SERVER.crt</replaceable> \
+  -inkey <replaceable>SERVER.key</replaceable> -out <replaceable>SERVER.p12</replaceable> \
+  -name Server-Cert</screen>
+  <para>
+   Replace <replaceable>SERVER.crt</replaceable> with the server certificate
+   and <replaceable>SERVER.key</replaceable> with the private key to be bundled.
+   With <option>-out</option>, specify the name of the <filename>*.p12</filename>
+   file. Use <option>-name</option> to set the friendly name to use:
+   <literal>Server-Cert</literal>.
+  </para>
+ </step>
+ <step>
+   <para>
+     Before you can import the file into the NSS database, you need to
+     obtain its password. To do this, use the following command:
+   </para>
+<screen>pk12util -i <replaceable>PATH_TO_SERVER.p12</replaceable> -d sql:PATH_TO_NSS_DB -n Server-cert -W <replaceable>SERVER.p12_PASSWORD</replaceable></screen>
+   <para>
+     You can then find the password in the
+     <filename>pwdfile.txt</filename> file in the
+     <replaceable>PATH_TO_NSS_DB</replaceable> directory.
+   </para>
+ </step>
+ <step>
+  <para>
+   Now import the <replaceable>SERVER.p12</replaceable> file
+   into your NSS database:
+  </para>
+  <screen>pk12util -i <replaceable>SERVER.p12</replaceable> -d <replaceable>PATH_TO_NSS_DB</replaceable></screen>
+ </step>
+ </procedure>
+ </sect1> 
 
 <sect1 xml:id="sec-security-ldap-server-yast" os="sles;osuse">
  <title>Setting Up a &ds389; with &yast;</title>


### PR DESCRIPTION
This expands and clarifies the steps for creating a new 389ds server instance
for testing, and setting up administration access

### Description

See sections 6.3, 6.3.1, and 6.3.2. (PDF attached)

### Are there any relevant issues/feature requests?

https://jira.suse.com/browse/SLE-16707
https://jira.suse.com/browse/SLE-14732

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [ x] 15 SP3  | (`master` only)   
| [x ] 15 SP2  | [ ] 
| [x ] 15 SP1  | [ ] 
| [ x] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 

[cha-security-ldap_color_en.pdf](https://github.com/SUSE/doc-sle/files/5567923/cha-security-ldap_color_en.pdf)