### PR TITLE
Update RMT Guide to sentence case (WIP)

### DIFF
--- a/xml/rmt_backup.xml
+++ b/xml/rmt_backup.xml
@@ -5,13 +5,13 @@
     %entities;
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-rmt-backup">
- <title>Backing Up an &rmt; Server</title>
+ <title>Backing up an &rmt; server</title>
  <para>
   This chapter explains how to create a backup of your &rmt; server and
   how to restore it.
  </para>
  <sect1 xml:id="sec-rmt-backup-create">
-  <title>Creating a Backup</title>
+  <title>Creating a backup</title>
   <para>
    This procedure details how to create a full backup of your &rmt;
    server. It is assumed that you have an external disk or network share
@@ -44,7 +44,7 @@
  </sect1>
 
  <sect1 xml:id="sec-rmt-backup-restore">
-  <title>Restoring a Backup</title>
+  <title>Restoring a backup</title>
   <para>
    This procedure details how to restore your &rmt; server from a backup
    created in <xref linkend="sec-rmt-backup-create" />. It is assumed that

--- a/xml/rmt_certificates.xml
+++ b/xml/rmt_certificates.xml
@@ -5,9 +5,9 @@
     %entities;
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-manage-certificates">
- <title>Managing SSL/TLS Certificates</title>
+ <title>Managing SSL/TLS certificates</title>
  <sect1 xml:id="cha-manage-certificates-https">
-  <title>Regenerating HTTPS Certificates</title>
+  <title>Regenerating HTTPS certificates</title>
   <para>
    HTTPS certificates should be regenerated before they expire or to
    include additional common alternative names. No additional actions
@@ -38,13 +38,13 @@
  </sect1>
  
  <sect1 xml:id="cha-manage-certificates-ca">
-  <title>Regenerating CA Certificates and HTTPS Certificates</title>
+  <title>Regenerating CA certificates and HTTPS certificates</title>
   <para>
    CA certificates can be regenerated after they have expired or in case
    of security issues.
   </para>
   <warning>
-   <title>Import CA Certificate on All Clients</title>
+   <title>Import CA certificate on all clients</title>
    <para>
     The newly generated CA certificate must be imported on all clients
     registered to the RMT server. This can be done by running the

--- a/xml/rmt_client.xml
+++ b/xml/rmt_client.xml
@@ -7,7 +7,7 @@
 
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-rmt-client">
 <!-- ================================================================== -->
- <title>Configuring Clients to Use &rmt;</title>
+ <title>Configuring clients to use &rmt;</title>
  <info/>
  <para>
   Any machine running &sle; 12 or newer can be configured to register
@@ -15,7 +15,7 @@
   communicating directly with the &scc;.
  </para>
  <tip>
-  <title>Register with &rmt; Server over HTTP</title>
+  <title>Register with &rmt; server over HTTP</title>
   <para>
    We recommend registering with the &rmt; server over a secured HTTPS
    protocol (all examples in this documentation use it). However, you can
@@ -58,7 +58,7 @@
  </itemizedlist>
 
  <tip>
-  <title>CA Certificate</title>
+  <title>CA certificate</title>
   <para>
    If you need the CA certificate of the &rmt; server, find it at
    <filename>/etc/rmt/ssl/rmt-ca.crt</filename> and
@@ -68,7 +68,7 @@
 
 <!-- ============================================================== -->
  <sect1 xml:id="sec-rmt-client-parameters">
-  <title>Configuring Clients with Boot Parameters</title>
+  <title>Configuring clients with boot parameters</title>
   <para>
    Any client can be configured to use &rmt; by providing the
    <literal>regurl</literal> parameter during machine boot.
@@ -84,7 +84,7 @@
   </para>
   <screen>regurl=https://rmt.&exampledomain;</screen>
   <warning>
-   <title>Beware of Typing Errors</title>
+   <title>Beware of typing errors</title>
    <para>
     Make sure the values you enter are correct. If <literal>regurl</literal>
     has not been specified correctly, the registration of the update source
@@ -92,7 +92,7 @@
    </para>
   </warning>
   <note>
-   <title>Change of &rmt; Server Certificate</title>
+   <title>Change of &rmt; server certificate</title>
    <para>
     If the &rmt; server gets a new certificate from an untrusted CA, the
     clients need to retrieve the new CA certificate file.  &yast; displays a
@@ -103,7 +103,7 @@
  </sect1>
 
  <sect1 xml:id="sec-rmt-client-autoyast">
-  <title>Configuring Clients with &ay; Profile</title>
+  <title>Configuring clients with &ay; profile</title>
   <para>
    Clients can be configured to register with &rmt; server via &ay; profile.
    For general information about creating &ay; profiles and preparing automatic
