### PR TITLE
AutoYaST: "control file" and "profile" are equivalent

### DIFF
--- a/xml/ay_bootloader.xml
+++ b/xml/ay_bootloader.xml
@@ -307,7 +307,7 @@
         If set to <literal>false</literal>, then UEFI secure boot is disabled.
         Works only for <literal>grub2-efi</literal> boot loader.
        </para>
-<screen>&lt;secure_boot"&gt;false&lt;/secure_boot&gt;</screen>
+<screen>&lt;secure_boot&gt;false&lt;/secure_boot&gt;</screen>
       </listitem>
      </varlistentry>
      

--- a/xml/ay_control_file.xml
+++ b/xml/ay_control_file.xml
@@ -22,10 +22,11 @@
    <title>Introduction</title>
 
    <para>
-    The control file is a configuration description for a single
-    system. It consists of sets of resources with properties including
-    support for complex structures such as lists, records, trees and large
-    embedded or referenced objects.
+    A <emphasis>control file</emphasis>, also known as
+    <emphasis>profile</emphasis>, is a configuration description for a single
+    system. It consists of sets of resources with properties including support
+    for complex structures such as lists, records, trees and large embedded or
+    referenced objects.
    </para>
 
    <important>


### PR DESCRIPTION
### Description

* Mention that "control file" and "profile" refers to the same thing. Is `<empashis>` the correct tag in this situation?
* Fix the `secure_boot` example.

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [x] 15 SP3  | (`master` only)   
| [x] 15 SP2  | [ ] 
| [x] 15 SP1  | [ ] 
| [x] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
