### PR TITLE
yast2_sw: Fix typo (fromq -> from)

### DIFF
--- a/xml/yast2_sw.xml
+++ b/xml/yast2_sw.xml
@@ -174,7 +174,7 @@
    <para>
     By default the system is registered with the &scc;. If your
     organization provides local registration servers, you can either
-    choose one fromq the list of auto-detected servers or provide the
+    choose one from the list of auto-detected servers or provide the
     URL manually.
    </para>
   </sect2>


### PR DESCRIPTION
### Description

This fixes a minor typo in the documentation.


### Are there any relevant issues/feature requests?

No.


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [ ] 15 SP3  | (`master` only)   
| [ ] 15 SP2  | [ ] 
| [ ] 15 SP1  | [ ] 
| [ ] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [x] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
