### PR TITLE
Convert table to variablelist

### DIFF
--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -544,63 +544,28 @@
     &lt;/partition&gt;
   &lt;/partitions&gt;
 &lt;/drive&gt;</screen>
-     <informaltable>
-      <tgroup cols="3">
-       <colspec colwidth="1*"/>
-       <colspec colwidth="3*"/>
-       <colspec colwidth="2*"/>
-       <thead>
-        <row>
-         <entry>
-          <para>
-           Attribute
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Values
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Description
-          </para>
-         </entry>
-        </row>
-       </thead>
-       <tbody>
-        <row>
-         <entry>
-          <para>
-           <literal>create</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Specify if this partition or logical volume must be created or if it already exists.
-          </para>
-          <screen>&lt;create config:type="boolean" &gt;false&lt;/create&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           If set to <literal>false</literal>, you also need to set one of
-           <literal>partition_nr</literal>, <literal>lv_name</literal>, <literal>label</literal>
-           or <literal>uuid</literal> to tell &ay; which device to use.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>crypt_method</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Partition will be encrypted using one of these methods:
-          </para>
-
-          <itemizedlist mark="bullet" spacing="normal">
+     <variablelist>
+         <varlistentry>
+             <term>create</term>
+             <listitem>
+                 <para>
+                     Specify if this partition or logical volume must be created, 
+                     or if it already exists. If set to <literal>false</literal>, 
+                     you also need to set one of <literal>partition_nr</literal>, <literal>lv_name</literal>, <literal>label</literal>, or <literal>uuid</literal> to tell &ay; which device to use.
+                 </para>
+<screen>&lt;create config:type="boolean"&gt;false&lt;/create&gt;</screen>                 
+             </listitem>
+         </varlistentry>
+     </variablelist>
+     
+     <variablelist>
+         <varlistentry>
+             <term>crypt_method</term>
+             <listitem>
+                 <para>
+                     Optional, the partition will be encrypted using one of these methods:
+                 </para>
+                     <itemizedlist mark="bullet" spacing="normal">
            <listitem>
             <para>
              <literal>luks1</literal>: regular LUKS1 encryption.
@@ -629,201 +594,158 @@
            </listitem>
           </itemizedlist>
           <screen>&lt;crypt_method config:type="symbol"&gt;luks1&lt;/crypt_method&gt;</screen>
-         </entry>
-         <entry>
           <para>
-           Optional. Encryption method selection was introduced in &productname;
+          Encryption method selection was introduced in &productname;
            <phrase os="sles;sled">15 SP2</phrase><phrase os="osuse">15.2</phrase>.
            To mimic the behavior of previous versions, use <literal>luks1</literal>.
           </para>
           <para>
-           See <literal>crypt_key</literal> element to find out how to specify
+           See <literal>crypt_key</literal> element to learn how to specify
            the encryption password if needed.
           </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>crypt_fs</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Partition will be encrypted. This element is deprecated. Use
-           <literal>crypt_method</literal> instead.
-          </para>
-          <screen>&lt;crypt_fs config:type="boolean"&gt;true&lt;/crypt_fs&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           Default is <literal>false</literal>.
-          </para>
-         </entry>
-        </row>
+             </listitem>
+         </varlistentry>
+     </variablelist>
 