@@ -175,7 +175,7 @@
  </sect1>
 <!-- ================================================================ -->
  <sect1 xml:id="sec-rmt-client-clientsetupscript">
-  <title>Configuring Clients with <command>rmt-client-setup</command></title>
+  <title>Configuring clients with <command>rmt-client-setup</command></title>
   <para>
    The <command>/usr/share/rmt/public/tools/rmt-client-setup</command>
    script is provided in the package <package>rmt-server</package>.
@@ -227,7 +227,7 @@
 
 <!-- ================================================================ -->
  <sect1 xml:id="sec-rmt-client-yast">
-  <title>Configuring Clients with &yast;</title>
+  <title>Configuring clients with &yast;</title>
    <para>
     To configure a client to perform the registration against an &rmt; server
     use the &yast; <guimenu>Product Registration</guimenu> module
@@ -241,7 +241,7 @@
    </para>
  </sect1>
  <sect1 xml:id="rmt-client-custom-repo">
-  <title>Configuring Clients for Custom Stand-alone Repositories</title>
+  <title>Configuring clients for custom stand-alone repositories</title>
   <para>
    If you created a custom stand-alone repository on the &rmt; server, it will
    not be registered on client machines with <command>SUSEConnect</command>
@@ -273,7 +273,7 @@
  </sect1>
 
  <sect1 xml:id="sec-rmt-client-list-repositories">
-  <title>Listing Accessible Repositories</title>
+  <title>Listing accessible repositories</title>
   <para>
    To list available modules and repositories, use <command>SUSEConnect
    --list-extensions</command>. Alternatively, you can also browse the
@@ -284,7 +284,7 @@
  </sect1>
 
  <sect1 xml:id="sec-rmt-client-online-migration">
-  <title>Online Migration of &sle; Clients</title>
+  <title>Online migration of &sle; clients</title>
   <para>
    &sle; clients registered against &rmt; can be migrated online to the
    latest service pack of the same major release the same way as

--- a/xml/rmt_config_files.xml
+++ b/xml/rmt_config_files.xml
@@ -6,7 +6,7 @@
 ]>
 
 <sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="sec-rmt-config">
- <title>&rmt; Configuration Files</title>
+ <title>&rmt; configuration files</title>
 
  <para>
   The main &rmt; configuration file is <filename>/etc/rmt.conf</filename>.
@@ -57,7 +57,7 @@
    </variablelist>
   </sect3>
   <sect3 xml:id="sec-rmt-config-rmtconf-client">
-   <title>HTTP Client Settings</title>
+   <title>HTTP client settings</title>
    <para>
     The <literal>http_client</literal> section defines the global HTTP
     connection settings of &rmt;.
@@ -136,7 +136,7 @@
    </variablelist>
   </sect3>
   <sect3 xml:id="sec-rmt-config-rmtconf-access-scc">
-   <title>Settings for Accessing &suse; Repositories</title>
+   <title>Settings for accessing &suse; repositories</title>
    <para>
     The <literal>scc</literal> section contains your mirroring
     credentials for contacting the &scc;. To obtain your mirroring
@@ -165,7 +165,7 @@
    </variablelist>
   </sect3>
   <sect3 xml:id="sec-rmt-config-web-server-settings">
-   <title>Web Server Settings</title>
+   <title>Web server settings</title>
    <para>
     The <literal>web_server</literal> section lets you tune the performance of your RMT server.
    </para>
@@ -208,7 +208,7 @@
  </sect2>
 
  <sect2 xml:id="sec-rmt-config-ssl">
-  <title>SSL Certificates and HTTPS</title>
+  <title>SSL certificates and HTTPS</title>
   <para>
    By default access to API endpoints consumed by
    <command>&suse;Connect</command> is limited to HTTPS only. nginx is

--- a/xml/rmt_install.xml
+++ b/xml/rmt_install.xml
@@ -9,14 +9,14 @@
          xmlns:xlink="http://www.w3.org/1999/xlink"
          version="5.0" xml:id="cha-rmt-installation">
 <!-- ==================================================================== -->
- <title>&rmt; Installation and Configuration</title>
+ <title>&rmt; installation and configuration</title>
  <para>
   &rmt; is included in &sls; starting with version 15. Install &rmt; directly
   during the installation of &productname; or install it on a running system.
   After the packages are installed, use &yast; to do an initial configuration.
  </para>
  <warning>
-  <title>&rmt; Server Will Conflict with Installation Server</title>
+  <title>&rmt; server will conflict with installation server</title>
   <para>
    Configuring a server to be an &rmt; server installs and configures the NGINX
    Web server, listening on port 80.
