### PR TITLE
Convert table to variablelist

### DIFF
--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -285,38 +285,23 @@
     &lt;/drive&gt;
   &lt;/partitioning&gt;
 &lt;/profile&gt;</screen>
-     <informaltable>
-      <tgroup cols="3">
-       <thead>
-        <row>
-         <entry>
+
+<variablelist>
+    <varlistentry>
+        <term>device</term>
+        <listitem>
           <para>
-           Attribute
+           Optional, the device you want to configure. If left out, &ay; tries 
+           to guess the device. See
+           <xref linkend="ay-partitioning-skip-devices"/> on how to influence
+           guessing.
           </para>
-         </entry>
-         <entry>
           <para>
-           Values
+           If set to <literal>ask</literal>, &ay; will ask the user which device 
+           to use during installation.
           </para>
-         </entry>
-         <entry>
           <para>
-           Description
-          </para>
-         </entry>
-        </row>
-       </thead>
-       <tbody>
-        <row>
-         <entry>
-          <para>
-           <literal>device</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           The device you want to configure in this section. You can use persistent
-           device names via ID, like
+            You can use persistent device names via ID, like
            <filename>/dev/disk/by-id/ata-WDC_WD3200AAKS-75L9A0_WD-WMAV27368122</filename>
            or <emphasis>by-path</emphasis>, like
            <filename>/dev/disk/by-path/pci-0001:00:03.0-scsi-0:0:0:0</filename>.
@@ -330,219 +315,128 @@
            See <xref linkend="ay-partition-multipath"/> for further information
            about dealing with multipath devices.
           </para>
-         </entry>
-         <entry>
+      </listitem>      
+  </varlistentry>
+  
+  <varlistentry>
+      <term>initialize</term>
+      <listitem>
           <para>
-           Optional. If left out, &ay; tries to guess the device. See
-           <xref linkend="ay-partitioning-skip-devices"/> on how to influence
-           guessing.
-          </para>
-          <para>
-           If set to <literal>ask</literal>, &ay; will ask the user which device to use
-           during installation.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>initialize</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           If set to <literal>true</literal>, the partition table gets wiped
+              Optional, the default is <literal>false</literal>. If set to 
+              <literal>true</literal>, the partition table is wiped
            out before &ay; starts the partition calculation.
           </para>
           <screen>&lt;initialize config:type="boolean"&gt;true&lt;/initialize&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           Optional. The default is <literal>false</literal>.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>partitions</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           A list of &lt;partition&gt; entries (see
-           <xref linkend="ay-partition-configuration"/>).
+      </listitem>
+  </varlistentry>
+  
+  <varlistentry>
+      <term>partitions</term>
+      <listitem>
+          <para>Optional, a list of <literal>&lt;partition&gt;</literal> entries 
+              (see <xref linkend="ay-partition-configuration"/>).
           </para>
           <screen>&lt;partitions config:type="list"&gt;
           &lt;partition&gt;...&lt;/partition&gt;
           ...
           &lt;/partitions&gt;</screen>
-         </entry>
-         <entry>
           <para>