-        <row>
-         <entry>
-          <para>
-           <literal>crypt_key</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Encryption key
-          </para>
-          <screen>&lt;crypt_key&gt;xxxxxxxx&lt;/crypt_key&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           Needed if <literal>crypt_method</literal> has been set to
-           a method that requires a password (i.e., <literal>luks1</literal>
-           or <literal>pervasive_luks2</literal>).
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>mount</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           The mount point of this partition.
-          </para>
-          <screen>&lt;mount&gt;/&lt;/mount&gt;
-&lt;mount&gt;swap&lt;/mount&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           You should have at least a root partition (/) and a swap
-           partition.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>fstopt</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Mount options for this partition.
-          </para>
-          <screen>&lt;fstopt&gt;
-  ro,noatime,user,data=ordered,acl,user_xattr
-&lt;/fstopt&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           See <command>man mount</command> for available mount options.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>label</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           The label of the partition. Useful when formatting the device
-           (especially if the <literal>mountby</literal> parameter is set to
-           <literal>label</literal>) and for identifying a device that already
-           exists (see <literal>create</literal> above).
-          </para>
-          <screen>&lt;label&gt;mydata&lt;/label&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           See <command>man e2label</command> for an example.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>uuid</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           The uuid of the partition. Only useful for identifying an existing
-           device (see <literal>create</literal> above). The uuid cannot be
-           enforced for new devices.
-          </para>
-          <screen>&lt;uuid
-&gt;1b4e28ba-2fa1-11d2-883f-b9a761bde3fb&lt;/uuid&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           See <command>man uuidgen</command>.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>size</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           The size of the partition, for example 4G, 4500M, etc. The /boot
-           partition and the swap partition can have <literal>auto</literal>
-           as size. Then &ay; calculates a reasonable size. One partition
-           can have the value <literal>max</literal> to use all remaining
-           space.
-          </para>
-          <para>
-           You can also specify the size in percentage. So 10% will use 10%
-           of the size of the hard disk or volume group. You can mix auto,
-           max, size, and percentage as you like.
-          </para>
-          <screen>&lt;size&gt;10G&lt;/size&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           Starting with &productname; 15, all values (including
-           <literal>auto</literal> and <literal>max</literal>) can be used for
-           resizing partitions as well.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>format</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Specify if &ay; should format the partition.
-          </para>
-          <screen>&lt;format config:type="boolean"&gt;false&lt;/format&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           If you set <literal>create</literal> to <literal>true</literal>,
-           then you likely want this option set to <literal>true</literal> as
-           well.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>file system</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Specify the file system to use on this partition:
-          </para>
-          <itemizedlist mark="bullet" spacing="normal">
+     <variablelist>
+         <varlistentry>
+             <term>crypt_fs</term>
+             <listitem>
+                 <para>
+                     Partition will be encrypted, the default is 
+                     <literal>false</literal>. This element is deprecated. Use
+                     <literal>crypt_method</literal> instead.
+                 </para>
+<screen>&lt;crypt_fs config:type="boolean"&gt;true&lt;/crypt_fs&gt;</screen>
+             </listitem>
+         </varlistentry>
+     </variablelist>
+
+     <variablelist>
+         <varlistentry>
+             <term>crypt_key</term>
+             <listitem>
+                 <para>
+                     Required if <literal>crypt_method</literal> has been set to
+                     a method that requires a password (i.e., 
+                     <literal>luks1</literal> or 
+                     <literal>pervasive_luks2</literal>).
+                 </para>
+<screen>&lt;crypt_key&gt;xxxxxxxx&lt;/crypt_key&gt;</screen>                 
+             </listitem>
+         </varlistentry>
+     </variablelist>      
+     
+     <variablelist>
+         <varlistentry>
+             <term>mount</term>
+             <listitem>
+                 <para>
+                     You should have at least a root partition (/) and a swap
+                     partition.
+                 </para>
+ <screen>&lt;mount&gt;/&lt;/mount&gt;&lt;mount&gt;swap&lt;/mount&gt;</screen>                
+             </listitem>
+         </varlistentry>
+     </variablelist>
+
+     <variablelist>
+         <varlistentry>
+             <term>fstopt</term>
+             <listitem>
+                 <para>
+                     Mount options for this partition; see 
+                     <command>man mount</command> for available mount options.
+                 </para>
+<screen>&lt;fstopt&gt;ro,noatime,user,data=ordered,acl,user_xattr&lt;/fstopt&gt;</screen>                 
+             </listitem>
+         </varlistentry>
+     </variablelist>  
+     
+       <variablelist>
+         <varlistentry>
+             <term>label</term>
+             <listitem>
+                 <para>
+                     The label of the partition. Useful when formatting the device
+                      (especially if the <literal>mountby</literal> parameter is
+                      set to <literal>label</literal>) and for identifying a 
+                      device that already exists (see <literal>create</literal> 
+                      above). See <command>man e2label</command> for an example.
+                 </para>
+<screen>&lt;label&gt;mydata&lt;/label&gt;</screen>               
+             </listitem>
+         </varlistentry>
+     </variablelist>  
+     
+       <variablelist>
+         <varlistentry>
+             <term>uuid</term>
+             <listitem>
+                 <para>
+                      The uuid of the partition. Only useful for identifying an
+                      existing device (see <literal>create</literal> above). The
+                      uuid cannot be enforced for new devices. (See
+                      <command>man uuidgen</command>.)
+                 </para>
+<screen>&lt;uuid&gt;1b4e28ba-2fa1-11d2-883f-b9a761bde3fb&lt;/uuid&gt;</screen>                
+             </listitem>
+         </varlistentry>
+     </variablelist>
+
+       <variablelist>
+         <varlistentry>
+             <term>size</term>
+             <listitem>
+                 <para>
+                      The size of the partition, for example 4G, 4500M, etc. The 
+                      /boot partition and the swap partition can have 
+                      <literal>auto</literal> as size. Then &ay; calculates a
+                      reasonable size. One partition can have the value 
+                      <literal>max</literal> to use all remaining space.
+                 </para>
+                 <para>
+                      You can also specify the size in percentage. So 10% will 
+                      use 10% of the size of the hard disk or volume group. You 
+                      can mix <literal>auto</literal>, <literal>max</literal>,
+                      <literal>size</literal>, and percentage as you like.
+                 </para>
+<screen>&lt;size&gt;10G&lt;/size&gt;</screen>                    
+                 <para>
+                     Starting with &productname; 15, all values (including
+                     <literal>auto</literal> and <literal>max</literal>) can be
+                     used for resizing partitions as well.
+                 </para>
+             </listitem>
+         </varlistentry>
+     </variablelist>  
+     
+       <variablelist>
+         <varlistentry>
+             <term>format</term>
+             <listitem>
+                 <para>
+                     Specify if &ay; should format the partition. If you set
+                     <literal>create</literal> to <literal>true</literal>,
+                     then you likely want this option set to 
+                     <literal>true</literal> as well. 
+                 </para>
+<screen>&lt;format config:type="boolean"&gt;false&lt;/format&gt;</screen>                
+             </listitem>
+         </varlistentry>
+     </variablelist>     
+     
+       <variablelist>
+         <varlistentry>
+             <term>file system</term>
+             <listitem>
+                 <para>
+                     Optional. The default is <literal>btrfs</literal> for the 
+                     root partition (<filename>/</filename>) and 
+                     <literal>xfs</literal> for data partitions. 
+                     Specify the file system to use on this partition:
+                 </para>
+         <itemizedlist mark="bullet" spacing="normal">
            <listitem>
             <para>
              <literal>btrfs</literal>
