### PR TITLE
Update AutoYaST Guide to sentence case (WIP)

### DIFF
--- a/xml/ay_12_migrate_15.xml
+++ b/xml/ay_12_migrate_15.xml
@@ -8,10 +8,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>
-  Differences Between &ay; Profiles in &slea; <phrase
-  os="sles;sled">12</phrase><phrase os="osuse">42.3</phrase> and 15
- </title>
+ <title>Differences between &ay; profiles in &slea; <phrase os="sles;sled">12</phrase><phrase os="osuse">42.3</phrase> and 15</title>
  <info>
   <abstract>
    <para>
@@ -24,7 +21,7 @@
   </abstract>
  </info>
  <sect1 os="sles;sled" xml:id="sec-ay-12vs15-product-selection">
-  <title>Product Selection</title>
+  <title>Product selection</title>
 
   <para>
    For backward compatibility with profiles created for pre-<phrase
@@ -76,7 +73,7 @@
   </itemizedlist>
 
   <note>
-   <title>Maintenance Updates</title>
+   <title>Maintenance updates</title>
    <para>
     Only using the registration server will grant access to all maintenance
     updates at installation time. Maintenance updates are not available when
@@ -85,7 +82,7 @@
   </note>
 
   <sect2 xml:id="sec-ay-12vs15-software-scc" os="sles;sled">
-   <title>Adding Modules or Extensions Using the Registration Server</title>
+   <title>Adding modules or extensions using the registration server</title>
    <para>
     To add a module or extension from the registration server, use the <tag
     class="element">addons</tag> tag for each module/extension in the
@@ -101,7 +98,7 @@
     os="sles;sled">&slea;</phrase> &productnumber; installed.
    </para>
    <example xml:id="ex-ay-12vs15-software-scc">
-     <title>Adding Modules and Extensions (online)</title>
+     <title>Adding modules and extensions (online)</title>
      <screen>&lt;suse_register&gt;
  &lt;addons config:type="list"&gt;
   &lt;addon&gt;
@@ -130,7 +127,7 @@
   </sect2>
 
   <sect2 xml:id="sec-ay-12vs15-software-packagemedia" os="sles;sled">
-   <title>Adding Modules or Extensions Using the &packagemedia; Image</title>
+   <title>Adding modules or extensions using the &packagemedia; image</title>
    <para>
     To add a module or extension using the &packagemedia; image, create entries in
     the add-on section as shown in the example below. The following XML code
@@ -138,7 +135,7 @@
    </para>
 
    <example xml:id="ex-ay-12vs15-software-packagemedia">
-     <title>Adding Modules and Extensions (offline)</title>
+     <title>Adding modules and extensions (offline)</title>
      <screen>&lt;add-on&gt;
  &lt;add_on_products config:type="list"&gt;
   &lt;listentry&gt;
@@ -151,7 +148,7 @@
    </example>
 
    <note>
-    <title>Product Name Matching</title>
+    <title>Product name matching</title>
     <para>
      <remark condition="clarity">
       2018-03-22 - fs: How to know which values to specify for &lt;product&gt;
@@ -164,7 +161,7 @@
    </note>
 
    <tip>
-    <title>Using the Installation Media Image from a Local Server</title>
+    <title>Using the installation media image from a local server</title>
     <para>
      You can share the content of the &usbflashdrive; on the local network via an NFS, FTP or HTTP
      server. To do so, replace the URL in the <tag
@@ -176,7 +173,7 @@
   </sect2>
 
   <sect2 xml:id="sec-ay-12vs15-software-patterns">
-   <title>Renamed Software Patterns</title>
+   <title>Renamed software patterns</title>
    <para>
     Software patterns have also changed since &productname; 15. Some patterns have
     been renamed; a short summary is provided in the following table.
@@ -316,7 +313,7 @@
   </sect2>
  </sect1>
  <sect1 os="sles;sled" xml:id="sec-ay-12vs15-registration">
-  <title>Registration of Module and Extension Dependencies</title>
+  <title>Registration of module and extension dependencies</title>
 
   <para>
    Starting with &productname; 15, &ay; automatically reorders the extensions
@@ -350,7 +347,7 @@
   </para>
 
   <sect2 xml:id="sec-ay-12vs15-registration-partitioning-gpt" arch="x86_64">
-   <title>GPT Becomes the Default Partition Type on &x86-64;</title>
+   <title>GPT becomes the default partition type on &x86-64;</title>
    <para>
     On &x86-64; systems, GPT is now the preferred partition type. However, if
     you would like to retain the old behavior, you can explicitly indicate
@@ -360,7 +357,7 @@
   </sect2>
 
   <sect2 xml:id="sec-ay-12vs15-partitioning-partition-numbers">
-   <title>Setting Partition Numbers</title>
+   <title>Setting partition numbers</title>
    <para>
     &ay; will no longer support forcing partition numbers, as it
     might not work in some situations. Moreover, GPT is now the preferred
@@ -374,7 +371,7 @@
   </sect2>
 
   <sect2 xml:id="sec-ay-12vs15-partitioning-forcing-primary">
-   <title>Forcing Primary Partitions</title>
+   <title>Forcing primary partitions</title>
    <para>
     It is still possible to force a partition as <literal>primary</literal>
     (only on MS-DOS partition tables) by setting the <tag
@@ -385,7 +382,7 @@
   </sect2>
 
   <sect2 xml:id="sec-ay-12vs15-partitioning-default-subvolume">
-   <title>Btrfs: Default Subvolume Name</title>
+   <title>Btrfs: default subvolume name</title>
    <para>
     The new storage layer allows the user to set different default subvolumes
     (or none) for every Btrfs file system. As shown in the example below,
@@ -394,7 +391,7 @@
    </para>
 
     <example xml:id="ex-ay-12vs15-partitioning-default-subvolume">
