### PR TITLE
Update GNOME User Guide to sentence case (WIP)

### DIFF
--- a/xml/apps_brasero.xml
+++ b/xml/apps_brasero.xml
@@ -11,7 +11,7 @@
  See FATE #305163
 -->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-gnome-burn">
- <title>Brasero: Burning CDs and DVDs</title>
+ <title>Brasero: burning CDs and DVDs</title>
  <info>
   <abstract>
    <para>
@@ -36,7 +36,7 @@
   </dm:docmanager>
  </info>
  <sect1 xml:id="sec-brasero-creating">
-  <title>Creating a Data CD or DVD</title>
+  <title>Creating a data CD or DVD</title>
 
   <para>
    After starting Brasero for the first time, the main window appears as shown
@@ -44,7 +44,7 @@
   </para>
 
   <figure xml:id="fig-brasero-main">
-   <title>Main View of Brasero</title>
+   <title>Main view of Brasero</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="brasero_main.png" width="70%"/>
@@ -113,7 +113,7 @@
      </listitem>
      <listitem>
       <formalpara>
-       <title>ISO Image</title>
+       <title>ISO image</title>
        <para>
         Specify a file name for your ISO image file.
        </para>
@@ -129,7 +129,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-brasero-creatingaudiocd">
-  <title>Creating an Audio CD</title>
+  <title>Creating an audio CD</title>
 
   <para>
    There are no significant differences between creating an audio CD and
@@ -217,7 +217,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-gnome-writingiso">
-  <title>Writing ISO Images</title>
+  <title>Writing ISO images</title>
 
   <para>
    If you already have an ISO image, click <guimenu>Burn image</guimenu> or go
@@ -230,7 +230,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-brasero-multisession">
-  <title>Creating a Multisession CD or DVD</title>
+  <title>Creating a multisession CD or DVD</title>
 
   <para>
    Multisession discs can be used to write data in more than one burning
@@ -273,7 +273,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-brasero-moreinfos">
-  <title>For More Information</title>
+  <title>For more information</title>
 
   <para>
    You can find more information about Brasero at

--- a/xml/apps_ekiga.xml
+++ b/xml/apps_ekiga.xml
@@ -8,7 +8,7 @@
 probably replace the Pidgin & Ekiga chapters with an Empathy chapter at some point.
 - sknorr, 2015-09-22 -->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-ekiga">
- <title>Ekiga: Using Voice over IP</title>
+ <title>Ekiga: using voice over IP</title>
  <info>
   <abstract>
    <para>
@@ -22,7 +22,7 @@ probably replace the Pidgin & Ekiga chapters with an Empathy chapter at some poi
   </dm:docmanager>
  </info>
  <note>
-  <title>Ekiga May Not Be Installed</title>
+  <title>Ekiga may not be installed</title>
   <para>
    Before proceeding, make sure that the package
    <package>ekiga</package>
@@ -177,7 +177,7 @@ probably replace the Pidgin & Ekiga chapters with an Empathy chapter at some poi
   </procedure>
  </sect1>
  <sect1 xml:id="sec-ekiga-ui">
-  <title>The Ekiga User Interface</title>
+  <title>The Ekiga user interface</title>
 
   <para>
    The user interface has different modes. To switch between views, use the
@@ -189,7 +189,7 @@ probably replace the Pidgin & Ekiga chapters with an Empathy chapter at some poi
   </para>
 
   <figure xml:id="fig-ekiga-main">
-   <title>Ekiga User Interface</title>
+   <title>Ekiga user interface</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="ekiga_main.png" width="45%" format="PNG"/>
@@ -212,7 +212,7 @@ probably replace the Pidgin & Ekiga chapters with an Empathy chapter at some poi
   </para>
 
   <table xml:id="tab-ekiga-shortcut">
-   <title>Key Combinations for Ekiga</title>
+   <title>Key combinations for Ekiga</title>
    <tgroup cols="2">
     <thead>
      <row>
@@ -426,7 +426,7 @@ probably replace the Pidgin & Ekiga chapters with an Empathy chapter at some poi
   </table>
  </sect1>
  <sect1 xml:id="sec-ekiga-firstcall">
-  <title>Making a Call</title>
+  <title>Making a call</title>
 
   <para>
    After Ekiga is properly configured, making a call is easy.
@@ -486,7 +486,7 @@ probably replace the Pidgin & Ekiga chapters with an Empathy chapter at some poi
   </para>
  </sect1>
  <sect1 xml:id="sec-ekiga-answer">
-  <title>Answering a Call</title>
+  <title>Answering a call</title>
 
   <para>
    Ekiga can receive calls in two different ways. First, it can be called
@@ -498,7 +498,7 @@ probably replace the Pidgin & Ekiga chapters with an Empathy chapter at some poi
 
   <variablelist>
    <varlistentry>
-    <term>Normal Application</term>
+    <term>Normal application</term>
     <listitem>
      <para>
       Incoming calls can only be received and answered if Ekiga is already
@@ -508,7 +508,7 @@ probably replace the Pidgin & Ekiga chapters with an Empathy chapter at some poi
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Panel Applet</term>
+    <term>Panel applet</term>
     <listitem>
      <para>
       Normally, the Ekiga panel applet runs silently without giving any notice
@@ -532,7 +532,7 @@ probably replace the Pidgin & Ekiga chapters with an Empathy chapter at some poi
   </para>
  </sect1>
  <sect1 xml:id="sec-ekiga-calladd">
-  <title>Using the Address Book</title>
+  <title>Using the address book</title>
 
   <para>
    Ekiga can manage your SIP contacts. All of the contacts are displayed in the
@@ -586,7 +586,7 @@ probably replace the Pidgin & Ekiga chapters with an Empathy chapter at some poi
   </para>
  </sect1>
  <sect1 xml:id="sec-ekiga-moreinfo">
-  <title>For More Information</title>
+  <title>For more information</title>
 
   <para>
    The official home page of Ekiga is

--- a/xml/apps_evolution.xml
+++ b/xml/apps_evolution.xml
@@ -1106,7 +1106,7 @@
      </para>
     </formalpara>
     <formalpara>
-     <title><guimenu>Copy folder to</guimenu>:</title>
+     <title><guimenu>Copy Folder To</guimenu>:</title>
      <para>
       Copies the folder to a different location. When you select this item,
       Evolution offers a choice of locations to copy the folder to.

--- a/xml/apps_evolution.xml
+++ b/xml/apps_evolution.xml
@@ -1113,7 +1113,7 @@
      </para>
     </formalpara>
     <formalpara>
-     <title><guimenu>Move folder to</guimenu>:</title>
+     <title><guimenu>Move Folder To</guimenu>:</title>
      <para>
       Moves the folder to another location.
      </para>

--- a/xml/apps_evolution.xml
+++ b/xml/apps_evolution.xml
@@ -40,7 +40,7 @@
   details, refer to the Evolution application help.
  </para>
  <sect1 xml:id="sec-gnome-evolution-first-start">
-  <title>Starting evolution</title>
+  <title>Starting Evolution</title>
 
   <para>
    To start Evolution, , open the Activities Overview by pressing <keycap
@@ -565,7 +565,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gnome-evolution-first-start-setup-assistant-receiving-opts-exchange">
-    <title>Exchange web services receiving options</title>
+    <title>Exchange Web services receiving options</title>
     <para>
      If you selected Exchange Web Services as the receiving server type, you
      will now see a page of options to specify the behavior of Evolution.

--- a/xml/apps_evolution.xml
+++ b/xml/apps_evolution.xml
@@ -6,7 +6,7 @@
 ]>
 
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-gnome-evolution">
- <title>Evolution: E-Mailing and Calendaring</title>
+ <title>Evolution: e-mailing and calendaring</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -40,7 +40,7 @@
   details, refer to the Evolution application help.
  </para>
  <sect1 xml:id="sec-gnome-evolution-first-start">
-  <title>Starting Evolution</title>
+  <title>Starting evolution</title>
 
   <para>
    To start Evolution, , open the Activities Overview by pressing <keycap
@@ -55,7 +55,7 @@
  user (unless the explanation of an option is more than "A=A")...
 -->
  <sect1 xml:id="sec-gnome-evolution-first-start-setup-assistant">
-  <title>Setup Assistant</title>
+  <title>Setup assistant</title>
 
   <para>
    The first time you start Evolution, it opens an assistant to help you set up
@@ -68,7 +68,7 @@
   </para>
 
   <sect2 xml:id="sec-gnome-evolution-first-start-restore">
-   <title>Restoring from a Backup File</title>
+   <title>Restoring from a backup file</title>
    <para>
     When the assistant starts, the <guimenu>Welcome</guimenu> page is
     displayed. Proceed to the <guimenu>Restore from Backup</guimenu> page. If
@@ -82,7 +82,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnome-evolution-first-start-setup-assistant-identity">
-   <title>Defining Your Identity</title>
+   <title>Defining your identity</title>
    <para>
     The <guimenu>Identity</guimenu> page is the next step in the assistant.
    </para>
@@ -125,7 +125,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnome-evolution-first-start-setup-assistant-receiving">
-   <title>Receiving Mail</title>
+   <title>Receiving mail</title>
    <para>
     The <guimenu>Receiving E-mail</guimenu> page lets you determine the server
     that you want to use to receive e-mail.
@@ -140,7 +140,7 @@
     following is a list of available server types:
    </para>
    <formalpara>
-    <title>Exchange Web Services:</title>
+    <title>Exchange web services:</title>
     <para>
      Allows you to connect to newer Microsoft Exchange servers to synchronize
      e-mail, calendar, and contact information. This is only available if you
@@ -170,13 +170,13 @@
     </para>
    </formalpara>
    <formalpara>
-    <title>USENET News:</title>
+    <title>USENET news:</title>
     <para>
      Connects to a news server and downloads a list of available news digests.
     </para>
    </formalpara>
    <formalpara>
-    <title>Local Delivery:</title>
+    <title>Local delivery:</title>
     <para>
      If you want to move e-mail from the spool and store it in your home
      directory, you need to provide the path to the mail spool you want to use.
@@ -185,7 +185,7 @@
     </para>
    </formalpara>
    <formalpara>
-    <title>MH Format Mail Directories:</title>
+    <title>MH format mail directories:</title>
     <para>
      To download your e-mail using <command>mh</command> or an
      <command>mh</command>-style program, you need to provide the path to the
@@ -193,7 +193,7 @@
     </para>
    </formalpara>
    <formalpara>
-    <title>Maildir Format Mail Directories:</title>
+    <title>Maildir format mail directories:</title>
     <para>
      If you download your e-mail using Qmail or another Maildir-style program,
      select this option. You need to provide the path to the mail directory you
@@ -201,7 +201,7 @@
     </para>
    </formalpara>
    <formalpara>
-    <title>Standard Unix Mbox Spool File or Directory:</title>
+    <title>Standard unix mbox spool file or directory:</title>
     <para>
      To read and store e-mail in the mail spool on your local system, select
      this option. You need to provide the path to the mail spool you want to
@@ -216,7 +216,7 @@
     </para>
    </formalpara>
    <sect3 xml:id="sec-gnome-evolution-first-start-setup-assistant-receiving-remote">
-    <title>Configuration Options for IMAP+, POP, and USENET</title>
+    <title>Configuration options for IMAP+, POP, and USENET</title>
     <para>
      If you selected IMAP+, POP, or USENET News as the server type, you need to
      specify additional information.
@@ -266,7 +266,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gnome-evolution-first-start-setup-assistant-receiving-exchange">
-    <title>Configuration Options for Exchange Web Services</title>
+    <title>Configuration options for exchange web services</title>
     <para>
      If you selected Exchange Web Services as the server type, you need to
      specify additional information.
@@ -319,7 +319,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gnome-evolution-first-start-setup-assistant-receiving-local">
-    <title>Local Configuration Options</title>
+    <title>Local configuration options</title>
     <para>
      If you selected <guimenu>Local Delivery</guimenu>, <guimenu>MH-Format Mail
      Directories</guimenu>, <guimenu>Maildir-Format Mail Directories</guimenu>,
@@ -330,13 +330,13 @@
   </sect2>
 
   <sect2 xml:id="sec-gnome-evolution-first-start-setup-assistant-receiving-opts">
-   <title>Receiving Options</title>
+   <title>Receiving options</title>
    <para>
     After you have selected a mail delivery mechanism, you can set some
     preferences for its behavior.
    </para>
    <sect3 xml:id="sec-gnome-evolution-first-start-setup-assistant-receiving-opts-imap">
-    <title>IMAP+ Receiving Options</title>
+    <title>IMAP+ receiving options</title>
     <para>
      If you selected IMAP+ as the receiving server type, you will now see a
      page of options to specify the behavior of Evolution.
@@ -376,7 +376,7 @@
         </listitem>
        </varlistentry>
        <varlistentry>
-        <term><guimenu>Use Quick Resync if the server supports it</guimenu>
+        <term><guimenu>Use quick resync if the server supports it</guimenu>
         </term>
         <listitem>
          <para>
@@ -422,7 +422,7 @@
         </listitem>
        </varlistentry>
        <varlistentry>
-        <term><guimenu>Check new messages for Junk contents</guimenu>
+        <term><guimenu>Check new messages for junk contents</guimenu>
         </term>
         <listitem>
          <para>
@@ -450,7 +450,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gnome-evolution-first-start-setup-assistant-receiving-opts-pop">
-    <title>POP Receiving Options</title>
+    <title>POP receiving options</title>
     <para>
      If you selected POP as the receiving server type, you will now see a page
      of options to specify the behavior of Evolution.
@@ -503,7 +503,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gnome-evolution-first-start-setup-assistant-receiving-opts-usenet">
-    <title>USENET News Receiving Options</title>
+    <title>USENET news receiving options</title>
     <para>
      If you selected USENET News as the receiving server type, you will now see
      a page of options to specify the behavior of Evolution.
@@ -565,7 +565,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gnome-evolution-first-start-setup-assistant-receiving-opts-exchange">
-    <title>Exchange Web Services Receiving Options</title>
+    <title>Exchange web services receiving options</title>
     <para>
      If you selected Exchange Web Services as the receiving server type, you
      will now see a page of options to specify the behavior of Evolution.
@@ -617,7 +617,7 @@
         </listitem>
        </varlistentry>
        <varlistentry>
-        <term><guimenu>Check new messages for Junk contents</guimenu>
+        <term><guimenu>Check new messages for junk contents</guimenu>
         </term>
         <listitem>
          <para>
@@ -665,7 +665,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gnome-evolution-first-start-setup-assistant-receiving-opts-local">
-    <title>Local Delivery Receiving Options</title>
+    <title>Local delivery receiving options</title>
     <para>
      If you selected that you want to receive mail through Local Delivery, you
      will now see a page of options to specify the behavior of Evolution.
@@ -686,7 +686,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gnome-evolution-first-start-setup-assistant-receiving-opts-mh">
-    <title>MH-Format Mail Directories Receiving Options</title>
+    <title>MH-format mail directories receiving options</title>
     <para>
      If you selected that you want to receive mail through MH-Format Mail
      Directories, you will now see a page of options to specify the behavior of
@@ -712,7 +712,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gnome-evolution-first-start-setup-assistant-receiving-opts-maildir">
-    <title>Maildir-Format Mail Directories Receiving Options</title>
+    <title>Maildir-format mail directories receiving options</title>
     <para>
      If you selected that you want to receive mail through Maildir-Format Mail
      Directories, you will now see a page of options to specify the behavior of
@@ -738,7 +738,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gnome-evolution-first-start-setup-assistant-receiving-opts-mbox">
-    <title>Standard Unix Mbox Spool or Directory Receiving Options</title>
+    <title>Standard unix mbox spool or directory receiving options</title>
     <para>
      If you selected that you want to receive mail through a Unix mbox Spool
      File or Directories, you will now see a page of options to specify the
@@ -772,7 +772,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnome-evolution-first-start-setup-assistant-sending">
-   <title>Sending Mail</title>
+   <title>Sending mail</title>
    <para>
     Now that you have entered information about how you plan to receive mail,
     Evolution needs to know about how you want to send it. Usually, a separate
@@ -803,7 +803,7 @@
     </para>
    </formalpara>
    <procedure>
-    <title>SMTP Configuration</title>
+    <title>SMTP configuration</title>
     <step>
      <para>
       Type the host address in the <guimenu>Server</guimenu> field.
@@ -863,7 +863,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnome-evolution-first-start-setup-assistant-account">
-   <title>Final Steps</title>
+   <title>Final steps</title>
    <para>
     Now that you have finished the e-mail configuration process, you need to
     give the account a name. The name can be any name you prefer. Type your
@@ -881,7 +881,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gnome-evolution-usage">
-  <title>Using Evolution</title>
+  <title>Using evolution</title>
 
   <para>
    Now that the first-run configuration has finished, you are ready to begin
@@ -890,7 +890,7 @@
   </para>
 
   <figure pgwide="0">
-   <title>Evolution Window</title>
+   <title>Evolution window</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="evolution.png" width="100%" format="PNG"/>
@@ -903,7 +903,7 @@
 
   <variablelist>
    <varlistentry>
-    <term>Menu Bar</term>
+    <term>Menu bar</term>
     <listitem>
      <para>
       The menu bar gives you access to nearly all of the features of Evolution.
@@ -911,7 +911,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Folder List</term>
+    <term>Folder list</term>
     <listitem>
      <para>
       The folder list gives you a list of the available folders for each
@@ -930,7 +930,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Search Bar</term>
+    <term>Search bar</term>
     <listitem>
      <para>
       The search bar lets you search for e-mails. You can filter e-mails,
@@ -941,7 +941,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Message List</term>
+    <term>Message list</term>
     <listitem>
      <para>
       The message list displays a list of e-mails that you have received. To
@@ -950,7 +950,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Shortcut Bar</term>
+    <term>Shortcut bar</term>
     <listitem>
      <para>
       The shortcut bar at the left lets you switch between folders and program
@@ -973,7 +973,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Preview Pane</term>
+    <term>Preview pane</term>
     <listitem>
      <para>
       The preview pane displays the contents of the e-mails that are selected
@@ -984,7 +984,7 @@
   </variablelist>
 
   <sect2 xml:id="sec-gnome-evolution-usage-menu-bar">
-   <title>The Menu Bar</title>
+   <title>The menu bar</title>
    <para>
     The menu bar’s contents always provide all the possible actions for any
     view of your data.
@@ -1037,7 +1037,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnome-evolution-usage-shortcut-bar">
-   <title>The Shortcut Bar</title>
+   <title>The shortcut bar</title>
    <para>
     The shortcut bar is the column on the left side of the main window. At the
     top, there is a list of folders for the selected Evolution component. The
@@ -1088,32 +1088,32 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gnome-evolution-usage-shortcut-bar-subfolders">
-    <title>Folder Management</title>
+    <title>Folder management</title>
     <para>
      Right-click a folder or subfolder to display a menu with the following
      options:
     </para>
     <formalpara>
-     <title><guimenu>Mark All Messages As Read</guimenu>:</title>
+     <title><guimenu>Mark all messages as read</guimenu>:</title>
      <para>
       Marks all the messages in the folder as read.
      </para>
     </formalpara>
     <formalpara>
-     <title><guimenu>New Folder</guimenu>:</title>
+     <title><guimenu>New folder</guimenu>:</title>
      <para>
       Creates a new folder or subfolder in the same location.
      </para>
     </formalpara>
     <formalpara>