@@ -858,78 +780,55 @@
             <para>
              <literal>swap</literal>
             </para>
+<screen>&lt;filesystem config:type="symbol"&gt;ext3&lt;/filesystem&gt;</screen>            
            </listitem>
           </itemizedlist>
-          <screen>&lt;filesystem config:type="symbol"
-&gt;ext3&lt;/filesystem&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           Optional. The default is <literal>btrfs</literal> for the root
-           partition (<filename>/</filename>) and <literal>xfs</literal> for
-           data partitions.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>mkfs_options</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Specify an option string that is added to the mkfs command.
-          </para>
-          <screen>&lt;mkfs_options&gt;-I 128&lt;/mkfs_options&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           Optional. Only use this when you know what you are doing.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>partition_nr</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           The partition number of this partition. If you have set
-           <literal>create=false</literal> or if you use LVM, then you can
-           specify the partition via <literal>partition_nr</literal>. You can
-           force &ay; to only create primary partitions by assigning
-           numbers below 5.
-          </para>
-          <screen>&lt;partition_nr config:type="integer"
-&gt;2&lt;/partition_nr&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           Usually, numbers 1 to 4 are primary partitions while 5 and higher
-           are logical partitions.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>partition_id</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           The <literal>partition_id</literal> sets the id of the partition.
-           If you want different identifiers than 131 for Linux partition or
-           130 for swap, configure them with partition_id.
-          </para>
-          <screen>&lt;partition_id config:type="integer"
-&gt;131&lt;/partition_id&gt;</screen>
-<para>
- Possible values are:
-</para>
+             </listitem>
+         </varlistentry>
+     </variablelist>     
+     
+       <variablelist>
+         <varlistentry>
+             <term>mkfs_options</term>
+             <listitem>
+                 <para>
+                     Optional, specify an option string for the 
+                     <command>mkfs</command>. Only use this when you know what 
+                     you are doing (see the relevant mkfs man page for the 
+                     filesystem you want to use.)
+                 </para>
+<screen>&lt;mkfs_options&gt;-I 128&lt;/mkfs_options&gt;</screen>                 
+             </listitem>
+         </varlistentry>
+     </variablelist> 
+     
+       <variablelist>
+         <varlistentry>
+             <term>partition_nr</term>
+             <listitem>
+                 <para>
+                     The number of this partition. If you have set
+                     <literal>create=false</literal> or if you use LVM, then you
+                     can specify the partition via <literal>partition_nr</literal>.
+                 </para>
+<screen>&lt;partition_nr config:type="integer"&gt;2&lt;/partition_nr&gt;</screen>                 
+             </listitem>
+         </varlistentry>
+     </variablelist>     
+     
+       <variablelist>
+         <varlistentry>
+             <term>partition_id</term>
+             <listitem>
+                 <para>
+                     The <literal>partition_id</literal> sets the id of the 
+                     partition. If you want different identifiers than 131 for 
+                     Linux partition or  130 for swap, configure them with
+                     <literal>partition_id.</literal> The default is 
+                     <literal>131</literal> for a Linux partition and
+                     <literal>130</literal> for swap.
+                 </para>
+<screen>&lt;partition_id config:type="integer"&gt;131&lt;/partition_id&gt;</screen>                 
 <simplelist>
  <member>Swap: <literal>130</literal></member>
  <member>Linux: <literal>131</literal></member>