-     <title>Specifying the Btrfs Default Subvolume Name</title>
+     <title>Specifying the Btrfs default subvolume name</title>
       <screen><![CDATA[<partition>
  <mount>/</mount>
  <filesystem config:type="symbol">btrfs</filesystem>
@@ -409,7 +406,7 @@
    </para>
 
     <example xml:id="ex-ay-12vs15-partitioning-disabling-btrfs-subvolumes">
-     <title>Disabling Btrfs Subvolumes</title>
+     <title>Disabling Btrfs subvolumes</title>
        <screen><![CDATA[<partition>
  <mount>/</mount>
  <filesystem config:type="symbol">btrfs</filesystem>
@@ -426,7 +423,7 @@
   </sect2>
 
   <sect2 xml:id="sec-ay-12v215-partitioning-disabling-subvolumes">
-    <title>Btrfs: Disabling Subvolumes</title>
+    <title>Btrfs: disabling subvolumes</title>
     <para>
      Btrfs subvolumes can be disabled by setting <tag
      class="element">create_subvolumes</tag> to <literal>false</literal>. To
@@ -441,9 +438,7 @@
   </sect2>
 
   <sect2 xml:id="sec-ay-12vs15-partitioning-fstab">
-   <title>
-    Reading an Existing <filename>/etc/fstab</filename> Is No Longer Supported
-   </title>
+   <title>Reading an existing <filename>/etc/fstab</filename> is no longer supported</title>
    <para>
     On &productname; 15 the ability to read an existing
     <filename>/etc/fstab</filename> from a previous installation when trying to
@@ -452,9 +447,7 @@
   </sect2>
 
   <sect2 xml:id="sec-ay-12vs15-partitioning-aligning">
-   <title>
-    Setting for Aligning Partitions Has Been Dropped
-   </title>
+   <title>Setting for aligning partitions has been dropped</title>
    <para>
     As cylinders have become obsolete, the
     <tag class="element">partition_alignment</tag>> tag makes no sense and it
@@ -464,9 +457,7 @@
   </sect2>
 
   <sect2 xml:id="sec-ay-12vs15-partitioning-lvm">
-    <title>
-     Using the <literal>type</literal> to Define an Volume Group
-    </title>
+    <title>Using the <literal>type</literal> to define an volume group</title>
     <para>
      The <literal>is_lvm_vg</literal> element has been dropped in favor of
      setting the <literal>type</literal> to the <literal>CT_LVM</literal>
@@ -476,7 +467,7 @@
  </sect1>
 
  <sect1 xml:id="sec-ay-12vs15-firewall">
-  <title>Firewall Configuration</title>
+  <title>Firewall configuration</title>
   <para>
    In &productname; 15, &susefirewall; has been replaced by &firewalld; as the
    default firewall. The configuration of these two firewalls differs
@@ -494,9 +485,7 @@
   </para>
 
   <table>
-   <title>&ay; Firewall Configuration in <phrase
-   os="sles;sled">&slea;</phrase><phrase os="osuse">Leap</phrase> 15: Backward
-   Compatibility</title>
+   <title>&ay; firewall configuration in <phrase os="sles;sled">&slea;</phrase><phrase os="osuse">leap</phrase> 15: backward compatibility</title>
    <tgroup cols="2">
     <colspec colnum="1" colname="1" colwidth="50*"/>
     <colspec colnum="2" colname="2" colwidth="50*"/>
@@ -633,7 +622,7 @@
    </para>
 
   <note>
-   <title>Enabling and Starting the Firewall</title>
+   <title>Enabling and starting the firewall</title>
    <para>
     Enabling and starting the &systemd; service for &firewalld; is done with
     the same syntax as in <phrase os="sles;sled">&slea;</phrase><phrase
@@ -655,7 +644,7 @@
   </para>
 
   <sect2 xml:id="sec-ay-12vs15-firewall-zones">
-   <title>Assigning Interfaces to Zones</title>
+   <title>Assigning interfaces to zones</title>
    <para>
     Both &susefirewall; and &firewalld; are zone-based, but have a different
     set of predefined rules and a different level of trust for network
@@ -663,7 +652,7 @@
    </para>
 
    <table>
-    <title>Mapping of &susefirewall; and &firewalld; Zones</title>
+    <title>Mapping of &susefirewall; and &firewalld; zones</title>
     <tgroup cols="2">
      <colspec colnum="1" colname="1" colwidth="50*"/>
      <colspec colnum="2" colname="2" colwidth="50*"/>
@@ -744,7 +733,7 @@
    </para>
 
    <sect3 xml:id="sec-ay-12vs15-firewall-zones-default">
-    <title>Default Configuration</title>
+    <title>Default configuration</title>
 
     <para>
      The following two examples show the default configuration that is applied
@@ -754,7 +743,7 @@
     </para>
 
     <example xml:id="ex-ay-12vs15-firewall-zones-default-deprecated">
-     <title>Assigning Zones: Default Configuration (Deprecated Syntax)</title>
+     <title>Assigning zones: default configuration (deprecated syntax)</title>
      <screen><![CDATA[<firewall>
  <FW_DEV_DMZ>any eth0</FW_DEV_DMZ>
  <FW_DEV_EXT>eth1 wlan0</FW_DEV_EXT>
@@ -763,9 +752,7 @@
     </example>
 
     <example xml:id="ex-ay-12vs15-firewall-zones-default-supported">
-     <title>Assigning Zones: Default Configuration (<phrase
-     os="sles;sled">&slea;</phrase><phrase
-     os="osuse">Leap</phrase> 15 Syntax)</title>
+     <title>Assigning zones: default configuration (<phrase os="sles;sled">&slea;</phrase><phrase os="osuse">leap</phrase> 15 syntax)</title>
      <screen><![CDATA[<firewall>
  <default_zone>dmz</default_zone>
  <zones config:type="list">
@@ -793,7 +780,7 @@
    </sect3>
 
    <sect3 xml:id="sec-ay-12vs15-firewall-masq">
-    <title>Masquerading and Protecting Internal Zones</title>
+    <title>Masquerading and protecting internal zones</title>
 
     <para>
      The following two examples show how to configure the interfaces
@@ -802,9 +789,7 @@
      masquerading and protected internal zones.
     </para>
    <example xml:id="ex-ay-12vs15-firewall-masq-deprecated">
-    <title>
-     Masquerading and Protecting Internal Zones (Deprecated Syntax)
-    </title>
+    <title>Masquerading and protecting internal zones (deprecated syntax)</title>
     <screen><![CDATA[<firewall>
  <FW_DEV_DMZ>any eth0</FW_DEV_DMZ>
  <FW_DEV_EXT>eth1 wlan0</FW_DEV_EXT>
@@ -815,11 +800,7 @@
    </example>
 
    <example xml:id="ex-ay-12vs15-firewall-masq-supported">
-    <title>
-     Masquerading and Protecting Internal Zones (<phrase
-     os="sles;sled">&slea;</phrase><phrase
-     os="osuse">Leap</phrase> 15 Syntax)
-    </title>
+    <title>Masquerading and protecting internal zones (<phrase os="sles;sled">&slea;</phrase><phrase os="osuse">leap</phrase> 15 syntax)</title>
     <screen><![CDATA[<firewall>
  <default_zone>dmz</default_zone>
  <zones config:type="list">
@@ -847,7 +828,7 @@
    </sect3>
   </sect2>
   <sect2 xml:id="sec-ay-12vs15-firewall-ports">
-   <title>Opening Ports</title>
+   <title>Opening ports</title>
    <para>
     In &susefirewall; the <tag
     class="element">FW_SERVICES_\{DMZ,EXT,INT}_\{TCP,UDP,IP,RPC}</tag> tags
@@ -873,9 +854,7 @@
     supported with &firewalld;.
    </para>
    <example xml:id="ex-ay-12vs15-firewall-ports-deprecated">
-    <title>
-     Opening Ports (Deprecated Syntax)
-    </title>
+    <title>Opening ports (deprecated syntax)</title>
 <screen><![CDATA[<firewall>
  <FW_SERVICES_DMZ_TCP>ftp ssh 80 5900:5999</FW_SERVICES_DMZ_TCP>
  <FW_SERVICES_EXT_UDP>1723 ipsec-nat-t</FW_SERVICES_EXT_UDP>
@@ -884,10 +863,7 @@
 </firewall>]]></screen>
    </example>
    <example xml:id="ex-ay-12vs15-firewall-ports-supported">
-    <title>
-     Opening Ports (<phrase os="sles;sled">&slea;</phrase><phrase
-     os="osuse">Leap</phrase> 15 Syntax)
-    </title>
+    <title>Opening ports (<phrase os="sles;sled">&slea;</phrase><phrase os="osuse">leap</phrase> 15 syntax)</title>
 <screen><![CDATA[<firewall>
  <zones config:type="list">
   <zone>
@@ -917,7 +893,7 @@
   </sect2>
 
   <sect2 xml:id="sec-ay-12vs15-firewall-services">
-   <title>Opening &firewalld; Services</title>
+   <title>Opening &firewalld; services</title>
    <para>
     For opening a combination of ports and/or protocols, &susefirewall; provides
     the <tag class="element">FW_CONFIGURATIONS_\{EXT, DMZ, INT}</tag> tags which
@@ -933,9 +909,7 @@
 </firewall>]]></screen>
    </example>
    <example xml:id="ex-ay-12vs15-firewall-services-supported">
-    <title>
-     Opening Services (<phrase os="sles;sled">&slea;</phrase><phrase os="osuse">Leap</phrase> 15 Syntax)
-    </title>
+    <title>Opening services (<phrase os="sles;sled">&slea;</phrase><phrase os="osuse">leap</phrase> 15 syntax)</title>
    <screen><![CDATA[<firewall>
  <zones config:type="list">
   <zone>
@@ -980,7 +954,7 @@
   </sect2>
 
   <sect2 xml:id="sec-ay-12vs15-firewall-further-documentation">
-   <title>For More Information</title>
+   <title>For more information</title>
    <itemizedlist>
     <listitem os="sles;sled">
      <para>
@@ -999,7 +973,7 @@
  </sect1>
 
  <sect1 xml:id="sec-ay-12vs15-ntp">
-  <title>NTP Configuration</title>
+  <title>NTP configuration</title>
 
   <para>
    The time server synchronization daemon <systemitem
@@ -1019,10 +993,7 @@
   </para>
 
   <example xml:id="ex-ay-12vs15-ntp">
-   <title>
-    NTP configuration (<phrase os="sles;sled">&slea;</phrase><phrase
-    os="osuse">Leap</phrase> 15 Syntax)
-   </title>
+   <title>NTP configuration (<phrase os="sles;sled">&slea;</phrase><phrase os="osuse">leap</phrase> 15 syntax)</title>
    <screen><![CDATA[<ntp-client>
  <ntp_policy>auto</ntp_policy>
  <ntp_servers config:type="list">
@@ -1038,7 +1009,7 @@
  </sect1>
 
  <sect1 xml:id="sec-ay-12vs15-2nd-stage">
-  <title>&ay; Packages Are Needed for the Second Stage</title>
+  <title>&ay; packages are needed for the second stage</title>
 
   <para>
    A regular installation is performed in a single stage, while an installation
@@ -1050,7 +1021,7 @@
  </sect1>
 
  <sect1 xml:id="sec-ay-12vs15-ca">
-  <title>The CA Management Module Has Been Dropped</title>
+  <title>The CA management module has been dropped</title>
 
   <para>
    The module for CA Management (<package>yast2-ca-management</package>>) has
@@ -1091,9 +1062,7 @@
     again using the <tag class="element">add-on</tag> option.
    </para>
    <example xml:id="ex-ay-12vs15-minimal-registration">
-    <title>
-     Minimal Registration Configuration for Upgrade
-    </title>
+    <title>Minimal registration configuration for upgrade</title>
     <screen><![CDATA[<suse_register>
   <do_registration config:type="boolean">true</do_registration>
 </suse_register>]]></screen>

--- a/xml/ay_apache_server.xml
+++ b/xml/ay_apache_server.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Apache HTTP Server Configuration</title>
+  <title>Apache HTTP server configuration</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -31,7 +31,7 @@
    </para>
 
    <example>
-    <title>HTTP Server Configuration</title>
+    <title>HTTP server configuration</title>
 <screen>
   &lt;http-server&gt;
     &lt;Listen config:type="list"&gt;

--- a/xml/ay_ask_user_values.xml
+++ b/xml/ay_ask_user_values.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Ask the User for Values during Installation</title>
+  <title>Ask the user for values during installation</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -41,7 +41,7 @@
 &lt;/general&gt;</screen>
 
    <table>
-    <title>Ask the User for Values: XML representation</title>
+    <title>Ask the user for values: XML representation</title>
     <tgroup cols="3">
      <thead>
       <row>
@@ -547,7 +547,7 @@
    </table>
 
    <sect2 xml:id="CreateProfile-Ask-default-value">
-    <title>Default Value Scripts</title>
+    <title>Default value scripts</title>
     <para>
      You can run scripts to set the default value for a question. This
      feature is useful if you can <literal>calculate</literal> a default
@@ -568,7 +568,7 @@
   &lt;/ask-list&gt;
 &lt;/general&gt;</screen>
     <table>
-     <title>Default Value Scripts: XML representation</title>
+     <title>Default value scripts: XML representation</title>
      <tgroup cols="3">
       <thead>
        <row>

--- a/xml/ay_audit_framework.xml
+++ b/xml/ay_audit_framework.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Linux Audit Framework (LAF)</title>
+  <title>Linux audit framework (LAF)</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">

--- a/xml/ay_auth_client.xml
+++ b/xml/ay_auth_client.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Authentication Client</title>
+  <title>Authentication client</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">

--- a/xml/ay_auto_installation.xml
+++ b/xml/ay_auto_installation.xml
@@ -10,7 +10,7 @@ xmlns:xi="http://www.w3.org/2001/XInclude"
 xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" 
 xml:id="Invoking">
 
- <title>The Auto-Installation Process</title>
+ <title>The auto-installation process</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -47,7 +47,7 @@ xml:id="Invoking">
    </para>
 
    <sect2 xml:id="Installation-Interface-X11">
-    <title>X11 Interface (graphical)</title>
+    <title>X11 interface (graphical)</title>
     <para>
      This is the default interface while auto-installing. No special
      variables are required to activate it.
@@ -55,7 +55,7 @@ xml:id="Invoking">
    </sect2>
 
    <sect2 xml:id="Installation-Interface-SerialConsole">
-    <title>Serial Console</title>
+    <title>Serial console</title>
     <para>
      Start installing a system using the serial console by adding the
      keyword <literal>console</literal> (for example
@@ -66,7 +66,7 @@ xml:id="Invoking">
    </sect2>
 
    <sect2 xml:id="Installation-Interface-Ncurses">
-    <title>Text-based &yast; Installation</title>
+    <title>Text-based &yast; installation</title>
     <para>
      This option can also be activated on the command line. To start
      &yast; in text mode, add <literal>textmode=1</literal> on the
@@ -80,7 +80,7 @@ xml:id="Invoking">
    </sect2>
   </sect1>
   <sect1 xml:id="bootmedium">
-   <title>Choosing the Right Boot Medium</title>
+   <title>Choosing the right boot medium</title>
 
    <para>
     There are different methods for booting the client. The computer can
@@ -100,7 +100,7 @@ xml:id="Invoking">
    </para>
 
    <sect2 xml:id="bootmedium-flash">
-    <title>Booting from a Flash Disk (for example, a USB stick)</title>
+    <title>Booting from a flash disk (for example, a USB stick)</title>
     <para>
      For testing/rescue purposes or because the NIC does not have a PROM or
      PXE you can build a bootable flash disk to use with &ay;. Flash
@@ -143,7 +143,7 @@ xml:id="Invoking">
    </sect2>
 
    <sect2 xml:id="bootmedium-installer">
-    <title>Booting from the &sle; Installation Media</title>
+    <title>Booting from the &sle; installation media</title>
     <para>
      You can use the &sle; installation media
      (<filename>&installmedia;</filename> or
@@ -155,7 +155,7 @@ xml:id="Invoking">
    </sect2>
 
    <sect2 xml:id="bootmedium-pxe">
-    <title>Booting via PXE over the Network</title>
+    <title>Booting via PXE over the network</title>
     <para>
      Booting via PXE requires a DHCP and a TFTP server in your network. The
      computer will then boot without a physical medium.  <phrase
@@ -211,14 +211,14 @@ xml:id="Invoking">
    </sect2>
   </sect1>
   <sect1 xml:id="invoking-autoinst">
-   <title>Invoking the Auto-Installation Process</title>
+   <title>Invoking the auto-installation process</title>
 
    <para>
     <remark role="fixme">Add a short description</remark>
    </para>
 
    <sect2 xml:id="invoking-autoinst-options">
-    <title>Command Line Options</title>
+    <title>Command line options</title>
     <para>
      Adding the command line variable <literal>autoyast</literal> causes
      <command>linuxrc</command> to start in automated mode. The <command>linuxrc</command>
@@ -388,7 +388,7 @@ xml:id="Invoking">
      Etherboot or PXE.
     </para>
     <note>
-      <title>Using <literal>autoyast2</literal> Boot Option instead of <literal>autoyast</literal></title>
+      <title>Using <literal>autoyast2</literal> boot option instead of <literal>autoyast</literal></title>
       <para>
           The <literal>autoyast2</literal> option is similar to the <literal>autoyast</literal> option, but
           <command>linuxrc</command> parses the provided value and, for example,
@@ -404,7 +404,7 @@ xml:id="Invoking">
      the format described in the following list.
     </para>
     <variablelist xml:id="Commandline-ay">
-        <title>&ay; Control File Locations</title>
+        <title>&ay; control file locations</title>
         <varlistentry>
             <term>Format of URIs</term>
             <listitem>
@@ -591,7 +591,7 @@ xml:id="Invoking">
         needs to be accessible via flash disk (for example, a USB stick) or network:
        </para>
        <formalpara>
-        <title>Flash Disk (for example, a USB stick)</title>
+        <title>Flash disk (for example, a USB stick)</title>
         <para>
          Access the control file via the
          <literal>autoyast=usb://<replaceable>PATH</replaceable></literal>
@@ -616,7 +616,7 @@ xml:id="Invoking">
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term>Using a Custom installation media</term>
+      <term>Using a custom installation media</term>
       <listitem>
        <para>
         In this case, you can include the control file directly on the
@@ -629,7 +629,7 @@ xml:id="Invoking">
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term>Using a Network Installation Source</term>
+      <term>Using a network installation source</term>
       <listitem>
        <para>
         This option is the most important one because installations of multiple
@@ -641,7 +641,7 @@ xml:id="Invoking">
         file can also reside in the following places:
        </para>
        <formalpara>
-        <title>Flash Disk (for example, a USB stick)</title>
+        <title>Flash disk (for example, a USB stick)</title>
         <para>
          Access the control file via the
          <literal>autoyast=usb://<replaceable>PATH</replaceable></literal>
@@ -664,7 +664,7 @@ xml:id="Invoking">
      </varlistentry>
     </variablelist>
     <note>
-     <title>Disabling Network and DHCP</title>
+     <title>Disabling network and DHCP</title>
      <para>
       To disable the network during installations where it is not needed or
       unavailable, for example when auto-installing from DVD-ROMs, use the
@@ -758,7 +758,7 @@ default</screen>
    </sect2>
 
    <sect2 xml:id="autoinstall-singlesystem">
-    <title>Auto-installing a Single System</title>
+    <title>Auto-installing a single system</title>
     <para>
      The easiest way to auto-install a system without any network connection is
      to use the original &productname; DVD-ROMs and a flash disk (for example,
@@ -772,7 +772,7 @@ default</screen>
    </sect2>
 
    <sect2 xml:id="invoking-autoinst-linuxrc">
-    <title>Combining the <command>linuxrc</command> <filename>info</filename> File with the &ay; Control File</title>
+    <title>Combining the <command>linuxrc</command> <filename>info</filename> file with the &ay; control file</title>
     <para>
      If you choose to pass information to <command>linuxrc</command> using the
      <filename>info</filename> file or as boot options, you may integrate the
@@ -784,7 +784,7 @@ default</screen>
 
     </para>
     <example>
-     <title><command>linuxrc</command> Options in the &ay; Control File</title>
+     <title><command>linuxrc</command> Options in the &ay; control file</title>
 <screen><![CDATA[....
   <install>
 ....
@@ -812,7 +812,7 @@ textmode: 1
    </sect2>
   </sect1>
   <sect1 xml:id="System-Configuration">
-   <title>System Configuration</title>
+   <title>System configuration</title>
 
    <para>
     The system configuration during auto-installation is the most important
@@ -825,7 +825,7 @@ textmode: 1
    </para>
 
    <sect2 xml:id="System-Configuration-post">
-    <title>Post-Install and System Configuration</title>
+    <title>Post-install and system configuration</title>
     <para>
      The post-installation and system configuration are initiated directly
      after the last package is installed on the target system and continue
@@ -848,7 +848,7 @@ textmode: 1
    </sect2>
 
    <sect2 xml:id="System-Configuration-custom">
-    <title>System Customization</title>
+    <title>System customization</title>
     <para>
      Most of the system customization is done in the second stage of the
      installation. If you require customization that cannot be done using

--- a/xml/ay_bootloader.xml
+++ b/xml/ay_bootloader.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>The Boot Loader</title>
+ <title>The boot loader</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -46,7 +46,7 @@
  &lt;/bootloader&gt;</screen>
 
    <sect2 xml:id="CreateProfile-Bootloader-type">
-    <title>Loader Type</title>
+    <title>Loader type</title>
     <para>
      This defines which boot loader (UEFI or BIOS/legacy) to use. Not
      all architectures support both legacy and EFI variants of the boot
@@ -104,7 +104,7 @@
 &lt;/global&gt;</screen>
     
     <variablelist>
-     <title>Bootloader Global Options</title>
+     <title>Bootloader global options</title>
      
      <varlistentry>
       <term>activate</term>

--- a/xml/ay_complete_configurations.xml
+++ b/xml/ay_complete_configurations.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Adding Complete Configurations</title>
+  <title>Adding complete configurations</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">

--- a/xml/ay_configuration_installation_options.xml
+++ b/xml/ay_configuration_installation_options.xml
@@ -10,7 +10,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Configuration and Installation Options</title>
+ <title>Configuration and installation options</title>
  <info>
   <abstract>
    <para>

--- a/xml/ay_configuration_management.xml
+++ b/xml/ay_configuration_management.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Configuration Management</title>
+  <title>Configuration management</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -26,7 +26,7 @@
     </para>
 
    <note>
-    <title>Only Salt is Officially Supported</title>
+    <title>Only salt is officially supported</title>
     <para>
       Although Puppet is mentioned in this document, only Salt is officially
       supported. Nevertheless, feel free to report any problem you might find with Puppet.
@@ -54,7 +54,7 @@
     </itemizedlist>
 
     <sect2 xml:id="CreateProfile-ConfigurationManagement-Server">
-     <title>Connecting to a Configuration Management Server</title>
+     <title>Connecting to a configuration management server</title>
 
      <para>
       This approach is especially useful when a configuration management
@@ -92,7 +92,7 @@
      </para>
 
      <example xml:id="configuration-management-manual-authentication">
-      <title>Client/Server with Manual Authentication</title>
+      <title>Client/server with manual authentication</title>
 <screen>&lt;configuration_management&gt;
     &lt;type&gt;salt&lt;/type&gt;
     &lt;master&gt;my-salt-server.example.net&lt;/master&gt;
@@ -108,7 +108,7 @@
      </para>
 
      <example xml:id="configuration-management-preseed-keys">
-      <title>Client/Server with Preseed Keys</title>
+      <title>Client/server with preseed keys</title>
 <screen>&lt;configuration_management&gt;
     &lt;type&gt;salt&lt;/type&gt;
     &lt;master&gt;my-salt-server.example.net&lt;/master&gt;
@@ -257,7 +257,7 @@
     </sect2>
 
     <sect2 xml:id="CreateProfile-ConfigurationManagement-Masterless">
-     <title>Running in Stand-alone Mode</title>
+     <title>Running in stand-alone mode</title>
      <para>
        For simple scenarios, deploying a configuration management server is
        unnecessary. Instead, use Salt or Puppet in
@@ -285,7 +285,7 @@
      </para>
 
      <example xml:id="configuration-management-masterless">
-      <title>Standalone Mode</title>
+      <title>Standalone mode</title>
 <screen>&lt;configuration_management&gt;
     &lt;type&gt;salt&lt;/type&gt;
     &lt;states_url&gt;my-salt-server.example.net&lt;/states_url&gt;
@@ -391,7 +391,7 @@
     </sect2>
 
     <sect2 xml:id="CreateProfile-ConfigurationManagement-SUMAFormulasSupport">
-     <title>&susemgr; Salt Formulas Support</title>
+     <title>&susemgr; salt formulas support</title>
 
      <para>
       &ay; offers support for &susemgr; Salt Formulas when running in stand-alone

--- a/xml/ay_configuration_management.xml
+++ b/xml/ay_configuration_management.xml
@@ -26,7 +26,7 @@
     </para>
 
    <note>
-    <title>Only salt is officially supported</title>
+    <title>Only Salt is officially supported</title>
     <para>
       Although Puppet is mentioned in this document, only Salt is officially
       supported. Nevertheless, feel free to report any problem you might find with Puppet.
@@ -391,7 +391,7 @@
     </sect2>
 
     <sect2 xml:id="CreateProfile-ConfigurationManagement-SUMAFormulasSupport">
-     <title>&susemgr; salt formulas support</title>
+     <title>&susemgr; Salt formulas support</title>
 
      <para>
       &ay; offers support for &susemgr; Salt Formulas when running in stand-alone

--- a/xml/ay_control_file.xml
+++ b/xml/ay_control_file.xml
@@ -10,7 +10,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>The &ay; Control File</title>
+ <title>The &ay; control file</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -30,7 +30,7 @@
    </para>
 
    <important>
-    <title>Control Files from OS Releases Older Than &slsa; 12&nbsp;GA and &opensuse; 42.0 Are Incompatible</title>
+    <title>Control files from OS releases older than &slsa; 12&nbsp;GA and &opensuse; 42.0 are incompatible</title>
     <para>
      Many major changes were introduced with &slsa; 12 and &opensuse; Leap 42.0,
      such as the switch to systemd and &grub;.
@@ -63,7 +63,7 @@
    <para>The following example shows a control file in XML format:
    </para>
    <example>
-    <title>&ay; Control File (Profile)</title>
+    <title>&ay; control file (profile)</title>
 <screen>&lt;?xml version="1.0"?&gt;
 &lt;!DOCTYPE profile&gt;
 &lt;profile
@@ -132,7 +132,7 @@ exit 0
    </para>
 
    <sect2 xml:id="Profile-Format-ressources">
-    <title>Resources and Properties</title>
+    <title>Resources and properties</title>
     <para>
      A resource element either contains multiple and distinct property and
      resource elements, or multiple instances of the same resource element,
@@ -162,7 +162,7 @@ exit 0
    </sect2>
 
    <sect2 xml:id="Profile-Format-ressources-nested">
-    <title>Nested Resources</title>
+    <title>Nested resources</title>
     <para>
      Nested resource elements allow a tree-like structure of configuration
      components to be built to any level.
@@ -174,7 +174,7 @@ exit 0
      items of the same type.
     </para>
     <example>
-     <title>Nested Resources</title>
+     <title>Nested resources</title>
 <screen>...
 &lt;drive&gt;
   &lt;device&gt;/dev/sda&lt;/device&gt;

--- a/xml/ay_country_settings.xml
+++ b/xml/ay_country_settings.xml
@@ -9,7 +9,7 @@
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Country Settings</title>
+ <title>Country settings</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">

--- a/xml/ay_create_control_file.xml
+++ b/xml/ay_create_control_file.xml
@@ -10,7 +10,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Creating an &ay; Control File</title>
+ <title>Creating an &ay; control file</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -19,7 +19,7 @@
  </info>
 
   <sect1 xml:id="Autoinstallation-collectInfo">
-   <title>Collecting Information</title>
+   <title>Collecting information</title>
 
    <para>
     To create the control file, you need to collect information about the
@@ -53,7 +53,7 @@
   </sect1>
   
   <sect1 xml:id="CreateProfile-CMS">
-   <title>Using the Configuration Management System (CMS)</title>
+   <title>Using the configuration management system (CMS)</title>
 
    <para>
     To create the control file for one or more computers, a configuration
@@ -70,7 +70,7 @@
    </para>
 
    <figure os="sles;sled">
-    <title>Configuration System</title>
+    <title>Configuration system</title>
     <mediaobject>
      <imageobject role="html">
       <imagedata fileref="autoyast2-maindialog.png"/>
@@ -82,7 +82,7 @@
    </figure>
 
    <figure os="osuse">
-    <title>Configuration System</title>
+    <title>Configuration system</title>
     <mediaobject>
      <imageobject role="html">
       <imagedata fileref="autoyast2-maindialog_kde.png"/>
@@ -94,7 +94,7 @@
    </figure>
 
    <sect2 xml:id="CreateProfile-CMS-new">
-    <title>Creating a New Control File</title>
+    <title>Creating a new control file</title>
      <para>
       The easiest way to create an &ay; profile is to use an existing
       &productname; system
@@ -119,7 +119,7 @@
      </para>
 
      <warning>
-     <title>Sensitive Data in Profiles</title>
+     <title>Sensitive data in profiles</title>
       <para>
        Beware that the profile might contain sensitive information such as
        password hashes and registration keys.
@@ -154,7 +154,7 @@
    </sect2>
   </sect1>
   <sect1 xml:id="CreateProfile-Manual">
-   <title>Creating/Editing a Control File Manually</title>
+   <title>Creating/editing a control file manually</title>
 
    <para>
     If editing the control file manually, make sure it has a valid syntax.  To
@@ -188,7 +188,7 @@
    </para>
 
    <note>
-    <title>Schema Extensions</title>
+    <title>Schema extensions</title>
 
     <para>
      &ay; can be extended by other products and modules, but the schema does not
@@ -232,7 +232,7 @@
    </para>
 
    <tip>
-    <title>Using Emacs as an XML Editor</title>
+    <title>Using emacs as an XML editor</title>
     <para>
      The built-in nxml-mode turns Emacs into a fully-fledged XML editor with
      automatic tag completion and validation. Refer to the Emacs help for
@@ -241,7 +241,7 @@
    </tip>
   </sect1>
   <sect1 xml:id="CreateProfile-XSLT">
-   <title>Creating a Control File via Script with XSLT</title>
+   <title>Creating a control file via script with XSLT</title>
 
    <para>
     If you have a template and want to change a few things via script or
@@ -256,7 +256,7 @@
    </para>
 
    <example>
-    <title>Example File for Replacing the Host Name/Domain by Script</title>
+    <title>Example file for replacing the host name/domain by script</title>
 <screen>&lt;?xml version="1.0" encoding="utf-8"?&gt;
 &lt;xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:y2="http://www.suse.com/1.0/yast2ns"

--- a/xml/ay_custom_user_scripts.xml
+++ b/xml/ay_custom_user_scripts.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Custom User Scripts</title>
+  <title>Custom user scripts</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -67,7 +67,7 @@
    </itemizedlist>
 
    <sect2 xml:id="pre-install-scripts">
-    <title>Pre-Install Scripts</title>
+    <title>Pre-install scripts</title>
     <para>
      Executed before &yast; does any real change to the system (before
      partitioning and package installation but after the hardware
@@ -88,7 +88,7 @@
      pre-install scripts.
     </para>
     <note>
-     <title>Pre-Install Scripts with Confirmation</title>
+     <title>Pre-install scripts with confirmation</title>
      <para>
       Pre-scripts are executed at an early stage of the installation. This
       means if you have requested to confirm the installation, the
@@ -97,7 +97,7 @@
      </para>
     </note>
     <note>
-     <title>Pre-Install and Zypper</title>
+     <title>Pre-install and Zypper</title>
      <para>
       To call <emphasis>zypper</emphasis> in the pre-install
       script you will need to set the environment variable <emphasis>ZYPP_LOCKFILE_ROOT="/var/run/autoyast"</emphasis>
@@ -117,7 +117,7 @@
    </sect2>
 
    <sect2 xml:id="postpartitioning-install-scripts">
-    <title>Post-partitioning Scripts</title>
+    <title>Post-partitioning scripts</title>
     <para>
      Executed after &yast; has done the partitioning and written
      <filename>/etc/fstab</filename>. The empty system is already mounted to
@@ -136,7 +136,7 @@
    </sect2>
 
    <sect2 xml:id="chroot-scripts">
-    <title>Chroot Environment Scripts</title>
+    <title>Chroot environment scripts</title>
     <para>
      Chroot scripts are executed before the machine reboots for the first
      time. You can execute chroot scripts before the installation chroots
@@ -157,7 +157,7 @@
    </sect2>
 
    <sect2 xml:id="post-install-scripts">
-    <title>Post-Install Scripts</title>
+    <title>Post-install scripts</title>
     <para>
      These scripts are executed after &ay; has completed the system
      configuration and after it has booted the system for the first time.
@@ -175,7 +175,7 @@
    </sect2>
 
    <sect2 xml:id="init-scripts">
-    <title>Init Scripts</title>
+    <title>Init scripts</title>
     <para>
      These scripts are executed when &yast; has finished, during the
      initial boot process after the network has been initialized. These
@@ -324,7 +324,7 @@ echo "Testing the init script" &gt;
    </sect2>
 
    <sect2 xml:id="scripts-syntax">
-    <title>Script XML Representation</title>
+    <title>Script XML representation</title>
     <para>
      Most of the XML elements described below can be used for all the script
      types described above, except for <emphasis>init scripts</emphasis>, whose
@@ -332,7 +332,7 @@ echo "Testing the init script" &gt;
      linkend="init-scripts" /> for further information about them.
     </para>
     <important>
-      <title>Deprecated Elements</title>
+      <title>Deprecated elements</title>
       <para>
        <literal>debug</literal> is a deprecated element and can be removed in future
        releases. To adapt, use an interpreter-specific debugging parameter in <literal>interpreter</literal>.
@@ -342,7 +342,7 @@ echo "Testing the init script" &gt;
       </para>
     </important>
     <table>
-     <title>Script XML Representation</title>
+     <title>Script XML representation</title>
      <tgroup cols="3">
       <colspec colwidth="1*"/>
       <colspec colwidth="3*"/>
@@ -623,9 +623,9 @@ echo "Testing the pre script" &gt; /tmp/pre-script_out.txt
    </sect2>
 
    <sect2 xml:id="script-examples">
-    <title>Script Example</title>
+    <title>Script example</title>
     <example>
-     <title>Script Configuration</title>
+     <title>Script configuration</title>
 <screen>&lt;?xml version="1.0"?&gt;
 &lt;!DOCTYPE profile&gt;
 &lt;profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns"&gt;

--- a/xml/ay_dhcp_server.xml
+++ b/xml/ay_dhcp_server.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>DHCP Server</title>
+  <title>DHCP server</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">

--- a/xml/ay_dns_server.xml
+++ b/xml/ay_dns_server.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>DNS Server</title>
+  <title>DNS server</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">

--- a/xml/ay_faq.xml
+++ b/xml/ay_faq.xml
@@ -13,7 +13,7 @@
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0"
  xml:id="app-ay-faq">
 
- <title>&ay; FAQ&mdash;Frequently Asked Questions</title>
+ <title>&ay; FAQ&mdash;frequently asked questions</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker>

--- a/xml/ay_fiber_channel.xml
+++ b/xml/ay_fiber_channel.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Fibre Channel over Ethernet Configuration (FCoE)</title>
+  <title>Fibre channel over ethernet configuration (FCoE)</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">

--- a/xml/ay_firewall.xml
+++ b/xml/ay_firewall.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Firewall Configuration</title>
+  <title>Firewall configuration</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -28,7 +28,7 @@
  </para>
 
  <important>
-  <title>Limited Backward Compatibility with SuSEFirewall2 Based Profiles</title>
+  <title>Limited backward compatibility with SuSEFirewall2 based profiles</title>
   <para>
    The use of &susefirewall; based profiles will be only
    partially supported as many options are not valid in &firewalld; and
@@ -37,7 +37,7 @@
  </important>
 
    <sect2 xml:id="CreateProfile-firewall-general">
-    <title>General Firewall Configuration</title>
+    <title>General firewall configuration</title>
 
     <para>
      In &firewalld; the general configuration only exposes a few
@@ -218,7 +218,7 @@
    </sect2>
 
    <sect2 xml:id="CreateProfile-firewall-zones">
-    <title>Firewall Zones Configuration</title>
+    <title>Firewall zones configuration</title>
 
     <para>
      The configuration of &firewalld; is based on the existence of several zones
@@ -342,7 +342,7 @@
 
    <!-- SLE 15 SP3 and up only -->
    <sect2 xml:id="CreateProfile-firewall-stage">
-      <title>Installation Stages When the &firewalld; Profile is Applied</title>
+      <title>Installation stages when the &firewalld; profile is applied</title>
 
       <para>
           Starting with &productname;&nbsp;15&nbsp;SP3, the &firewalld; profile is completely
@@ -396,7 +396,7 @@
    </sect2>
 
    <sect2 xml:id="CreateProfile-firewall-example">
-    <title>A Full Example</title>
+    <title>A full example</title>
 
     <para>
      A full example of the firewall section, including general and zone specific

--- a/xml/ay_firstboot.xml
+++ b/xml/ay_firstboot.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Firstboot Workflow</title>
+  <title>Firstboot workflow</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -28,7 +28,7 @@
     </para>
 
    <example>
-    <title>Enabling Firstboot Workflow</title>
+    <title>Enabling firstboot workflow</title>
     <screen>
       &lt;firstboot&gt;
         &lt;firstboot_enabled config:type="boolean"&gt;true&lt;/firstboot_enabled&gt;

--- a/xml/ay_ftp_server.xml
+++ b/xml/ay_ftp_server.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>FTP Server</title>
+  <title>FTP server</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">

--- a/xml/ay_general_options.xml
+++ b/xml/ay_general_options.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>General Options</title>
+  <title>General options</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -120,7 +120,7 @@
   </calloutlist>
 
   <sect2 xml:id="CreateProfile-General-mode">
-   <title>The Mode Section</title>
+   <title>The mode section</title>
 
    <para>
     The mode section configures the behavior of &ay; with regard to user
@@ -272,7 +272,7 @@
  ...
 </general>]]></screen>
       <important>
-       <title>Drivers May Need a Reboot</title>
+       <title>Drivers may need a reboot</title>
        <para>
         <remark>2013-03-18 - fs: bnc #802387</remark>
         Some drivers, for example the proprietary drivers for Nvidia and ATI
@@ -366,7 +366,7 @@
   </sect2>
 
   <sect2 xml:id="CreateProfile-General-proposal">
-   <title>Configuring the Installation Settings Screen</title>
+   <title>Configuring the installation settings screen</title>
 
    <para>
     &ay; allows you to configure the <guimenu>Installation Settings</guimenu>
@@ -388,7 +388,7 @@
   </sect2>
 
   <sect2 xml:id="CreateProfile-General-self-update">
-   <title>The Self-Update Section</title>
+   <title>The self-update section</title>
 
    <para>
     During the installation, &yast; can update itself to solve bugs in the
@@ -397,7 +397,7 @@
    </para>
 <!--taroth 2019-09-12: same note used in deployment_yast_installer.xml-->
   <important>
-   <title>Quarterly Media Update: Self-Update Disabled</title>
+   <title>Quarterly media update: self-update disabled</title>
    <para>
     The installer self-update is only available if you use the <literal>GM</literal>
     images of the &leanos; and Packages ISOs. If you install from the ISOs published
@@ -439,7 +439,7 @@
        For more information, refer to the &deploy;.
       </para>
       <important>
-       <title>Installer Self-Update Repository Only</title>
+       <title>Installer self-update repository only</title>
        <para>
         The <option>self_update_url</option> parameter expects only the
         installer self-update repository URL. Do not supply any other
@@ -470,7 +470,7 @@
   </sect2>
 
   <sect2 xml:id="CreateProfile-General-semi-automatic">
-   <title>The Semi-Automatic Section</title>
+   <title>The semi-automatic section</title>
 
    <para>
     &ay; offers to start some &yast; modules during the installation. This is
@@ -510,7 +510,7 @@
   </sect2>
 
   <sect2 xml:id="CreateProfile-General-signature">
-   <title>The Signature Handling Section</title>
+   <title>The signature handling section</title>
 
    <para>
     By default &ay; will only install signed packages from sources with known
@@ -518,7 +518,7 @@
    </para>
 
    <warning>
-    <title>Overwriting the Signature Handling Defaults</title>
+    <title>Overwriting the signature handling defaults</title>
     <para>
      Installing unsigned packages, packages with failing checksum checks, or
      packages from sources you do not trust is a major security
@@ -649,7 +649,7 @@
   </sect2>
 
   <sect2 xml:id="CreateProfile-General-wait">
-   <title>The Wait Section</title>
+   <title>The wait section</title>
 
    <para>
     In the second stage of the installation the system is configured by running
@@ -725,7 +725,7 @@
   </sect2>
 
   <sect2 xml:id="CreateProfile-General-cio-ignore" arch="zseries">
-   <title>Blacklisting Unused Devices on &zseries;</title>
+   <title>Blacklisting unused devices on &zseries;</title>
 
    <para>
     On &zseries;, you can prevent the kernel from looking at unused hardware
@@ -742,14 +742,14 @@
   </sect2>
 
   <sect2 xml:id="CreateProfile-General-example-common">
-   <title>Examples for the <tag class="element">general</tag> Section</title>
+   <title>Examples for the <tag class="element">general</tag> section</title>
 
    <para>
     Find examples covering several use cases in this section.
    </para>
 
    <example xml:id="ex-general-common">
-    <title>General Options</title>
+    <title>General options</title>
     <para>
      This example shows the most commonly used options in the general section.
      The scripts in the pre- and post-modules sections are only dummy scripts

--- a/xml/ay_handling_rules.xml
+++ b/xml/ay_handling_rules.xml
@@ -13,7 +13,7 @@
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0"
  xml:id="handlingrules">
 
-<title>Handling Rules</title>
+<title>Handling rules</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker>
@@ -26,7 +26,7 @@
    of retrieval and merge.
   </para>
   <figure xml:id="rulesflow">
-   <title>Rules Retrieval Process</title>
+   <title>Rules retrieval process</title>
    <mediaobject>
     <imageobject role="html">
      <imagedata fileref="rules_flow.png"/>

--- a/xml/ay_hardware.xml
+++ b/xml/ay_hardware.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Miscellaneous Hardware and System Components</title>
+  <title>Miscellaneous hardware and system components</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">

--- a/xml/ay_hosts.xml
+++ b/xml/ay_hosts.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Hosts Definition</title>
+  <title>Hosts definition</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">

--- a/xml/ay_import_ssh.xml
+++ b/xml/ay_import_ssh.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Importing SSH Keys and Configuration</title>
+  <title>Importing SSH keys and configuration</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -25,7 +25,7 @@
     </para>
 
     <example xml:id="import-ssh">
-     <title>Importing SSH Keys and Configuration from /dev/sda2</title>
+     <title>Importing SSH keys and configuration from /dev/sda2</title>
 <screen>&lt;ssh_import&gt;
   &lt;import config:type="boolean"&gt;true&lt;/import&gt;
   &lt;copy_config config:type="boolean"&gt;true&lt;/copy_config&gt;

--- a/xml/ay_introduction.xml
+++ b/xml/ay_introduction.xml
@@ -62,7 +62,7 @@
    </para>
   </sect1>
 <sect1 xml:id="overviewandconcept">
-   <title>Overview and Concept</title>
+   <title>Overview and concept</title>
 
    <para>
     Using &ay;, multiple systems can easily be installed in parallel and
@@ -115,7 +115,7 @@
    </itemizedlist>
 
    <note>
-    <title>Second Stage</title>
+    <title>Second stage</title>
     <para>
      A regular installation of &productname; &productnumber; is
      performed in a single stage. The auto-installation process, however, is

--- a/xml/ay_iscsi_client.xml
+++ b/xml/ay_iscsi_client.xml
@@ -9,7 +9,7 @@
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>iSCSI Initiator Overview</title>
+ <title>iSCSI initiator overview</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -42,7 +42,7 @@
 
 
  <variablelist>
-  <title>iSCSI Initiator Configuration Settings</title>
+  <title>iSCSI initiator configuration settings</title>
   <varlistentry>
    <term>initiatorname</term>
    <listitem>

--- a/xml/ay_kernel_dumps.xml
+++ b/xml/ay_kernel_dumps.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Kernel Dumps</title>
+  <title>Kernel dumps</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -93,7 +93,7 @@
 <!-- {{{ Memory Reservation -->
 
    <sect2 xml:id="CreateProfile-kdump-reservation">
-    <title>Memory Reservation</title>
+    <title>Memory reservation</title>
     <para>
      The first step is to reserve memory for Kdump at boot-up. Because the
      memory must be reserved very early during the boot process, the
@@ -155,7 +155,7 @@
      The following table shows the settings necessary to reserve memory:
     </para>
     <table>
-     <title>Kdump Memory Reservation Settings:XML Representation</title>
+     <title>Kdump memory reservation settings:XML representation</title>
      <tgroup cols="3">
       <thead>
        <row>
@@ -225,7 +225,7 @@
    </sect2>
 
    <sect2 xml:id="CreateProfile-kdump-saving">
-    <title>Dump Saving</title>
+    <title>Dump saving</title>
     <para>
      This section describes where and how crash dumps will be stored.
     </para>
@@ -289,7 +289,7 @@
      </para>
     </sect3>
     <sect3 xml:id="CreateProfile-kdump-saving-compression">
-     <title>Filtering and Compression</title>
+     <title>Filtering and compression</title>
      <para>
       The kernel dump is uncompressed and unfiltered. It can get as large as
       your system RAM. To get smaller files, compress the dump file
@@ -312,7 +312,7 @@
     <sect3 xml:id="CreateProfile-kdump-saving-summary">
      <title>Summary</title>
      <table>
-      <title>Dump Target Settings: XML Representation</title>
+      <title>Dump target settings: XML representation</title>
       <tgroup cols="3">
        <thead>
         <row>
@@ -422,7 +422,7 @@
    </sect2>
 
    <sect2 xml:id="CreateProfile-kdump-notification">
-    <title>E-Mail Notification</title>
+    <title>E-mail notification</title>
     <para>
      Configure e-mail notification to be informed when a machine
      crashes and a dump is saved.
@@ -445,7 +445,7 @@
     </para>
 <!-- {{{ Table: XML representation of the e-mail notification settings -->
     <table>
-     <title>E-Mail Notification Settings: XML Representation</title>
+     <title>E-mail notification settings: XML representation</title>
      <tgroup cols="3">
       <thead>
        <row>
@@ -574,7 +574,7 @@
    </sect2>
 
    <sect2 xml:id="CreateProfile-kdump-kernel">
-    <title>Kdump Kernel Settings</title>
+    <title>Kdump kernel settings</title>
     <para>
      As already mentioned, a special kernel is booted to save the dump. If
      you do not want to use the auto-detection mechanism to find out which
@@ -596,7 +596,7 @@
      set <literal>KDUMP_COMMANDLINE</literal>.
     </para>
     <table>
-     <title>Kernel Settings: XML Representation</title>
+     <title>Kernel settings: XML representation</title>
      <tgroup cols="3">
       <thead>
        <row>
@@ -684,9 +684,9 @@
    </sect2>
 
    <sect2 xml:id="CreateProfile-kdump-expert">
-    <title>Expert Settings</title>
+    <title>Expert settings</title>
     <table>
-     <title>Expert Settings: XML Representations</title>
+     <title>Expert settings: XML representations</title>
      <tgroup cols="3">
       <thead>
        <row>

--- a/xml/ay_linuxrc_options.xml
+++ b/xml/ay_linuxrc_options.xml
@@ -13,7 +13,7 @@
  xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0"
  xml:id="appendix-linuxrc">
 
- <title>Advanced <command>linuxrc</command> Options</title>
+ <title>Advanced <command>linuxrc</command> options</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker>
@@ -28,7 +28,7 @@
    or a rescue system, and to guide the operation of &yast;.
   </para>
   <note>
-   <title>&ay; and <command>linuxrc</command> Settings Are Not Identical</title>
+   <title>&ay; and <command>linuxrc</command> settings are not identical</title>
    <para>
     Some <command>linuxrc</command> settings coincidentally have the same names
     as settings used by &ay; in its <filename>autoyast.xml</filename> file. This
@@ -51,7 +51,7 @@
    <link xlink:href="https://en.opensuse.org/SDB:Linuxrc"/>.
   </para>
   <note>
-   <title>Running <command>linuxrc</command> on an Installed System</title>
+   <title>Running <command>linuxrc</command> on an installed system</title>
    <para>
     If you run <command>linuxrc</command> on an installed system, it will work
     slightly differently so as not to destroy your installation. As a
@@ -65,7 +65,7 @@
    libraries in the initial RAM disk, <filename>initrd</filename>.
   </para>
   <sect1 xml:id="ay-cmd-parameters">
-   <title>Passing Parameters to <command>linuxrc</command></title>
+   <title>Passing parameters to <command>linuxrc</command></title>
 
    <para>
     Unless <command>linuxrc</command> is in manual mode, it will look for an
@@ -89,7 +89,7 @@
    </para>
   </sect1>
   <sect1 xml:id="info-file-format">
-   <title><filename>info</filename> File Format</title>
+   <title><filename>info</filename> File format</title>
 
    <para>
     Lines starting with <literal>#</literal> are comments. Valid entries are
@@ -117,7 +117,7 @@
    </para>
 
    <table>
-    <title>Advanced <command>linuxrc</command> Keywords</title>
+    <title>Advanced <command>linuxrc</command> keywords</title>
     <tgroup cols="2">
      <colspec colnum="1" colname="1" colwidth="30*"/>
      <colspec colnum="2" colname="2" colwidth="70*"/>
@@ -603,7 +603,7 @@
    </table>
   </sect1>
   <sect1 xml:id="ay-adv-network">
-   <title>Advanced Network Setup</title>
+   <title>Advanced network setup</title>
 
    <para>
     Even if parameters like <literal>hostip</literal>, <literal>nameserver</literal>,
@@ -625,7 +625,7 @@
    </para>
    <variablelist>
     <varlistentry>
-     <term>DHCP Network Configuration</term>
+     <term>DHCP network configuration</term>
      <listitem>
       <para>
        The general syntax to configure DHCP is
@@ -649,7 +649,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Static Network Configuration</term>
+     <term>Static network configuration</term>
      <listitem>
       <para>
        The general syntax to configure a static network is

--- a/xml/ay_mail_server.xml
+++ b/xml/ay_mail_server.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Mail Server Configuration</title>
+  <title>Mail server configuration</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -25,7 +25,7 @@
    </para>
 
    <example>
-    <title>Mail Configuration</title>
+    <title>Mail configuration</title>
 <screen>&lt;mail&gt;
   &lt;aliases config:type="list"&gt;
     &lt;alias&gt;

--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Network Configuration</title>
+  <title>Network configuration</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -83,7 +83,7 @@ config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
    </para>
 
    <example xml:id="ex-ay-network-config-general">
-    <title>Network Configuration</title>
+    <title>Network configuration</title>
 <screen>&lt;networking&gt;
   &lt;dns&gt;
     &lt;dhcp_hostname config:type="boolean"&gt;true&lt;/dhcp_hostname&gt;
@@ -187,7 +187,7 @@ config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
    </itemizedlist>
 
    <tip>
-    <title>IPv6 Address Support</title>
+    <title>IPv6 address support</title>
     <para>
      Using IPv6 addresses in &ay; is fully supported. To disable IPv6
      Address Support, set &lt;ipv6
@@ -707,7 +707,7 @@ config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
    </informaltable>
 
     <example xml:id="ex-ay-network-config-bond">
-     <title>Bonding Interface Configuration</title>
+     <title>Bonding interface configuration</title>
 <screen>
 &lt;networking&gt;
   &lt;setup_before_proposal config:type="boolean"&gt;false&lt;/setup_before_proposal&gt;
@@ -753,7 +753,7 @@ config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
     </example>
 
    <example xml:id="ex-ay-network-config-bridge">
-     <title>Bridge Interface Configuration</title>
+     <title>Bridge interface configuration</title>
 <screen>
 &lt;interfaces config:type="list"&gt;
   &lt;interface&gt;
@@ -783,7 +783,7 @@ config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
   </sect2>
 
    <sect2 xml:id="CreateProfile-Network-names">
-    <title>Persistent Names of Network Interfaces</title>
+    <title>Persistent names of network interfaces</title>
     <para>
      The <literal>net-udev</literal> element allows to specify a set of udev
      rules that can be used to assign persistent names to interfaces.
@@ -822,7 +822,7 @@ config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
      
     </variablelist>
     <tip>
-     <title>Handling Collisions in Device Names</title>
+     <title>Handling collisions in device names</title>
      <para>
       When creating an incomplete <emphasis>udev</emphasis> rule set, the
       chosen device name can collide with existing device names. For
@@ -834,7 +834,7 @@ config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
     </tip>
 
     <example>
-     <title>Assigning a Persistent Name Using the MAC Address</title>
+     <title>Assigning a persistent name using the MAC address</title>
 <screen>&lt;net-udev config:type="list"&gt;
   &lt;rule&gt;
   &lt;name&gt;eth1&lt;/name&gt;
@@ -846,7 +846,7 @@ config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
    </sect2>
 
    <sect2 xml:id="CreateProfile-Network-DNS">
-    <title>Domain Name System</title>
+    <title>Domain name system</title>
     <para>
      The <literal>dns</literal> section is used to define name-service related
      settings, such as the host name or name servers.
@@ -996,7 +996,7 @@ config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
    </sect2>
 
    <sect2 xml:id="CreateProfile-Network-s390">
-    <title>s390 Options</title>
+    <title>s390 options</title>
     <para>
      The following elements must be between the
      &lt;<literal>s390-devices</literal>&gt;...
@@ -1096,7 +1096,7 @@ config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
      <literal>proxy_user</literal> and <literal>proxy_password</literal>,
     </para>
     <example>
-     <title>Network configuration: Proxy</title>
+     <title>Network configuration: proxy</title>
 <screen>&lt;proxy&gt;
   &lt;enabled config:type="boolean"&gt;true&lt;/enabled&gt;
   &lt;ftp_proxy&gt;http://192.168.1.240:3128&lt;/ftp_proxy&gt;
@@ -1136,7 +1136,7 @@ config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
     </para>
 
     <example>
-     <title>Inetd Example</title>
+     <title>Inetd example</title>
 <screen>&lt;profile&gt;
   &lt;inetd&gt;
     &lt;netd_service config:type="symbol"&gt;xinetd&lt;/netd_service&gt;

--- a/xml/ay_nfs.xml
+++ b/xml/ay_nfs.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>NFS Client and Server</title>
+  <title>NFS client and server</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -41,7 +41,7 @@
    </para>
 
    <example>
-    <title>Network Configuration: NFS Client</title>
+    <title>Network configuration: NFS client</title>
 <screen>&lt;nfs&gt;
   &lt;enable_nfs4 config:type="boolean"&gt;true&lt;/enable_nfs4&gt;
   &lt;idmapd_domain&gt;suse.cz&lt;/idmapd_domain&gt;
@@ -69,7 +69,7 @@
    </example>
 
    <example>
-    <title>Network Configuration: NFS Server</title>
+    <title>Network configuration: NFS server</title>
 <screen>&lt;nfs_server&gt;
   &lt;nfs_exports config:type="list"&gt;
     &lt;nfs_export&gt;

--- a/xml/ay_nis_client.xml
+++ b/xml/ay_nis_client.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>NIS Client and Server</title>
+  <title>NIS client and server</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">

--- a/xml/ay_nis_server.xml
+++ b/xml/ay_nis_server.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>NIS Server</title>
+  <title>NIS server</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -24,7 +24,7 @@
    </para>
 
    <example>
-    <title>NIS Server Configuration</title>
+    <title>NIS server configuration</title>
 <screen>
   &lt;nis_server&gt;
     &lt;domain&gt;mydomain.de&lt;/domain&gt;

--- a/xml/ay_ntp_client.xml
+++ b/xml/ay_ntp_client.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>NTP Client</title>
+  <title>NTP client</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -18,7 +18,7 @@
   </dm:docmanager>
  </info>
    <important>
-    <title>NTP Client Profile Incompatible</title>
+    <title>NTP client profile incompatible</title>
     <para>
      Starting with &productname;&nbsp;15, the NTP client profile has a new format
      and is <emphasis>not</emphasis> compatible with previous profiles. You
@@ -32,7 +32,7 @@
    </para>
 
    <example>
-    <title>Network Configuration: NTP Client</title>
+    <title>Network configuration: NTP client</title>
 <screen>
 &lt;ntp-client>
 &lt;ntp_policy>auto&lt;/ntp_policy><co xml:id="co-ay-ntp-policy"/>

--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -54,7 +54,7 @@
    </para>
 
    <sect2 xml:id="CreateProfile-Automatic-Partitioning">
-    <title>Automatic Partitioning</title>
+    <title>Automatic partitioning</title>
 
     <para>
      &ay; can come up with a sensible partitioning layout without any
@@ -80,7 +80,7 @@
    <sect2 xml:id="CreateProfile-Guided-Partitioning">
 <!-- this section differs from older releases, do not backport, 
       see https://github.com/SUSE/doc-sle/pull/513. (cjs, feb 4 2020) -->       
-    <title>Guided Partitioning</title>
+    <title>Guided partitioning</title>
 
     <para>
      Although &ay; can come up with a partitioning layout without any user
@@ -99,7 +99,7 @@
     </para>
 
     <example xml:id="example-lvm-guided">
-     <title>LVM-based Guided Partitioning</title>
+     <title>LVM-based guided partitioning</title>
      <screen>&lt;general&gt;
    &lt;storage&gt;
      &lt;proposal&gt;
@@ -213,7 +213,7 @@
    </sect2>
 
    <sect2 xml:id="CreateProfile-Expert-Partitioning">
-    <title>Expert Partitioning</title>
+    <title>Expert partitioning</title>
 
     <para>
      As an alternative to guided partitioning, &ay; allows to describe the
@@ -262,7 +262,7 @@
     </example>
 
     <tip xml:id="ay-boot-partition">
-     <title>Proposing a Boot Partition</title>
+     <title>Proposing a boot partition</title>
      <para>
       &ay; checks whether the layout described in the profile is bootable or
       not. If it is not, it adds the missing partitions. So, if you are unsure
@@ -272,7 +272,7 @@
     </tip>
 
     <sect3 xml:id="CreateProfile-Partitioning-config">
-     <title>Drive Configuration</title>
+     <title>Drive configuration</title>
      <para>
       The elements listed below must be placed within the following XML
       structure:
@@ -490,7 +490,7 @@
 </variablelist>
 
      <important>
-      <title>Beware of Data Loss</title>
+      <title>Beware of data loss</title>
       <para>
        The value provided in the <literal>use</literal> property determines
        how existing data and partitions are treated. The value
@@ -502,7 +502,7 @@
      </important>
 
      <tip xml:id="ay-partitioning-skip-devices">
-      <title>Skipping Devices</title>
+      <title>Skipping devices</title>
       <para>
        You can influence &ay;'s device-guessing for cases where you do not
        specify a &lt;device&gt; entry on your own. Usually &ay;
@@ -541,7 +541,7 @@
     </sect3>
 
     <sect3 xml:id="ay-partition-configuration">
-     <title>Partition Configuration</title>
+     <title>Partition configuration</title>
      <para>
       The elements listed below must be placed within the following XML
       structure:
@@ -1235,7 +1235,7 @@
     </sect3>
 
     <sect3 xml:id="ay-use-whole-disk">
-     <title>Using the Whole Disk</title>
+     <title>Using the whole disk</title>
 
      <para>
       &ay; allows to use a whole disk without creating any partition by setting
@@ -1251,7 +1251,7 @@
      </para>
 
      <example>
-      <title>Using a Whole Disk as a File System</title>
+      <title>Using a whole disk as a file system</title>
       <screen>&lt;partitioning config:type="list"&gt;
   &lt;drive&gt;
     &lt;device&gt;/dev/sda&lt;/device&gt;
@@ -1292,7 +1292,7 @@
     </sect3>
 
     <sect3 xml:id="ay-auto-partitioning">
-     <title>Filling the Gaps</title>
+     <title>Filling the gaps</title>
      <para>
       When using the Expert Partitioner approach, &ay; can create a
       partition plan from a rather incomplete profile. The following profiles
@@ -1300,7 +1300,7 @@
       let &ay; do the rest.
      </para>
      <example>
-      <title>Automated Partitioning on Selected Drives</title>
+      <title>Automated partitioning on selected drives</title>
       <para>
        The following is an example of a single drive system, which is not
        pre-partitioned and should be automatically partitioned according to
@@ -1320,7 +1320,7 @@
       drives are handled.
      </para>
      <example>
-      <title>Installing on Multiple Drives</title>
+      <title>Installing on multiple drives</title>
       <screen>&lt;partitioning config:type="list"&gt;
   &lt;drive&gt;
     &lt;device&gt;/dev/sda&lt;/device&gt;
@@ -1359,12 +1359,12 @@
    </sect2>
 
    <sect2 xml:id="ay-partition-advanced">
-    <title>Advanced Partitioning Features</title>
+    <title>Advanced partitioning features</title>
     <para>
      <remark role="fixme">Add a short description</remark>
     </para>
     <sect3 xml:id="ay-partition-advanced-wipe">
-     <title>Wipe out Partition Table</title>
+     <title>Wipe out partition table</title>
      <para>
       Usually this is not needed because &ay; can delete partitions one
       by one automatically. But you need the option to let &ay; clear the
@@ -1382,7 +1382,7 @@
      </para>
     </sect3>
     <sect3 xml:id="ay-partition-advanced-mount">
-     <title>Mount Options</title>
+     <title>Mount options</title>
      <para>
       By default a file system to be mounted is identified in
       <filename>/etc/fstab</filename> by the device name. This
@@ -1438,7 +1438,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term>Mountable by User (<literal>user</literal>)</term>
+       <term>Mountable by user (<literal>user</literal>)</term>
        <listitem>
         <para>
          The file system can be mounted by a normal user. Default is
@@ -1486,7 +1486,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term>Access Control List (<literal>acl</literal>)</term>
+       <term>Access control list (<literal>acl</literal>)</term>
        <listitem>
         <para>
          Enable access control lists on the file system.
@@ -1494,7 +1494,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term>Extended User Attributes (<literal>user_xattr</literal>)</term>
+       <term>Extended user attributes (<literal>user_xattr</literal>)</term>
        <listitem>
         <para>
          Allow extended user attributes on the file system.
@@ -1503,7 +1503,7 @@
       </varlistentry>
      </variablelist>
      <example>
-      <title>Mount Options</title>
+      <title>Mount options</title>
 <screen>&lt;partitions config:type="list"&gt;
   &lt;partition&gt;
     &lt;filesystem config:type="symbol"&gt;ext4&lt;/filesystem&gt;
@@ -1529,7 +1529,7 @@
     </note>
     </sect3>
     <sect3 xml:id="ay-partition-advanced-keep">
-     <title>Keeping Specific Partitions</title>
+     <title>Keeping specific partitions</title>
      <para>
       In some cases you should leave partitions untouched and only format
       specific target partitions, rather than creating them from scratch.
@@ -1643,7 +1643,7 @@
      </example>
 
      <note>
-      <title>Keeping Encrypted Devices</title>
+      <title>Keeping encrypted devices</title>
       <para>
        When &ay; is probing the storage devices, the partitioning
        section from the profile is not yet analyzed. In some scenarios,
@@ -1657,13 +1657,13 @@
    </sect2>
 
    <sect2 xml:id="ay-partition-lvm">
-    <title>Logical Volume Manager (LVM)</title>
+    <title>Logical volume manager (LVM)</title>
     <para>
      To configure LVM, first create a physical volume using the normal
      partitioning method described above.
     </para>
     <example>
-     <title>Create LVM Physical Volume</title>
+     <title>Create LVM physical volume</title>
      <para>
       The following example shows how to prepare for LVM in the
       <literal>partitioning</literal> resource. A non-formatted partition is
@@ -1690,7 +1690,7 @@
 &lt;/partitioning&gt;</screen>
     </example>
     <example>
-     <title>LVM Logical Volumes</title>
+     <title>LVM logical volumes</title>
 <screen>&lt;partitioning config:type="list"&gt;
   &lt;drive&gt;
     &lt;device&gt;/dev/sda&lt;/device&gt;
@@ -1826,7 +1826,7 @@
      and another one from the second disk as RAID members:
     </para>
     <example>
-     <title>RAID1 Configuration</title>
+     <title>RAID1 configuration</title>
 <screen>&lt;partitioning config:type="list"&gt;
   &lt;drive&gt;
     &lt;device&gt;/dev/sda&lt;/device&gt;
@@ -1882,7 +1882,7 @@
     </para>
 
     <example>
-     <title>RAID1 Without Partitions</title>
+     <title>RAID1 without partitions</title>
 <screen>&lt;drive&gt;
   &lt;device&gt;/dev/md/0&lt;/device&gt;
   &lt;disklabel&gt;none&lt;/disklabel&gt;
@@ -1902,7 +1902,7 @@
     </example>
 
    <sect3 xml:id="ay-partition-sw-raid-deprecated">
-    <title>Using the Deprecated Syntax</title>
+    <title>Using the deprecated syntax</title>
     <para>
      If the installer self-update feature is enabled, it is possible to partition a software RAID
      for &productname; 15. However, that scenario was not supported in previous versions and hence
@@ -1942,7 +1942,7 @@
     </itemizedlist>
 
     <example>
-     <title>Old Style RAID1 Configuration</title>
+     <title>Old style RAID1 configuration</title>
 <screen>&lt;partitioning config:type="list"&gt;
   &lt;drive&gt;
     &lt;device&gt;/dev/sda&lt;/device&gt;
@@ -1995,7 +1995,7 @@
    </sect3>
 
    <sect3 xml:id="ay-raid-configuration">
-    <title>RAID Options</title>
+    <title>RAID options</title>
     <para>
      The following elements must be placed within the following XML
      structure:
@@ -2077,7 +2077,7 @@
   <sect2 xml:id="ay-partition-multipath">
 <!-- this section differs from older releases, do not backport, 
       see https://github.com/SUSE/doc-sle/pull/535. (cjs, feb 4 2020) -->      
-   <title>Multipath Support</title>
+   <title>Multipath support</title>
    <para>
     &ay; can handle multipath devices. In order to take advantage of
     them, you need to enable multipath support, as shown in <xref
@@ -2094,7 +2094,7 @@
    </para>
 
     <example xml:id="multipath-example">
-     <title>Using Multipath Devices</title>
+     <title>Using multipath devices</title>
      <screen><![CDATA[<general>
   <storage>
     <start_multipath config:type="boolean">true</start_multipath>
@@ -2148,7 +2148,7 @@ size=40G features='0' hwhandler='0' wp=rw
     </example>
 
     <example xml:id="multipath-wwid-example">
-     <title>Using the WWID to Identify a Multipath Device</title>
+     <title>Using the WWID to identify a multipath device</title>
      <screen><![CDATA[<drive>
   <partitions config:type="list">
     <device>/dev/mapper/14945540000000000f86756dce9286158be4c6e3567e75ba5</device>
@@ -2165,7 +2165,7 @@ size=40G features='0' hwhandler='0' wp=rw
   </sect2>
 
   <sect2 xml:id="ay-partition-bcache">
-   <title>&bcache; Configuration</title>
+   <title>&bcache; configuration</title>
    <para>
     &bcache; is a caching system which allows the use of multiple fast drives to speed up the access
     to one or more slower drives. For example, you can improve the performance
@@ -2207,7 +2207,7 @@ size=40G features='0' hwhandler='0' wp=rw
    </itemizedlist>
 
    <example>
-    <title>&bcache; Definition</title>
+    <title>&bcache; definition</title>
 <screen>&lt;partitioning config:type="list"&gt;
   &lt;drive&gt;
     &lt;device&gt;/dev/sda&lt;/device&gt;
@@ -2323,7 +2323,7 @@ size=40G features='0' hwhandler='0' wp=rw
   </sect2>
 
   <sect2 xml:id="ay-multidevice-btrfs">
-   <title>Multi-device Btrfs Configuration</title>
+   <title>Multi-device Btrfs configuration</title>
 
    <para>
     Btrfs supports creating a single volume that spans more than one
@@ -2429,7 +2429,7 @@ as per ancorgs' comment on Github-->
 
 
   <sect2 xml:id="ay-partition-nfs">
-   <title>NFS Configuration</title>
+   <title>NFS configuration</title>
 
    <para>
     &ay; allows to install &productname; onto
@@ -2446,7 +2446,7 @@ as per ancorgs' comment on Github-->
    </para>
 
    <example>
-    <title>NFS Share Definition</title>
+    <title>NFS share definition</title>
       <screen>
         &lt;partitioning config:type="list"&gt;
           &lt;drive&gt;
@@ -2506,10 +2506,10 @@ as per ancorgs' comment on Github-->
   </sect2>
 
    <sect2 os="sles" xml:id="ay-partition-s390">
-    <title>&zseries; Specific Configuration</title>
+    <title>&zseries; specific configuration</title>
     <para/>
     <sect3 xml:id="ay-partition-s390-dasd">
-     <title>Configuring DASD Disks</title>
+     <title>Configuring DASD disks</title>
      <para>
       The elements listed below must be placed within the following XML
       structure:
@@ -2528,7 +2528,7 @@ as per ancorgs' comment on Github-->
      </para>
 
      <variablelist>
-      <title>DASD Configuration</title>
+      <title>DASD configuration</title>
       
       <varlistentry>
        <term>device</term>
@@ -2585,7 +2585,7 @@ as per ancorgs' comment on Github-->
      </variablelist>
     </sect3>
     <sect3 xml:id="ay-partition-s390-zfcp">
-     <title>Configuring zFCP Disks</title>
+     <title>Configuring zFCP disks</title>
      <para>
       The following elements must be placed within the following XML
       structure:

--- a/xml/ay_registration_extensions.xml
+++ b/xml/ay_registration_extensions.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>System Registration and Extension Selection</title>
+  <title>System registration and extension selection</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -64,7 +64,7 @@
 &lt;/general&gt;</screen>
 
    <tip>
-    <title>Using the Installation Network Settings</title>
+    <title>Using the installation network settings</title>
     <para>
      In case you need to use the same network settings that were used for
      the installation, &ay; needs to run the network setup in stage 1
@@ -253,7 +253,7 @@
    </variablelist>
 
    <tip>
-    <title>Obtaining a Server Certificate Fingerprint</title>
+    <title>Obtaining a server certificate fingerprint</title>
     <para>
      To obtain a server certificate fingerprint for use with
      the <literal>reg_server_cert_fingerprint</literal> entry, run the
@@ -292,7 +292,7 @@ x509 -noout -fingerprint -sha256</screen>
           on x86_64: -->
     </para>
     <note>
-     <title>Availability of Extensions</title>
+     <title>Availability of extensions</title>
      <para>
       The availability of extensions is product and architecture dependent,
       not all extensions are available on all architectures.
@@ -327,7 +327,7 @@ x509 -noout -fingerprint -sha256</screen>
 </addons>]]></screen>
 
 <note>
- <title>Extension Dependencies</title>
+ <title>Extension dependencies</title>
  <para>
    Since &slsa; 15, &ay; automatically reorders the extensions according to
    their dependencies during registration. This means the order of the

--- a/xml/ay_reporting.xml
+++ b/xml/ay_reporting.xml
@@ -42,7 +42,7 @@
    </itemizedlist>
 
    <example>
-    <title>Reporting Behavior</title>
+    <title>Reporting behavior</title>
 <screen>&lt;report&gt;
   &lt;errors&gt;
     &lt;show config:type="boolean"&gt;true&lt;/show&gt;
@@ -81,7 +81,7 @@
    </para>
 
    <warning>
-    <title>Critical System Messages</title>
+    <title>Critical system messages</title>
     <para>
      Note that not all messages during installation are controlled by the
      <literal>report</literal> resource. Some critical messages concerning

--- a/xml/ay_rules_classes.xml
+++ b/xml/ay_rules_classes.xml
@@ -10,7 +10,7 @@ xmlns:xi="http://www.w3.org/2001/XInclude"
 xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" 
 xml:id="rulesandclass">
 
- <title>Rules and Classes</title>
+ <title>Rules and classes</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -36,7 +36,7 @@ xml:id="rulesandclass">
    </listitem>
   </itemizedlist>
   <note>
-    <title>Use <literal>autoyast</literal> Boot Option Only</title>
+    <title>Use <literal>autoyast</literal> boot option only</title>
     <para>
      Rules and classes are only supported by the boot parameter
      <literal>autoyast=<replaceable>URL</replaceable></literal>.
@@ -48,7 +48,7 @@ xml:id="rulesandclass">
     </para>
   </note>
   <sect1 xml:id="rules">
-   <title>Rule-based Automatic Installation</title>
+   <title>Rule-based automatic installation</title>
 
    <para>
     Rules offer the possibility to configure a system depending on system
@@ -124,9 +124,9 @@ autoyast=http://10.10.0.1/profile/rules/rules.xml</screen>
    </para>
 
    <sect2 xml:id="rulesfile">
-    <title>Rules File Explained</title>
+    <title>Rules file explained</title>
     <example>
-     <title>Simple Rules File</title>
+     <title>Simple rules file</title>
      <para>
       The following simple example illustrates how the rules file is used to
       retrieve the configuration for a client with known hardware.
@@ -186,7 +186,7 @@ autoyast=http://10.10.0.1/profile/rules/rules.xml</screen>
      more attributes in the rule resource as shown in the next example.
     </para>
     <example>
-     <title>Simple Rules File</title>
+     <title>Simple rules file</title>
      <para>
       The following example illustrates how the rules file is used to
       retrieve the configuration for a client with known hardware.
@@ -236,7 +236,7 @@ autoyast=http://10.10.0.1/profile/rules/rules.xml</screen>
    </sect2>
 
    <sect2 xml:id="customrules">
-    <title>Custom Rules</title>
+    <title>Custom rules</title>
     <para>
      If the attributes &ay; provides for rules are not enough for your
      purposes, use custom rules. Custom rules contain a shell script. The
@@ -280,7 +280,7 @@ fi;
    </sect2>
 
    <sect2 xml:id="matchtypes">
-    <title>Match Types for Rules</title>
+    <title>Match types for rules</title>
     <para>
      You can use five different match_types:
     </para>
@@ -325,7 +325,7 @@ fi;
    </sect2>
 
    <sect2 xml:id="rulescombination">
-    <title>Combine Attributes</title>
+    <title>Combine attributes</title>
     <para>
      Multiple attributes can be combined via a logical operator. It is
      possible to let a rule match if <literal>disksize</literal> is greater than 1GB or <literal>memsize</literal>
@@ -355,7 +355,7 @@ fi;
    </sect2>
 
    <sect2 xml:id="rulesstructure">
-    <title>Rules File Structure</title>
+    <title>Rules file structure</title>
     <para>
      The <filename>rules.xml</filename> file needs to:
     </para>
@@ -385,7 +385,7 @@ fi;
    </sect2>
 
    <sect2 xml:id="ruleattributes">
-    <title>Predefined System Attributes</title>
+    <title>Predefined system attributes</title>
     <para>
      The following table lists the predefined system attributes you can
      match in the rules file.
@@ -399,7 +399,7 @@ fi;
      cannot run it during the installation.
     </para>
     <table>
-     <title>System Attributes</title>
+     <title>System attributes</title>
      <tgroup cols="3">
       <thead>
        <row>
@@ -789,7 +789,7 @@ fi;
    </sect2>
 
    <sect2 xml:id="rules-dialogs">
-    <title>Rules with Dialogs</title>
+    <title>Rules with dialogs</title>
     <para>
      You can use dialog pop-ups with check boxes to select rules you want
      matched.
@@ -1082,7 +1082,7 @@ echo -n 100
    </itemizedlist>
 
    <figure os="sles;sled">
-    <title>Defining Classes</title>
+    <title>Defining classes</title>
     <mediaobject>
      <imageobject role="html">
       <imagedata fileref="cms-class-definitions.png"/>
@@ -1094,7 +1094,7 @@ echo -n 100
    </figure>
 
    <figure os="osuse">
-    <title>Defining Classes</title>
+    <title>Defining classes</title>
     <mediaobject>
      <imageobject role="html">
       <imagedata fileref="cms-class-definitions_kde.png"/>
@@ -1148,7 +1148,7 @@ echo -n 100
    </para>
   </sect1>
   <sect1 xml:id="mixinfrulesclasses">
-   <title>Mixing Rules and Classes</title>
+   <title>Mixing rules and classes</title>
 
    <para>
     It is possible to mix rules and classes during an auto-installation
@@ -1165,7 +1165,7 @@ echo -n 100
    </para>
   </sect1>
   <sect1 xml:id="merging">
-   <title>Merging of Rules and Classes</title>
+   <title>Merging of rules and classes</title>
 
    <para>
     With classes and with rules, multiple XML files get merged into one

--- a/xml/ay_running_system.xml
+++ b/xml/ay_running_system.xml
@@ -10,7 +10,7 @@ xmlns:xi="http://www.w3.org/2001/XInclude"
 xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" 
 xml:id="InstalledSystem">
 
- <title>Running &ay; in an Installed System</title>
+ <title>Running &ay; in an installed system</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>

--- a/xml/ay_samba_server.xml
+++ b/xml/ay_samba_server.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Samba Server</title>
+  <title>Samba server</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -23,7 +23,7 @@
    </para>
 
    <example>
-    <title>Samba Server configuration</title>
+    <title>Samba server configuration</title>
 <screen>
   &lt;samba-server&gt;
     &lt;accounts config:type="list"/&gt;

--- a/xml/ay_security_settings.xml
+++ b/xml/ay_security_settings.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Security Settings</title>
+  <title>Security settings</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -62,7 +62,7 @@
    </example>
 
    <sect2 xml:id="CreateProfile-Security-password">
-    <title>Password Settings Options</title>
+    <title>Password settings options</title>
     <para>
      Change various password settings. These settings are mainly stored in
      the <filename>/etc/login.defs</filename> file.
@@ -86,7 +86,7 @@
    </sect2>
 
    <sect2 xml:id="CreateProfile-Security-boot">
-    <title>Boot Settings</title>
+    <title>Boot settings</title>
     <para>
      Use the security resource, to change various boot settings.
     </para>
@@ -117,7 +117,7 @@
    </sect2>
 
    <sect2 xml:id="CreateProfile-Security-login">
-    <title>Login Settings</title>
+    <title>Login settings</title>
     <para>
      Change various login settings. These settings are mainly stored in the
      <filename>/etc/login.defs</filename> file.

--- a/xml/ay_services_targets.xml
+++ b/xml/ay_services_targets.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Services and Targets</title>
+  <title>Services and targets</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -53,7 +53,7 @@
    </para>
 
    <example>
-    <title>Configuring Services and Targets</title>
+    <title>Configuring services and targets</title>
 <screen>&lt;services-manager&gt;
   &lt;default_target&gt;multi-user&lt;/default_target&gt;
   &lt;services&gt;

--- a/xml/ay_software.xml
+++ b/xml/ay_software.xml
@@ -23,7 +23,7 @@
    </para>
 
    <sect2 xml:id="Software-Selections-base-product" os="sles;sled">
-    <title>Product Selection</title>
+    <title>Product selection</title>
     <para>
      Starting with &productname; 15, all products are distributed using a single
      installation medium. Therefore you need to choose which product to install
@@ -75,7 +75,7 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term>SUSE-Manager-Server</term>
+      <term>SUSE-manager-server</term>
       <listitem>
        <para>
         SUSE Manager Server
@@ -83,7 +83,7 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term>SUSE-Manager-Retail-Branch-Server</term>
+      <term>SUSE-manager-retail-branch-server</term>
       <listitem>
        <para>
         SUSE Manager for Retail
@@ -91,7 +91,7 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term>SUSE-Manager-Proxy</term>
+      <term>SUSE-manager-proxy</term>
       <listitem>
        <para>
         SUSE Manager Proxy
@@ -100,7 +100,7 @@
      </varlistentry>
     </variablelist>
     <example>
-     <title>Explicit Product Selection</title>
+     <title>Explicit product selection</title>
      <para>
       In the following example, &sled; is the chosen product:
      </para>
@@ -129,12 +129,12 @@
    </sect2>
 
    <sect2 xml:id="Software-Selections-sles10">
-    <title>Package Selection with Patterns and Packages Sections</title>
+    <title>Package selection with patterns and packages sections</title>
     <para>
      Patterns or packages are configured like this:
     </para>
     <example>
-     <title>Package Selection in the Control File with Patterns and Packages Sections</title>
+     <title>Package selection in the control file with patterns and packages sections</title>
 <screen>&lt;software&gt;
   &lt;patterns config:type="list"&gt;
     &lt;pattern&gt;directory_server&lt;/pattern&gt;
@@ -147,7 +147,7 @@
 &lt;/software&gt;</screen>
     </example>
     <note>
-     <title>Package and Pattern Names</title>
+     <title>Package and pattern names</title>
      <para>
       The values are real package or pattern names. If the package name
       has been changed because of an upgrade, you will need to adapt these
@@ -157,12 +157,12 @@
    </sect2>
 
    <sect2 xml:id="Software-Selections-images" os="osuse">
-    <title>Deploying Images</title>
+    <title>Deploying images</title>
     <para>
      You can use images during installation to speed up the installation.
     </para>
     <example>
-     <title>Activating Image Deployment</title>
+     <title>Activating image deployment</title>
 <screen>&lt;!-- note! this is not in the software section! --&gt;
 &lt;deploy_image&gt;
   &lt;image_installation config:type="boolean"&gt;false&lt;/image_installation&gt;
@@ -171,7 +171,7 @@
    </sect2>
 
    <sect2 xml:id="Software-Selections-additional">
-    <title>Installing Additional/Customized Packages or Products</title>
+    <title>Installing additional/customized packages or products</title>
     <para>
      In addition to the packages available for installation on the DVD-ROMs,
      you can add external packages including customized kernels. Customized
@@ -192,7 +192,7 @@
      When creating the database, all languages will be reset to English.
     </para>
     <example>
-     <title>Creating a Package Database With the Additional Package inst-source-utils.rpm</title>
+     <title>Creating a package database with the additional package inst-source-utils.rpm</title>
      <para>
      The unpacked DVD is located in <literal>/usr/local/DVDs/LATEST</literal>.
      </para>
@@ -267,7 +267,7 @@
      updated. - sknorr, 2020-07-02
     </remark>
     <example>
-     <title>Adding the SDK Extension and a User Defined Repository</title>
+     <title>Adding the SDK extension and a user defined repository</title>
 <screen>&lt;add-on&gt;
   &lt;add_on_products config:type="list"&gt;
     &lt;listentry&gt;
@@ -395,7 +395,7 @@
      file.
     </para>
     <note>
-     <title>Unsigned Installation Sources&mdash;Limitations</title>
+     <title>Unsigned installation sources&mdash;limitations</title>
      <para>
       You can only disable signature checking during the first stage of the
       auto-installation process. In stage two, the installed system's configuration
@@ -581,7 +581,7 @@
    </sect2>
 
    <sect2 xml:id="Software-Selections-kernel">
-    <title>Kernel Packages</title>
+    <title>Kernel packages</title>
     <para>
      Kernel packages are not part of any selection. The required kernel is
      determined during installation. If the kernel package is added to any
@@ -595,7 +595,7 @@
      installed even if an SMP or other kernel is required.
     </para>
     <example>
-     <title>Kernel Selection in the Control File</title>
+     <title>Kernel selection in the control file</title>
 <screen>&lt;software&gt;
   &lt;kernel&gt;kernel-default&lt;/kernel&gt;
   ...
@@ -604,7 +604,7 @@
    </sect2>
 
    <sect2 xml:id="Software-Selections-remove-packs">
-    <title>Removing Automatically Selected Packages</title>
+    <title>Removing automatically selected packages</title>
     <para>
      Some packages are selected automatically either because of a dependency
      or because it is available in a selection.
@@ -621,7 +621,7 @@
      done:
     </para>
     <example>
-     <title>Package Selection in Control File</title>
+     <title>Package selection in control file</title>
 <screen>&lt;software&gt;
   &lt;packages config:type="list"&gt;
     &lt;package&gt;sendmail&lt;/package&gt;
@@ -633,7 +633,7 @@
     </example>
 
     <note>
-     <title>Package Removal Failure</title>
+     <title>Package removal failure</title>
      <para>
       Note that it is not possible to remove a package that is part of a
       pattern (see <xref linkend="Software-Selections-sles10"/>).  When
@@ -647,7 +647,7 @@
    </sect2>
 
    <sect2 xml:id="Software-Selections-recommend-packs">
-    <title>Installing Recommended Packages/Patterns</title>
+    <title>Installing recommended packages/patterns</title>
     <para>
      By default all recommended packages/patterns will be installed.
      To have a minimal installation which includes required
@@ -670,7 +670,7 @@
    </sect2>
 
    <sect2 xml:id="Software-Selections-stage2-packs">
-    <title>Installing Packages in Stage 2</title>
+    <title>Installing packages in stage 2</title>
     <para>
      To install packages after the reboot during stage two, you can
      use the <literal>post-packages</literal> element for that:
@@ -683,7 +683,7 @@
    </sect2>
 
    <sect2 xml:id="Software-Selections-stage2-patterns">
-    <title>Installing Patterns in Stage 2</title>
+    <title>Installing patterns in stage 2</title>
     <para>
      You can also install patterns in stage 2. Use the
      <literal>post-patterns</literal> element for that:
@@ -696,7 +696,7 @@
    </sect2>
 
    <sect2 xml:id="Software-Selections-stage2-update">
-    <title>Online Update in Stage 2</title>
+    <title>Online update in stage 2</title>
     <para>
      You can perform an online update at the end of the installation. Set
      the boolean <literal>do_online_update</literal> to

--- a/xml/ay_squid_server.xml
+++ b/xml/ay_squid_server.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Squid Server</title>
+  <title>Squid server</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -23,7 +23,7 @@
    </para>
 
    <example>
-    <title>Squid Server Configuration</title>
+    <title>Squid server configuration</title>
 <screen>
   &lt;squid&gt;
     &lt;acls config:type="list"&gt;

--- a/xml/ay_sysconfig.xml
+++ b/xml/ay_sysconfig.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>System Variables (Sysconfig)</title>
+  <title>System variables (sysconfig)</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -32,7 +32,7 @@
    </para>
 
    <example>
-    <title>Sysconfig Configuration</title>
+    <title>Sysconfig configuration</title>
 <screen>&lt;sysconfig config:type="list" &gt;
   &lt;sysconfig_entry&gt;
     &lt;sysconfig_key&gt;XNTPD_INITIAL_NTPDATE&lt;/sysconfig_key&gt;

--- a/xml/ay_tftp_server.xml
+++ b/xml/ay_tftp_server.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>TFTP Server</title>
+  <title>TFTP server</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">

--- a/xml/ay_upgrade.xml
+++ b/xml/ay_upgrade.xml
@@ -68,7 +68,7 @@
    </para>
 
    <example>
-    <title>Upgrade and Backup</title>
+    <title>Upgrade and backup</title>
     <screen>
   &lt;upgrade&gt;
     &lt;stop_on_solver_conflict config:type="boolean"&gt;true&lt;/stop_on_solver_conflict&gt;
@@ -121,7 +121,7 @@
 
    <para>To start the &ay; upgrade mode, you need:</para>
    <procedure xml:id="pro-upgrade-offline-upgrade-mode">
-    <title>Starting &ay; in Offline Upgrade Mode</title>
+    <title>Starting &ay; in offline upgrade mode</title>
     <step>
      <para>
       Copy the &ay; profile to <filename>/root/autoupg.xml</filename> on
@@ -143,7 +143,7 @@
    </procedure>
 
    <procedure xml:id="pro-upgrade-online-upgrade-mode">
-    <title>Starting &ay; in Online Upgrade Mode</title>
+    <title>Starting &ay; in online upgrade mode</title>
     <step>
      <para>Boot the system from the installation media.</para>
     </step>

--- a/xml/ay_users_groups.xml
+++ b/xml/ay_users_groups.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Users and Groups</title>
+  <title>Users and groups</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -29,7 +29,7 @@
     </para>
 
     <example>
-     <title>Minimal User Configuration</title>
+     <title>Minimal user configuration</title>
      <screen>&lt;users config:type="list"&gt;
   &lt;user&gt;
     &lt;username&gt;root&lt;/username&gt;
@@ -51,7 +51,7 @@
     </para>
 
     <example>
-     <title>Complex User Configuration</title>
+     <title>Complex user configuration</title>
      <screen>&lt;users config:type="list"&gt;
   &lt;user&gt;
     &lt;username&gt;root&lt;/username&gt;
@@ -81,7 +81,7 @@
     </example>
 
     <note>
-     <title><literal>authorized_keys</literal> File Will Be Overwritten</title>
+     <title><literal>authorized_keys</literal> File will be overwritten</title>
 
      <para>
       If the profile defines a set of SSH authorized keys for a user in the
@@ -94,7 +94,7 @@
     </note>
 
     <note>
-     <title>Combine <literal>rootpassword</literal> and Root User Options</title>
+     <title>Combine <literal>rootpassword</literal> and root user options</title>
 
      <para>
       It is possible to specify <literal>rootpassword</literal> in
@@ -106,7 +106,7 @@
     </note>
 
     <note xml:id="ann-Configuration-Security-users-uid">
-     <title>Specifying a User ID (<literal>uid</literal>)</title>
+     <title>Specifying a user ID (<literal>uid</literal>)</title>
      <para>
       Each user on a Linux system has a numeric user ID. You can either
       specify such a user ID within the &ay; control file manually by using
@@ -427,7 +427,7 @@
    </sect2>
 
    <sect2 xml:id="Configuration-Security-user-defaults">
-    <title>User Defaults</title>
+    <title>User defaults</title>
 
     <para>
      The profile can specify a set of default values for new users like
@@ -641,7 +641,7 @@
     </para>
 
     <example>
-     <title>Group Configuration</title>
+     <title>Group configuration</title>
      <screen>&lt;groups config:type="list"&gt;
   &lt;group&gt;
     &lt;gid&gt;100&lt;/gid&gt;
@@ -772,7 +772,7 @@
    </sect2>
 
    <sect2 xml:id="Configuration-Security-login-settings">
-    <title>Login Settings</title>
+    <title>Login settings</title>
 
     <para>Two special login settings can be enabled through an &ay; profile:
     autologin and password-less login. Both of them are disabled by default.</para>

--- a/xml/ay_windows_domain_client.xml
+++ b/xml/ay_windows_domain_client.xml
@@ -9,7 +9,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-  <title>Windows Domain Membership</title>
+  <title>Windows domain membership</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -24,7 +24,7 @@
    </para>
 
    <example>
-    <title>Samba Client configuration</title>
+    <title>Samba client configuration</title>
 <screen>
   &lt;samba-client&gt;
     &lt;disable_dhcp_hostname config:type="boolean"&gt;true&lt;/disable_dhcp_hostname&gt;

--- a/xml/book_autoyast.xml
+++ b/xml/book_autoyast.xml
@@ -40,7 +40,7 @@
 <!-- Part: The Control File                                                -->
 <!-- ===================================================================== -->
  <part xml:id="part-control">
-     <title>Understanding and Creating the &ay; Control File</title>
+     <title>Understanding and creating the &ay; control file</title>
  <xi:include href="ay_control_file.xml"/>
  <xi:include href="ay_create_control_file.xml"/>
  </part>
@@ -49,7 +49,7 @@
 <!-- Part: Configuration and Installation Options                          -->
 <!-- ===================================================================== -->
  <part xml:id="part-configuration">
-     <title>&ay; Configuration Examples</title>
+     <title>&ay; configuration examples</title>
  <xi:include href="ay_configuration_installation_options.xml"/>
  </part>
  
@@ -57,7 +57,7 @@
 <!-- Part: Rules and Classes                                               -->
 <!-- ===================================================================== -->
  <part xml:id="part-rules-classes">
-     <title>Managing Mass Installations with Rules and Classes</title>
+     <title>Managing mass installations with rules and classes</title>
  
  <xi:include href="ay_rules_classes.xml"/>
 </part>
@@ -66,7 +66,7 @@
 <!-- Part: The Auto-Installation Process                                   -->
 <!-- ===================================================================== -->
 <part>
-    <title>Understanding the Auto-Installation Process</title>
+    <title>Understanding the auto-installation process</title>
 <xi:include href="ay_auto_installation.xml"/>
 </part>
  
@@ -74,7 +74,7 @@
 <!-- Part: Running AutoYaST in an Installed System                         -->
 <!-- ===================================================================== -->
 <part>
-    <title>Uses for &ay; on Installed Systems</title>
+    <title>Uses for &ay; on installed systems</title>
 <xi:include href="ay_running_system.xml"/>
 </part>
 


### PR DESCRIPTION
### Description

* The new capitalization rules are documented at https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-capitalization, read carefully
* This is the result of an automatic conversion and will most likely need further adjustments
  * Make sure to review the entire diff
  * Entity files have not been changed and need to be updated manually
  * Some product/project names may have been inadvertently changed to the wrong capitalization
  * Some titles may have been missed, either because they're split across multiple source lines or because of improper markup
* Update the conversion commit and remove the (WIP) from the commit message before merging
* This is the tenth PR in a series of 14 PRs


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [x] 15 SP3  | (`master` only)   
| [ ] 15 SP2  | [ ] 
| [ ] 15 SP1  | [ ] 
| [ ] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
