### PR TITLE
Update rmt_mirroring.xml

### DIFF
--- a/xml/rmt_mirroring.xml
+++ b/xml/rmt_mirroring.xml
@@ -29,8 +29,8 @@
      To change the default location of the mirrored repositories,
      point the <filename>/usr/share/rmt/public/repo</filename>
      symbolic link to the desired directory. This can be done using
-     the <command>ln -sfn /usr/share/rmt/public/repo
-     <replaceable>TARGET</replaceable></command> command (replace
+     the <command>ln -sfn <replaceable>TARGET</replaceable> /usr/share/rmt/public/repo
+     </command> command (replace
      <literal>TARGET</literal> with the desired destination). Make
      sure that the target must have read and write permissions for the
      <literal>rmt</literal> user and <literal>nginx</literal> group.


### PR DESCRIPTION
The ln command has syntax "ln TARGET LINKNAME"  the provided example command for moving the  default repo location has these arguments reversed which results in an incorrect configuration.

### Description

Fix a typo in the documentation.


### Are there any relevant issues/feature requests?

none.


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [x ] 15 SP3  | (`master` only)   
| [ ] 15 SP2  | [ ] 
| [ ] 15 SP1  | [ ] 
| [ ] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
