### PR TITLE
Describe auditctl -e 0 option in Security Guide

### DIFF
--- a/xml/audit_components.xml
+++ b/xml/audit_components.xml
@@ -842,13 +842,14 @@ cp_client_max_idle = 0</screen>
      <command>auditctl</command> <option>-s</option> to query the current
      status of the audit daemon
     </para>
-    <tip>
+   </listitem>
+   <listitem>
      <para>
-      Before running <command>auditctl -S</command> on your system, add
-      <option>-F arch=b64</option> to prevent the architecture mismatch
+      <command>auditctl</command> <option>-S</option> specifies which system
+      call to audit. Before running <command>auditctl -S</command> on your system, 
+      add <option>-F arch=b64</option> to prevent the architecture mismatch
       warning.
      </para>
-    </tip>
    </listitem>
   </itemizedlist>
 
@@ -871,7 +872,17 @@ cp_client_max_idle = 0</screen>
 
   <example xml:id="ex-auditctl-status">
    <title>Example output of <command>auditctl</command> <option>-s</option></title>
-<screen>AUDIT_STATUS: enabled=1 flag=2 pid=3105 rate_limit=0 backlog_limit=8192 lost=0 backlog=0</screen>
+<screen>
+enabled 1
+failure 1
+pid 790
+rate_limit 0
+backlog_limit 64
+lost 0
+backlog 0
+backlog_wait_time 15000
+loginuid_immutable 0 unlocked    
+</screen>
   </example>
 
   <table xml:id="tab-audit-auditctl">
@@ -906,7 +917,10 @@ cp_client_max_idle = 0</screen>
       <entry>
        <para>
         Set the enable flag. [0..2] 0=disable, 1=enable, 2=enable and lock
-        down the configuration
+        down the configuration. Note that this only disables logging syscalls,
+        and other events may still be logged. (See 
+        <command>man 3 audit_set_enabled</command> in the 
+        <package>audit-devel<package>.)
        </para>
       </entry>
       <entry>

--- a/xml/audit_components.xml
+++ b/xml/audit_components.xml
@@ -920,7 +920,7 @@ loginuid_immutable 0 unlocked
         down the configuration. Note that this only disables logging syscalls,
         and other events may still be logged. (See 
         <command>man 3 audit_set_enabled</command> in the 
-        <package>audit-devel<package>.)
+        <package>audit-devel</package>.)
        </para>
       </entry>
       <entry>


### PR DESCRIPTION
re https://bugzilla.suse.com/show_bug.cgi?id=1178819

### Description

Explain that disabling audit doesn't disable all auditing


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [ x] 15 SP3  | (`master` only)   
| [x ] 15 SP2  | [ ] 
| [ x] 15 SP1  | [ ] 
| [x ] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
