### PR TITLE
bfq I/O path is the only option for SLE15 SP2 and up

### DIFF
--- a/xml/vt_best_practices.xml
+++ b/xml/vt_best_practices.xml
@@ -772,15 +772,15 @@ Swap:      6171644          0    6171644</screen>
    <sect3 xml:id="sec-vt-best-perf-io">
     <title>I/O Scheduler</title>
     <para>
-     The default I/O scheduler is Completely Fair Queuing (CFQ). The main aim
-     of the CFQ scheduler is to provide a fair allocation of the disk I/O
+     The I/O scheduler for &sle; 15 SP2 and up is Budget Fair Queueing (BFQ). The main aim
+     of the BFQ scheduler is to provide a fair allocation of the disk I/O
      bandwidth for all processes that request an I/O operation. You can have
      different I/O schedulers for different devices.
     </para>
     <para>
      To get better performance in host and &vmguest;, use
-     <literal>noop</literal> in the &vmguest; (disable the I/O scheduler) and
-     the <literal>deadline</literal> scheduler for a virtualization host.
+     <literal>none</literal> in the &vmguest; (disable the I/O scheduler) and
+     the <literal>mq-deadline</literal> scheduler for a virtualization host.
     </para>
     <procedure>
      <title>Checking and Changing the I/O Scheduler at Runtime</title>
@@ -790,24 +790,24 @@ Swap:      6171644          0    6171644</screen>
        <replaceable>sdX</replaceable> by the disk you want to check), run:
       </para>
 <screen>&prompt.user;cat /sys/block/<replaceable>sdX</replaceable>/queue/scheduler
-noop deadline [cfq]</screen>
+mq-deadline kyber [bfq] none</screen>
       <para>
        The value in square brackets is the one currently selected
-       (<literal>cfq</literal> in the example above).
+       (<literal>bfq</literal> in the example above).
       </para>
      </step>
      <step>
       <para>
        You can change the scheduler at runtime with the following command:
       </para>
-<screen>&prompt.user;&sudo; echo deadline &gt; /sys/block/<replaceable>sdX</replaceable>/queue/scheduler</screen>
+<screen>&prompt.user;&sudo; echo mq-deadline &gt; /sys/block/<replaceable>sdX</replaceable>/queue/scheduler</screen>
      </step>
     </procedure>
     <para>
      To permanently set an I/O scheduler for all disks of a system, use the
      kernel parameter <literal>elevator</literal>. The respective values are
-     <option>elevator=deadline</option> for the &vmhost; and
-     <option>elevator=noop</option> for &vmguest;s. See
+     <option>elevator=mq-deadline</option> for the &vmhost; and
+     <option>elevator=none</option> for &vmguest;s. See
      <xref
     linkend="sec-vt-best-kernel-parameter"/> for further
      instructions.
@@ -816,13 +816,13 @@ noop deadline [cfq]</screen>
      If you need to specify different I/O schedulers for each disk, create the
      file <filename>/usr/lib/tmpfiles.d/IO_ioscheduler.conf</filename> with
      content similar to the following example. It defines the
-     <literal>deadline</literal> scheduler for <filename>/dev/sda</filename>
-     and the <literal>noop</literal> scheduler for
+     <literal>mq-eadline</literal> scheduler for <filename>/dev/sda</filename>
+     and the <literal>none</literal> scheduler for
      <filename>/dev/sdb</filename>. This feature is available on &slea; 12 and
      15 only.
     </para>
-<screen>w /sys/block/sda/queue/scheduler - - - - deadline
-w /sys/block/sdb/queue/scheduler - - - - noop</screen>
+<screen>w /sys/block/sda/queue/scheduler - - - - mq-deadline
+w /sys/block/sdb/queue/scheduler - - - - none</screen>
    </sect3>
    <sect3 xml:id="sec-vt-best-io-async">
     <title>Asynchronous I/O</title>
@@ -4173,8 +4173,7 @@ ln -sf /dev/xvda1 /dev/hda1
    </listitem>
    <listitem>
     <para>
-     <link xlink:href="https://www.kernel.org/doc/Documentation/block/cfq-iosched.txt">CFQ's
-     kernel documentation</link>
+     <link xlink:href="https://www.kernel.org/doc/html/latest/block/bfq-iosched.html">BFQ (Budget Fair Queueing)</link>
     </para>
    </listitem>
    <listitem>

--- a/xml/vt_best_practices.xml
+++ b/xml/vt_best_practices.xml
@@ -804,22 +804,13 @@ mq-deadline kyber [bfq] none</screen>
      </step>
     </procedure>
     <para>
-     To permanently set an I/O scheduler for all disks of a system, use the
-     kernel parameter <literal>elevator</literal>. The respective values are
-     <option>elevator=mq-deadline</option> for the &vmhost; and
-     <option>elevator=none</option> for &vmguest;s. See
-     <xref
-    linkend="sec-vt-best-kernel-parameter"/> for further
-     instructions.
-    </para>
-    <para>
      If you need to specify different I/O schedulers for each disk, create the
      file <filename>/usr/lib/tmpfiles.d/IO_ioscheduler.conf</filename> with
      content similar to the following example. It defines the
-     <literal>mq-eadline</literal> scheduler for <filename>/dev/sda</filename>
+     <literal>mq-deadline</literal> scheduler for <filename>/dev/sda</filename>
      and the <literal>none</literal> scheduler for
      <filename>/dev/sdb</filename>. This feature is available on &slea; 12 and
-     15 only.
+     up.
     </para>
 <screen>w /sys/block/sda/queue/scheduler - - - - mq-deadline
 w /sys/block/sdb/queue/scheduler - - - - none</screen>


### PR DESCRIPTION
cfq and bfq are both available in earlier releases
https://bugzilla.suse.com/show_bug.cgi?id=1178938

### Description

Update Virtualization Best Practices guide with the correct scheduler for SLE 15 SP2 and up

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [ x] 15 SP3  | (`master` only)   
| [x ] 15 SP2  | [ ] 
| [ ] 15 SP1  | [ ] 
| [ ] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
