### PR TITLE
Add information about setting Btrfs quotas

### DIFF
--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -581,6 +581,28 @@
           </para>
          </entry>
         </row>
+        <row>
+         <entry>
+          <para>
+           <literal>quotas</literal>
+           </para>
+         </entry>
+         <entry>
+          <para>
+           Enables support for Btrfs subvolumes quotas.
+          </para>
+          <screen>&lt;quotas config:type="boolean"&gt;true&lt;/quotas&gt;</screen>
+          </entry>
+          <entry>
+           <para>
+             Optional. The default is <literal>false</literal>. Setting this
+             element to <literal>true</literal> will enable support for quotas
+             for the file system. However, you need to set the limits for each
+             subvolume. Check <xref linkend="ay-btrfs-subvolumes"/> for further
+             information.
+           </para>
+         </entry>
+        </row>
        </tbody>
       </tgroup>
      </informaltable>
@@ -1115,11 +1137,7 @@
   &lt;path&gt;tmp&lt;/path&gt;
   &lt;path&gt;opt&lt;/path&gt;
   &lt;path&gt;srv&lt;/path&gt;
-  &lt;path&gt;var/crash&lt;/path&gt;
-  &lt;path&gt;var/lock&lt;/path&gt;
-  &lt;path&gt;var/run&lt;/path&gt;
-  &lt;path&gt;var/tmp&lt;/path&gt;
-  &lt;path&gt;var/spool&lt;/path&gt;
+  &lt;path&gt;var&lt;/path&gt;
   ...
 &lt;/subvolumes&gt;</screen>
          </entry>
@@ -1380,41 +1398,136 @@
      <para>
       As mentioned in <xref linkend="ay-partition-configuration"/>, it is
       possible to define a set of subvolumes for each Btrfs file system. In
-      its simplest form, this is a list of entries:
+      its simplest form, they are specified using a list of paths:
      </para>
 
 <screen>&lt;subvolumes config:type="list"&gt;
+  &lt;path&gt;usr/local&lt;/path&gt;
   &lt;path&gt;tmp&lt;/path&gt;
   &lt;path&gt;opt&lt;/path&gt;
   &lt;path&gt;srv&lt;/path&gt;
-  &lt;path&gt;var/crash&lt;/path&gt;
-  &lt;path&gt;var/lock&lt;/path&gt;
-  &lt;path&gt;var/run&lt;/path&gt;
-  &lt;path&gt;var/tmp&lt;/path&gt;
-  &lt;path&gt;var/spool&lt;/path&gt;
+  &lt;path&gt;var&lt;/path&gt;
 &lt;/subvolumes&gt;</screen>
 
      <para>
-      &ay; supports disabling copy-on-write for a given subvolume. In that
-      case, a slightly more complex syntax should be used:
+      However, it is possible to specify additional settings for each
+      subvolume. For instance, we might want to set a quota or to disable the
+      copy-on-write mechanism. For that purpose, it is possible to expand any
+      of the elements of the list as shown in the example below:
      </para>
 
 <screen>&lt;subvolumes config:type="list"&gt;
-&lt;listentry&gt;tmp&lt;/listentry&gt;
-&lt;listentry&gt;opt&lt;/listentry&gt;
-&lt;listentry&gt;srv&lt;/listentry&gt;
-&lt;listentry&gt;
-  &lt;path&gt;var/lib/pgsql&lt;/path&gt;
-  &lt;copy_on_write config:type="boolean"&gt;false&lt;/copy_on_write&gt;
-&lt;/listentry&gt;
+  &lt;listentry&gt;usr/local&lt;/listentry&gt;
+  &lt;listentry&gt;
+    &lt;path&gt;tmp&lt;/path&gt;
+    &lt;referenced_limit&gt;1 GiB&lt;/referenced_limit&gt;
+  &lt;/listentry&gt;
+  &lt;listentry&gt;opt&lt;/listentry&gt;
+  &lt;listentry&gt;srv&lt;/listentry&gt;
+  &lt;listentry&gt;
+    &lt;path&gt;var/lib/pgsql&lt;/path&gt;
+    &lt;copy_on_write config:type="boolean"&gt;false&lt;/copy_on_write&gt;
+  &lt;/listentry&gt;
 &lt;/subvolumes&gt;</screen>
+
+     <para>
+
+     </para>
+
+     <informaltable>
+      <tgroup cols="3">
+       <colspec colwidth="1*"/>
+       <colspec colwidth="3*"/>
+       <colspec colwidth="2*"/>
+       <thead>
+        <row>
+         <entry>
+          <para>
+           Attribute
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Values
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Description
+          </para>
+         </entry>
+        </row>
+       </thead>
+       <tbody>
+        <row>
+         <entry>
+          <para>
+           <literal>path</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Mount point for the subvolume.
+          </para>
+          <screen>&lt;path&gt;tmp&lt;/tmp&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           Required. &ay; will ignore the subvolume if the
+           <literal>path</literal> is not specified.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>copy-on-write</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Whether copy-on-write should be enabled for the subvolume.
+          </para>
+          <screen>&lt;copy-on-write config:type="boolean"&gt;false&lt;/copy-on-write&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           Optional. The default value is <literal>false</literal>.
+          </para>
+         </entry>
+        </row>
+        <row>
+         <entry>
+          <para>
+           <literal>referenced_limit</literal>
+          </para>
+         </entry>
+         <entry>
+          <para>
+           Set a quota for the subvolume.
+          </para>
+          <screen>&lt;referenced_limit&gt;1 GiB&lt;/referenced_limit&gt;</screen>
+         </entry>
+         <entry>
+          <para>
+           Optional. The default value is <literal>unlimited</literal>. Btrfs
+           supports two kind of limits: <literal>referenced</literal> and
+           <literal>exclusive</literal>. At this point, only the former is
+           supported.
+          </para>
+         </entry>
+        </row>
+       </tbody>
+      </tgroup>
+     </informaltable>
 
      <para>
       If there is a default subvolume used for the distribution (for example
       <filename>@</filename> in &productname;), the name of this default
-      subvolume is automatically prefixed to the names in this list. This
-      behavior can be disabled by setting the
-      <literal>subvolumes_prefix</literal>.
+      subvolume is automatically prefixed to the names of the defined
+      subvolumes. This behavior can be disabled by setting the
+      <literal>subvolumes_prefix</literal> in the <link
+      xlink:href="CreateProfile-Partitioning-config">drive</link> section
      </para>
 
      <screen>&lt;subvolumes_prefix&gt;&lt;![CDATA[]]&gt;&lt;/subvolumes_prefix&gt;</screen>


### PR DESCRIPTION
### Description

This PR adds information about setting Btrfs quotas. The code is merged and this PR is ready for review.

Thanks!

Related to: https://github.com/yast/yast-storage-ng/pull/1186.

### Are there any relevant issues/feature requests?

* jsc#SLE-7742

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [x] 15 SP3  | (`master` only)   
| [ ] 15 SP2  | [ ] 
| [ ] 15 SP1  | [ ] 
| [ ] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