-     <title><guimenu>Copy Folder To</guimenu>:</title>
+     <title><guimenu>Copy folder to</guimenu>:</title>
      <para>
       Copies the folder to a different location. When you select this item,
       Evolution offers a choice of locations to copy the folder to.
      </para>
     </formalpara>
     <formalpara>
-     <title><guimenu>Move Folder To</guimenu>:</title>
+     <title><guimenu>Move folder to</guimenu>:</title>
      <para>
       Moves the folder to another location.
      </para>
@@ -1154,7 +1154,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnome-evolution-usage-e-mail">
-   <title>Using E-Mail</title>
+   <title>Using e-mail</title>
    <para>
     The e-mail component of Evolution has the following standout features:
    </para>
@@ -1185,7 +1185,7 @@
    </para>
    <variablelist>
     <varlistentry>
-     <term>Message List</term>
+     <term>Message list</term>
      <listitem>
       <para>
        The message list displays all the e-mails that you have. This includes
@@ -1197,7 +1197,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Preview Pane</term>
+     <term>Preview pane</term>
      <listitem>
       <para>
        This is where your e-mail is displayed.
@@ -1244,7 +1244,7 @@
    </para>
    <variablelist>
     <varlistentry>
-     <term>Appointment List</term>
+     <term>Appointment list</term>
      <listitem>
       <para>
        The appointment list displays all your scheduled appointments.
@@ -1252,7 +1252,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Month Pane</term>
+     <term>Month pane</term>
      <listitem>
       <para>
        The month pane is a small view of a calendar month. You can also select
@@ -1285,7 +1285,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnome-evolution-usage-contacts">
-   <title>Managing Contacts</title>
+   <title>Managing contacts</title>
    <para>
     To use the contacts component, click <guimenu>Contacts</guimenu> in the
     shortcut bar. The Evolution contacts component can handle all of the
@@ -1305,7 +1305,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-evolution-moreinfo">
-  <title>For More Information</title>
+  <title>For more information</title>
 
   <para>
    Get more information about Evolution from the application help available via

--- a/xml/apps_evolution.xml
+++ b/xml/apps_evolution.xml
@@ -1094,7 +1094,7 @@
      options:
     </para>
     <formalpara>
-     <title><guimenu>Mark all messages as read</guimenu>:</title>
+     <title><guimenu>Mark All Messages As Read</guimenu>:</title>
      <para>
       Marks all the messages in the folder as read.
      </para>

--- a/xml/apps_evolution.xml
+++ b/xml/apps_evolution.xml
@@ -1100,7 +1100,7 @@
      </para>
     </formalpara>
     <formalpara>
-     <title><guimenu>New folder</guimenu>:</title>
+     <title><guimenu>New Folder</guimenu>:</title>
      <para>
       Creates a new folder or subfolder in the same location.
      </para>

--- a/xml/apps_firefox.xml
+++ b/xml/apps_firefox.xml
@@ -31,7 +31,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-firefox-navigating">
-  <title>Navigating web sites</title>
+  <title>Navigating Web sites</title>
 
   <para>
    The look and feel of Firefox is similar to that of other browsers. It is

--- a/xml/apps_firefox.xml
+++ b/xml/apps_firefox.xml
@@ -206,7 +206,7 @@
   </para>
 
   <sect2 xml:id="sec-firefox-searchengine">
-   <title>Finding information on the web</title>
+   <title>Finding information on the Web</title>
    <para>
     Firefox has a search bar that can access different engines like Google,
     Yahoo, or Amazon. For example, if you want to find information about &suse;

--- a/xml/apps_firefox.xml
+++ b/xml/apps_firefox.xml
@@ -6,7 +6,7 @@
   <!ENTITY hamburger-icon "<inlinemediaobject xmlns='http://docbook.org/ns/docbook'><textobject role='description'><phrase>Three-lines button</phrase></textobject><imageobject role='fo'><imagedata fileref='hamburger_button.svg' width='0.8em' format='SVG'/></imageobject><imageobject role='html'><imagedata fileref='hamburger_button-fallback.png' width='1em' format='PNG'/></imageobject></inlinemediaobject>">
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-firefox">
- <title>Firefox: Browsing the Web</title>
+ <title>Firefox: browsing the web</title>
  <info>
   <abstract>
    <para>
@@ -31,7 +31,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-firefox-navigating">
-  <title>Navigating Web Sites</title>
+  <title>Navigating web sites</title>
 
   <para>
    The look and feel of Firefox is similar to that of other browsers. It is
@@ -43,7 +43,7 @@
   </para>
 
   <note>
-   <title>Using the Menu Bar</title>
+   <title>Using the menu bar</title>
    <para>
     While most functions of Firefox are available through the three-lines
     button (&hamburger-icon;), some are only available from the menu bar.
@@ -62,7 +62,7 @@
   </note>
 
   <figure xml:id="fig-firefox-main">
-   <title>The Browser Window of Firefox</title>
+   <title>The browser window of Firefox</title>
    <mediaobject>
     <imageobject role="html">
      <imagedata fileref="firefox_main.png" width="100%"/>
@@ -74,7 +74,7 @@
   </figure>
 
   <sect2 xml:id="sec-firefox-locationbar">
-   <title>The Location Bar</title>
+   <title>The location bar</title>
    <para>
     When typing into the location bar, an auto-completion drop-down box opens.
     It shows all previous location addresses and bookmarks containing the
@@ -118,7 +118,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-tabbedbrowsing">
-   <title>Tabbed Browsing</title>
+   <title>Tabbed browsing</title>
    <para>
     Tabbed browsing allows you to load multiple Web sites in a single window.
     To switch between pages in use, use the tabs at the top of the window. If
@@ -127,7 +127,7 @@
    </para>
    <variablelist>
     <varlistentry>
-     <term>Opening Tabs</term>
+     <term>Opening tabs</term>
      <listitem>
       <para>
        To open a new tab, from the menu bar, select <menuchoice>
@@ -143,7 +143,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Closing Tabs</term>
+     <term>Closing tabs</term>
      <listitem>
       <para>
        Right-click a tab to open a context menu, giving you access to tab
@@ -160,7 +160,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Sorting Tabs</term>
+     <term>Sorting tabs</term>
      <listitem>
       <para>
        By default, tabs are sorted in the order you opened them. Rearrange the
@@ -173,7 +173,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Dragging and Dropping</term>
+     <term>Dragging and dropping</term>
      <listitem>
       <para>
        Drag and drop also works with tabs. Drag a link onto an existing tab to
@@ -187,7 +187,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-sidebar">
-   <title>Using the Sidebar</title>
+   <title>Using the sidebar</title>
    <para>
     Use the left side of your browser window for viewing bookmarks or browsing
     history. Extensions may add new ways to use the sidebar as well. To display
@@ -197,7 +197,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-firefox-findinfo">
-  <title>Finding Information</title>
+  <title>Finding information</title>
 
   <para>
    There are two ways to find information in Firefox: to search the Internet
@@ -206,7 +206,7 @@
   </para>
 
   <sect2 xml:id="sec-firefox-searchengine">
-   <title>Finding Information on the Web</title>
+   <title>Finding information on the web</title>
    <para>
     Firefox has a search bar that can access different engines like Google,
     Yahoo, or Amazon. For example, if you want to find information about &suse;
@@ -219,7 +219,7 @@
     of the search provider icons at the bottom of the appearing pop-up.
    </para>
    <sect3 xml:id="sec-firefox-searchengine-add">
-    <title>Customizing the Search Bar</title>
+    <title>Customizing the search bar</title>
     <para>
      If you want to change the order, add, or delete a search engine, proceed
      as follows.
@@ -261,7 +261,7 @@
      </step>
     </procedure>
     <figure xml:id="fig-firefox-manage-search">
-     <title>Firefox&mdash;Manage Search Engines</title>
+     <title>Firefox&mdash;manage search engines</title>
      <mediaobject>
       <imageobject role="html">
        <imagedata fileref="firefox_manage_searchengines.png" width="70%"/>
@@ -279,7 +279,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-searchengine-smartkeywords">
-    <title>Adding Keywords to Your Online Searches</title>
+    <title>Adding keywords to your online searches</title>
     <para>
      Firefox lets you define own <emphasis>keywords</emphasis>: abbreviations
      to use as a URL shortcut for a particular search engine. If you have
@@ -325,7 +325,7 @@
      </step>
     </procedure>
     <tip>