@@ -31,7 +31,7 @@
   </para>
  </warning>
  <sect1 xml:id="sec-rmt-storage-requirements">
-  <title>Storage Requirements</title>
+  <title>Storage requirements</title>
 
   <para>
    Downloaded packages are stored in
@@ -48,7 +48,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-rmt-installation-yast">
-  <title>Installation During System Installation</title>
+  <title>Installation during system installation</title>
 
   <para>
    To install it during installation, select the <package>rmt-server</package>
@@ -58,7 +58,7 @@
   </para>
 
   <figure>
-   <title>&rmt; Pattern</title>
+   <title>&rmt; pattern</title>
    <mediaobject>
     <imageobject role="fo">
      <imagedata fileref="rmt_installation.png" width="70%" format="PNG"/>
@@ -77,7 +77,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-rmt-installation-zypper">
-  <title>Installation on Existing System</title>
+  <title>Installation on existing system</title>
 
   <para>
    To install &rmt; on a running &productname; installation, use
@@ -87,7 +87,7 @@
 <screen>&prompt.sudo;<command>zypper in rmt-server</command></screen>
  </sect1>
  <sect1 xml:id="sec-rmt-installation-yast-configuration">
-  <title>&rmt; Configuration with &yast;</title>
+  <title>&rmt; configuration with &yast;</title>
 
   <para>
    Configure &rmt; with &yast; as described in the following procedure. It is
@@ -134,7 +134,7 @@
      When all common names are entered, select <guimenu>Next</guimenu>.
     </para>
     <tip>
-     <title>Certificate Locations for RMT</title>
+     <title>Certificate locations for RMT</title>
 
      <itemizedlist>
       <listitem>
@@ -166,7 +166,7 @@
      required ports.
     </para>
     <figure>
-     <title>Enabling Ports in &firewalld;</title>
+     <title>Enabling ports in &firewalld;</title>
      <mediaobject>
       <imageobject role="fo">
        <imagedata fileref="rmt_firewalld.png" width="60%"/>
@@ -182,7 +182,7 @@
      module.
     </para>
     <tip>
-     <title>Fine-tuning &firewalld; Settings</title>
+     <title>Fine-tuning &firewalld; settings</title>
      <para>
       By clicking <guimenu>Firewall Details</guimenu>, you can open the
       relevant ports for specific network interfaces only.
@@ -202,7 +202,7 @@
   </procedure>
   </sect1>
   <sect1>
-  <title>Enabling SLP Announcements</title>
+  <title>Enabling SLP announcements</title>
 
   <para>
    &rmt; includes the SLP service description file

--- a/xml/rmt_migrate_from_smt.xml
+++ b/xml/rmt_migrate_from_smt.xml
@@ -13,9 +13,9 @@
   on &slsa; 15.
  </para>
  <sect1 xml:id="sec-rmt-migrate-notes">
-  <title>Important Notes</title>
+  <title>Important notes</title>
   <warning>
-   <title>Read This Section Carefully</title>
+   <title>Read this section carefully</title>
    <para>
     Carefully read this section. It contains vital information about
     the migration process.
@@ -23,7 +23,7 @@
   </warning>
   <variablelist>
    <varlistentry>
-    <term>Use New Host</term>
+    <term>Use new host</term>
     <listitem>
      <para>
       We recommend that you install &rmt; on a newly-installed &slsa;
@@ -34,7 +34,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Repository Metadata and Settings</term>
+    <term>Repository metadata and settings</term>
     <listitem>
      <para>
       The settings of staged repositories will <emphasis>not</emphasis>
@@ -44,7 +44,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Custom Repositories</term>
+    <term>Custom repositories</term>
     <listitem>
      <para>
       It is only possible to export repositories that are marked for
@@ -53,7 +53,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Expired Subscriptions</term>
+    <term>Expired subscriptions</term>
     <listitem>
      <para>
       Products no longer available on the organization subscriptions
@@ -62,7 +62,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Client Information</term>
+    <term>Client information</term>
     <listitem>
      <para>
       Systems and their activated products will be exported. &smt;
@@ -72,7 +72,7 @@
    </varlistentry>
   </variablelist>
   <table xml:id="sec-rmt-migrate-notes-features">
-   <title>Feature Comparison</title>
+   <title>Feature comparison</title>
    <tgroup cols="3">
     <colspec colnum="1" colname="1" colwidth="40*"/>
     <colspec colnum="2" colname="2" colwidth="30*"/>
@@ -546,9 +546,9 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-rmt-migrate-smt-export">
-  <title>Exporting &smt; Data</title>
+  <title>Exporting &smt; data</title>
   <procedure>