@@ -937,333 +836,253 @@
  <member>MD RAID: <literal>253</literal></member>
  <member>EFI partition: <literal>259</literal></member>
 </simplelist>
-         </entry>
-         <entry>
-          <para>
-           The default is <literal>131</literal> for Linux partition and
-           <literal>130</literal> for swap.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>partition_type</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           When using an <literal>msdos</literal> partition table, this
-           element sets the type of the partition. The value can be
-           <literal>primary</literal> or <literal>logical</literal>.
-           This value is ignored when using a <literal>gpt</literal>
-           partition table, because such a distinction does not exist in
-           that case.
-          </para>
-          <screen>&lt;partition_type&gt;primary&lt;/partition_type&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           Optional. Allowed values are <literal>primary</literal> (default) and
-           <literal>logical</literal>.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>mountby</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Instead of a partition number, you can tell &ay; to mount a
-           partition by <literal>device</literal>, <literal>label</literal>,
-           <literal>uuid</literal>, <literal>path</literal> or
-           <literal>id</literal>, which are the udev path and udev id (see
-           <filename>/dev/disk/...</filename>).
-          </para>
-          <screen>&lt;mountby config:type="symbol"
-&gt;label&lt;/mountby&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           See <literal>label</literal> and <literal>uuid</literal>
-           documentation above. The default depends on &yast; and usually
-           is <literal>id</literal>.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>subvolumes</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           List of subvolumes to create for a file system of type Btrfs. This
-           key only makes sense for file systems of type Btrfs. See
-           <xref linkend="ay-btrfs-subvolumes"/> for more information.
-          </para>
-          <screen>&lt;subvolumes config:type="list"&gt;
+             </listitem>
+         </varlistentry>
+     </variablelist>   
+     
+        <variablelist>
+         <varlistentry>
+             <term>partition_type</term>
+             <listitem>
+                 <para>
+                     Optional. Allowed values are <literal>primary</literal>
+                     (default) and <literal>logical</literal>.When using an
+                     <literal>msdos</literal> partition table, this
+                     element sets the type of the partition. The value can be
+                     <literal>primary</literal> or <literal>logical</literal>.
+                     This value is ignored when using a <literal>gpt</literal>
+                     partition table, because such a distinction does not exist in
+                     that case.
+                 </para>
+<screen>&lt;partition_type&gt;primary&lt;/partition_type&gt;</screen>                 
+             </listitem>
+         </varlistentry>
+     </variablelist>     
+     
+        <variablelist>
+         <varlistentry>
+             <term>mountby</term>
+             <listitem>
+                 <para>
+                     Instead of a partition number, you can tell &ay; to mount a
+                     partition by <literal>device</literal>, 
+                     <literal>label</literal>, <literal>uuid</literal>,
+                     <literal>path</literal> or <literal>id</literal>, which 
+                     are the udev path and udev id (see 
+                     <filename>/dev/disk/...</filename>).
+                 </para>
+                 <para>
+                     See <literal>label</literal> and <literal>uuid</literal>
+                     documentation above. The default depends on &yast; and 
+                     usually is <literal>id</literal>.
+                 </para>
+<screen>&lt;mountby config:type="symbol"&gt;label&lt;/mountby&gt;</screen>               
+             </listitem>
+         </varlistentry>
+     </variablelist>    
+     
+        <variablelist>
+         <varlistentry>
+             <term>subvolumes</term>
+             <listitem>
+                 <para>
+                     List of subvolumes to create for a file system of type 
+                     Btrfs. This key only makes sense for file systems of type Btrfs. 
+                     (See <xref linkend="ay-btrfs-subvolumes"/> for more information.)
+                 </para>
+                 <para>
+                     If no <tag>subvolumes</tag> section has been defined for a
+                     partition description, &ay; will create a predefined set of
+                     subvolumes for the given mount point.
+                 </para>
+<screen>&lt;subvolumes config:type="list"&gt;
   &lt;path&gt;tmp&lt;/path&gt;
   &lt;path&gt;opt&lt;/path&gt;
   &lt;path&gt;srv&lt;/path&gt;
   &lt;path&gt;var&lt;/path&gt;
   ...