-           Optional. If no partitions are specified, &ay; will create a
-           reasonable partitioning (see
+          If no partitions are specified, &ay; will create a reasonable 
+          partitioning layout (see
            <xref linkend="ay-auto-partitioning"/>).
           </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
+      </listitem>
+  </varlistentry>  
+  <varlistentry>
+      <term>pesize</term>
+      <listitem>
           <para>
-           <literal>pesize</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           This value only makes sense with LVM.
+              Optional, for LVM only. The default is 4M for LVM volume groups.
           </para>
           <screen>&lt;pesize&gt;8M&lt;/pesize&gt;</screen>
-         </entry>
-         <entry>
+      </listitem>
+  </varlistentry>
+  
+  <varlistentry>
+      <term>use</term>
+      <listitem>
           <para>
-           Optional. Default is 4M for LVM volume groups.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>use</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Specifies the strategy &ay; will use to partition the hard
-           disk.
+           Recommended, specifies the strategy &ay; will use to partition the hard
+           disk. Choose from:
           </para>
           <para>
-           Choose between:
+             <literal>all</literal>, uses the whole device while calculating
+             the new partitioning.
           </para>
-          <itemizedlist mark="bullet" spacing="normal">
-           <listitem>
-            <para>
-             <literal>all</literal> (uses the whole device while calculating
-             the new partitioning),
+          <para>
+             <literal>linux</literal>, only existing Linux partitions are
+             used.
+          </para>
+          <para>
+             <literal>free</literal>, only unused space on the device is
+             used, no existing partitions are touched.
+          </para>
+          <para>
+             <replaceable>1,2,3</replaceable>, a list of comma-separated partition 
+             numbers to use.
+          </para>
+      </listitem>
+  </varlistentry>
+  
+  <varlistentry>
+      <term>type</term>
+      <listitem>
+          <para>
+              Optional, specify the type of the <literal>drive</literal>. The
+              default is <literal>CT_DISK</literal> for a normal physical hard 
+              disk. The following is a list of all options:
+          </para>
+          <para>
+             <literal>CT_DISK</literal> for physical hard disks (default).
             </para>
-           </listitem>
-           <listitem>
             <para>
-             <literal>linux</literal> (only existing Linux partitions are
-             used),
+             <literal>CT_LVM</literal> for LVM volume groups.
             </para>
-           </listitem>
-           <listitem>
             <para>
-             <literal>free</literal> (only unused space on the device is
-             used, no other partitions are touched),
+             <literal>CT_RAID</literal> for software RAID devices.
             </para>
-           </listitem>
-           <listitem>
-            <para>
-             1,2,3 (a list of comma separated partition numbers to use).
-            </para>
-           </listitem>
-          </itemizedlist>
-         </entry>
-         <entry>
-          <para>
-           This parameter should be provided.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>type</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Specify the type of the <literal>drive</literal>,
-          </para>
-          <para>
-           Choose between:
-          </para>
-          <itemizedlist mark="bullet" spacing="normal">
-           <listitem>
-            <para>
-             <literal>CT_DISK</literal> for physical hard disks (default),
-            </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>CT_LVM</literal> for LVM volume groups,
-            </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>CT_RAID</literal> for software RAID devices,
-            </para>
-           </listitem>
-           <listitem>
             <para>
              <literal>CT_BCACHE</literal> for software &bcache; devices.
             </para>
-           </listitem>
-          </itemizedlist>
           <screen>&lt;type config:type="symbol"&gt;CT_LVM&lt;/type&gt;</screen>
-         </entry>
-         <entry>
+      </listitem>
+  </varlistentry>
+  
+  <varlistentry>
+      <term>disklabel</term>
+      <listitem>
           <para>
-           Optional. Default is <literal>CT_DISK</literal> for a normal
-           physical hard disk.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>disklabel</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Describes the type of the partition table.
+              Optional. By default &yast; decides what makes sense. If a 
+              partition table of a different type already exists, it will be 
+              recreated with the given type only if it does not include any 
+              partition that should be kept or reused. To use the disk without 
+              creating any partition, set this element to <literal>none</literal>.
+              The following is a list of all options:
           </para>
           <para>
-           Choose between:
-          </para>
-          <itemizedlist mark="bullet" spacing="normal">
-           <listitem>
-            <para>
              <literal>msdos</literal>
             </para>
-           </listitem>
-           <listitem>
             <para>
              <literal>gpt</literal>
             </para>
-           </listitem>
-           <listitem>
             <para>
              <literal>none</literal>
             </para>
-           </listitem>
-          </itemizedlist>
           <screen>&lt;disklabel&gt;gpt&lt;/disklabel&gt;</screen>
-         </entry>
-         <entry>
+      </listitem>
+  </varlistentry>
+  
+  <varlistentry>
+      <term>keep_unknown_lv</term>
+      <listitem>
           <para>
-           Optional. By default &yast; decides what makes sense. If a partition
-           table of a different type already exists, it will be recreated with
-           the given type only if it does not include any partition that should
-           be kept or reused. To use the disk without creating any partition, set
-           this element to <literal>none</literal>.
+           Optional, the default is <literal>false</literal>.
           </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>keep_unknown_lv</literal>
-          </para>
-         </entry>
-         <entry>
           <para>
            This value only makes sense for type=CT_LVM drives. If you are
            reusing a logical volume group and you set this to
@@ -551,61 +445,40 @@
            &lt;partitioning&gt; section. So you can keep existing
            logical volumes without specifying them.
           </para>
-          <screen>&lt;keep_unknown_lv config:type="boolean"
-          &gt;false&lt;/keep_unknown_lv&gt;</screen>
-         </entry>
-         <entry>
+          <screen>&lt;keep_unknown_lv config:type="boolean"&gt;false&lt;/keep_unknown_lv&gt;</screen>          
+      </listitem>
+  </varlistentry> 
+  
+  <varlistentry>
+      <term>enable_snapshots</term>
+      <listitem>
           <para>
-           Optional. The default is <literal>false</literal>.
+           Optional, the default is <literal>true</literal>.
           </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>enable_snapshots</literal>
-          </para>
-         </entry>
-         <entry>
           <para>
            Enables snapshots on Btrfs file systems mounted at <literal>/</literal>
            (does not apply to other file systems, or Btrfs file systems not mounted
            at <literal>/</literal>).
           </para>
-          <screen>&lt;enable_snapshots config:type="boolean"
-          &gt;false&lt;/enable_snapshots&gt;</screen>
-         </entry>
-         <entry>
+          <screen>&lt;enable_snapshots config:type="boolean"&gt;false&lt;/enable_snapshots&gt;</screen>          
+      </listitem>
+  </varlistentry>
+  <varlistentry>
+      <term>quotas</term>
+      <listitem>
           <para>
-           Optional. The default is <literal>true</literal>.
+           Optional, the default is <literal>false</literal>.
           </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
           <para>
-           <literal>quotas</literal>
-           </para>
-         </entry>
-         <entry>
-          <para>
-           Enables support for Btrfs subvolumes quotas.
+           Enables support for Btrfs subvolumes quotas. Setting this element to 
+           <literal>true</literal> will enable support for quotas for the file 
+           system. However, you need to set the limits for each subvolume. Check 
+           <xref linkend="ay-btrfs-subvolumes"/> for further information. 
           </para>
-          <screen>&lt;quotas config:type="boolean"&gt;true&lt;/quotas&gt;</screen>
-          </entry>
-          <entry>
-           <para>
-             Optional. The default is <literal>false</literal>. Setting this
-             element to <literal>true</literal> will enable support for quotas
-             for the file system. However, you need to set the limits for each
-             subvolume. Check <xref linkend="ay-btrfs-subvolumes"/> for further
-             information.
-           </para>
-         </entry>
-        </row>
-       </tbody>
-      </tgroup>
-     </informaltable>
+          <screen>&lt;quotas config:type="boolean"&gt;true&lt;/quotas&gt;</screen>          
+      </listitem>
+  </varlistentry>
+</variablelist>
 
      <important>
       <title>Beware of Data Loss</title>


### PR DESCRIPTION
Part of ongoing work to convert tables in the AutoYaST Guide to variablelists,
because they render awkwardly in PDF

https://trello.com/c/zMJy4Uqz/151-restructure-autoyast-guide-fix-wide-tables

### Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [x ] 15 SP3  | (`master` only)   
| [ ] 15 SP2  | [ ] 
| [ ] 15 SP1  | [ ] 
| [ ] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