-   <title>Export &smt; Data</title>
+   <title>Export &smt; data</title>
    <step>
     <para>
      Update your SMT server installation by running
@@ -576,7 +576,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-rmt-migrate-rmt-import">
-  <title>Importing &smt; Data to &rmt;</title>
+  <title>Importing &smt; data to &rmt;</title>
   <procedure>
    <step>
     <para>

--- a/xml/rmt_mirroring.xml
+++ b/xml/rmt_mirroring.xml
@@ -7,7 +7,7 @@
 
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-rmt-mirroring">
 <!-- ==================================================================== -->
- <title>Mirroring Repositories on the &rmt; Server</title>
+ <title>Mirroring repositories on the &rmt; server</title>
  <info/>
  <para>
   You can mirror the installation and update repositories on the &rmt;
@@ -46,13 +46,13 @@
   from the &rmt; server will be used by Zypper on the client machine.
  </para>
  <important>
-  <title>&sls; 11 Clients</title>
+  <title>&sls; 11 clients</title>
   <para>
    &rmt; does not support clients with &sls; versions 11 and below.
   </para>
  </important>
  <sect1 xml:id="sec-rmt-mirroring-credentials">
-  <title>Mirroring Credentials</title>
+  <title>Mirroring credentials</title>
 
   <para>
    Before you create a local mirror of the &sle; repositories,
@@ -102,7 +102,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-rmt-mirroring-synchronization">
-  <title>Synchronizing Repository Metadata</title>
+  <title>Synchronizing repository metadata</title>
   <para>
    The local &rmt; database needs to be updated periodically with the
    information downloaded from &scc;. This includes information about
@@ -127,7 +127,7 @@ Jun 22 04:22:34 d31 systemd[1]: Started RMT Sync timer.</screen>
  </sect1>
 
  <sect1 xml:id="sec-rmt-mirroring-mirroring">
-  <title>Mirroring Packages</title>
+  <title>Mirroring packages</title>
   <para>
    Packages for enabled repositories are mirrored on your &rmt; server.
    Packages are downloaded periodically once a day. But the download
@@ -154,7 +154,7 @@ Jun 22 04:22:34 d31 systemd[1]: Started RMT Mirror timer.</screen>
  </sect1>
 
  <sect1 xml:id="sec-rmt-mirroring-enable-disable">
-  <title>Enabling and Disabling Mirroring of Repositories</title>
+  <title>Enabling and disabling mirroring of repositories</title>
   <para>
    Mirroring of repositories can be enabled or disabled individually or by
    stating a product. You can specify one or more repositories or products at
@@ -166,7 +166,7 @@ Jun 22 04:22:34 d31 systemd[1]: Started RMT Mirror timer.</screen>
    product.
   </para>
   <sect2 xml:id="sec-rmt-mirroring-enable-disable-product">
-   <title>Using Products</title>
+   <title>Using products</title>
    <para>
     To enable or disable all repositories of a product, use the
     <command>rmt-cli products enable
@@ -209,7 +209,7 @@ Disabling SUSE Package Hub 15 x86_64:
 
  To clean up downloaded files, run 'rmt-cli repos clean'</screen>
 <tip>
- <title>Enabling and Disabling Multiple Products at Once</title>
+ <title>Enabling and disabling multiple products at once</title>
  <para>
   To enable or disable multiple products at once, specify a space delimited
   list of their IDs or product strings, for example:
@@ -243,7 +243,7 @@ Enabling SUSE Linux Enterprise Server 12 x86_64:
 
   </sect2>
   <sect2 xml:id="sec-rmt-mirroring-enable-disable-repository">
-   <title>Using Repositories</title>
+   <title>Using repositories</title>
    <para>
     To enable or disable mirroring of specific repositories, use the
     <command>rmt-cli repos enable
@@ -275,7 +275,7 @@ Repository by ID 3061 successfully disabled.
 To clean up downloaded files, please run 'rmt-cli repos clean'
 </screen>
 <tip>
- <title>Enabling and Disabling Multiple Repositories at Once</title>
+ <title>Enabling and disabling multiple repositories at once</title>
  <para>
   To enable or disable multiple repositories at once, specify a space delimited
   list of their IDs, for example:
@@ -295,7 +295,7 @@ To clean up downloaded files, please run 'rmt-cli repos clean'
  </sect1>
 
  <sect1 xml:id="sec-rmt-mirroring-delete">
-  <title>Deleting Mirrored Data</title>
+  <title>Deleting mirrored data</title>
   <para>
    After you disable the mirroring of a repository or product as described in <xref linkend="sec-rmt-mirroring-enable-disable"/>, the mirrored data still remains on your local hard disk. This includes the mirrored RPM packages.
   </para>