-     <title>Keywords for Regular Web Sites</title>
+     <title>Keywords for regular web sites</title>
      <para>
       Using keywords is not restricted to search engines. You can also add a
       keyword to a bookmark (via the bookmark's properties). For example, if
@@ -337,7 +337,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-findinfo-page">
-   <title>Searching in the Current Page</title>
+   <title>Searching in the current page</title>
    <para>
     To search inside a Web page, in the menu bar, click <menuchoice>
     <guimenu>Edit</guimenu> <guimenu>Find</guimenu> </menuchoice> or press
@@ -361,7 +361,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-firefox-bookmarks">
-  <title>Managing Bookmarks</title>
+  <title>Managing bookmarks</title>
 
   <para>
    Bookmarks offer a convenient way of saving links to your favorite Web sites.
@@ -391,14 +391,14 @@
   </para>
 
   <sect2 xml:id="sec-firefox-bookmarks-organise">
-   <title>Organizing Bookmarks</title>
+   <title>Organizing bookmarks</title>
    <para>
     The <guimenu>Library</guimenu> can be used to manage the properties (name
     and address location) for each bookmark and organize the bookmarks into
     folders and sections. It resembles <xref linkend="fig-firefox-library"/>.
    </para>
    <figure xml:id="fig-firefox-library">
-    <title>The Firefox Bookmark Library</title>
+    <title>The Firefox bookmark library</title>
     <mediaobject>
      <imageobject role="html">
       <imagedata fileref="firefox_library.png" width="85%"/>
@@ -437,14 +437,14 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>All Bookmarks</term>
+     <term>All bookmarks</term>
      <listitem>
       <para>
        This category contains the three main bookmark folders:
       </para>
       <variablelist>
        <varlistentry>
-        <term>Bookmarks Toolbar</term>
+        <term>Bookmarks toolbar</term>
         <listitem>
          <para>
           Contains the bookmarks and folders displayed beneath the location
@@ -454,7 +454,7 @@
         </listitem>
        </varlistentry>
        <varlistentry>
-        <term>Bookmarks Menu</term>
+        <term>Bookmarks menu</term>
         <listitem>
          <para>
           Holds the bookmarks and folder accessible via the
@@ -464,7 +464,7 @@
         </listitem>
        </varlistentry>
        <varlistentry>
-        <term>Unsorted Bookmarks</term>
+        <term>Unsorted bookmarks</term>
         <listitem>
          <para>
           Contains all bookmarks created with a single click the star in the
@@ -516,7 +516,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-imexport">
-   <title>Importing and Exporting Bookmarks</title>
+   <title>Importing and exporting bookmarks</title>
 <!-- There is an import assistant for importing from other installed
    browsers. It is pretty useless though, since a) only Firefox is included with
    SLE, b) Epiphany and Chromium are not supported. (Though you can import from
@@ -546,7 +546,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-live">
-   <title>Live Bookmarks</title>
+   <title>Live bookmarks</title>
    <para>
     Live Bookmarks display headlines in your bookmark menu and keep you up to
     date with the latest news. This enables you to save time with one glance at
@@ -569,7 +569,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-smart">
-   <title>Smart Bookmark Folders</title>
+   <title>Smart bookmark folders</title>
    <para>
     Smart bookmark folders are virtual bookmark folders that are dynamically
     updated. There are three smart bookmark folders: The <guimenu>Most
@@ -580,7 +580,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-toolbar">
-   <title>The Bookmarks Toolbar</title>
+   <title>The bookmarks toolbar</title>
    <para>
     The <literal>Bookmarks Toolbar</literal> is displayed beneath the location
     bar and lets you quickly access bookmarks. You can also add, organize, and
@@ -611,7 +611,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-firefox-downloadmanager">
-  <title>Using the Download Manager</title>
+  <title>Using the download manager</title>
 
   <para>
    Keep track of your current and past downloads with the download manager. To
@@ -636,7 +636,7 @@
   </para>
 
   <tip>
-   <title>Resuming Downloads</title>
+   <title>Resuming downloads</title>
    <para>
     If your browser crashes or is closed while downloading, all pending
     downloads will automatically be resumed in the background when starting
@@ -660,7 +660,7 @@
   </para>
 
   <sect2 xml:id="sec-firefox-security-instant-id">
-   <title>Instant Web Site ID</title>
+   <title>Instant web site ID</title>
    <para>
     Firefox allows you to check the identity of a Web page with a single
     glance. The icon in the location bar next to the address indicates which
@@ -668,7 +668,7 @@
    </para>
    <variablelist>
     <varlistentry>
-     <term>Gray Globe</term>
+     <term>Gray globe</term>
      <listitem>
       <para>
        The site does not provide any identity information and communication
@@ -678,7 +678,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Gray Triangle</term>
+     <term>Gray triangle</term>
      <listitem>
       <para>
        This site is from a domain that has been verified by a certificate, so
@@ -690,7 +690,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Gray Padlock</term>
+     <term>Gray padlock</term>
      <listitem>
       <para>
        This site is from a domain that has been verified by a certificate, so
@@ -701,7 +701,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Green Padlock</term>
+     <term>Green padlock</term>
      <listitem>
       <para>
        This site completely identifies itself by a certificate that ensures a
@@ -731,7 +731,7 @@
     items.
    </para>
    <figure xml:id="fig-firefox-pageinfo">
-    <title>The Firefox Page Info Window</title>
+    <title>The Firefox page info window</title>
     <mediaobject>
      <imageobject role="html">
       <imagedata fileref="firefox_page_info.png" width="70%"/>
@@ -744,7 +744,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-security-instant-id-cert-import">
-   <title>Importing Certificates</title>
+   <title>Importing certificates</title>
    <para>
     Firefox comes with a certificate store for identifying certificate
     authorities (CA). Using these certificates enables the browser to
@@ -776,7 +776,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-security-passwords">
-   <title>Password Management</title>
+   <title>Password management</title>
    <para>
     Each time you enter a user name and a password on a Web site, Firefox
     offers to store this data. A pop-up at the top of the page opens, asking
@@ -806,7 +806,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-security-private-browsing">
-   <title>Private Browsing</title>
+   <title>Private browsing</title>
    <para>
     By default, Firefox keeps track of your browsing history by storing content
     and links of visited Web sites, cookies, downloads, passwords, search terms
@@ -835,7 +835,7 @@
     then choose <guimenu>Always use private browsing mode</guimenu>.
    </para>
    <warning>
-    <title>Bookmarks and Downloads</title>
+    <title>Bookmarks and downloads</title>
     <para>
      Downloads and bookmarks you made during Private Browsing mode will be
      kept.
@@ -882,7 +882,7 @@
     clicking the question mark icon in the dialog.
    </para>
    <figure xml:id="fig-firefox-preferences">
-    <title>The Preferences Window</title>
+    <title>The preferences window</title>
     <mediaobject>
      <imageobject role="html">
       <imagedata fileref="firefox_preferences.png" width="70%"/>
@@ -914,7 +914,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-preferences-language">
-    <title>Language Preferences for Web Sites</title>
+    <title>Language preferences for web sites</title>
     <para>
      When sending a request to a Web server, the browser always sends the
      information about which language is preferred by the user. Web sites that
@@ -929,7 +929,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-preferences-spelling">
-    <title>Spell Checking</title>
+    <title>Spell checking</title>
     <para>
      By default, Firefox spell-checks what you type when typing into
      multiple-line text boxes. Misspelled words are underlined in red. To
@@ -950,7 +950,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-extensions">
-   <title>Add-Ons</title>
+   <title>Add-ons</title>
    <para>
     Extensions let you personalize Firefox to fit your needs. With extensions,
     you can change the look and feel of Firefox, enhance existing
@@ -969,7 +969,7 @@
     the appearance of the browser.
    </para>
    <sect3 xml:id="sec-firefox-extensions-install">
-    <title>Installing Add-ons</title>
+    <title>Installing add-ons</title>
     <para>
      To add an extension or theme, start the add-ons manager with <menuchoice>
      <guimenu>Tools</guimenu> <guimenu>Add-Ons</guimenu> </menuchoice> from the
@@ -984,7 +984,7 @@
      detailed information by clicking the <guimenu>More</guimenu> link.
     </para>
     <figure xml:id="fig-firefox-extensions">
-     <title>Installing Firefox Extensions</title>
+     <title>Installing Firefox extensions</title>
      <mediaobject>
       <imageobject role="html">
        <imagedata fileref="firefox_addon_manager.png" width="80%"/>
@@ -1009,7 +1009,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-extensions-manage">
-    <title>Managing Add-ons</title>
+    <title>Managing add-ons</title>
     <para>
      The Add-ons Manager also offers a convenient interface to manage
      extensions, themes, and plug-ins. <guimenu>Extensions</guimenu> can be
@@ -1033,7 +1033,7 @@
 
 <!--  <sect2 id="sec-firefox-lockdown"
    os="sled">
-   <title>Disabling Features</title>
+   <title>Disabling features</title>
    <para>
     <remark condition="generic"> 2008-02-29 - fs: Fate #302023 and #300976 </remark>
     For special-use cases (for example when using &productname; as an
@@ -1087,7 +1087,7 @@
       not find an #Adone Flash Player' entry in the main menu-->
 <!--
   <sect1 xml:id="sec-firefox-flashplayer-props">
-  <title>Controlling Adobe Flash Player Settings</title>
+  <title>Controlling adobe flash player settings</title>
 
   <para>
    Adobe Flash Player is a software that extends browsers with the ability to
@@ -1107,7 +1107,7 @@
   </para>
   </sect1>-->
  <sect1 xml:id="sec-firefox-moreinfo">
-  <title>For More Information</title>
+  <title>For more information</title>
 
   <para>
    To get more information about Firefox see the following links:

--- a/xml/apps_firefox.xml
+++ b/xml/apps_firefox.xml
@@ -914,7 +914,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-preferences-language">
-    <title>Language preferences for web sites</title>
+    <title>Language preferences for Web sites</title>
     <para>
      When sending a request to a Web server, the browser always sends the
      information about which language is preferred by the user. Web sites that

--- a/xml/apps_firefox.xml
+++ b/xml/apps_firefox.xml
@@ -6,7 +6,7 @@
   <!ENTITY hamburger-icon "<inlinemediaobject xmlns='http://docbook.org/ns/docbook'><textobject role='description'><phrase>Three-lines button</phrase></textobject><imageobject role='fo'><imagedata fileref='hamburger_button.svg' width='0.8em' format='SVG'/></imageobject><imageobject role='html'><imagedata fileref='hamburger_button-fallback.png' width='1em' format='PNG'/></imageobject></inlinemediaobject>">
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-firefox">
- <title>Firefox: browsing the web</title>
+ <title>Firefox: browsing the Web</title>
  <info>
   <abstract>
    <para>

--- a/xml/apps_firefox.xml
+++ b/xml/apps_firefox.xml
@@ -660,7 +660,7 @@
   </para>
 
   <sect2 xml:id="sec-firefox-security-instant-id">
-   <title>Instant web site ID</title>
+   <title>Instant Web site ID</title>
    <para>
     Firefox allows you to check the identity of a Web page with a single
     glance. The icon in the location bar next to the address indicates which

--- a/xml/apps_gimp.xml
+++ b/xml/apps_gimp.xml
@@ -6,7 +6,7 @@
 ]>
 
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-gimp">
- <title>GIMP: Manipulating Graphics</title>
+ <title>GIMP: manipulating graphics</title>
  <info>
   <abstract>
    <para>
@@ -30,7 +30,7 @@
   information about the program.
  </para>
  <sect1 xml:id="sec-gimp-graphics">
-  <title>Graphics Formats</title>
+  <title>Graphics formats</title>
 
   <para>
    There are two main types of digital graphics: raster and vector. GIMP is
@@ -39,7 +39,7 @@
   </para>
 
   <formalpara>
-   <title>Raster Images</title>
+   <title>Raster images</title>
    <para>
     A raster image is a collection of pixels: Small blocks of color that create
     an entire image when put together. High resolution images contain a large
@@ -55,7 +55,7 @@
   </para>
 
   <formalpara>
-   <title>Vector Images</title>
+   <title>Vector images</title>
    <para>
     Unlike raster images, vector images do not store information about
     individual pixels. Instead, they use geometric primitives such as points,
@@ -114,7 +114,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-gimp-starting-defaultwin">
-  <title>User Interface Overview</title>
+  <title>User interface overview</title>
 
   <para>
    By default, GIMP shows three windows. The toolbox, an empty image window
@@ -136,7 +136,7 @@
   </para>
 
   <sect2 xml:id="sec-gimp-getstart-imagewin">
-   <title>The Image Window</title>
+   <title>The image window</title>
    <para>
     If there is currently no image open, the image window is empty, containing
     only the menu bar and the drop area, which can be used to open any file by
@@ -173,7 +173,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-starting-defaultwin-toolbox">
-   <title>The Toolbox</title>
+   <title>The toolbox</title>
    <para>
     The toolbox contains drawing tools, a color selector, and a freely
     configurable space for options pages. If you accidentally close the
@@ -187,7 +187,7 @@
     simply dragging and dropping it there.
    </para>
    <figure xml:id="fig-gimp-toolbox">
-    <title>The Toolbox</title>
+    <title>The toolbox</title>
     <mediaobject>
      <imageobject role="html">
       <imagedata fileref="gimp-toolbox.png" width="35%" format="PNG"/>
@@ -213,7 +213,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-starting-defaultwin-lcpu">
-   <title>Layers, Channels, Paths, Undo</title>
+   <title>Layers, channels, paths, undo</title>
    <para>
     <guimenu>Layers</guimenu> shows the different layers in the current image
     and can be used to manipulate the layers. Information is available in
@@ -234,7 +234,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gimp-getstart">
-  <title>Getting Started</title>
+  <title>Getting started</title>
 
   <para>
    Although GIMP can be a bit overwhelming for new users, most quickly find it
@@ -243,7 +243,7 @@
   </para>
 
   <sect2 xml:id="sec-gimp-getstart-creating">
-   <title>Creating a New Image</title>
+   <title>Creating a new image</title>
    <procedure>
     <step>
      <para>
@@ -258,7 +258,7 @@
       <guimenu>Template</guimenu>.
      </para>
      <note>
-      <title>Custom Templates</title>
+      <title>Custom templates</title>
       <para>
        To create a custom template, select <menuchoice>
        <guimenu>Windows</guimenu> <guimenu>Dockable Dialogs</guimenu>
@@ -309,7 +309,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-getstart-open">
-   <title>Opening an Existing Image</title>
+   <title>Opening an existing image</title>
    <para>
     To open an existing image, select <menuchoice> <guimenu>File</guimenu>
     <guimenu>Open</guimenu></menuchoice>.
@@ -321,14 +321,14 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gimp-saving">
-  <title>Saving and Exporting Images</title>
+  <title>Saving and exporting images</title>
 
   <para>
    GIMP makes a distinction between saving and exporting images.
   </para>
 
   <formalpara>
-   <title>Saving an Image</title>
+   <title>Saving an image</title>
    <para>
     The image is stored with all its properties in a lossless format. This
     includes, for example, layer and path information. This means that
@@ -422,7 +422,7 @@
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-gimp-basics">
-  <title>Editing Images</title>
+  <title>Editing images</title>
 
   <para>
    GIMP provides several tools for making changes to images. The functions
@@ -430,7 +430,7 @@
   </para>
 
   <sect2 xml:id="sec-gimp-basics-size">
-   <title>Changing the Size of an Image</title>
+   <title>Changing the size of an image</title>
    <para>
     After an image is scanned or a digital photograph is loaded from the
     camera, it is often necessary to modify the size for display on a Web page
@@ -444,7 +444,7 @@
     cropping.
    </para>
    <sect3 xml:id="sec-gimp-basics-size-cropping">
-    <title>Cropping an Image</title>
+    <title>Cropping an image</title>
     <procedure>
      <step>
       <para>
@@ -479,7 +479,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-size-scaling">
-    <title>Scaling an Image</title>
+    <title>Scaling an image</title>
     <procedure>
      <step>
       <para>
@@ -513,7 +513,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-size-canvas">
-    <title>Changing the Canvas Size</title>
+    <title>Changing the canvas size</title>
     <para>
      The canvas is the entire visible area of an image. Canvas and image are
      independent from each other. If the canvas is smaller than the image, you
@@ -551,7 +551,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-basics-select">
-   <title>Selecting Parts of Images</title>
+   <title>Selecting parts of images</title>
    <para>
     It is often useful to perform an image operation on only part of an image.
     To do this, the part of the image with which you want to work must be
@@ -562,7 +562,7 @@
     ants</emphasis>.
    </para>
    <sect3 xml:id="sec-gimp-basics-select-tools">
-    <title>Using the Selection Tools</title>
+    <title>Using the selection tools</title>
     <para>
      The main selection tools are easy to use. The more complicated paths tool
      is not described here.
@@ -578,7 +578,7 @@
     </remark>
     <variablelist>
      <varlistentry>
-      <term>Rectangle Select</term>
+      <term>Rectangle select</term>
       <listitem>
        <para>
         This tool can be used to select rectangular or square areas. To select
@@ -590,7 +590,7 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term>Ellipse Select</term>
+      <term>Ellipse select</term>
       <listitem>
        <para>
         Use this to select elliptical or circular areas. The same options are
@@ -600,7 +600,7 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term>Free Select (Lasso)</term>
+      <term>Free select (lasso)</term>
       <listitem>
        <para>
         With this tool, you can create a selection based on a combination of
@@ -614,7 +614,7 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term>Fuzzy Select (Magic Wand)</term>
+      <term>Fuzzy select (magic wand)</term>
       <listitem>
        <para>
         This tool selects a continuous region based on color similarities. Set
@@ -626,7 +626,7 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term>Select by Color</term>
+      <term>Select by color</term>
       <listitem>
        <para>
         With this tool, select all the pixels in the image with the same or a
@@ -651,7 +651,7 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term>Foreground Selection</term>
+      <term>Foreground selection</term>
       <listitem>
        <para>
         The <guimenu>Foreground Selection</guimenu> tool lets you
@@ -707,7 +707,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-select-quickmask">
-    <title>Using the Quick Mask</title>
+    <title>Using the quick mask</title>
     <para>
      The quick mask is a way of selecting parts of an image using the paint
      tools. A good way to use it is to first create a rough selection using the
@@ -727,7 +727,7 @@
        selected.
       </para>
       <note>
-       <title>Changing the Color of the Mask</title>
+       <title>Changing the color of the mask</title>
        <para>
         To use a different color for displaying the quick mask, right-click the
         quick mask button then select <guimenu>Configure Color and
@@ -759,7 +759,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-basics-color">
-   <title>Applying and Removing Color</title>
+   <title>Applying and removing color</title>
    <para>
     Most image editing involves applying or removing color. By selecting a part
     of the image, you can limit where color can be applied or removed. When you
@@ -773,7 +773,7 @@
     area will be painted.
    </para>
    <sect3 xml:id="sec-gimp-basics-color-selecting">
-    <title>Selecting Colors</title>
+    <title>Selecting colors</title>
     <para>
      The GIMP toolbox always shows two color swatches. The foreground color is
      used by the paint tools. The background color is used much more rarely,
@@ -794,7 +794,7 @@
        color is shown in <guimenu>Old</guimenu>.
       </para>
       <figure xml:id="fig-gimp-colorselector">
-       <title>The Basic Color Selector Dialog</title>
+       <title>The basic color selector dialog</title>
        <mediaobject>
         <imageobject role="html">
          <imagedata fileref="gimp-color.png" width="70%" format="PNG"/>
@@ -841,7 +841,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-color-painting">
-    <title>Painting and Erasing</title>
+    <title>Painting and erasing</title>
     <para>
      To paint and erase, use the tools from the toolbox. There are a number of
      options available to fine-tune each tool. Pressure sensitivity options
@@ -856,7 +856,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-color-text">
-    <title>Adding Text</title>
+    <title>Adding text</title>
     <para>
      To add text, use the text tool. Use the tool options to select the desired
      font and text properties. Click into the image, then start writing.
@@ -869,7 +869,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-color-clone">
-    <title>Retouching Images&mdash;The Clone Tool</title>
+    <title>Retouching images&mdash;the clone tool</title>
     <para>
      The clone tool is ideal for retouching images. It enables you to paint in
      an image using information from another part of the image. If desired, it
@@ -894,7 +894,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-basics-levels">
-   <title>Adjusting Color Levels</title>
+   <title>Adjusting color levels</title>
    <para>
     Images often need a little adjusting to get ideal print or display results.
    </para>
@@ -934,7 +934,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-basics-undo">
-   <title>Undoing Mistakes</title>
+   <title>Undoing mistakes</title>
    <para>
     Most modifications made in GIMP can be undone. To view a history of
     modifications, use the undo dialog included in the default window layout or
@@ -983,7 +983,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-advanced-modes">
-   <title>Image Modes</title>
+   <title>Image modes</title>
    <para>
     GIMP has three image modes:
    </para>
@@ -1014,7 +1014,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-advanced-effects">
-   <title>Special Effects</title>
+   <title>Special effects</title>
    <para>
     GIMP includes a wide range of filters and scripts for enhancing images,
     adding special effects to them or making artistic manipulations. They are
@@ -1024,7 +1024,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gimp-printing">
-  <title>Printing Images</title>
+  <title>Printing images</title>
 
   <para>
    To print an image, select <menuchoice> <guimenu>File</guimenu>
@@ -1035,7 +1035,7 @@
   </para>
 
   <figure xml:id="fig-gimp-print">
-   <title>The Print Dialog</title>
+   <title>The print dialog</title>
    <mediaobject>
     <imageobject role="html">
      <imagedata fileref="gimp-print.png" width="75%" format="PNG"/>
@@ -1052,7 +1052,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-gimp-moreinfo">
-  <title>For More Information</title>
+  <title>For more information</title>
 
   <para>
    The following resources are very useful for users of GIMP. They contain much

--- a/xml/apps_librecalc.xml
+++ b/xml/apps_librecalc.xml
@@ -329,7 +329,7 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term><guimenu>All cells</guimenu>
+      <term><guimenu>All Cells</guimenu>
       </term>
       <listitem>
        <para>

--- a/xml/apps_librecalc.xml
+++ b/xml/apps_librecalc.xml
@@ -27,7 +27,7 @@
   and the sources listed in <xref linkend="sec-lo-oview-help"/>.
  </para>
  <note>
-  <title>VBA Macros</title>
+  <title>VBA macros</title>
   <para>
    Calc can process many VBA macros in Excel documents. However, support for
    VBA macros is not complete. When opening an Excel spreadsheet that makes
@@ -35,7 +35,7 @@
   </para>
  </note>
  <sect1 xml:id="sec-lo-calc-createnew">
-  <title>Creating a New Document</title>
+  <title>Creating a new document</title>
 
   <para>
    There are two ways to create a new Calc document:
@@ -44,7 +44,7 @@
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <formalpara>
-     <title>From Scratch</title>
+     <title>From scratch</title>
      <para>
       To create a new empty document, click <menuchoice>
       <guimenu>File</guimenu> <guimenu>New</guimenu>
@@ -54,7 +54,7 @@
    </listitem>
    <listitem>
     <formalpara>
-     <title>From a Template</title>
+     <title>From a template</title>
      <para>
       To use a template, click
       <menuchoice> <guimenu>File</guimenu> <guimenu>New</guimenu>
@@ -81,7 +81,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-lo-calc-styles">
-  <title>Using Formatting and Styles in Calc</title>
+  <title>Using formatting and styles in Calc</title>
 
   <para>
    Calc comes with a few built-in cell and page styles to improve the
@@ -91,7 +91,7 @@
   </para>
 
   <procedure xml:id="pro-lo-calc-createstyle">
-   <title>Creating a Style</title>
+   <title>Creating a style</title>
    <step>
     <para>
      Click <menuchoice> <guimenu>Format</guimenu> <guimenu>Styles</guimenu>
@@ -126,7 +126,7 @@
   </procedure>
 
   <procedure>
-   <title>Modifying a Style</title>
+   <title>Modifying a style</title>
    <step>
     <para>
      Click <menuchoice> <guimenu>Format</guimenu> <guimenu>Styles</guimenu>
@@ -165,7 +165,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-lo-calc-sheets">
-  <title>Working With Sheets</title>
+  <title>Working with sheets</title>
 
   <para>
    Sheets are a good method to organize your calculations. For example, if you
@@ -184,7 +184,7 @@
   </para>
 
   <procedure xml:id="pro-lo-insert-sheet">
-   <title>Inserting New Sheets</title>
+   <title>Inserting new sheets</title>
    <step>
     <para>
      Right-click a sheet tab and select <guimenu>Insert Sheet</guimenu>. A
@@ -248,7 +248,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-lo-calc-condformat">
-  <title>Conditional Formatting</title>
+  <title>Conditional formatting</title>
 
   <para>
    Conditional formatting is a useful feature to highlight certain values in
@@ -268,7 +268,7 @@
   </note>
 
   <procedure xml:id="pro-lo-calc-condformat">
-   <title>Using Conditional Formatting</title>
+   <title>Using conditional formatting</title>
    <step>
     <para>
      Define a style first. This style is applied to each cell when your
@@ -329,7 +329,7 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term><guimenu>All Cells</guimenu>
+      <term><guimenu>All cells</guimenu>
       </term>
       <listitem>
        <para>
@@ -390,7 +390,7 @@
   </remark>
  </sect1>
  <sect1 xml:id="sec-lo-calc-grouping">
-  <title>Grouping and Ungrouping Cells</title>
+  <title>Grouping and ungrouping cells</title>
 
   <para>
    Grouping a cell range allows hiding parts of a spreadsheet. This makes
@@ -404,7 +404,7 @@
   </para>
 
   <procedure>
-   <title>Grouping a Selected Cell Range</title>
+   <title>Grouping a selected cell range</title>
    <step>
     <para>
      Select a cell range in your spreadsheet.
@@ -440,7 +440,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-lo-calc-freezing">
-  <title>Freezing Rows or Columns as Headers</title>
+  <title>Freezing rows or columns as headers</title>
 
   <para>
    If you have a spreadsheet with lots of data, scrolling usually makes the
@@ -453,7 +453,7 @@
   </para>
 
   <procedure>
-   <title>Freezing a Single Row or Column</title>
+   <title>Freezing a single row or column</title>
    <step>
     <para>
      To create a frozen area before a row, click the header of the row
@@ -479,7 +479,7 @@
   </para>
 
   <procedure>
-   <title>Freezing Row and Column</title>
+   <title>Freezing row and column</title>
    <step>
     <para>
      Click into the cell to the right of the column and below the row you want

--- a/xml/apps_libreoffice.xml
+++ b/xml/apps_libreoffice.xml
@@ -1346,7 +1346,7 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term><guimenu>Custom properties</guimenu>
+      <term><guimenu>Custom Properties</guimenu>
       </term>
       <listitem>
        <para>

--- a/xml/apps_libreoffice.xml
+++ b/xml/apps_libreoffice.xml
@@ -523,7 +523,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>E-mailing a document to a Microsoft word user</term>
+     <term>E-mailing a document to a Microsoft Word user</term>
      <listitem>
       <para>
        Click <menuchoice> <guimenu>File</guimenu> <guimenu>Send</guimenu>

--- a/xml/apps_libreoffice.xml
+++ b/xml/apps_libreoffice.xml
@@ -236,7 +236,7 @@
 
   <variablelist>
    <varlistentry>
-    <term><menuchoice><guimenu>&libo;</guimenu><guimenu>User data</guimenu></menuchoice>
+    <term><menuchoice><guimenu>&libo;</guimenu><guimenu>User Data</guimenu></menuchoice>
     </term>
     <listitem>
      <para>

--- a/xml/apps_libreoffice.xml
+++ b/xml/apps_libreoffice.xml
@@ -14,7 +14,7 @@
   * SLE12 SP2 [beta 4]: 5.1.1.3
 -->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-lo-oview">
- <title>&libo;: The Office Suite</title>
+ <title>&libo;: the office suite</title>
  <info>
   <abstract>
    <para>
@@ -33,7 +33,7 @@
   </dm:docmanager>
  </info>
  <sect1 xml:id="sec-lo-oview-modules">
-  <title>&libo; Modules</title>
+  <title>&libo; modules</title>
 
   <para>
    &libo; consists of several application modules (subprograms) which are
@@ -49,7 +49,7 @@
   </para>
 
   <table xml:id="tab-lo-oview-module">
-   <title>The &libo; Application Modules</title>
+   <title>The &libo; application modules</title>
    <tgroup cols="3">
     <colspec colnum="1" colname="module" colwidth="20*"/>
     <colspec colnum="2" colname="purpose" colwidth="55*"/>
@@ -236,7 +236,7 @@
 
   <variablelist>
    <varlistentry>
-    <term><menuchoice><guimenu>&libo;</guimenu><guimenu>User Data</guimenu></menuchoice>
+    <term><menuchoice><guimenu>&libo;</guimenu><guimenu>User data</guimenu></menuchoice>
     </term>
     <listitem>
      <para>
@@ -259,7 +259,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><menuchoice><guimenu>Load/Save</guimenu><guimenu>General</guimenu></menuchoice>
+    <term><menuchoice><guimenu>Load/save</guimenu><guimenu>General</guimenu></menuchoice>
     </term>
     <listitem>
      <para>
@@ -278,14 +278,14 @@
  </sect1>
 
  <sect1 xml:id="sec-lo-interface">
-  <title>The &libo; User Interface</title>
+  <title>The &libo; user interface</title>
 
   <para>
    The user interface of most of &libo; is very similar across its modules:
   </para>
   <variablelist>
    <varlistentry>
-    <term>Menu Bar</term>
+    <term>Menu bar</term>
     <listitem>
      <para>
       At the top of the application, there is the menu bar which gives access
@@ -311,7 +311,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Side Bar</term>
+    <term>Side bar</term>
     <listitem>
      <para>
       By default, the side bar is positioned at the right side of the &libo;
@@ -352,7 +352,7 @@
  </sect1>
 
  <sect1 xml:id="sec-lo-oview-migration">
-  <title>Compatibility with Other Office Applications</title>
+  <title>Compatibility with other office applications</title>
 
   <para>
    The native file format of &libo; is the OpenDocument format. OpenDocument is
@@ -364,7 +364,7 @@
   </para>
 
   <sect2 xml:id="sec-lo-openother">
-   <title>Opening Documents from Other Office Suites</title>
+   <title>Opening documents from other office suites</title>
    <para>
     If you use &libo; in an environment where you need to share documents with
     Microsoft Word users, you should have little or no trouble exchanging
@@ -380,7 +380,7 @@
    <itemizedlist>
     <listitem>
      <formalpara>
-      <title>Text Documents</title>
+      <title>Text documents</title>
       <para>
        Consider opening text documents in the original application and saving
        them as RTF or plain text (TXT). However, saving as plain text means
@@ -403,7 +403,7 @@
   </sect2>
 
   <sect2 xml:id="sec-lo-oview-migration-convert">
-   <title>Converting Documents to the OpenDocument Format</title>
+   <title>Converting documents to the OpenDocument format</title>
    <para>
     &libo; can read, edit, and save documents in several formats. It is not
     necessary to convert files from those formats to the OpenDocument format
@@ -464,7 +464,7 @@
   </sect2>
 
   <sect2 xml:id="sec-lo-oview-migration-share">
-   <title>Sharing Files with Users of Other Office Suites</title>
+   <title>Sharing files with users of other office suites</title>
    <para>
     &libo; is available for several operating systems. This makes it
     an excellent tool when a group of users frequently need to share files
@@ -523,7 +523,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>E-mailing a document to a Microsoft Word user</term>
+     <term>E-mailing a document to a Microsoft word user</term>
      <listitem>
       <para>
        Click <menuchoice> <guimenu>File</guimenu> <guimenu>Send</guimenu>
@@ -536,7 +536,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-lo-oview-passwd">
-  <title>Saving Files with a Password</title>
+  <title>Saving files with a password</title>
 
   <para>
    You can save files, no matter in which &libo; format, with a password. Unlike
@@ -595,7 +595,7 @@
  </sect1>
 
  <sect1 os="sled;osuse" arch="x86_64" xml:id="sec-lo-oview-certstore">
-  <title>Signing Documents</title>
+  <title>Signing documents</title>
 
   <remark>
    taroth 081201: is this the correct place where the cert
@@ -721,7 +721,7 @@
   </para>
 
   <figure xml:id="fig-lo-oview-custom">
-   <title>Customization Dialog in Writer</title>
+   <title>Customization dialog in writer</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
@@ -733,7 +733,7 @@
   </figure>
 
   <note>
-   <title>Further Information</title>
+   <title>Further information</title>
    <para>
     Click <guimenu>Help</guimenu> for more information about the options in the
     <guimenu>Customize</guimenu> dialog.
@@ -741,7 +741,7 @@
   </note>
 
   <procedure>
-   <title>Customizing Toolbars</title>
+   <title>Customizing toolbars</title>
    <step>
     <para>
      In the customization dialog, click the tab <guimenu>Toolbars</guimenu>.
@@ -780,7 +780,7 @@
   </procedure>
 
   <procedure>
-   <title>Customizing Menus</title>
+   <title>Customizing menus</title>
    <para>
     You can add or delete items from current menus, reorganize menus, and even
     create new menus.
@@ -831,7 +831,7 @@
   </procedure>
 
   <procedure>
-   <title>Customizing Key Combinations</title>
+   <title>Customizing key combinations</title>
    <para>
     You can reassign currently assigned key combinations and assign new ones to
     frequently used functions.
@@ -868,7 +868,7 @@
   </procedure>
 
   <procedure>
-   <title>Customizing Events</title>
+   <title>Customizing events</title>
    <para>
     &libo; also provides ways to assign macros to events such as
     application start-up or the saving of a document. The assigned macro
@@ -898,7 +898,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-lo-oview-global">
-  <title>Changing the Global Settings</title>
+  <title>Changing the global settings</title>
 
   <para>
    Global settings can be changed in any &libo; module by clicking
@@ -908,7 +908,7 @@
   </para>
 
   <figure xml:id="fig-ooo-cust-globalsettings">
-   <title>The Options Window</title>
+   <title>The options window</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="oo_options.png" width="95%" format="PNG"/>
@@ -933,7 +933,7 @@
   </para>
 
   <table xml:id="tab-ooo-globalcategory">
-   <title>Global Setting Categories</title>
+   <title>Global setting categories</title>
    <tgroup cols="3">
     <colspec colnum="1" colname="1" colwidth="25*"/>
     <colspec colnum="2" colname="2" colwidth="55*"/>
@@ -1160,7 +1160,7 @@
   </table>
 
   <important>
-   <title>Settings Apply Globally</title>
+   <title>Settings apply globally</title>
    <para>
     All settings listed in the table apply <emphasis>globally</emphasis> for
     the specified modules. That means, they are used as defaults for every
@@ -1169,7 +1169,7 @@
   </important>
  </sect1>
  <sect1 xml:id="sec-lo-oview-templates">
-  <title>Using Templates</title>
+  <title>Using templates</title>
 
   <para>
    A template is a document containing only the styles&mdash;and
@@ -1208,7 +1208,7 @@
   </para>
 
   <procedure xml:id="pro-lo-oview-templates">
-   <title>Creating &libo; Templates</title>
+   <title>Creating &libo; templates</title>
    <para>
     For text documents, spreadsheets, presentations, and drawings, you can
     create a template from an existing document as follows:
@@ -1253,7 +1253,7 @@
   </procedure>
 
   <note>
-   <title>Converting Microsoft Word Templates</title>
+   <title>Converting Microsoft word templates</title>
    <para>
     You can convert Microsoft Word templates like you would convert any other
     Word document. For more information, see
@@ -1262,7 +1262,7 @@
   </note>
  </sect1>
  <sect1 xml:id="sec-lo-overview-properties">
-  <title>Setting Metadata and Properties</title>
+  <title>Setting metadata and properties</title>
 
   <para>
    When exchanging documents with other people, it is sometimes useful to
@@ -1307,7 +1307,7 @@
   </para>
 
   <procedure>
-   <title>Setting Properties</title>
+   <title>Setting properties</title>
    <step>
     <para>
      Click <menuchoice> <guimenu>File</guimenu> <guimenu>Properties</guimenu>
@@ -1346,7 +1346,7 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term><guimenu>Custom Properties</guimenu>
+      <term><guimenu>Custom properties</guimenu>
       </term>
       <listitem>
        <para>
@@ -1356,7 +1356,7 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term><guimenu>CMIS Properties</guimenu>
+      <term><guimenu>CMIS properties</guimenu>
       </term>
       <listitem>
        <para>
@@ -1451,7 +1451,7 @@
  </sect1>
 
  <sect1 xml:id="sec-lo-oview-help">
-  <title>For More Information</title>
+  <title>For more information</title>
 
   <para>
    &libo; contains extensive online help. In addition, a large community

--- a/xml/apps_libreoffice.xml
+++ b/xml/apps_libreoffice.xml
@@ -1356,7 +1356,7 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term><guimenu>CMIS properties</guimenu>
+      <term><guimenu>CMIS Properties</guimenu>
       </term>
       <listitem>
        <para>

--- a/xml/apps_libreoffice.xml
+++ b/xml/apps_libreoffice.xml
@@ -259,7 +259,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><menuchoice><guimenu>Load/save</guimenu><guimenu>General</guimenu></menuchoice>
+    <term><menuchoice><guimenu>Load/Save</guimenu><guimenu>General</guimenu></menuchoice>
     </term>
     <listitem>
      <para>

--- a/xml/apps_libreoffice.xml
+++ b/xml/apps_libreoffice.xml
@@ -1253,7 +1253,7 @@
   </procedure>
 
   <note>
-   <title>Converting Microsoft word templates</title>
+   <title>Converting Microsoft Word templates</title>
    <para>
     You can convert Microsoft Word templates like you would convert any other
     Word document. For more information, see

--- a/xml/apps_libreoffice.xml
+++ b/xml/apps_libreoffice.xml
@@ -721,7 +721,7 @@
   </para>
 
   <figure xml:id="fig-lo-oview-custom">
-   <title>Customization dialog in writer</title>
+   <title>Customization dialog in <guimenu>Writer</guimenu></title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>

--- a/xml/apps_librevarious.xml
+++ b/xml/apps_librevarious.xml
@@ -471,7 +471,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-lo-various-draw">
-  <title>Creating graphics with draw</title>
+  <title>Creating graphics with <guimenu>Draw</guimenu></title>
 
   <para>
    Use &libo; Draw to create graphics and diagrams.

--- a/xml/apps_librevarious.xml
+++ b/xml/apps_librevarious.xml
@@ -5,7 +5,7 @@
     %entities;
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-lo-various">
- <title>&libo; Impress, Base, Draw, and Math</title>
+ <title>&libo; impress, base, draw, and math</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -25,7 +25,7 @@
   databases, draw up graphics and diagrams, and create mathematical formulas.
  </para>
  <sect1 xml:id="sec-lo-various-impress">
-  <title>Using Presentations with Impress</title>
+  <title>Using presentations with impress</title>
 
   <para>
    Use &libo; Impress to create presentations for screen display or printing. If
@@ -34,7 +34,7 @@
   </para>
 
   <sect2 xml:id="sec-lo-various-impress-create">
-   <title>Creating a Presentation</title>
+   <title>Creating a presentation</title>
    <para>
     There are two ways to create a new Impress document. When starting Impress,
     the <guimenu>Select a Template</guimenu> dialog opens. To use one of the
@@ -45,7 +45,7 @@
   </sect2>
 
   <sect2 xml:id="sec-lo-various-impress-master">
-   <title>Using Master Pages</title>
+   <title>Using master pages</title>
    <para>
     Master pages give your presentation a consistent look by defining what
     fonts and other design elements are used. Impress uses two types of master
@@ -53,7 +53,7 @@
    </para>
    <variablelist>
     <varlistentry>
-     <term>Master Slide</term>
+     <term>Master slide</term>
      <listitem>
       <para>
        Contains elements that appear on all slides. For example, you might want
@@ -65,7 +65,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Master Notes</term>
+     <term>Master notes</term>
      <listitem>
       <para>
        Determines the formatting and appearance of the notes in your
@@ -75,7 +75,7 @@
     </varlistentry>
    </variablelist>
    <sect3 xml:id="sec-lo-various-impress-master-create">
-    <title>Creating a Master Slide</title>
+    <title>Creating a master slide</title>
     <para>
      Impress comes with a collection of preformatted master pages. To customize
      presentations further, create your own slide masters.
@@ -122,7 +122,7 @@
      </step>
     </procedure>
     <tip>
-     <title>Collect Master Slides in a Template</title>
+     <title>Collect master slides in a template</title>
      <para>
       When you have created all of the master slides you want to use in your
       presentations, you can save them in an Impress template. Then, any time
@@ -132,7 +132,7 @@
     </tip>
    </sect3>
    <sect3 xml:id="sec-lo-various-impress-master-apply">
-    <title>Applying a Master Slide</title>
+    <title>Applying a master slide</title>
     <para>
      Master slides can be applied to selected slides or to all slides of a
      presentation.
@@ -171,7 +171,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-lo-various-base">
-  <title>Using Databases with Base</title>
+  <title>Using databases with base</title>
 
   <para>
    &libo; includes the database module Base. Use Base to design a database to
@@ -193,7 +193,7 @@
   </para>
 
   <sect2 xml:id="sec-lo-various-base-predefined">
-   <title>Creating a Database Using Predefined Options</title>
+   <title>Creating a database using predefined options</title>
    <para>
     Base comes with several predefined database fields to help you create a
     database. A wizard guides you through the steps to create a new database.
@@ -228,7 +228,7 @@
     </listitem>
    </orderedlist>
    <sect3 xml:id="sec-lo-various-base-predefined-create">
-    <title>Creating the Database</title>
+    <title>Creating the database</title>
     <procedure>
      <step>
       <para>
@@ -262,7 +262,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-lo-various-base-predefined-setup">
-    <title>Setting Up the Database Table</title>
+    <title>Setting up the database table</title>
     <para>
      After you have created the database, if you have selected the
      <guimenu>Create tables using the table wizard</guimenu> check box, the
@@ -371,7 +371,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-lo-various-base-predefined-createform">
-    <title>Creating a Form</title>
+    <title>Creating a form</title>
     <para>
      Next, create the form to use when entering data into your address book.
     </para>
@@ -427,7 +427,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-lo-various-base-predefined-modifyform">
-    <title>Modifying the Form</title>
+    <title>Modifying the form</title>
     <para>
      After the form has been defined, you can modify the appearance of the form
      to suit your preferences.
@@ -457,7 +457,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-lo-base-predefined-info">
-    <title>Further Steps</title>
+    <title>Further steps</title>
     <para>
      After you have created your database tables and forms, you are ready to
      enter your data. You can also design queries and reports to help sort and
@@ -471,7 +471,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-lo-various-draw">
-  <title>Creating Graphics with Draw</title>
+  <title>Creating graphics with draw</title>
 
   <para>
    Use &libo; Draw to create graphics and diagrams.
@@ -484,7 +484,7 @@
   </para>
 
   <procedure>
-   <title>Creating a Graphic</title>
+   <title>Creating a graphic</title>
    <step>
     <para>
      Start &libo; Draw.
@@ -535,7 +535,7 @@
   </para>
 
   <procedure xml:id="pro-lo-various-draw">
-   <title>Opening Draw From Other &libo; Modules</title>
+   <title>Opening draw from other &libo; modules</title>
    <para>
     <remark>Personally, I find this feature a plain weird experience: you open
     Writer, and then temporarily switch to the Draw UI while you are editing
@@ -571,7 +571,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-lo-various-math">
-  <title>Creating Mathematical Formulas with Math</title>
+  <title>Creating mathematical formulas with math</title>
 
   <para>
    It is usually difficult to include complex mathematical formulas in your
@@ -583,7 +583,7 @@
   </para>
 
   <note>
-   <title>Math is For Creating Mathematical Formulas</title>
+   <title>Math is for creating mathematical formulas</title>
    <para>
     Math is not a calculator. The functions it creates are graphical objects.
     Even if they are imported into Calc, these functions cannot be evaluated.
@@ -636,7 +636,7 @@
   </para>
 
   <figure xml:id="fig-lo-various-math">
-   <title>Mathematical Formula in &libo; Math</title>
+   <title>Mathematical formula in &libo; math</title>
    <mediaobject>
     <imageobject role="html">
      <imagedata fileref="oo_formula.png" width="100%"/>

--- a/xml/apps_librevarious.xml
+++ b/xml/apps_librevarious.xml
@@ -171,7 +171,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-lo-various-base">
-  <title>Using databases with base</title>
+  <title>Using databases with <guimenu>Base</guimenu></title>
 
   <para>
    &libo; includes the database module Base. Use Base to design a database to

--- a/xml/apps_librevarious.xml
+++ b/xml/apps_librevarious.xml
@@ -571,7 +571,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-lo-various-math">
-  <title>Creating mathematical formulas with math</title>
+  <title>Creating mathematical formulas with <guimenu>Math</guimenu></title>
 
   <para>
    It is usually difficult to include complex mathematical formulas in your

--- a/xml/apps_librevarious.xml
+++ b/xml/apps_librevarious.xml
@@ -636,7 +636,7 @@
   </para>
 
   <figure xml:id="fig-lo-various-math">
-   <title>Mathematical formula in &libo; math</title>
+   <title>Mathematical formula in <guimenu>&libo; Math</guimenu></title>
    <mediaobject>
     <imageobject role="html">
      <imagedata fileref="oo_formula.png" width="100%"/>

--- a/xml/apps_librevarious.xml
+++ b/xml/apps_librevarious.xml
@@ -25,7 +25,7 @@
   databases, draw up graphics and diagrams, and create mathematical formulas.
  </para>
  <sect1 xml:id="sec-lo-various-impress">
-  <title>Using presentations with impress</title>
+  <title>Using presentations with <guimenu>Impress</guimenu></title>
 
   <para>
    Use &libo; Impress to create presentations for screen display or printing. If

--- a/xml/apps_librevarious.xml
+++ b/xml/apps_librevarious.xml
@@ -535,7 +535,7 @@
   </para>
 
   <procedure xml:id="pro-lo-various-draw">
-   <title>Opening draw from other &libo; modules</title>
+   <title>Opening <guimenu>Draw</guimenu> from other &libo; modules</title>
    <para>
     <remark>Personally, I find this feature a plain weird experience: you open
     Writer, and then temporarily switch to the Draw UI while you are editing

--- a/xml/apps_librevarious.xml
+++ b/xml/apps_librevarious.xml
@@ -5,7 +5,7 @@
     %entities;
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-lo-various">
- <title>&libo; impress, base, draw, and math</title>
+ <title>&libo; <guimenu>Impress</guimenu>, <guimenu>Base</guimenu>, <guimenu>Draw</guimenu>, and <guimenu>Math</guimenu></title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>

--- a/xml/apps_librewriter.xml
+++ b/xml/apps_librewriter.xml
@@ -290,7 +290,7 @@
   </para>
 
   <sect2 xml:id="sec-lo-writer-styles-window">
-   <title>The side bar panel <guimenu>Styles and formatting</guimenu></title>
+   <title>The side bar panel <guimenu>Styles and Formatting</guimenu></title>
    <para>
     The side bar panel <guimenu>Styles and Formatting</guimenu> is a versatile
     formatting tool for applying styles to text, paragraphs, pages, frames, and

--- a/xml/apps_librewriter.xml
+++ b/xml/apps_librewriter.xml
@@ -6,7 +6,7 @@
   <!ENTITY libo-insert-icon "<inlinemediaobject xmlns='http://docbook.org/ns/docbook'><textobject role='description'><phrase>Insert</phrase></textobject><imageobject role='fo'><imagedata fileref='libreoffice-writer-master-insert.png' width='0.8em' format='PNG'/></imageobject><imageobject role='html'><imagedata fileref='libreoffice-writer-master-insert.png' width='1em' format='PNG'/></imageobject></inlinemediaobject>">
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-lo-writer">
- <title>&libo; writer</title>
+ <title><guimenu>&libo; Writer</guimenu></title>
  <info>
   <abstract>
    <para>

--- a/xml/apps_librewriter.xml
+++ b/xml/apps_librewriter.xml
@@ -6,7 +6,7 @@
   <!ENTITY libo-insert-icon "<inlinemediaobject xmlns='http://docbook.org/ns/docbook'><textobject role='description'><phrase>Insert</phrase></textobject><imageobject role='fo'><imagedata fileref='libreoffice-writer-master-insert.png' width='0.8em' format='PNG'/></imageobject><imageobject role='html'><imagedata fileref='libreoffice-writer-master-insert.png' width='1em' format='PNG'/></imageobject></inlinemediaobject>">
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-lo-writer">
- <title>&libo; Writer</title>
+ <title>&libo; writer</title>
  <info>
   <abstract>
    <para>
@@ -35,7 +35,7 @@
   </dm:docmanager>
  </info>
  <sect1 xml:id="sec-lo-writer-createnew">
-  <title>Creating a New Document</title>
+  <title>Creating a new document</title>
 
   <para>
    There are multiple ways to create a new Writer document:
@@ -44,7 +44,7 @@
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <formalpara>
-     <title>From Scratch</title>
+     <title>From scratch</title>
      <para>
       To create a new empty document, click <menuchoice>
       <guimenu>File</guimenu> <guimenu>New</guimenu> <guimenu>Text
@@ -54,7 +54,7 @@
    </listitem>
    <listitem>
     <formalpara>
-     <title>Using a Wizard</title>
+     <title>Using a wizard</title>
      <para>
       To use a standard format and predefined elements for your own documents,
       use a wizard. Click <menuchoice> <guimenu>File</guimenu>
@@ -65,7 +65,7 @@
    </listitem>
    <listitem>
     <formalpara>
-     <title>From a Template</title>
+     <title>From a template</title>
      <para>
       To use a template, click
       <menuchoice> <guimenu>File</guimenu> <guimenu>New</guimenu>
@@ -86,7 +86,7 @@
   </para>
 
   <figure xml:id="fig-lo-writer-createnew-wizard">
-   <title>A &libo; Wizard</title>
+   <title>A &libo; wizard</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="oo-wizard.png" width="100%" format="PNG"/>
@@ -108,7 +108,7 @@
  </sect1>
 
  <sect1 xml:id="sec-lo-writer-styles">
-  <title>Formatting with Styles</title>
+  <title>Formatting with styles</title>
 
   <para>
    The traditional way of formatting office documents is direct formatting.
@@ -143,7 +143,7 @@
   </itemizedlist>
 
   <example xml:id="ex-lo-usestyle">
-   <title>Use of Styles</title>
+   <title>Use of styles</title>
    <para>
     Imagine that you emphasize text by selecting it and clicking the button
     <guimenu>Bold</guimenu>. Later, you decide you want the emphasized text to
@@ -162,7 +162,7 @@
   </para>
 
   <table xml:id="tab-lo-writer-styles">
-   <title>Types of Styles</title>
+   <title>Types of styles</title>
    <tgroup cols="2">
     <colspec colnum="1" colname="1" colwidth="28*"/>
     <colspec colnum="2" colname="2" colwidth="72*"/>
@@ -290,7 +290,7 @@
   </para>
 
   <sect2 xml:id="sec-lo-writer-styles-window">
-   <title>The Side Bar Panel <guimenu>Styles and Formatting</guimenu></title>
+   <title>The side bar panel <guimenu>Styles and formatting</guimenu></title>
    <para>
     The side bar panel <guimenu>Styles and Formatting</guimenu> is a versatile
     formatting tool for applying styles to text, paragraphs, pages, frames, and
@@ -300,7 +300,7 @@
     bar, or press <keycap>F11</keycap>.
    </para>
    <figure xml:id="fig-lo-writer-stylist">
-    <title>Styles and Formatting Panel</title>
+    <title>Styles and formatting panel</title>
     <mediaobject>
      <imageobject role="fo">
       <imagedata fileref="oo-stylist.png" width="40%" format="PNG"/>
@@ -320,7 +320,7 @@
   </sect2>
 
   <sect2 xml:id="sec-lo-writer-styles-apply">
-   <title>Applying a Style</title>
+   <title>Applying a style</title>
    <para>
     To apply a style, select the element you want to apply the style to, and
     double-click the style in the panel <guimenu>Styles and
@@ -335,7 +335,7 @@
   </sect2>
 
   <sect2 xml:id="sec-lo-writer-styles-change">
-   <title>Changing a Style</title>
+   <title>Changing a style</title>
    <para>
     By changing styles, you can change formatting throughout a document, rather
     than applying the change separately everywhere you want to apply the new
@@ -374,14 +374,14 @@
   </sect2>
 
   <sect2 xml:id="sec-lo-writer-styles-create">
-   <title>Creating a Style</title>
+   <title>Creating a style</title>
    <para>
     &libo; comes with a collection of styles to suit many needs of most users.
     However, if you need a style that does not yet exist and want to create
     your own style, follow the procedure below:
    </para>
    <procedure xml:id="pro-lo-writer-styles-create">
-    <title>Creating a New Style</title>
+    <title>Creating a new style</title>
     <step>
      <para>
       Open the panel <guimenu>Styles and Formatting</guimenu> with
@@ -427,7 +427,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term><guimenu>Next Style</guimenu>
+       <term><guimenu>Next style</guimenu>
        </term>
        <listitem>
         <para>
@@ -439,7 +439,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term><guimenu>Inherit From</guimenu>
+       <term><guimenu>Inherit from</guimenu>
        </term>
        <listitem>
         <para>
@@ -464,13 +464,13 @@
     </step>
    </procedure>
    <sect3 xml:id="sec-lo-writer-style-exa-note">
-    <title>Example: Defining a Note Style</title>
+    <title>Example: defining a note style</title>
     <para>
      Let us assume, you need a note with a different background and borders. To
      create such a style, proceed as follows:
     </para>
     <procedure>
-     <title>Creating a Note Style</title>
+     <title>Creating a note style</title>
      <step>
       <para>
        Press <keycap>F11</keycap>. The panel <guimenu>Styles and
@@ -586,14 +586,14 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-lo-writer-style-exa-page">
-    <title>Example: Defining an Even-Odd Page Style</title>
+    <title>Example: defining an even-odd page style</title>
     <para>
      If you want to create double-sided printouts of your documents, especially
      if they are supposed to be bound, use templates for even and odd pages. To
      create page styles for this, proceed as follows:
     </para>
     <procedure xml:id="pro-lo-writer-style-exa-page-even">
-     <title>Create an Even (Left) Page Style</title>
+     <title>Create an even (left) page style</title>
      <step>
       <para>
        Press <keycap>F11</keycap>. The panel <guimenu>Styles and
@@ -690,7 +690,7 @@
      </step>
     </procedure>
     <procedure xml:id="pro-lo-writer-style-exa-page-odd">
-     <title>Create an Odd (Right) Page Style</title>
+     <title>Create an odd (right) page style</title>
      <step>
       <para>
        Follow the instruction in
@@ -722,7 +722,7 @@
      Then connect the left page style with the right page style:
     </para>
     <procedure xml:id="pro-lo-writer-style-exa-page-connect">
-     <title>Connect the Right Page Style with the Left Page Style</title>
+     <title>Connect the right page style with the left page style</title>
      <step>
       <para>
        Right-click the entry <guimenu>Left Content Page</guimenu> and choose
@@ -751,7 +751,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-lo-writer-largedocs">
-  <title>Working with Large Documents</title>
+  <title>Working with large documents</title>
 
   <para>
    You can use Writer to work on large documents. Large documents can be either
@@ -759,7 +759,7 @@
   </para>
 
   <sect2 xml:id="sec-lo-writer-largedocs-navig">
-   <title>Navigating in Large Documents</title>
+   <title>Navigating in large documents</title>
    <para>
     The Navigator tool displays information about the contents of a document.
     It also lets you quickly jump to different elements. For example,
@@ -780,7 +780,7 @@
     Double-click an item in the Navigator to jump to that item in the document.
    </para>
    <figure xml:id="fig-ooo-navigator">
-    <title>Navigator Tool in Writer</title>
+    <title>Navigator tool in writer</title>
     <mediaobject>
      <imageobject role="fo">
       <imagedata fileref="oo_navigator.png" width="55%" format="PNG"/>
@@ -793,7 +793,7 @@
   </sect2>
 
   <sect2 xml:id="sec-lo-createmaster">
-   <title>Using Master Documents</title>
+   <title>Using master documents</title>
    <para>
     If you are working with a very large document, such as a book, it can be
     easier to manage the book with a master document, rather than
@@ -812,7 +812,7 @@
     others.
    </para>
    <procedure>
-    <title>Creating a Master Document</title>
+    <title>Creating a master document</title>
     <step>
      <para>
       Click <menuchoice> <guimenu>New</guimenu> <guimenu>Master
@@ -846,7 +846,7 @@
     </step>
    </procedure>
    <procedure xml:id="pro-lo-master-addnewdocument">
-    <title>Adding a New Document to a Master Document</title>
+    <title>Adding a new document to a master document</title>
     <step>
      <para>
       In the window or panel <guimenu>Navigator</guimenu>, choose
@@ -886,7 +886,7 @@
     Documents and Subdocuments</citetitle>.
    </para>
    <tip>
-    <title>Styles and Templates in Master Documents</title>
+    <title>Styles and templates in master documents</title>
     <para>
      The styles from all of your subdocuments are imported into the master
      document. To ensure that formatting is consistent throughout your master
@@ -905,7 +905,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-lo-writer-html">
-  <title>Using Writer as an HTML Editor</title>
+  <title>Using writer as an HTML editor</title>
 
   <para>
    In addition to being a full-featured word processor, Writer also functions
@@ -916,7 +916,7 @@
   </para>
 
   <procedure xml:id="pro-lo-writer-html-create">
-   <title>Creating an HTML Page</title>
+   <title>Creating an HTML page</title>
    <step>
     <para>
      Click <menuchoice> <guimenu>File</guimenu> <guimenu>New</guimenu>

--- a/xml/apps_librewriter.xml
+++ b/xml/apps_librewriter.xml
@@ -780,7 +780,7 @@
     Double-click an item in the Navigator to jump to that item in the document.
    </para>
    <figure xml:id="fig-ooo-navigator">
-    <title>Navigator tool in writer</title>
+    <title>Navigator tool in <guimenu>Writer</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
       <imagedata fileref="oo_navigator.png" width="55%" format="PNG"/>

--- a/xml/apps_pidgin.xml
+++ b/xml/apps_pidgin.xml
@@ -29,7 +29,7 @@
   your contacts.
  </para>
  <sect1 xml:id="sec-gnome-pidgin-start">
-  <title>Starting pidgin</title>
+  <title>Starting <guimenu>Pidgin</guimenu></title>
 
   <para>
    To start Pidgin, open the Activities Overview by pressing <keycap

--- a/xml/apps_pidgin.xml
+++ b/xml/apps_pidgin.xml
@@ -6,7 +6,7 @@
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-gnome-pidgin">
- <title>Pidgin: Instant Messaging</title>
+ <title>Pidgin: instant messaging</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -29,7 +29,7 @@
   your contacts.
  </para>
  <sect1 xml:id="sec-gnome-pidgin-start">
-  <title>Starting Pidgin</title>
+  <title>Starting pidgin</title>
 
   <para>
    To start Pidgin, open the Activities Overview by pressing <keycap
@@ -37,7 +37,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-gnome-pidgin-configure">
-  <title>Configuring Accounts</title>
+  <title>Configuring accounts</title>
 
   <para>
    To use Pidgin, you must already have an account for the messaging service
@@ -46,7 +46,7 @@
   </para>
 
   <procedure>
-   <title>Adding and Editing Accounts in Pidgin</title>
+   <title>Adding and editing accounts in pidgin</title>
    <step>
     <para>
      If you start Pidgin for the first time, a message appears, prompting you
@@ -92,7 +92,7 @@
 
  </sect1>
  <sect1 xml:id="sec-gnome-pidgin-buddy-list">
-  <title>Managing Contacts</title>
+  <title>Managing contacts</title>
 
   <para>
    Use the <guimenu>Contact List</guimenu> to manage your contacts (so-called
@@ -101,7 +101,7 @@
   </para>
 
   <procedure>
-   <title>Adding Contacts</title>
+   <title>Adding contacts</title>
    <step>
     <para>
      To add a contact, click <menuchoice> <guimenu>Buddies</guimenu>
@@ -156,7 +156,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-gnome-pidgin-chat">
-  <title>Chatting with Friends</title>
+  <title>Chatting with friends</title>
 
   <para>
    To chat with other participants, you need to be connected to the Internet.
@@ -185,7 +185,7 @@
   </para>
 
   <tip>
-   <title>Finding a Contact</title>
+   <title>Finding a contact</title>
    <para>
     In case you contact list is very long, contacts may be hard to find. Use
     <keycombo> <keycap function="control"/> <keycap>F</keycap> </keycombo> to
@@ -197,7 +197,7 @@
 
  </sect1>
  <sect1 xml:id="sec-gnome-pidgin-more">
-  <title>For More Information</title>
+  <title>For more information</title>
 
   <para>
    This chapter only explains the basic configuration and usage option of

--- a/xml/apps_pidgin.xml
+++ b/xml/apps_pidgin.xml
@@ -46,7 +46,7 @@
   </para>
 
   <procedure>
-   <title>Adding and editing accounts in pidgin</title>
+   <title>Adding and editing accounts in <guimenu>Pidgin</guimenu></title>
    <step>
     <para>
      If you start Pidgin for the first time, a message appears, prompting you

--- a/xml/apps_totem.xml
+++ b/xml/apps_totem.xml
@@ -334,7 +334,7 @@
     font and encoding used to display subtitles.
    </para>
    <figure pgwide="0" xml:id="fig-gnome-totem-prefs-general">
-    <title>&gnome; videos general preferences</title>
+    <title><guimenu>&gnome; Videos</guimenu> general preferences</title>
     <mediaobject>
      <imageobject role="fo">
       <imagedata fileref="totem_general.png" width="55%" format="PNG"/>

--- a/xml/apps_totem.xml
+++ b/xml/apps_totem.xml
@@ -318,7 +318,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gnome-totem-prefs">
-  <title>Modifying &gnome; videos preferences</title>
+  <title>Modifying <guimenu>&gnome; Videos</guimenu> preferences</title>
 
   <para>
    To modify &gnome; Videos preferences, click <menuchoice>

--- a/xml/apps_totem.xml
+++ b/xml/apps_totem.xml
@@ -9,7 +9,7 @@
   <!ENTITY previous-icon "<inlinemediaobject xmlns='http://docbook.org/ns/docbook'><textobject role='description'><phrase>&gnome; Videos Previous</phrase></textobject><imageobject role='fo'><imagedata fileref='totem_previous_button.svg' width='0.8em' format='SVG'/></imageobject><imageobject role='html'><imagedata fileref='totem_previous_button-fallback.png' width='1em' format='PNG'/></imageobject></inlinemediaobject>">
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-gnome-totem">
- <title>&gnome; videos</title>
+ <title><guimenu>&gnome; Videos</guimenu></title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>

--- a/xml/apps_totem.xml
+++ b/xml/apps_totem.xml
@@ -9,7 +9,7 @@
   <!ENTITY previous-icon "<inlinemediaobject xmlns='http://docbook.org/ns/docbook'><textobject role='description'><phrase>&gnome; Videos Previous</phrase></textobject><imageobject role='fo'><imagedata fileref='totem_previous_button.svg' width='0.8em' format='SVG'/></imageobject><imageobject role='html'><imagedata fileref='totem_previous_button-fallback.png' width='1em' format='PNG'/></imageobject></inlinemediaobject>">
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-gnome-totem">
- <title>&gnome; Videos</title>
+ <title>&gnome; videos</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -67,14 +67,14 @@
   function="meta"/> and search for <literal>video</literal>.
  </para>
  <sect1 xml:id="sec-gnome-totem-using">
-  <title>Using &gnome; Videos</title>
+  <title>Using &gnome; videos</title>
 
   <para>
    When you start &gnome; Videos, the following window is displayed.
   </para>
 
   <figure pgwide="0" xml:id="fig-gnome-totem-using-startup">
-   <title>&gnome; Videos Start-Up Window</title>
+   <title>&gnome; videos start-up window</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
@@ -86,7 +86,7 @@
   </figure>
 
   <sect2 xml:id="sec-gnome-totem-using-open-file">
-   <title>Opening a Video or Audio File</title>
+   <title>Opening a video or audio file</title>
    <procedure>
     <step>
      <para>
@@ -107,7 +107,7 @@
     beneath the display area and in the titlebar of the window.
    </para>
    <note>
-    <title>Unrecognized File Format</title>
+    <title>Unrecognized file format</title>
     <para>
      If you try to open a file format that &gnome; Videos does not recognize,
      the application displays an error message and recommends a suitable codec.
@@ -120,7 +120,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnome-totem-using-open-uri">
-   <title>Opening a Video or Audio File By URI Location</title>
+   <title>Opening a video or audio file by URI location</title>
    <procedure>
     <step>
      <para>
@@ -173,7 +173,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnome-totem-using-seek">
-   <title>Seeking Through Movies or Songs</title>
+   <title>Seeking through movies or songs</title>
    <para>
     To seek through movies or songs, use any of the following methods:
    </para>
@@ -220,7 +220,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnome-totem-using-zoom">
-   <title>Changing the Zoom Factor</title>
+   <title>Changing the zoom factor</title>
    <para>
     To change the zoom factor of the display area, use any of the following
     methods:
@@ -277,7 +277,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnome-totem-using-controls">
-   <title>Showing or Hiding Controls</title>
+   <title>Showing or hiding controls</title>
    <para>
     To hide the window controls of &gnome; Videos, click <menuchoice>
     <guimenu>View</guimenu> <guimenu>Show Controls</guimenu> </menuchoice> and
@@ -291,7 +291,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnome-totem-using-subtitles">
-   <title>Choosing Subtitles</title>
+   <title>Choosing subtitles</title>
    <para>
     To choose the language of the subtitles, click <menuchoice>
     <guimenu>View</guimenu> <guimenu>Subtitles</guimenu> <guimenu>Select Text
@@ -318,7 +318,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gnome-totem-prefs">
-  <title>Modifying &gnome; Videos Preferences</title>
+  <title>Modifying &gnome; videos preferences</title>
 
   <para>
    To modify &gnome; Videos preferences, click <menuchoice>
@@ -327,14 +327,14 @@
   </para>
 
   <sect2 xml:id="sec-gnome-totem-prefs-general">
-   <title>General Preferences</title>
+   <title>General preferences</title>
    <para>
     The General Preferences let you select a network connection speed, specify
     if media files should be played from the last used position, and change the
     font and encoding used to display subtitles.
    </para>
    <figure pgwide="0" xml:id="fig-gnome-totem-prefs-general">
-    <title>&gnome; Videos General Preferences</title>
+    <title>&gnome; videos general preferences</title>
     <mediaobject>
      <imageobject role="fo">
       <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
@@ -366,7 +366,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Text Subtitles</term>
+     <term>Text subtitles</term>
      <listitem>
       <para>
        Lets you specify whether to load the subtitles automatically, and change
@@ -378,14 +378,14 @@
   </sect2>
 
   <sect2 xml:id="sec-gnome-totem-prefs-display">
-   <title>Display Preferences</title>
+   <title>Display preferences</title>
    <para>
     The Display Preferences let you choose to automatically resize the window
     when a new video is loaded, change the color balance, and configure visual
     effects when an audio file is played.
    </para>
    <figure pgwide="0" xml:id="fig-gnome-totem-prefs-display">
-    <title>&gnome; Videos Display Preferences</title>
+    <title>&gnome; videos display preferences</title>
     <mediaobject>
      <imageobject role="fo">
       <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
@@ -418,7 +418,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Visual Effects</term>
+     <term>Visual effects</term>
      <listitem>
       <para>
        You can choose to show visual effects when an audio file is playing,
@@ -428,7 +428,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Color Balance</term>
+     <term>Color balance</term>
      <listitem>
       <para>
        Specify the level of color brightness, contrast, saturation, and hue.
@@ -439,12 +439,12 @@
   </sect2>
 
   <sect2 xml:id="sec-gnome-totem-prefs-audio">
-   <title>Audio Preferences</title>
+   <title>Audio preferences</title>
    <para>
     The Audio Preferences dialog lets you select the audio output type.
    </para>
    <figure pgwide="0" xml:id="fig-gnome-totem-prefs-audio">
-    <title>&gnome; Videos Audio Preferences</title>
+    <title>&gnome; videos audio preferences</title>
     <mediaobject>
      <imageobject role="fo">
       <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>

--- a/xml/apps_totem.xml
+++ b/xml/apps_totem.xml
@@ -67,7 +67,7 @@
   function="meta"/> and search for <literal>video</literal>.
  </para>
  <sect1 xml:id="sec-gnome-totem-using">
-  <title>Using &gnome; videos</title>
+  <title>Using <guimenu>&gnome; Videos</guimenu></title>
 
   <para>
    When you start &gnome; Videos, the following window is displayed.

--- a/xml/apps_totem.xml
+++ b/xml/apps_totem.xml
@@ -385,7 +385,7 @@
     effects when an audio file is played.
    </para>
    <figure pgwide="0" xml:id="fig-gnome-totem-prefs-display">
-    <title>&gnome; videos display preferences</title>
+    <title><guimenu>&gnome; Videos</guimenu> display preferences</title>
     <mediaobject>
      <imageobject role="fo">
       <imagedata fileref="totem_display.png" width="55%" format="PNG"/>

--- a/xml/apps_totem.xml
+++ b/xml/apps_totem.xml
@@ -74,7 +74,7 @@
   </para>
 
   <figure pgwide="0" xml:id="fig-gnome-totem-using-startup">
-   <title>&gnome; videos start-up window</title>
+   <title><guimenu>&gnome; Videos</guimenu> start-up window</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="totem_a.png" width="75%" format="PNG"/>

--- a/xml/apps_totem.xml
+++ b/xml/apps_totem.xml
@@ -444,7 +444,7 @@
     The Audio Preferences dialog lets you select the audio output type.
    </para>
    <figure pgwide="0" xml:id="fig-gnome-totem-prefs-audio">
-    <title>&gnome; videos audio preferences</title>
+    <title><guimenu>&gnome; Videos</guimenu> audio preferences</title>
     <mediaobject>
      <imageobject role="fo">
       <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>

--- a/xml/backup.xml
+++ b/xml/backup.xml
@@ -13,7 +13,7 @@ taroth 2011-08-05: bug was fixed, but only temporarily, reopened for SP2 -
 taroth 2013-02-19: reopended for SP3
 -->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-userbackup">
- <title>Backing Up User Data</title>
+ <title>Backing up user data</title>
  <info>
   <abstract>
    <para>
@@ -46,7 +46,7 @@ taroth 2013-02-19: reopended for SP3
 </informalfigure>
 
 <sect1 xml:id="sec-gnome-backup-config">
- <title>Configuring Backups</title>
+ <title>Configuring backups</title>
  <para>
   Before you can start to backup data, configure which files to back up, which
   ones to ignore and where to store the backup.
@@ -87,7 +87,7 @@ taroth 2013-02-19: reopended for SP3
 </sect1>
 
 <sect1 xml:id="sec-gnome-backup-start">
- <title>Creating Backups</title>
+ <title>Creating backups</title>
  <para>
   Once you have configured which folders to back up and where to store them,
   you have two choices for backing up. First, by manually starting the
@@ -104,7 +104,7 @@ taroth 2013-02-19: reopended for SP3
 </sect1>
 
 <sect1 xml:id="cha-userbackup-restore">
- <title>Restoring Data</title>
+ <title>Restoring data</title>
 
  <para>
   To restore a previous state of your data, switch to the

--- a/xml/book_gnomeuser.xml
+++ b/xml/book_gnomeuser.xml
@@ -50,7 +50,7 @@
 <!-- Part:  Connectivity, Files and Resources                     -->
 <!-- ===================================================================== -->
  <part xml:id="part-gnome-manage">
-  <title>Connectivity, Files and Resources</title>
+  <title>Connectivity, files and resources</title>
   <info/>
   <xi:include href="gnome_networking.xml"/>
   <xi:include href="gnome_print.xml"/>
@@ -72,7 +72,7 @@
 <!-- Part: Internet, Communication & Collaboration                                    -->
 <!-- ===================================================================== -->
  <part xml:id="part-communication">
-  <title>Internet and Communication</title>
+  <title>Internet and communication</title>
   <xi:include href="apps_firefox.xml"/>
   <xi:include href="apps_evolution.xml"/>
   <xi:include href="apps_pidgin.xml"/>
@@ -82,7 +82,7 @@
 <!-- Part: Graphics and Multimedia                                         -->
 <!-- ===================================================================== -->
  <part xml:id="part-graphics">
-  <title>Graphics and Multimedia</title>
+  <title>Graphics and multimedia</title>
   <xi:include href="apps_gimp.xml"/>
   <xi:include href="apps_totem.xml"/>
   <xi:include href="apps_brasero.xml"/>

--- a/xml/gnome_accessibility.xml
+++ b/xml/gnome_accessibility.xml
@@ -5,7 +5,7 @@
     %entities;
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-gnome-accessibility">
- <title>Assistive Technologies</title>
+ <title>Assistive technologies</title>
  <info>
   <abstract>
    <para>
@@ -22,7 +22,7 @@
   </dm:docmanager>
  </info>
  <sect1 xml:id="sec-general-accessibility-enable">
-  <title>Enabling Assistive Technologies</title>
+  <title>Enabling assistive technologies</title>
 
   <para>
    To configure accessibility features, open the respective settings dialog by
@@ -39,7 +39,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-general-accessibility-visual">
-  <title>Visual Assistance</title>
+  <title>Visual assistance</title>
 
   <para>
    In the <guimenu>Seeing</guimenu> section of the <guimenu>Universal
@@ -88,7 +88,7 @@
   </itemizedlist>
  </sect1>
  <sect1 xml:id="sec-general-accessibility-hearing">
-  <title>Hearing Assistance</title>
+  <title>Hearing assistance</title>
 
   <para>
    In the <guimenu>Hearing</guimenu> section of the <guimenu>Universal
@@ -103,7 +103,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-general-accessibility-mobility">
-  <title>Keyboard and Mouse</title>
+  <title>Keyboard and mouse</title>
 
   <para>
    In the <guimenu>Typing</guimenu> and <guimenu>Pointing and
@@ -247,7 +247,7 @@
   </itemizedlist>
  </sect1>
  <sect1 xml:id="sec-general-accessibility-more">
-  <title>For More Information</title>
+  <title>For more information</title>
 
   <para>
    You can find further information in the &gnome; help, which is also

--- a/xml/gnome_crypto.xml
+++ b/xml/gnome_crypto.xml
@@ -18,7 +18,7 @@
  go to new file security_certificatestore.xml
 -->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-gnome-crypto">
- <title>Passwords and keys: signing and encrypting data</title>
+ <title><guimenu>Passwords and Keys</guimenu>: signing and encrypting data</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>

--- a/xml/gnome_crypto.xml
+++ b/xml/gnome_crypto.xml
@@ -18,7 +18,7 @@
  go to new file security_certificatestore.xml
 -->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-gnome-crypto">
- <title>Passwords and Keys: Signing and Encrypting Data</title>
+ <title>Passwords and keys: signing and encrypting data</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -36,7 +36,7 @@
   function="meta"/> and search for <literal>pass</literal>.
  </para>
  <figure pgwide="0">
-  <title>Password and Keys Main Window</title>
+  <title>Password and keys main window</title>
   <mediaobject>
    <imageobject role="fo">
     <imagedata fileref="seahorse_main.png" width="73%" format="PNG"/>
@@ -47,7 +47,7 @@
   </mediaobject>
  </figure>
  <sect1 xml:id="sec-gnome-crypto-sign-encrypt">
-  <title>Signing and Encryption</title>
+  <title>Signing and encryption</title>
 
   <formalpara>
    <title>Signing</title>
@@ -78,7 +78,7 @@
   </formalpara>
  </sect1>
  <sect1 xml:id="cha-gnome-crypto-gen-key">
-  <title>Generating a New Key Pair</title>
+  <title>Generating a new key pair</title>
 
   <para>
    To exchange encrypted messages with other users, you must first generate
@@ -88,7 +88,7 @@
   <itemizedlist>
    <listitem>
     <formalpara>
-     <title>Public Key</title>
+     <title>Public key</title>
      <para>
       This key is used for encryption. Distribute it to your communication
       partners, so they can use it to encrypt files or messages for you.
@@ -97,7 +97,7 @@
    </listitem>
    <listitem>
     <formalpara>
-     <title>Private Key</title>
+     <title>Private key</title>
      <para>
       This key is used for decryption. Use it to make encrypted files or
       messages from others (or yourself) legible again.
@@ -107,7 +107,7 @@
   </itemizedlist>
 
   <important>
-   <title>Access to the Private Key</title>
+   <title>Access to the private key</title>
    <para>
     If others gain access to your private key, they can decrypt files and
     messages intended only for you. Never grant others access to your private
@@ -116,7 +116,7 @@
   </important>
 
   <sect2 xml:id="cha-gnome-crypto-gen-key-openpgp">
-   <title>Creating OpenPGP Keys</title>
+   <title>Creating OpenPGP keys</title>
    <para>
     OpenPGP is a non-proprietary protocol for encrypting e-mail with the use of
     public-key cryptography based on PGP. It defines standard formats for
@@ -162,7 +162,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term>Encryption Type</term>
+       <term>Encryption type</term>
        <listitem>
         <para>
          Specifies the encryption algorithms used to generate your keys.
@@ -174,7 +174,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term>Key Strength</term>
+       <term>Key strength</term>
        <listitem>
         <para>
          Specifies the length of the key in bits. The longer the key, the more
@@ -186,7 +186,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term>Expiration Date</term>
+       <term>Expiration date</term>
        <listitem>
         <para>
          Specifies the date at which the key will cease to be usable for
@@ -229,7 +229,7 @@
   </sect2>
 
   <sect2 xml:id="cha-gnome-crypto-gen-key-ssh">
-   <title>Creating Secure Shell Keys</title>
+   <title>Creating secure shell keys</title>
    <para>
     Secure Shell (SSH) is a method of logging in to a remote computer to
     execute commands on that machine. SSH keys are used in key-based
@@ -271,7 +271,7 @@
       following advanced options for the key.
      </para>
      <formalpara>
-      <title>Encryption Type</title>
+      <title>Encryption type</title>
       <para>
        Specifies the encryption algorithms used to generate your keys. Select
        <guimenu>RSA</guimenu> to use the Rivest-Shamir-Adleman (RSA) algorithm
@@ -281,7 +281,7 @@
       </para>
      </formalpara>
      <formalpara>
-      <title>Key Strength</title>
+      <title>Key strength</title>
       <para>
        Specifies the length of the key in bits. The longer the key, the more
        secure it is (provided a strong passphrase is used). Keep in mind that
@@ -320,14 +320,14 @@
   </sect2>
  </sect1>
  <sect1 xml:id="cha-gnome-crypto-modify-key">
-  <title>Modifying Key Properties</title>
+  <title>Modifying key properties</title>
 
   <para>
    You can modify properties of existing OpenPGP or SSH keys.
   </para>
 
   <sect2 xml:id="cha-gnome-crypto-modify-key-openpgp">
-   <title>Editing OpenPGP Key Properties</title>
+   <title>Editing OpenPGP key properties</title>
    <para>
     The descriptions in this section apply to all OpenPGP keys.
    </para>
@@ -425,7 +425,7 @@
       </para>
      </formalpara>
      <formalpara>
-      <title>Override Owner Trust:</title>
+      <title>Override owner trust:</title>
       <para>
        Here you can set the level of trust in the owner of the key. Trust is an
        indication of how sure you are of a person's ability to correctly extend
@@ -435,7 +435,7 @@
       </para>
      </formalpara>
      <formalpara>
-      <title>Export Secret Key:</title>
+      <title>Export secret key:</title>
       <para>
        Exports the key to a file.
       </para>
@@ -466,7 +466,7 @@
     </step>
    </procedure>
    <sect3 xml:id="cha-gnome-crypto-modify-key-openpgp-add-user">
-    <title>Adding a User ID</title>
+    <title>Adding a user ID</title>
     <para>
      User IDs allow multiple identities and e-mail addresses to be used with
      the same key. Adding a user ID is useful, for example, when you want to
@@ -530,7 +530,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="cha-gnome-crypto-modify-key-openpgp-edit-subkey">
-    <title>Editing OpenPGP Subkey Properties</title>
+    <title>Editing OpenPGP subkey properties</title>
     <para>
      Each OpenPGP key has a single master key used to sign only. Subkeys are
      used to encrypt and to sign as well. In this way, if your subkey is
@@ -632,7 +632,7 @@
   </sect2>
 
   <sect2 xml:id="cha-gnome-crypto-modify-key-ssh">
-   <title>Editing Secure Shell Key Properties</title>
+   <title>Editing secure shell key properties</title>
    <para>
     The descriptions in this section apply to all SSH keys.
    </para>
@@ -689,7 +689,7 @@
       </para>
      </formalpara>
      <formalpara>
-      <title>Export Complete Key:</title>
+      <title>Export complete key:</title>
       <para>
        Exports the key to a file.
       </para>
@@ -714,7 +714,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="cha-gnome-crypto-import-key">
-  <title>Importing Keys</title>
+  <title>Importing keys</title>
 
   <para>
    Keys can be exported to text files. These files contain human-readable text
@@ -779,7 +779,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="cha-gnome-crypto-export-key">
-  <title>Exporting Keys</title>
+  <title>Exporting keys</title>
 
   <para>
    To export keys:
@@ -842,7 +842,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="cha-gnome-crypto-sign-key">
-  <title>Signing a Key</title>
+  <title>Signing a key</title>
 
   <para>
    Signing another person's key means that you are giving trust to that person.
@@ -903,7 +903,7 @@
  </sect1>
 <!-- FIXME openSUSE: Check if valid -->
  <sect1 os="osuse" xml:id="cha-gnome-crypto-nautilus">
-  <title>File Manager Integration</title>
+  <title>File manager integration</title>
 
 <!-- Required package nautilus-extension-seahorse is not present on SLE
        - sknorr, 2015-09-21 -->
@@ -915,7 +915,7 @@
   </para>
 
   <note>
-   <title>Enabling File Manager Integration</title>
+   <title>Enabling file manager integration</title>
    <para>
     The package <systemitem>nautilus-extension-seahorse</systemitem> has to be
     installed to enable file manager integration.
@@ -923,7 +923,7 @@
   </note>
 
   <sect2 xml:id="cha-gnome-crypto-nautilus-encrypt">
-   <title>Encrypting Files From &nautilus;</title>
+   <title>Encrypting files from &nautilus;</title>
    <procedure>
     <step performance="required">
      <para>
@@ -951,7 +951,7 @@
   </sect2>
 
   <sect2 xml:id="cha-gnome-crypto-nautilus-sign">
-   <title>Signing Files From &nautilus;</title>
+   <title>Signing files from &nautilus;</title>
    <procedure>
     <step performance="required">
      <para>
@@ -978,7 +978,7 @@
   </sect2>
 
   <sect2 xml:id="cha-gnome-crypto-nautilus-decrypt">
-   <title>Decrypting Files From &nautilus;</title>
+   <title>Decrypting files from &nautilus;</title>
    <para>
     To decrypt an encrypted file in &nautilus;, simply double-click the file
     you want to decrypt.
@@ -989,7 +989,7 @@
   </sect2>
 
   <sect2 xml:id="cha-gnome-crypto-nautilus-verify">
-   <title>Verifying Signatures From &nautilus;</title>
+   <title>Verifying signatures from &nautilus;</title>
    <para>
     To verify files, simply double-click the detached signature file. Detached
     signature file names often have a <filename>.sig</filename> extension.
@@ -997,7 +997,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="cha-gnome-crypto-prefs-keyrings">
-  <title>Password Keyrings</title>
+  <title>Password keyrings</title>
 
   <para>
    You can use password keyring preferences to create or remove keyrings, to
@@ -1047,7 +1047,7 @@
   </para>
  </sect1>
  <sect1 xml:id="cha-gnome-crypto-prefs-servers">
-  <title>Key Servers</title>
+  <title>Key servers</title>
 
   <para>
    You can keep your keys up-to-date by synchronizing keys periodically with
@@ -1084,7 +1084,7 @@
      key servers.
     </para>
     <formalpara>
-     <title>HKP Key Servers:</title>
+     <title>HKP key servers:</title>
      <para>
       HKP key servers are ordinary Web-based key servers, such as the popular
       <literal>hkp://pgp.mit.edu:11371</literal>, also accessible at
@@ -1092,7 +1092,7 @@
      </para>
     </formalpara>
     <formalpara>
-     <title>LDAP Key Servers:</title>
+     <title>LDAP key servers:</title>
      <para>
       LDAP key servers are less common, but use the standard LDAP protocol to
       serve keys. <literal>ldap://keyserver.pgp.com</literal> is a good LDAP
@@ -1120,7 +1120,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="cha-gnome-crypto-prefs-sharing">
-  <title>Key Sharing</title>
+  <title>Key sharing</title>
 
   <para>
    Key Sharing is provided by DNS-SD, also known as Bonjour or Rendezvous.

--- a/xml/gnome_crypto.xml
+++ b/xml/gnome_crypto.xml
@@ -36,7 +36,7 @@
   function="meta"/> and search for <literal>pass</literal>.
  </para>
  <figure pgwide="0">
-  <title>Password and keys main window</title>
+  <title><guimenu>Passwords and Keys</guimenu> main window</title>
   <mediaobject>
    <imageobject role="fo">
     <imagedata fileref="seahorse_main.png" width="73%" format="PNG"/>

--- a/xml/gnome_custom.xml
+++ b/xml/gnome_custom.xml
@@ -576,7 +576,7 @@
 
    <variablelist>
     <varlistentry>
-     <term><guimenu>Display mode</guimenu></term>
+     <term><guimenu>Display Mode</guimenu></term>
      <listitem>
       <para>
        Choose how to use the monitors. With <guimenu>Join Displays</guimenu>

--- a/xml/gnome_custom.xml
+++ b/xml/gnome_custom.xml
@@ -537,7 +537,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><guimenu>Night light</guimenu></term>
+     <term><guimenu>Night Light</guimenu></term>
      <listitem>
       <para>
        If you are working in a dark environment, your eyes can easily be

--- a/xml/gnome_custom.xml
+++ b/xml/gnome_custom.xml
@@ -5,7 +5,7 @@
     %entities;
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-gnome-settings">
- <title>Customizing Your Settings</title>
+ <title>Customizing your settings</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -59,7 +59,7 @@
   </para>
 
   <sect1 xml:id="sec-gnome-settings-look-deskback">
-   <title>Changing the Desktop Background</title>
+   <title>Changing the desktop background</title>
    <para>
     The desktop background is the image or color that is applied to your
     desktop. You can also customize the image shown when the screen is locked.
@@ -104,7 +104,7 @@
   </sect1>
 
   <sect1 xml:id="sec-gnome-settings-lang">
-   <title>Configuring Language Settings</title>
+   <title>Configuring language settings</title>
    <para>
     &productname; can be configured to use any of several languages. The
     language setting determines the language of dialogs and menus and can also
@@ -171,7 +171,7 @@
 </sect1>
    
 <sect1 xml:id="sec-gnome-settings-hardware-keyboard">
-  <title>Configuring the Keyboard</title>
+  <title>Configuring the keyboard</title>
   <para>
    Refer to <xref linkend="sec-general-accessibility-mobility"/> for
    additional settings, such as key autorepetition and cursor blink rate,
@@ -184,7 +184,7 @@
    <guimenu>Devices</guimenu> <guimenu>Keyboard Shortcuts</guimenu> </menuchoice>.
   </para>
   <figure xml:id="fig-gnome-settings-hardware-keyboard">
-   <title>Keyboard Shortcut Dialog</title>
+   <title>Keyboard shortcut dialog</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="preferences_keyboard.png" width="100%" format="PNG"/>
@@ -203,7 +203,7 @@
  </sect1>
 
    <sect1 xml:id="sec-gnome-settings-xmodmap">
-       <title>Using XCompose to Type Special Characters</title>
+       <title>Using XCompose to type special characters</title>
        <para>GNOME supports fast input source (keyboard layout) switching 
            (<xref linkend="sec-gnome-settings-lang"/>). However, if you are using
            <command>xmodmap</command> to create custom keymaps, it may not
@@ -235,7 +235,7 @@
             key (<xref linkend="fig-gnome-settings-keyboard-compose"/>).
         </para>
           <figure xml:id="fig-gnome-settings-keyboard-compose">
-   <title>Enabling the Compose Key in Tweaks</title>
+   <title>Enabling the compose key in tweaks</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
@@ -282,7 +282,7 @@
   </sect1>
 
  <sect1 xml:id="sec-gnome-settings-hardware-bluetooth">
-  <title>Configuring Bluetooth Settings</title>
+  <title>Configuring Bluetooth settings</title>
   <para>
    <remark>taroth 2020-04-09: could not check nor update this section
    as I only had a VM at hand and did not have a bluetooth dongle</remark>
@@ -311,7 +311,7 @@
      list may be empty.
     </para>
     <note>
-     <title>Temporary Visibility</title>
+     <title>Temporary visibility</title>
      <para>
       The <guimenu>Visibility</guimenu> switch is meant to be used only
       temporarily. You only need to turn it on for the initial setup of a
@@ -377,7 +377,7 @@
  </sect1>
 
  <sect1 xml:id="sec-gnome-settings-hardware-power">
-  <title>Configuring Power Settings</title>
+  <title>Configuring power settings</title>
   <para>
    Settings available in this dialog depend on your hardware. In the following
    we describe options that are typically available when using a laptop. On a
@@ -407,7 +407,7 @@
  </sect1>
 
  <sect1 xml:id="sec-gnome-settings-hardware-mouse">
-  <title>Configuring the Mouse and Touchpad</title>
+  <title>Configuring the mouse and touchpad</title>
   <para>
    To modify mouse and touchpad options, right-click the desktop and choose
    <guimenu>Settings</guimenu>. Now choose <menuchoice>
@@ -415,7 +415,7 @@
    </menuchoice>.
   </para>
   <figure xml:id="fig-gnome-settings-hardware-mouse">
-   <title>Mouse and Touchpad Settings Dialog</title>
+   <title>Mouse and touchpad settings dialog</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
@@ -472,7 +472,7 @@
  </sect1>
 
  <sect1 xml:id="sec-gnome-settings-hardware-printer">
-  <title>Installing and Configuring Printers</title>
+  <title>Installing and configuring printers</title>
   <para>
    The <guimenu>Printers</guimenu> dialog lets you connect to any available
    local or remote CUPS server and configure printers.
@@ -486,7 +486,7 @@
  </sect1>
 
  <sect1 xml:id="sec-gnome-settings-hardware-screen">
-  <title>Configuring Screens</title>
+  <title>Configuring screens</title>
   <para>
    To specify resolution and orientation for your screen or to configure
    multiple screens, right-click the desktop and choose <guimenu>Display
@@ -495,10 +495,10 @@
   </para>
 
   <sect2 xml:id="sec-gnome-settings-hardware-screen-single">
-   <title>Changing Settings: Single Monitor Setup</title>
+   <title>Changing settings: single monitor setup</title>
 
    <figure xml:id="fig-gnome-settings-hardware-screen-single">
-    <title>Single Monitor Settings Dialog</title>
+    <title>Single monitor settings dialog</title>
     <mediaobject>
      <imageobject role="fo">
       <imagedata fileref="preferences_screen_single.png" width="100%"
@@ -537,7 +537,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><guimenu>Night Light</guimenu></term>
+     <term><guimenu>Night light</guimenu></term>
      <listitem>
       <para>
        If you are working in a dark environment, your eyes can easily be
@@ -553,10 +553,10 @@
   </sect2>
 
   <sect2 xml:id="sec-gnome-settings-hardware-screen-multi">
-   <title>Changing Settings: Multiple Monitor Setup</title>
+   <title>Changing settings: multiple monitor setup</title>
 <!--taroth 2020-04-09: could not check multi-display setup on the VM-->
    <figure xml:id="fig-gnome-settings-hardware-screen-multi">
-    <title>Single Monitor Settings Dialog</title>
+    <title>Single monitor settings dialog</title>
     <mediaobject>
      <imageobject role="fo">
       <imagedata fileref="preferences_screen.png" width="100%"
@@ -576,7 +576,7 @@
 
    <variablelist>
     <varlistentry>
-     <term><guimenu>Display Mode</guimenu></term>
+     <term><guimenu>Display mode</guimenu></term>
      <listitem>
       <para>
        Choose how to use the monitors. With <guimenu>Join Displays</guimenu>
@@ -588,7 +588,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Display Arrangement</term>
+     <term>Display arrangement</term>
      <listitem>
       <para>
        Drag and Drop the monitor pictograms to order them so they match your
@@ -600,7 +600,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Monitor Configuration</term>
+     <term>Monitor configuration</term>
      <listitem>
       <para>
        To configure orientation and resolution for each monitor, select a
@@ -614,7 +614,7 @@
  </sect1>
 
  <sect1 xml:id="sec-gnome-settings-hardware-audio">
-  <title>Configuring Sound Settings</title>
+  <title>Configuring sound settings</title>
   <para>
    The <guimenu>Sound</guimenu> tool lets you manage sound devices.
    In the top part of the dialog, you can select the general
@@ -625,7 +625,7 @@
    <guimenu>Settings</guimenu>. Now choose <guimenu>Sound</guimenu>.
   </para>
   <figure>
-   <title>Configuring Sound Settings</title>
+   <title>Configuring sound settings</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="sound_devices.png" width="100%" format="PNG"/>
@@ -652,7 +652,7 @@
  </sect1>
 
  <sect1 xml:id="sec-gnome-settings-prefapps">
-  <title>Setting Default Applications</title>
+  <title>Setting default applications</title>
   <procedure>
    <step>
     <para>
@@ -663,7 +663,7 @@
      Applications</guimenu> </menuchoice>.
     </para>
     <figure>
-     <title>Default Applications</title>
+     <title>Default applications</title>
      <mediaobject>
       <imageobject role="fo">
        <imagedata fileref="preferences_preferred_apps.png" width="100%" format="PNG"/>
@@ -685,7 +685,7 @@
  </sect1>
 
  <sect1 xml:id="sec-gnome-settings-share">
-  <title>Setting Session Sharing Preferences</title>
+  <title>Setting session sharing preferences</title>
   <para>
    To open a configuration dialog for allowing remote logins
    via ssh, right-click the desktop and choose <guimenu>Settings</guimenu>. Now

--- a/xml/gnome_custom.xml
+++ b/xml/gnome_custom.xml
@@ -415,7 +415,7 @@
    </menuchoice>.
   </para>
   <figure xml:id="fig-gnome-settings-hardware-mouse">
-   <title>Mouse and touchpad settings dialog</title>
+   <title><guimenu>Mouse and Touchpad</guimenu> settings dialog</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>

--- a/xml/gnome_networking.xml
+++ b/xml/gnome_networking.xml
@@ -5,7 +5,7 @@
     %entities;
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-gnome-network" xml:lang="en">
- <title>Accessing Network Resources</title>
+ <title>Accessing network resources</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -20,7 +20,7 @@
  </para>
  <variablelist>
   <varlistentry>
-   <term>Network Browsing</term>
+   <term>Network browsing</term>
    <listitem>
     <para>
      Your file manager, &nautilus;, lets you browse your network for shared
@@ -30,7 +30,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>Sharing Directories in Mixed Environments</term>
+   <term>Sharing directories in mixed environments</term>
    <listitem>
     <para>
      Using &nautilus;, configure your files and directories to share with other
@@ -41,7 +41,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>Managing Windows Files</term>
+   <term>Managing Windows files</term>
    <listitem>
     <para>
      &productname; can be configured to integrate into an existing Windows
@@ -53,7 +53,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>Configuring and Accessing a Windows Network Printer</term>
+   <term>Configuring and accessing a Windows network printer</term>
    <listitem>
     <para>
      You can configure a Windows network printer through the &gnome; control
@@ -64,7 +64,7 @@
   </varlistentry>
  </variablelist>
  <sect1 xml:id="sec-gnomeuser-start-network-connect">
-  <title>Connecting to a Network</title>
+  <title>Connecting to a network</title>
 
   <para>
    You can connect to a network with wired and wireless connections. To view
@@ -78,10 +78,10 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-gnome-network-general">
-  <title>General Notes on File Sharing and Network Browsing</title>
+  <title>General notes on file sharing and network browsing</title>
 
   <important os="sles;sled">
-   <title>Contact Your Administrator Before Setup</title>
+   <title>Contact your administrator before setup</title>
    <para>
     Whether and to what extent you can use file sharing and network browsing
     and in your network highly depends on the network structure and on the
@@ -129,7 +129,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-gnome-network-accshare">
-  <title>Accessing Network Shares</title>
+  <title>Accessing network shares</title>
 
   <para>
    Networking workstations can be set up to share directories. Typically, files
@@ -152,7 +152,7 @@
   </para>
 
   <figure>
-   <title>Network File Browser</title>
+   <title>Network file browser</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="network_browser.png" width="100%" format="PNG"/>
@@ -164,14 +164,14 @@
   </figure>
 
   <procedure>
-   <title>Adding a Network Place</title>
+   <title>Adding a network place</title>
    <step>
     <para>
      Open &nautilus; and click <guimenu>Other Locations</guimenu> in the
      sidebar. It shows a <guimenu>Connect to Server</guimenu> text box.
     </para>
 <!--<figure>
-     <title>Connect to the Server Dialog</title>
+     <title>Connect to the server dialog</title>
      <mediaobject>
       <imageobject role="fo">
        <imagedata fileref="connect_server_a.png" format="PNG" width="50%"/>
@@ -195,7 +195,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-gnome-network-smbshare">
-  <title>Sharing Directories</title>
+  <title>Sharing directories</title>
 
   <para>
    Sharing and exchanging documents is a must-have in corporate environments.
@@ -204,7 +204,7 @@
   </para>
 
   <sect2 xml:id="sec-gnome-network-sharingcomputer">
-   <title>Enabling Sharing on the Computer</title>
+   <title>Enabling sharing on the computer</title>
    <para>
     Before you can share a directory, you must enable sharing on your computer.
     To enable sharing:
@@ -236,7 +236,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnome-network-sharingfolder">
-   <title>Enabling Sharing for a Directory</title>
+   <title>Enabling sharing for a directory</title>
    <para>
     To configure file sharing for a directory:
    </para>
@@ -292,7 +292,7 @@
     The directory icon changes to indicate that the directory is now shared.
    </para>
    <important>
-    <title>Samba Domain Browsing and Firewalls</title>
+    <title>Samba domain browsing and firewalls</title>
     <para>
      Samba domain browsing only works if your system's firewall is configured
      accordingly. Either disable the firewall entirely or assign the browsing
@@ -303,7 +303,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gnome-network-ad-data">
-  <title>Managing Windows Files</title>
+  <title>Managing Windows files</title>
 
   <para>
    With your &productname; machine being an Active Directory client, you can
@@ -313,7 +313,7 @@
 
   <variablelist>
    <varlistentry>
-    <term>Browsing Windows Files with &nautilus;</term>
+    <term>Browsing Windows files with &nautilus;</term>
     <listitem>
      <para>
       Use &nautilus;'s network browsing features to browse your Windows data.
@@ -321,7 +321,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Viewing Windows Data with &nautilus;</term>
+    <term>Viewing Windows data with &nautilus;</term>
     <listitem>
      <para>
       Use &nautilus; to display the contents of your Windows user directory as
@@ -331,7 +331,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Manipulating Windows Data with &gnome; Applications</term>
+    <term>Manipulating Windows data with &gnome; applications</term>
     <listitem>
      <para>
       Many &gnome; applications allow you to open files on the Windows server,
@@ -340,7 +340,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Single Sign-On</term>
+    <term>Single sign-on</term>
     <listitem>
      <para>
       &gnome; applications, including &nautilus;, support Single Sign-On. This
@@ -390,7 +390,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-gnome-network-ad-printer">
-  <title>Configuring and Accessing a Windows Network Printer</title>
+  <title>Configuring and accessing a Windows network printer</title>
 
 <!--taroth 2016-06-02: by default, the dialog shows the following message
    "Sorry! The system printing service does not seem to be available", despite

--- a/xml/gnome_networking.xml
+++ b/xml/gnome_networking.xml
@@ -171,7 +171,7 @@
      sidebar. It shows a <guimenu>Connect to Server</guimenu> text box.
     </para>
 <!--<figure>
-     <title>Connect to the server dialog</title>
+     <title><guimenu>Connect to the Server</guimenu> dialog</title>
      <mediaobject>
       <imageobject role="fo">
        <imagedata fileref="connect_server_a.png" format="PNG" width="50%"/>

--- a/xml/gnome_print.xml
+++ b/xml/gnome_print.xml
@@ -5,7 +5,7 @@
     %entities;
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-gnome-print">
- <title>Managing Printers</title>
+ <title>Managing printers</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -21,7 +21,7 @@
    bare-metal and a printer attached to it</remark>
  </para>
  <sect1 xml:id="sec-gnome-print-inst">
-  <title>Installing a Printer</title>
+  <title>Installing a printer</title>
 
 <!--taroth 2016-06-02: by default, the dialog shows the following message
    "Sorry! The system printing service does not seem to be available", despite
@@ -95,7 +95,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term><guimenu>Internet Printing Protocol (ipp)</guimenu>
+       <term><guimenu>Internet printing protocol (ipp)</guimenu>
        </term>
        <listitem>
         <para>
@@ -106,7 +106,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term><guimenu>LPD/LPR Host or Printer</guimenu>
+       <term><guimenu>LPD/LPR host or printer</guimenu>
        </term>
        <listitem>
         <para>
@@ -116,7 +116,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term><guimenu>Windows Printer via SAMBA</guimenu>
+       <term><guimenu>Windows printer via SAMBA</guimenu>
        </term>
        <listitem>
         <para>
@@ -167,7 +167,7 @@
   </para>
 
 <!--<sect2>
-   <title>Installing a Local Printer</title>
+   <title>Installing a local printer</title>
    <procedure>
     <step>
      <para>
@@ -217,7 +217,7 @@
   </sect2>
  </sect1>
  <sect1>
-  <title>Modifying Printer Settings</title>
+  <title>Modifying printer settings</title>
 
   <procedure>
    <step>
@@ -240,7 +240,7 @@
   </procedure>
  </sect1>
  <sect1>
-  <title>Canceling Print Jobs</title>
+  <title>Canceling print jobs</title>
 
   <procedure>
    <step>
@@ -268,7 +268,7 @@
   </procedure>
  </sect1>
  <sect1>
-  <title>Deleting a Printer</title>
+  <title>Deleting a printer</title>
 
   <procedure>
    <step>

--- a/xml/gnome_print.xml
+++ b/xml/gnome_print.xml
@@ -95,7 +95,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term><guimenu>Internet printing protocol (ipp)</guimenu>
+       <term><guimenu>Internet Printing Protocol (IPP)</guimenu>
        </term>
        <listitem>
         <para>

--- a/xml/gnome_print.xml
+++ b/xml/gnome_print.xml
@@ -106,7 +106,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term><guimenu>LPD/LPR host or printer</guimenu>
+       <term><guimenu>LPD/LPR Host or Printer</guimenu>
        </term>
        <listitem>
         <para>

--- a/xml/gnome_print.xml
+++ b/xml/gnome_print.xml
@@ -116,7 +116,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term><guimenu>Windows printer via SAMBA</guimenu>
+       <term><guimenu>Windows Printer via SAMBA</guimenu>
        </term>
        <listitem>
         <para>

--- a/xml/gnome_start.xml
+++ b/xml/gnome_start.xml
@@ -403,7 +403,7 @@
     </itemizedlist>
    </sect3>
    <sect3 xml:id="sec-gnome-start-activities-use">
-    <title>Using the activities overview</title>
+    <title>Using the <guimenu>Activities Overview</guimenu></title>
     <remark>screenshot useful -- sknor, 2015-09-10</remark>
     <para>
      In the following, the most important parts of the Activities Overview are

--- a/xml/gnome_start.xml
+++ b/xml/gnome_start.xml
@@ -370,7 +370,7 @@
   </figure>
 
   <sect2 xml:id="sec-gnome-start-activities">
-   <title>Activities overview</title>
+   <title><guimenu>Activities Overview</guimenu></title>
    <para>
     Activities Overview is a full screen mode that comprises all the ways in
     which you can switch from one activity to another. It shows previews of all

--- a/xml/gnome_start.xml
+++ b/xml/gnome_start.xml
@@ -378,7 +378,7 @@
     integrates searching and browsing functionality.
    </para>
    <sect3 xml:id="sec-gnome-start-activities-open">
-    <title>Opening the activities overview</title>
+    <title>Opening the <guimenu>Activities Overview</guimenu></title>
     <para>
      There are multiple ways to open the Activities Overview:
     </para>

--- a/xml/gnome_start.xml
+++ b/xml/gnome_start.xml
@@ -5,7 +5,7 @@
     %entities;
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-gnomeuser-start">
- <title>Getting Started with the &gnome; Desktop</title>
+ <title>Getting started with the &gnome; desktop</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -24,7 +24,7 @@
   combinations.
  </para>
  <note os="sles;sled">
-  <title>Included Session Configurations</title>
+  <title>Included session configurations</title>
   <para>
    Some versions of &sle; ship with as many as three different session
    configurations based on &gnome;. These are &gnome;, &gnome; Classic, and
@@ -33,7 +33,7 @@
   </para>
  </note>
  <note os="osuse">
-  <title>Included Session Configurations</title>
+  <title>Included session configurations</title>
   <para>
    &productname; ships with as three different session
    configurations based on &gnome;. These are &gnome;, &gnome; Classic, and
@@ -44,7 +44,7 @@
   </para>
  </note>
  <sect1 xml:id="sec-gnome-login">
-  <title>Logging In</title>
+  <title>Logging in</title>
 
   <para>
    In general, all users must authenticate&mdash;unless <guimenu>Auto
@@ -65,7 +65,7 @@
   </para>
 
   <figure>
-   <title>Default GNOME Login Screen</title>
+   <title>Default GNOME login screen</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata os="sles;sled" fileref="login_sled.png" width="90%"
@@ -83,7 +83,7 @@
   </figure>
 
   <procedure>
-   <title>Normal Login</title>
+   <title>Normal login</title>
    <step>
     <remark>Not ideal... -- sknorr, 2015-09-10</remark>
     <para>
@@ -102,7 +102,7 @@
   </procedure>
 
   <sect2 xml:id="sec-gnome-switchsession">
-   <title>Switching the Session Type Before Logging In</title>
+   <title>Switching the session type before logging in</title>
    <para>
     If you want to try one of the additional &gnome; session configurations or
     try another desktop environment, follow the steps below.
@@ -119,7 +119,7 @@
       To change the session type, click the cog wheel icon. A menu appears.
      </para>
      <figure>
-      <title>Default GNOME Login Screen&mdash;Session Type</title>
+      <title>Default GNOME login screen&mdash;session type</title>
       <mediaobject>
        <imageobject role="fo">
         <imagedata os="sles" fileref="login_sessiontype_sles.png"
@@ -169,7 +169,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term>&gnome; Classic</term>
+       <term>&gnome; classic</term>
        <listitem>
         <para>
          A &gnome; 3 configuration that is designed to appeal to former users
@@ -179,7 +179,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term>IceWM Session</term>
+       <term>IceWM session</term>
        <listitem>
         <para>
          A basic desktop designed to use little resources. It can be used
@@ -188,7 +188,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term>&slea; Classic</term>
+       <term>&slea; classic</term>
        <listitem>
         <para>
          The GNOME look and feel that was used on &sle; 12. This desktop
@@ -199,7 +199,7 @@
        </listitem>
       </varlistentry>
       <varlistentry os="sled">
-       <term>&slea; Classic on Xorg</term>
+       <term>&slea; classic on Xorg</term>
        <listitem>
         <para>
          By default &productname; uses &slea; Classic with Wayland. Choose this
@@ -232,7 +232,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnome-loginassistance">
-   <title>Assistive Tools</title>
+   <title>Assistive tools</title>
    <para>
     In the top right corner, there are status icons and the assistive
     technologies menu. By clicking the status icons, open a menu that allows
@@ -241,7 +241,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gnome-desktop">
-  <title>Desktop Basics</title>
+  <title>Desktop basics</title>
 
   <para>
    The &gnome; desktop appears after you first log in. It displays a panel at
@@ -346,7 +346,7 @@
   </variablelist>
 
   <figure os="sles;sled">
-   <title>&gnome; Desktop with Activities Overview</title>
+   <title>&gnome; desktop with activities overview</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="desktop_sled_menu.png" width="95%" format="PNG"/>
@@ -358,7 +358,7 @@
   </figure>
 
   <figure os="osuse">
-   <title>&gnome; Desktop</title>
+   <title>&gnome; desktop</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="desktop_gnome_osuse.png" width="95%" format="PNG"/>
@@ -370,7 +370,7 @@
   </figure>
 
   <sect2 xml:id="sec-gnome-start-activities">
-   <title>Activities Overview</title>
+   <title>Activities overview</title>
    <para>
     Activities Overview is a full screen mode that comprises all the ways in
     which you can switch from one activity to another. It shows previews of all
@@ -378,7 +378,7 @@
     integrates searching and browsing functionality.
    </para>
    <sect3 xml:id="sec-gnome-start-activities-open">
-    <title>Opening the Activities Overview</title>
+    <title>Opening the activities overview</title>
     <para>
      There are multiple ways to open the Activities Overview:
     </para>
@@ -403,7 +403,7 @@
     </itemizedlist>
    </sect3>
    <sect3 xml:id="sec-gnome-start-activities-use">
-    <title>Using the Activities Overview</title>
+    <title>Using the activities overview</title>
     <remark>screenshot useful -- sknor, 2015-09-10</remark>
     <para>
      In the following, the most important parts of the Activities Overview are
@@ -462,7 +462,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnome-start-startprograms">
-   <title>Starting Programs</title>
+   <title>Starting programs</title>
    <para>
     To start a program, you have several options:
    </para>
@@ -500,7 +500,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gnomeuser-start-logout">
-  <title>Pausing or Finishing Your Session</title>
+  <title>Pausing or finishing your session</title>
 
   <para>
    When you have finished using the computer, there are multiple ways to finish
@@ -512,7 +512,7 @@
   <itemizedlist>
    <listitem>
     <formalpara>
-     <title>Locking the Computer</title>
+     <title>Locking the computer</title>
      <para>
       Pause your session, but keep the computer on. Make sure that nobody can
       look at or change your work while you are away on a break. Other users
@@ -523,7 +523,7 @@
    </listitem>
    <listitem>
     <formalpara>
-     <title>Logging Out</title>
+     <title>Logging out</title>
      <para>
       Finish the current session, but leave the computer on, so other users can
       log in.
@@ -532,7 +532,7 @@
    </listitem>
    <listitem>
     <formalpara>
-     <title>Shutting Down</title>
+     <title>Shutting down</title>
      <para>
       Finish the current session and turn off the computer.
      </para>
@@ -549,7 +549,7 @@
    </listitem>
    <listitem>
     <formalpara>
-     <title>Suspending the Computer</title>
+     <title>Suspending the computer</title>
      <para>
       Pause your session and put the computer in a state where it consumes a
       minimal amount of energy. Suspend mode can be configured to lock your
@@ -564,7 +564,7 @@
   </itemizedlist>
 
   <sect2 xml:id="sec-gnomeuser-start-login-lock">
-   <title>Locking the Screen</title>
+   <title>Locking the screen</title>
    <para>
     To lock the screen, click the status icons on the right of the main panel
     and click the padlock icon.
@@ -578,7 +578,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnomeuser-start-logout-logout">
-   <title>Logging Out or Switching Users</title>
+   <title>Logging out or switching users</title>
    <procedure>
     <step>
      <para>
@@ -596,7 +596,7 @@
      </para>
      <variablelist>
       <varlistentry>
-       <term>Log Out</term>
+       <term>Log out</term>
        <listitem>
         <para>
          Logs you out of the current session and returns you to the Login
@@ -605,7 +605,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term>Switch User</term>
+       <term>Switch user</term>
        <listitem>
         <para>
          Suspends your session, allowing another user to log in and use the
@@ -614,7 +614,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term>Account Settings</term>
+       <term>Account settings</term>
        <listitem>
         <para>
          Takes you to the user settings where you can change your password.
@@ -627,7 +627,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnomeuser-start-logout-restart">
-   <title>Restarting or Shutting Down the Computer</title>
+   <title>Restarting or shutting down the computer</title>
    <procedure>
     <step>
      <para>
@@ -645,7 +645,7 @@
      </para>
      <variablelist>
       <varlistentry>
-       <term>Power Off</term>
+       <term>Power off</term>
        <listitem>
         <para>
          Logs you out of the current session, then turns off the computer.
@@ -666,7 +666,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnomeuser-start-suspend">
-   <title>Suspending the Computer</title>
+   <title>Suspending the computer</title>
    <procedure>
     <step>
      <para>

--- a/xml/gnome_use.xml
+++ b/xml/gnome_use.xml
@@ -604,7 +604,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Using the activities overview</term>
+    <term>Using the <guimenu>Activities Overview</guimenu></term>
     <listitem>
      <para>
       Open the Activities Overview by pressing <keycap function="meta"/>. Then

--- a/xml/gnome_use.xml
+++ b/xml/gnome_use.xml
@@ -5,7 +5,7 @@
     %entities;
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-gnomeuser-use">
- <title>Working with Your Desktop</title>
+ <title>Working with your desktop</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -17,7 +17,7 @@
   also find out how to perform regular tasks with your desktop.
  </para>
  <sect1 xml:id="sec-gnomeuser-use-nautilus">
-  <title>Managing Files and Directories</title>
+  <title>Managing files and directories</title>
 
   <para>
    To start &nautilus; open the Activities Overview by pressing <keycap
@@ -25,7 +25,7 @@
   </para>
 
   <figure pgwide="1">
-   <title>File Manager</title>
+   <title>File manager</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
@@ -75,7 +75,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Content Area</term>
+    <term>Content area</term>
     <listitem>
      <para>
       Displays files and directories.
@@ -90,7 +90,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Context Menus</term>
+    <term>Context menus</term>
     <listitem>
      <para>
       Open a context menu by right-clicking inside the content area. The items
@@ -105,7 +105,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Floating Statusbar</term>
+    <term>Floating statusbar</term>
     <listitem>
      <para>
       The floating statusbar appears when a file is selected. It displays the
@@ -116,12 +116,12 @@
   </variablelist>
 
   <sect2 xml:id="sec-gnomeuser-use-nautilus-shortcuts">
-   <title>Key Combinations</title>
+   <title>Key combinations</title>
    <para>
     The following table lists a selection of key combinations of &nautilus;.
    </para>
    <table rowsep="1">
-    <title>&nautilus; Key Combinations</title>
+    <title>&nautilus; key combinations</title>
     <tgroup cols="2">
      <colspec colnum="1" colname="1" colwidth="41*"/>
      <colspec colnum="2" colname="2" colwidth="59*"/>
@@ -317,7 +317,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnomeuser-use-nautilus-archiving">
-   <title>Compressing Files or Directories</title>
+   <title>Compressing files or directories</title>
    <para>
     Sometimes, it is useful to archive or compress files, for example:
    </para>
@@ -470,7 +470,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnomeuser-use-nautilus-bookmarks">
-   <title>Creating a Bookmark</title>
+   <title>Creating a bookmark</title>
    <para>
     Use the bookmarks feature in &nautilus; to quickly jump to your favorite
     directories from the sidebar.
@@ -516,7 +516,7 @@
 
 <!--taroth 2016-05-24: could not find those with Beta 1...
    <sect2 xml:id="sec-gnomeuser-use-nautilus-prefs">
-   <title>File Manager Preferences</title>
+   <title>File manager preferences</title>
    <para>
     Open the file manager preferences by clicking the cog wheel icon
     and selecting <guimenu>Preferences</guimenu>.
@@ -527,7 +527,7 @@
   </sect2>-->
 
   <sect2 xml:id="sec-gnomeuser-use-network">
-   <title>Accessing Remote Files</title>
+   <title>Accessing remote files</title>
    <para>
     <remark role="clarity"> fs 2008-12-10: Removed section Accessing Network
      Resources because it was almost identical to cha.gnome.network. </remark>
@@ -537,7 +537,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gnomeuser-use-media">
-  <title>Accessing Removable Media</title>
+  <title>Accessing removable media</title>
 
   <para>
    To access CDs/DVDs or flash disks, insert or attach the medium. An icon for
@@ -549,7 +549,7 @@
   </para>
 
   <warning>
-   <title>Unmount to Prevent Data Loss</title>
+   <title>Unmount to prevent data loss</title>
    <remark>
     Pressing the Eject button on any &gnome; system of the past ten years
     has resulted in the disc being unmounted automatically. Diskettes (where
@@ -581,7 +581,7 @@
   </warning>
  </sect1>
  <sect1 xml:id="sec-gnomeuser-use-search-files">
-  <title>Searching for Files</title>
+  <title>Searching for files</title>
 
   <para>
    There are multiple ways to search for files or directories. In all cases,
@@ -604,7 +604,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Using the Activities Overview</term>
+    <term>Using the activities overview</term>
     <listitem>
      <para>
       Open the Activities Overview by pressing <keycap function="meta"/>. Then
@@ -616,7 +616,7 @@
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-gnomeuser-use-cutnpaste">
-  <title>Copying Text Between Applications</title>
+  <title>Copying text between applications</title>
 
   <para>
    Copy and paste works the same as in other operating systems. First select
@@ -656,7 +656,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-gnomeuser-use-connections">
-  <title>Managing Internet Connections</title>
+  <title>Managing Internet connections</title>
 
   <para>
    To surf the Web or send and receive e-mail messages, you must have
@@ -691,7 +691,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-gnomeuser-use-mail">
-  <title>E-mail and Scheduling</title>
+  <title>E-mail and scheduling</title>
 
   <para>
    For reading and managing your mail and events, use Evolution. Evolution is a
@@ -736,7 +736,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-gnomeuser-use-oo">
-  <title>Opening or Creating Documents with &libo;</title>
+  <title>Opening or creating documents with &libo;</title>
 
   <para>
    For creating and editing documents, &libo; is installed with the &gnome;
@@ -755,7 +755,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-gnomeuser-use-power-mgmt">
-  <title>Controlling Your Desktop’s Power Management</title>
+  <title>Controlling your desktop’s power management</title>
 
   <para>
    To see the state of the computer battery on your laptop, check the battery
@@ -777,7 +777,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-gnomeuser-use-archives">
-  <title>Creating, Displaying, and Decompressing Archives</title>
+  <title>Creating, displaying, and decompressing archives</title>
 
   <para>
    You can use the Archive Manager application (also known as File Roller) to
@@ -801,7 +801,7 @@
   </para>
 
   <figure>
-   <title>Archive Manager</title>
+   <title>Archive manager</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="file_roller.png" format="PNG" width="90%"/>
@@ -813,7 +813,7 @@
   </figure>
 
   <sect2 xml:id="sec-gnomeuser-use-archives-open">
-   <title>Opening an Archive</title>
+   <title>Opening an archive</title>
    <procedure>
     <step>
      <para>
@@ -879,7 +879,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnomeuser-use-archives-extract">
-   <title>Extracting Files from an Archive</title>
+   <title>Extracting files from an archive</title>
    <procedure>
     <step>
      <para>
@@ -1028,7 +1028,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gnomeuser-use-archives-create">
-   <title>Creating Archives</title>
+   <title>Creating archives</title>
    <procedure>
     <step>
      <para>
@@ -1089,7 +1089,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gnomeuser-use-screnshots">
-  <title>Taking Screenshots</title>
+  <title>Taking screenshots</title>
 
   <para>
    You can take a snapshot of your screen or of an individual application
@@ -1113,7 +1113,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-gnomeuser-use-pdfs">
-  <title>Viewing PDF Files</title>
+  <title>Viewing PDF files</title>
 
   <para>
    Documents that need to be shared or printed across platforms can be saved as
@@ -1122,7 +1122,7 @@
   </para>
 
   <note>
-   <title>Rare Display Issues</title>
+   <title>Rare display issues</title>
    <para>
     In rare cases, documents will not be displayed correctly in Document
     Viewer. This can happen, for example, with certain forms, animations or 3D
@@ -1133,7 +1133,7 @@
   </note>
 
   <figure>
-   <title>Document Viewer</title>
+   <title>Document viewer</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="evince.png" format="PNG" width="90%"/>
@@ -1164,7 +1164,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-gnomeuser-use-updates">
-  <title>Obtaining Software Updates</title>
+  <title>Obtaining software updates</title>
 
   <para>
    When you connect to the Internet, the updater applet automatically checks
@@ -1179,7 +1179,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-gnomeuser-use-more">
-  <title>For More Information</title>
+  <title>For more information</title>
 
   <para>
    Along with the applications described in this chapter for getting started,

--- a/xml/gnomeuser_intro.xml
+++ b/xml/gnomeuser_intro.xml
@@ -5,7 +5,7 @@
     %entities;
 ]>
 <preface xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="pre-gnome-about">
- <title>About This Guide</title>
+ <title>About this guide</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -38,7 +38,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>Connectivity, Files and Resources</term>
+   <term>Connectivity, files and resources</term>
    <listitem>
     <para>
      Learn how to manage and exchange data on your system or on a network:
@@ -59,7 +59,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>Internet, Communication and Collaboration</term>
+   <term>Internet, communication and collaboration</term>
    <listitem>
     <para>
      Use a Web browser and get to know the e-mailing and calendaring software.
@@ -68,7 +68,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>Graphics and Multimedia</term>
+   <term>Graphics and multimedia</term>
    <listitem>
     <para>
      Get to know GIMP, an image manipulation program that meets the needs of

--- a/xml/help_user.xml
+++ b/xml/help_user.xml
@@ -8,7 +8,7 @@
 <!--taroth: @maintainer: the following varlist is included in
  both help_user.xml and help_admin.xml -
  if you change anything, take care to keep them in sync! -->
- <title>Help and Documentation</title>
+ <title>Help and documentation</title>
  <info>
   <abstract>
    <para>
@@ -27,7 +27,7 @@
  if you change anything, take care to keep them in sync! -->
  <variablelist>
   <varlistentry>
-   <term>Desktop Help Center</term>
+   <term>Desktop help center</term>
    <listitem>
     <para>
      The help center of the &gnome; desktop (&yelp;) provides central access to
@@ -39,7 +39,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>Separate Help Packages for Some Applications</term>
+   <term>Separate help packages for some applications</term>
    <listitem>
     <para>
      When installing new software with &yast;, the software documentation is
@@ -62,7 +62,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>Man Pages and Info Pages for Shell Commands</term>
+   <term>Man pages and info pages for shell commands</term>
    <listitem>
     <para>
      When working with the shell, you do not need to know the options of the
@@ -88,7 +88,7 @@
   </para>
 
   <figure>
-   <title>Main Window of &yelp;</title>
+   <title>Main window of &yelp;</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
@@ -113,7 +113,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-help-furtherdoc">
-  <title>Additional Help Resources</title>
+  <title>Additional help resources</title>
 
   <para>
     In addition to the
@@ -180,7 +180,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-help-more">
-  <title>For More Information</title>
+  <title>For more information</title>
 
   <para>
    Apart from the product-specific help resources, there is a broad range of
@@ -188,7 +188,7 @@
   </para>
 
   <sect2 xml:id="sec-help-more-tldp">
-   <title>The Linux Documentation Project</title>
+   <title>The Linux documentation project</title>
    <para>
     The Linux Documentation Project (TLDP) is run by a team of volunteers who
     write Linux-related documentation (see
@@ -210,7 +210,7 @@
     </para>
    </sect3>-->
    <sect3 xml:id="sec-helpmore-tldp-faq">
-    <title>Frequently Asked Questions</title>
+    <title>Frequently asked questions</title>
     <para>
      FAQs (frequently asked questions) are a series of questions and answers.
      They originate from Usenet newsgroups where the purpose was to reduce
@@ -279,7 +279,7 @@
   </sect2>-->
 
   <sect2 xml:id="sec-help-more-wikipedia">
-   <title>Wikipedia: The Free Online Encyclopedia</title>
+   <title>Wikipedia: the free online encyclopedia</title>
    <remark>Translators: Translate the link http://en.wikipedia.org into your language: Replace "en"
     with your ISO language code.</remark>
    <para>
@@ -294,7 +294,7 @@
   </sect2>
 
   <sect2 xml:id="sec-help-more-standards">
-   <title>Standards and Specifications</title>
+   <title>Standards and specifications</title>
    <para>
     There are various sources that provide information about standards or
     specifications.


### PR DESCRIPTION
### Description

* The new capitalization rules are documented at https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-capitalization, read carefully
* This is the result of an automatic conversion and will most likely need further adjustments
  * Make sure to review the entire diff
  * Entity files have not been changed and need to be updated manually
  * Some product/project names may have been inadvertently changed to the wrong capitalization
  * Some titles may have been missed, either because they're split across multiple source lines or because of improper markup
* Update the conversion commit and remove the (WIP) from the commit message before merging
* This is the third PR in a series of 14 PRs


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [x] 15 SP3  | (`master` only)   
| [ ] 15 SP2  | [ ] 
| [ ] 15 SP1  | [ ] 
| [ ] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