-&lt;/subvolumes&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           If no <tag>subvolumes</tag> section has been defined for a partition
-           description, &ay; will create a predefined set of subvolumes for the
-           given mount point.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>create_subvolumes</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Determine whether Btrfs subvolumes should be created or not.
-          </para>
-         </entry>
-         <entry>
-          <para>
-           It is set to <literal>true</literal> by default. When set to
-           <literal>false</literal>, no subvolumes will be created.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>subvolumes_prefix</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Set the Btrfs subvolumes prefix name. If no prefix is wanted,
-           it must be set to an empty value:
-          </para>
-          <screen>&lt;subvolumes_prefix&gt;&lt;![CDATA[]]&gt;&lt;/subvolumes_prefix&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           It is set to <literal>@</literal> by default.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>lv_name</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           If this partition is on a logical volume in a volume group, specify
-           the logical volume name here (see the <literal>type</literal>
-           parameter in the drive configuration).
-          </para>
-          <screen>&lt;lv_name&gt;opt_lv&lt;/lv_name&gt;</screen>
-         </entry>
-         <entry>
-          <para/>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>stripes</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           An integer that configures LVM striping. Specify across how many
-           devices you want to stripe (spread data).
-          </para>
-          <screen>&lt;stripes config:type="integer"&gt;2&lt;/stripes&gt;</screen>
-         </entry>
-         <entry>
-          <para/>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>stripesize</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Specify the size of each block in KB.
-          </para>
-          <screen>&lt;stripesize config:type="integer"
-&gt;4&lt;/stripesize&gt;</screen>
-         </entry>
-         <entry>
-          <para/>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>lvm_group</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           If this is a physical partition used by (part of) a volume group
-           (LVM), you need to specify the name of the volume group here.
-          </para>
-<screen>&lt;lvm_group&gt;system&lt;/lvm_group&gt;</screen>
-         </entry>
-         <entry>
-          <para/>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>pool</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           <literal>pool</literal> must be set to <literal>true</literal> if
-           the LVM logical volume should be an LVM thin pool.
-          </para>
-          <screen>&lt;pool config:type="boolean"&gt;false&lt;/pool&gt;</screen>
-         </entry>
-         <entry>
-          <para/>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>used_pool</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           The name of the LVM thin pool that is used as a data store for
-           this thin logical volume. If this is set to something non-empty,
-           it implies that the volume is a so-called thin logical volume.
-          </para>
-          <screen>&lt;used_pool&gt;my_thin_pool&lt;/used_pool&gt;</screen>
-         </entry>
-         <entry>
-          <para/>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>raid_name</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           If this physical volume is part of a RAID, specify the name of the
-           RAID.
-          </para>
-          <screen>&lt;raid_name&gt;/dev/md/0&lt;/raid_name&gt;</screen>
-         </entry>
-         <entry>
-          <para/>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>raid_options</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Specify RAID options, see below.
-          </para>
-          <screen>&lt;raid_options&gt;...&lt;/raid_options&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           Setting the RAID options at <literal>partition</literal> level is deprecated.
-           See <xref linkend="ay-partition-sw-raid"/>.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           bcache_backing_for
-          </para>
-         </entry>
-         <entry>
-          <para>
-           If this device is used as a <emphasis>&bcache; backing device</emphasis>, specify the name
-           of the &bcache; device.
-          </para>
-          <screen>&lt;bcache_backing_for&gt;/dev/bcache0&lt;/bcache_backing_for&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           See <xref linkend="ay-partition-bcache"/> for further details.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           bcache_caching_for
-          </para>
-         </entry>
-         <entry>
-          <para>
-           If this device is used as a <emphasis>&bcache; caching device</emphasis>, specify the names
-           of the &bcache; devices.
-          </para>
-          <screen>&lt;bcache_caching_for config:type="list"&gt;
-  &lt;listentry&gt;/dev/bcache0&lt;/listentry&gt;
-&lt;/bcache_caching_for&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           See <xref linkend="ay-partition-bcache"/> for further details.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>resize</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           This boolean must be <literal>true</literal> if an existing
-           partition should be resized. In this case, you need to tell &ay;
-           to reuse the device (see <literal>create</literal>) and specify
-           a <literal>size</literal>.
-          </para>
-          <screen>&lt;resize config:type="boolean"&gt;false&lt;/resize&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           Starting with &productname; 15 resizing works with physical disk
-           partitions and with LVM volumes.
-          </para>
-         </entry>
-        </row>
-       </tbody>
-      </tgroup>
-     </informaltable>
+&lt;/subvolumes&gt;</screen>                 
+             </listitem>
+         </varlistentry>
+     </variablelist>
+     
+        <variablelist>
+         <varlistentry>
+             <term>create_subvolumes</term>
+             <listitem>
+                 <para>
+                     Determine whether Btrfs subvolumes should be created or not.
+                     It is set to <literal>true</literal> by default. When set to
+                     <literal>false</literal>, no subvolumes will be created.
+                 </para>
+             </listitem>
+         </varlistentry>
+     </variablelist>
+     
+        <variablelist>
+         <varlistentry>
+             <term>subvolumes_prefix</term>
+             <listitem>
+                 <para>
+                     Set the Btrfs subvolumes prefix name. If no prefix is wanted,
+                     it must be set to an empty value:
+                 </para>
+<screen>&lt;subvolumes_prefix&gt;&lt;![CDATA[]]&gt;&lt;/subvolumes_prefix&gt;</screen>
+                 <para>It is set to <literal>@</literal> by default.
+                 </para>
+             </listitem>
+         </varlistentry>
+     </variablelist> 
+
+        <variablelist>
+         <varlistentry>
+             <term>lv_name</term>
+             <listitem>
+                 <para>
+                     If this partition is on a logical volume in a volume group,
+                     specify the logical volume name here (see the 
+                     <literal>type</literal> parameter in the drive configuration).
+                 </para>
+<screen>&lt;lv_name&gt;opt_lv&lt;/lv_name&gt;</screen>                 
+             </listitem>
+         </varlistentry>
+     </variablelist>
+     
+        <variablelist>
+         <varlistentry>
+             <term>stripes</term>
+             <listitem>
+                 <para>
+                     An integer that configures LVM striping. Specify across how 
+                     many devices you want to stripe (spread data).
+                 </para>
+<screen>&lt;stripes config:type="integer"&gt;2&lt;/stripes&gt;</screen>               
+             </listitem>
+         </varlistentry>
+     </variablelist>
+
+        <variablelist>
+         <varlistentry>
+             <term>stripesize</term>
+             <listitem>
+                 <para>
+                     Specify the size of each block in KB.
+                 </para>
+<screen>&lt;stripesize config:type="integer"&gt;4&lt;/stripesize&gt;</screen>               
+             </listitem>
+         </varlistentry>
+     </variablelist>
+
+        <variablelist>
+         <varlistentry>
+             <term>lvm_group</term>
+             <listitem>
+                 <para>
+                     If this is a physical partition used by (part of) a volume
+                     group (LVM), you need to specify the name of the volume group
+                     here.
+                 </para>
+<screen>&lt;lvm_group&gt;system&lt;/lvm_group&gt;</screen>                 
+             </listitem>
+         </varlistentry>
+     </variablelist>
+     
+        <variablelist>
+         <varlistentry>
+             <term>pool</term>
+             <listitem>
+                 <para>
+                     <literal>pool</literal> must be set to <literal>true</literal>
+                     if the LVM logical volume should be an LVM thin pool.
+                 </para>
+<screen>&lt;pool config:type="boolean"&gt;true&lt;/pool&gt;</screen>              
+             </listitem>
+         </varlistentry>
+     </variablelist>
+     
+        <variablelist>
+         <varlistentry>
+             <term>used_pool</term>
+             <listitem>
+                 <para>
+                      The name of the LVM thin pool that is used as a data store
+                      for this thin logical volume. If this is set to something
+                      non-empty, it implies that the volume is a so-called thin
+                      logical volume. 
+                 </para>
+<screen>&lt;used_pool&gt;my_thin_pool&lt;/used_pool&gt;</screen>              
+             </listitem>
+         </varlistentry>
+     </variablelist>     
+
+        <variablelist>
+         <varlistentry>
+             <term>raid_name</term>
+             <listitem>
+                 <para>
+                     If this physical volume is part of a RAID array, specify 
+                     the name of the RAID array.
+                 </para>
+<screen>&lt;raid_name&gt;/dev/md/0&lt;/raid_name&gt;</screen>               
+             </listitem>
+         </varlistentry>
+     </variablelist> 
+     
+        <variablelist>
+         <varlistentry>
+             <term>raid_options</term>
+             <listitem>
+                 <para>
+                     Specify RAID options, Setting the RAID options at the
+                     <literal>partition</literal> level is deprecated.
+                     See <xref linkend="ay-partition-sw-raid"/>
+                 </para>
+             </listitem>
+         </varlistentry>
+     </variablelist>  
+     
+        <variablelist>
+         <varlistentry>
+             <term>bcache_backing_for</term>
+             <listitem>
+                 <para>
+                     If this device is used as a <emphasis>&bcache; backing
+                     device</emphasis>, specify the name of the &bcache;
+                     device. See <xref linkend="ay-partition-bcache"/> for 
+                     further details.
+                 </para>
+<screen>&lt;bcache_backing_for&gt;/dev/bcache0&lt;/bcache_backing_for&gt;</screen>              
+             </listitem>
+         </varlistentry>
+     </variablelist>    
+     
+        <variablelist>
+         <varlistentry>
+             <term>bcache_caching_for</term>
+             <listitem>
+                 <para>
+                     If this device is used as a 
+                     <emphasis>&bcache; caching device</emphasis>, specify the 
+                     names of the &bcache; devices. See 
+                     <xref linkend="ay-partition-bcache"/> for further details.
+                 </para>
+  <screen>&lt;bcache_caching_for config:type="list"&gt;&lt;listentry&gt;/dev/bcache0&lt;/listentry&gt;&lt;/bcache_caching_for&gt;</screen>               
+             </listitem>
+         </varlistentry>
+     </variablelist>      
+     
+        <variablelist>
+         <varlistentry>
+             <term>resize</term>
+             <listitem>
+                 <para>
+                     Starting with &productname; 15 resizing works with physical
+                     disk partitions and with LVM volumes
+                 </para>
+ <screen>&lt;resize config:type="boolean"&gt;false&lt;/resize&gt;</screen>                
+             </listitem>
+         </varlistentry>
+     </variablelist>     
     </sect3>
 
     <sect3 xml:id="ay-btrfs-subvolumes">


### PR DESCRIPTION
Part of ongoing work to convert tables in the AutoYaST Guide to variablelists,
because they render awkwardly in PDF

https://trello.com/c/zMJy4Uqz/151-restructure-autoyast-guide-fix-wide-tables

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [ x] 15 SP3  | (`master` only)   
| [ ] 15 SP2  | [ ] 
| [ ] 15 SP1  | [ ] 
| [ ] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