@@ -325,14 +325,14 @@ Deleted locally mirrored files from repository 'SLE15-Installer-Updates for sle-
 Clean finished. An estimated 157 MB were removed.
    </screen>
   <tip>
-   <title>Manually Remove Repository Data</title>
+   <title>Manually remove repository data</title>
    <para>To delete disabled repository data, manually remove its corresponding directory:</para>
    <screen>&prompt.sudo;<command>rm -r /usr/share/rmt/public/repo/SUSE/Products/<replaceable>PRODUCT</replaceable>/<replaceable>VERSION</replaceable>/<replaceable>ARCHITECTURE</replaceable>/</command></screen>
   </tip>
  </sect1>
 
  <sect1 xml:id="sec-rmt-mirroring-custom-repository">
-  <title>Adding Custom Repositories</title>
+  <title>Adding custom repositories</title>
   <para>
    You can mirror custom repositories with the &rmt; server. These
    repositories are not provided by the &scc;. Repositories can be
@@ -392,7 +392,7 @@ Clean finished. An estimated 157 MB were removed.
  </sect1>
 
  <sect1 xml:id="sec-rmt-mirroring-export-import">
-  <title>Exporting and Importing Repositories</title>
+  <title>Exporting and importing repositories</title>
   <para>
    &rmt; has built-in functions to import and export data about
    available repositories and the mirrored packages. For example, this
@@ -489,7 +489,7 @@ Clean finished. An estimated 157 MB were removed.
    </step>
   </procedure>
   <note>
-   <title>Exporting Enabled Settings from Air-Gapped Server</title>
+   <title>Exporting enabled settings from air-gapped server</title>
    <para>
     If your air-gapped server (<literal>sirius</literal>) has many
     enabled repositories, or if the enabled repositories change

--- a/xml/rmt_overview.xml
+++ b/xml/rmt_overview.xml
@@ -6,7 +6,7 @@
 ]>
 
 <preface xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="pre-rmt">
- <title>About This Guide</title>
+ <title>About this guide</title>
  <info/>
  <sect1>
   <title>Overview</title>
@@ -75,7 +75,7 @@
   </para>
  </sect1>
  <sect1>
-  <title>Additional Documentation and Resources</title>
+  <title>Additional documentation and resources</title>
 
   <para>
    Chapters in this manual contain links to additional documentation resources

--- a/xml/rmt_rmt-cli.xml
+++ b/xml/rmt_rmt-cli.xml
@@ -6,11 +6,11 @@
 ]>
 
 <sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="sec-rmt-tools-rmt-cli">
- <title>&rmt; Command Line Interface</title>
+ <title>&rmt; command line interface</title>
  <para/>
 
  <sect2 xml:id="sec-rmt-tools-rmt-cli-overview">
-  <title>rmt-cli Overview</title>
+  <title>rmt-cli overview</title>
   <para>
    The key command to manage the &rmt; is <command>rmt-cli</command>
    (<filename>/usr/bin/rmt-cli</filename>). The <command>rmt-cli</command> command

--- a/xml/rmt_systemd.xml
+++ b/xml/rmt_systemd.xml
@@ -6,7 +6,7 @@
 ]>
 
 <sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="sec-rmt-tools-systemd">
- <title>&rmt; &systemd; Commands</title>
+ <title>&rmt; &systemd; commands</title>
  <para>
   You can manage &rmt;-related services with the standard &systemd;
   commands. The &rmt; server has the following services and timers:

--- a/xml/rmt_tools.xml
+++ b/xml/rmt_tools.xml
@@ -6,7 +6,7 @@
 ]>
 
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-rmt-tools">
- <title>&rmt; Tools and Configuration Files</title>
+ <title>&rmt; tools and configuration files</title>
  <info/>
  <para>
   This chapter describes the most important scripts, configuration


### PR DESCRIPTION
### Description

* The new capitalization rules are documented at https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-capitalization, read carefully
* This is the result of an automatic conversion and will most likely need further adjustments
  * Make sure to review the entire diff
  * Entity files have not been changed and need to be updated manually
  * Some product/project names may have been inadvertently changed to the wrong capitalization
  * Some titles may have been missed, either because they're split across multiple source lines or because of improper markup
* Update the conversion commit and remove the (WIP) from the commit message before merging
* This is the twelfth PR in a series of 14 PRs


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [x] 15 SP3  | (`master` only)   
| [ ] 15 SP2  | [ ] 
| [ ] 15 SP1  | [ ] 
| [ ] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
