### PR TITLE
Update openSUSE guides to sentence case (WIP)

### DIFF
--- a/xml/art_opensuse_install_quick.xml
+++ b/xml/art_opensuse_install_quick.xml
@@ -42,7 +42,7 @@
   </para>
 
   <sect2 xml:id="sec-osuse-installquick-sysreqs">
-   <title>Minimum System Requirements</title>
+   <title>Minimum system requirements</title>
    <itemizedlist mark="bullet" spacing="normal">
     <listitem>
      <para>
@@ -76,7 +76,7 @@
     machine, or if you want to replace an existing Linux system.
    </para>
    <sect3 xml:id="sec-opensuse-installquick-boot">
-    <title>Booting the Installation System</title>
+    <title>Booting the installation system</title>
     <para>
      Insert a DVD or a bootable USB stick containing the installation image for
      &productname;, then reboot the computer to start the installation
@@ -109,7 +109,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-opensuse-installquick-language">
-    <title>Language, Keyboard and License Agreement</title>
+    <title>Language, keyboard and license agreement</title>
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
@@ -135,7 +135,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-opensuse-installquick-network">
-    <title>Network Settings</title>
+    <title>Network settings</title>
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
@@ -159,7 +159,7 @@
    </sect3>
 
    <sect3 xml:id="sec-opensuse-installquick-online-repos">
-    <title>Online Repositories</title>
+    <title>Online repositories</title>
     <para>
      A system analysis is performed, where the installer probes for storage
      devices, and tries to find other installed systems. If a network
@@ -247,7 +247,7 @@
    </sect3>
 
    <sect3 xml:id="sec-opensuse-installquick-ui">
-    <title>System Role</title>
+    <title>System role</title>
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
@@ -291,7 +291,7 @@
      <guimenu>Details</guimenu>, you can select individual packages.
     </para>
     <tip>
-     <title>Release Notes</title>
+     <title>Release notes</title>
      <para>
       From this point on, the Release Notes can be viewed from any screen
       during the installation process by selecting <guimenu>Release
@@ -301,7 +301,7 @@
    </sect3>
 
    <sect3 xml:id="sec-opensuse-installquick-partitioning">
-    <title>Suggested Partitioning</title>
+    <title>Suggested partitioning</title>
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
@@ -319,7 +319,7 @@
     </para>
     <variablelist>
      <varlistentry>
-      <term><guimenu>Guided Setup</guimenu>
+      <term><guimenu>Guided setup</guimenu>
       </term>
       <listitem>
        <para>
@@ -337,7 +337,7 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term><guimenu>Expert Partitioner</guimenu>
+      <term><guimenu>Expert partitioner</guimenu>
       </term>
       <listitem>
        <para>
@@ -351,7 +351,7 @@
     </variablelist>
 
     <note>
-     <title>Separate Home Partition</title>
+     <title>Separate home partition</title>
      <para>
       The default proposal no longer suggests to create a separate partition
       for <filename>/home</filename>. The <filename>/home</filename> directory
@@ -378,7 +378,7 @@
    </sect3>
 
    <sect3 xml:id="sec-opensuse-installquick-time">
-    <title>Clock and Time Zone</title>
+    <title>Clock and time zone</title>
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
@@ -399,7 +399,7 @@
    </sect3>
 
    <sect3 xml:id="sec-opensuse-installquick-user">
-    <title>Local User</title>
+    <title>Local user</title>
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
@@ -469,7 +469,7 @@
      with <guimenu>Next</guimenu>.
     </para>
     <tip>
-     <title>Passwords and Keyboard Layout</title>
+     <title>Passwords and keyboard layout</title>
      <para>
       It is recommended to only use characters that are available on an
       English keyboard. In case of a system error or when you need to start
@@ -487,7 +487,7 @@
    </sect3>
 
    <sect3 xml:id="sec-opensuse-installquick-inst-settings">
-    <title>Installation Settings</title>
+    <title>Installation settings</title>
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
@@ -507,7 +507,7 @@
      links.
     </para>
     <tip>
-     <title>Remote System Access</title>
+     <title>Remote system access</title>
      <para>
       Changes you can make in the <guimenu>Installation Settings</guimenu>,
       can also be made later at any time from the installed system. However,
@@ -547,7 +547,7 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term><guimenu>Default Systemd Target</guimenu>
+      <term><guimenu>Default systemd target</guimenu>
       </term>
       <listitem>
        <para>
@@ -595,7 +595,7 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term><guimenu>Network Configuration</guimenu>
+      <term><guimenu>Network configuration</guimenu>
       </term>
       <listitem>
        <para>
@@ -609,7 +609,7 @@
    </sect3>
 
    <sect3 xml:id="sec-opensuse-installquick-confirm">
-    <title>Start the Installation</title>
+    <title>Start the installation</title>
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
@@ -632,7 +632,7 @@
    </sect3>
 
    <sect3 xml:id="sec-opensuse-installquick-inst-process">
-    <title>The Installation Process</title>
+    <title>The installation process</title>
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">

--- a/xml/book_opensuse_reference.xml
+++ b/xml/book_opensuse_reference.xml
@@ -31,7 +31,7 @@
  <!-- Part: Advanced Administration                                         -->
  <!-- ===================================================================== -->
  <part xml:id="part-reference-adv-admin">
- <title>Advanced Administration</title>
+ <title>Advanced administration</title>
   <xi:include href="yast2_ncurses.xml"/>
   <xi:include href="sw_managing_commandline.xml"/>
   <xi:include href="snapper.xml"/>
@@ -77,7 +77,7 @@
  <!-- Part: Mobility                                                        -->
  <!-- ===================================================================== -->
  <part xml:id="part-reference-mobility">
-  <title>Mobile Computers</title>
+  <title>Mobile computers</title>
   <xi:include href="mobile.xml"/>
   <xi:include href="nm.xml" />
   <xi:include href="powermanagement.xml"/>

--- a/xml/book_opensuse_startup.xml
+++ b/xml/book_opensuse_startup.xml
@@ -46,7 +46,7 @@
 <!-- Part: Managing and Updating Software                                  -->
 <!-- ===================================================================== -->
  <part xml:id="part-reference-software">
-  <title>Managing and Updating Software</title>
+  <title>Managing and updating software</title>
   <xi:include href="yast2_sw.xml"/>
   <xi:include href="yast2_sw_addon_osuse.xml"/>
   <xi:include href="yast2_you.xml"/>
@@ -56,7 +56,7 @@
 <!-- Part: The Bash Shell                                                  -->
 <!-- ===================================================================== -->
  <part xml:id="part-bash">
-  <title>The Bash Shell</title>
+  <title>The Bash shell</title>
   <xi:include href="newbie_bash.xml"/>
   <xi:include href="adm_shell.xml"/>
  </part>
@@ -64,7 +64,7 @@
 <!-- Part: Help and Troubleshooting                                        -->
 <!-- ===================================================================== -->
  <part xml:id="part-help">
-  <title>Help and Troubleshooting</title>
+  <title>Help and troubleshooting</title>
   <xi:include href="help_admin.xml"/>
   <xi:include href="troubleshooting.xml"/>
  </part>

--- a/xml/common_intro_source_code_i.xml
+++ b/xml/common_intro_source_code_i.xml
@@ -8,7 +8,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Source Code</title>
+ <title>Source code</title>
  <para>
   The source code of &productname; is publicly available. Refer to <link
   xlink:href="http://en.opensuse.org/Source_code"/> for download links and more

--- a/xml/mobile.xml
+++ b/xml/mobile.xml
@@ -5,7 +5,7 @@
     %entities;
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-mobile">
- <title>Mobile Computing with Linux</title>
+ <title>Mobile computing with Linux</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -46,7 +46,7 @@
   </para>
 
   <sect2 xml:id="sec-mobile-powerm">
-   <title>Power Conservation</title><indexterm>
+   <title>Power conservation</title><indexterm>
    <primary>laptops</primary>
    <secondary>power management</secondary></indexterm><indexterm>
    <primary>power management</primary></indexterm>
@@ -95,7 +95,7 @@
   </sect2>
 
   <sect2 xml:id="sec-mobile-nbook-change">
-   <title>Integration in Changing Operating Environments</title><indexterm>
+   <title>Integration in changing operating environments</title><indexterm>
    <primary>laptops</primary></indexterm>
    <para>
     Your system needs to adapt to changing operating environments when used for
@@ -104,7 +104,7 @@
     for you.
    </para>
    <figure xml:id="fig-mobile-scpm">
-    <title>Integrating a Mobile Computer in an Existing Environment</title>
+    <title>Integrating a mobile computer in an existing environment</title>
     <mediaobject>
      <imageobject role="fo">
       <imagedata width="90%" fileref="mobile_scpm.svg" format="SVG"/>
@@ -138,7 +138,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>E-Mail and Proxies</term>
+     <term>E-mail and proxies</term>
      <listitem>
       <para>
        As with printing, the list of the corresponding servers must be current.
@@ -146,7 +146,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>X (Graphical Environment)</term>
+     <term>X (graphical environment)</term>
      <listitem>
       <para>
        If your laptop is temporarily connected to a projector or an external
@@ -178,7 +178,7 @@
        For more information, see <xref linkend="sec-nm-configure"/>.
       </para>
       <table>
-       <title>Use Cases for &nm;</title>
+       <title>Use cases for &nm;</title>
        <tgroup cols="2">
         <thead>
          <row>
@@ -251,7 +251,7 @@
        handle network configuration.
       </para>
       <tip>
-       <title>DNS Configuration and Various Types of Network Connections</title>
+       <title>DNS configuration and various types of network connections</title>
        <para>
         If you travel frequently with your laptop and change different types of
         network connections, &nm; works fine when all DNS addresses are
@@ -289,7 +289,7 @@
   </sect2>
 
   <sect2 xml:id="sec-mobile-nbook-soft">
-   <title>Software Options</title>
+   <title>Software options</title>
    <para>
     There are various task areas in mobile use that are covered by dedicated
     software: system monitoring (especially the battery charge), data
@@ -298,14 +298,14 @@
     &productname; provides for each task.
    </para>
    <sect3 xml:id="sec-mobile-nbook-soft-mon">
-    <title>System Monitoring</title><indexterm>
+    <title>System monitoring</title><indexterm>
     <primary>system monitoring</primary></indexterm>
     <para>
      Two system monitoring tools are provided by &productname;:
     </para>
     <variablelist>
      <varlistentry>
-      <term>Power Management</term>
+      <term>Power management</term>
       <listitem>
        <para>
         <indexterm>
@@ -323,7 +323,7 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term>System Monitor</term>
+      <term>System monitor</term>
       <listitem>
        <para>
         <indexterm>
@@ -349,7 +349,7 @@
     </variablelist>
    </sect3>
    <sect3 xml:id="sec-mobile-nbook-soft-sync">
-    <title>Synchronizing Data</title>
+    <title>Synchronizing data</title>
     <para>
      When switching between working on a mobile machine disconnected from the
      network and working at a networked workstation in an office, it is
@@ -360,7 +360,7 @@
     </para>
     <variablelist>
      <varlistentry>
-      <term>Synchronizing E-Mail</term>
+      <term>Synchronizing e-mail</term>
       <listitem>
        <para>
         <indexterm>
@@ -383,7 +383,7 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term>Synchronizing Files and Directories</term>
+      <term>Synchronizing files and directories</term>
       <listitem>
        <para>
         <indexterm>
@@ -398,7 +398,7 @@
     </variablelist>
    </sect3>
    <sect3 xml:id="sec-mobile-nbook-soft-wifi">
-    <title>Wireless Communication: Wi-Fi</title><indexterm>
+    <title>Wireless communication: Wi-fi</title><indexterm>
     <primary>networks</primary>
     <secondary>Wi-Fi</secondary></indexterm>
     <para>
@@ -423,7 +423,7 @@
      implement hardware with proprietary or draft features.
     </para>
     <table xml:id="tab-mobile-wifistd">
-     <title>Overview of Various Wi-Fi Standards</title>
+     <title>Overview of various Wi-fi standards</title>
      <tgroup cols="4">
       <thead>
        <row>
@@ -593,7 +593,7 @@
      802.11n standard, but cards using 802.11g are still available.
     </para>
     <sect4 xml:id="sec-mobile-wlan-modes">
-     <title>Operating Modes</title>
+     <title>Operating modes</title>
      <para>
       In wireless networking, various techniques and configurations are used to
       ensure fast, high-quality, and secure connections. Usually your Wi-Fi
@@ -603,7 +603,7 @@
      </para>
      <variablelist>
       <varlistentry>
-       <term>Managed Mode (Infrastructure Mode), via Access Point (default mode)</term>
+       <term>Managed mode (infrastructure mode), via access point (default mode)</term>
        <listitem>
         <para>
          Managed networks have a managing element: the access point. In this
@@ -617,7 +617,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term>Ad-hoc Mode (Peer-to-Peer Network)</term>
+       <term>Ad-hoc mode (peer-to-peer network)</term>
        <listitem>
         <para>
          Ad-hoc networks do not have an access point. The stations communicate
@@ -630,7 +630,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term>Master Mode</term>
+       <term>Master mode</term>
        <listitem>
         <para>
          In master mode, your Wi-Fi card is used as the access point, assuming
@@ -640,7 +640,7 @@
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term>Mesh Mode</term>
+       <term>Mesh mode</term>
        <listitem>
         <para>
          Wireless mesh networks are organized in a <emphasis>mesh
@@ -728,7 +728,7 @@
     </sect4>
    </sect3>
    <sect3 xml:id="sec-mobile-nbook-soft-bluetooth">
-    <title>Wireless Communication: Bluetooth</title>
+    <title>Wireless communication: Bluetooth</title>
     <para>
      <indexterm>
      <primary>networks</primary>
@@ -746,7 +746,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-mobile-nbook-soft-irda">
-    <title>Wireless Communication: IrDA</title>
+    <title>Wireless communication: IrDA</title>
     <para>
      <indexterm>
      <primary>networks</primary>
@@ -766,7 +766,7 @@
   </sect2>
 
   <sect2 xml:id="sec-mobile-nbook-sec">
-   <title>Data Security</title><indexterm>
+   <title>Data security</title><indexterm>
    <primary>mobility</primary>
    <secondary>data security</secondary></indexterm><indexterm>
    <primary>security</primary>
@@ -779,7 +779,7 @@
    </para>
    <variablelist>
     <varlistentry>
-     <term>Protection against Theft</term>
+     <term>Protection against theft</term>
      <listitem>
       <para>
        Always physically secure your system against theft whenever possible.
@@ -788,7 +788,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Strong Authentication</term>
+     <term>Strong authentication</term>
      <listitem>
       <para>
        Use biometric authentication in addition to standard authentication via
@@ -797,7 +797,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Securing Data on the System</term>
+     <term>Securing data on the system</term>
      <listitem>
       <para>
        Important data should not only be encrypted during transmission, but
@@ -807,7 +807,7 @@
        create encrypted home directories when adding the user with &yast;.
       </para>
       <important>
-       <title>Data Security and Suspend to Disk</title>
+       <title>Data security and suspend to disk</title>
        <para>
         Encrypted partitions are not unmounted during a suspend to disk event.
         Thus, all data on these partitions is available to any party who
@@ -817,7 +817,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Network Security</term>
+     <term>Network security</term>
      <listitem>
       <para>
        Any transfer of data should be secured, no matter how the transfer is
@@ -830,7 +830,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-mobile-hw">
-  <title>Mobile Hardware</title><indexterm>
+  <title>Mobile hardware</title><indexterm>
 
   <primary>mobility</primary>
 
@@ -878,7 +878,7 @@
 
   <variablelist>
    <varlistentry>
-    <term>External Hard Disks (USB and FireWire)</term>
+    <term>External hard disks (USB and FireWire)</term>
     <listitem>
      <para>
       When an external hard disk is correctly recognized by the system, its
@@ -906,7 +906,7 @@
     </listitem>
    </varlistentry>
    <varlistentry os="sled;osuse">
-    <term>Digital Cameras (USB and FireWire)</term>
+    <term>Digital cameras (USB and FireWire)</term>
     <listitem>
      <para>
       Digital cameras recognized by the system also appear as external drives
@@ -920,7 +920,7 @@
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-mobile-comm">
-  <title>Mobile Devices (Smartphones and Tablets)</title><indexterm>
+  <title>Mobile devices (smartphones and tablets)</title><indexterm>
 
   <primary>mobility</primary>
 
@@ -951,7 +951,7 @@
  </sect1>
  <!-- This section is outdated  and somewhat redundant dpopov 2019-09-27
       <sect1 xml:id="sec-mobile-info">
-  <title>For More Information</title>
+  <title>For more information</title>
 
   <para>
    The central point of reference for all questions regarding mobile devices

--- a/xml/mobile.xml
+++ b/xml/mobile.xml
@@ -398,7 +398,7 @@
     </variablelist>
    </sect3>
    <sect3 xml:id="sec-mobile-nbook-soft-wifi">
-    <title>Wireless communication: Wi-fi</title><indexterm>
+    <title>Wireless communication: Wi-Fi</title><indexterm>
     <primary>networks</primary>
     <secondary>Wi-Fi</secondary></indexterm>
     <para>
@@ -423,7 +423,7 @@
      implement hardware with proprietary or draft features.
     </para>
     <table xml:id="tab-mobile-wifistd">
-     <title>Overview of various Wi-fi standards</title>
+     <title>Overview of various Wi-Fi standards</title>
      <tgroup cols="4">
       <thead>
        <row>

--- a/xml/newbie_bash.xml
+++ b/xml/newbie_bash.xml
@@ -869,7 +869,7 @@ drwxr-xr-x 1 tux users  70733 2015-06-21 09:35 public_html
   </sect2>
  </sect1>
  <sect1 xml:id="sec-new-bash-root">
-  <title>Becoming root</title>
+	 <title>Becoming &rootuser;</title>
 
   <para>
    &rootuser;, also called the superuser, has privileges which authorize them

--- a/xml/newbie_bash.xml
+++ b/xml/newbie_bash.xml
@@ -869,7 +869,7 @@ drwxr-xr-x 1 tux users  70733 2015-06-21 09:35 public_html
   </sect2>
  </sect1>
  <sect1 xml:id="sec-new-bash-root">
-	 <title>Becoming &rootuser;</title>
+  <title>Becoming &rootuser;</title>
 
   <para>
    &rootuser;, also called the superuser, has privileges which authorize them

--- a/xml/newbie_bash.xml
+++ b/xml/newbie_bash.xml
@@ -8,7 +8,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Shell Basics</title>
+ <title>Shell basics</title>
  <para>
   When working with Linux, you can communicate with the system
   almost without ever requiring a command line interpreter (the shell).
@@ -40,7 +40,7 @@
   <xref linkend="cha-adm-shell"/>.
  </para>
  <sect1 xml:id="sec-new-bash-start">
-  <title>Starting a Shell</title>
+  <title>Starting a shell</title>
 
   <para>
    Basically, there are two different ways to start a shell from the
@@ -138,7 +138,7 @@ tux@linux:~&gt;</screen>
   </para>
  </sect1>
  <sect1 xml:id="sec-new-bash-commands">
-  <title>Entering Commands</title>
+  <title>Entering commands</title>
 
   <para>
    As soon as the prompt appears on the shell it is ready to receive and
@@ -157,7 +157,7 @@ tux@linux:~&gt;</screen>
   </para>
 
   <important>
-   <title>No News Is Good News</title>
+   <title>No news is good news</title>
    <para>
     The shell is not verbose: in contrast to some graphical user interfaces,
     it usually does not provide confirmation messages when commands have
@@ -174,7 +174,7 @@ tux@linux:~&gt;</screen>
   </important>
 
   <sect2 xml:id="sec-new-bash-commands-simple">
-   <title>Using Commands without Options</title>
+   <title>Using commands without options</title>
    <para>
     In <xref linkend="sec-new-bash-accperm-ugo"/> you already got to know
     one of the most basic commands: <command>ls</command>,
@@ -196,7 +196,7 @@ bin Desktop Documents public_html tux.txt
   </sect2>
 
   <sect2 xml:id="sec-new-bash-commands-options">
-   <title>Using Commands with Options</title>
+   <title>Using commands with options</title>
    <para>
     A better way to get more details about the contents of a
     directory is using the <command>ls</command> command with a string of
@@ -308,7 +308,7 @@ drwxr-xr-x 1 tux users  70733 2015-06-21 09:35 public_html
   </sect2>
 
   <sect2 xml:id="sec-new-bash-commands-shortcuts">
-   <title>Bash Shortcut Keys</title>
+   <title>Bash shortcut keys</title>
    <para>
     After having entered several commands, your shell will begin to fill up
     with all sorts of commands and the corresponding outputs. In the
@@ -443,7 +443,7 @@ drwxr-xr-x 1 tux users  70733 2015-06-21 09:35 public_html
  </sect1>
 
  <sect1 xml:id="sec-new-bash-commands-help">
-  <title>Getting Help</title>
+  <title>Getting help</title>
   <para>
    If you remember the name of command but are not sure about the options or
    the syntax of the command, choose one of the following possibilities:
@@ -462,7 +462,7 @@ drwxr-xr-x 1 tux users  70733 2015-06-21 09:35 public_html
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Manual Pages</term>
+    <term>Manual pages</term>
     <listitem>
      <para>
       To learn more about the various commands, you can also use the manual
@@ -500,7 +500,7 @@ drwxr-xr-x 1 tux users  70733 2015-06-21 09:35 public_html
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Info Pages</term>
+    <term>Info pages</term>
     <listitem>
      <para>
       Info pages usually provide even more information about commands. To
@@ -544,7 +544,7 @@ drwxr-xr-x 1 tux users  70733 2015-06-21 09:35 public_html
  </sect1>
 
  <sect1 xml:id="sec-new-bash-fildir">
-  <title>Working with Files and Directories</title>
+  <title>Working with files and directories</title>
 
   <para>
    To address a certain file or directory, you must specify the path leading
@@ -553,7 +553,7 @@ drwxr-xr-x 1 tux users  70733 2015-06-21 09:35 public_html
 
   <variablelist>
    <varlistentry>
-    <term>Absolute Path
+    <term>Absolute path
     </term>
     <listitem>
      <para>
@@ -566,7 +566,7 @@ drwxr-xr-x 1 tux users  70733 2015-06-21 09:35 public_html
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Relative Path
+    <term>Relative path
     </term>
     <listitem>
      <para>
@@ -602,7 +602,7 @@ drwxr-xr-x 1 tux users  70733 2015-06-21 09:35 public_html
   </para>
 
   <note>
-   <title>Handling Blanks in Filenames or Directory Names</title>
+   <title>Handling blanks in filenames or directory names</title>
    <para>
     If a filename or the name of a directory contains a space, either escape
     the space using a back slash (<literal>\</literal>) in front of the
@@ -672,14 +672,14 @@ drwxr-xr-x 1 tux users  70733 2015-06-21 09:35 public_html
 
   <sect2
    xml:id="sec-new-bash-fildir-ex">
-   <title>Examples for Working with Files and Directories</title>
+   <title>Examples for working with files and directories</title>
    <para>
     Suppose you want to copy a file located somewhere in your home directory
     to a subdirectory of <filename>/tmp</filename> that you need to create
     first.
    </para>
    <procedure>
-    <title>Creating and Changing Directories</title>
+    <title>Creating and changing directories</title>
     <para>
      From your home directory create a subdirectory in
      <filename>/tmp</filename>:
@@ -715,14 +715,14 @@ drwxr-xr-x 1 tux users  70733 2015-06-21 09:35 public_html
     </step>
    </procedure>
    <procedure>
-    <title>Creating and Copying Files</title>
+    <title>Creating and copying files</title>
     <para>
      Now create a new file in a subdirectory of your home directory and copy
      it to <filename>/tmp/test</filename>. Use a relative path for this
      task.
     </para>
     <important>
-     <title>Overwriting of Existing Files</title>
+     <title>Overwriting of existing files</title>
      <para>
       Before copying, moving or renaming a file, check if your target
       directory already contains a file with the same name. If yes, consider
@@ -793,7 +793,7 @@ drwxr-xr-x 1 tux users  70733 2015-06-21 09:35 public_html
     </step>
    </procedure>
    <procedure>
-    <title>Renaming and Removing Files or Directories</title>
+    <title>Renaming and removing files or directories</title>
     <para>
      Now suppose you want to rename <filename>myfile.txt </filename> into
      <filename>tuxfile.txt</filename>. Finally you decide to remove the
@@ -869,7 +869,7 @@ drwxr-xr-x 1 tux users  70733 2015-06-21 09:35 public_html
   </sect2>
  </sect1>
  <sect1 xml:id="sec-new-bash-root">
-  <title>Becoming Root</title>
+  <title>Becoming root</title>
 
   <para>
    &rootuser;, also called the superuser, has privileges which authorize them
@@ -964,7 +964,7 @@ drwxr-xr-x 1 tux users  70733 2015-06-21 09:35 public_html
  <xi:include href="newbie_perm_i.xml"/>
 
  <sect1 xml:id="sec-new-bash-feat">
-  <title>Time-Saving Features of Bash</title>
+  <title>Time-saving features of Bash</title>
 
   <para>
    Entering commands in Bash can involve a lot of typing. This section
@@ -1037,7 +1037,7 @@ drwxr-xr-x 1 tux users  70733 2015-06-21 09:35 public_html
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Wild Cards</term>
+    <term>Wild cards</term>
     <listitem>
      <para>
       You can replace one or more characters in a filename with a wild card
@@ -1105,13 +1105,13 @@ drwxr-xr-x 1 tux users  70733 2015-06-21 09:35 public_html
   </variablelist>
 
   <sect2 xml:id="sec-new-bash-feat-ex">
-   <title>Examples For Using History, Completion and Wildcards</title>
+   <title>Examples for using history, completion and wildcards</title>
    <para>
     The following examples illustrate how to make use of these convenient
     features of Bash.
    </para>
    <procedure>
-    <title>Using History and Completion</title>
+    <title>Using history and completion</title>
     <para>
      If you already did the example <xref linkend="sec-new-bash-fildir-ex"/>,
      your shell buffer should be filled with commands which you can retrieve
@@ -1169,7 +1169,7 @@ Desktop/ Documents/ Downloads/
     </step>
    </procedure>
    <procedure>
-    <title>Using Wildcards</title>
+    <title>Using wildcards</title>
     <para>
      Now suppose that your home directory contains several files with
      various file extensions. It also holds several versions of one file
@@ -1287,7 +1287,7 @@ Desktop/ Documents/ Downloads/
     files with the extension <filename>.txt</filename> available.
    </para>
    <note>
-    <title>Using Wildcards in <command>rm</command> Commands</title>
+    <title>Using wildcards in <command>rm</command> commands</title>
     <para>
      Wildcards in a <command>rm </command> command can be very useful but
      also dangerous: you might delete more files from your directory than
@@ -1299,7 +1299,7 @@ Desktop/ Documents/ Downloads/
   </sect2>
  </sect1>
  <sect1 xml:id="sec-new-bash-edit">
-  <title>Editing Texts</title>
+  <title>Editing texts</title>
 
   <para>
    In order to edit files from the command line, you will need to know the
@@ -1350,10 +1350,10 @@ Desktop/ Documents/ Downloads/
   </para>
 
   <sect2 xml:id="sec-new-bash-edit-ex">
-   <title>Example: Editing with vi</title>
+   <title>Example: editing with vi</title>
    <procedure>
     <note>
-     <title>Display of Keys</title>
+     <title>Display of keys</title>
      <para>
       In the following, find several commands that you can enter in vi by
       just pressing keys. These appear in uppercase as on a keyboard. If you
@@ -1421,7 +1421,7 @@ Desktop/ Documents/ Downloads/
   </sect2>
  </sect1>
  <sect1 xml:id="sec-new-bash-search">
-  <title>Searching for Files or Contents</title>
+  <title>Searching for files or contents</title>
 
   <para>
    Bash offers you several commands to search for files and to search for
@@ -1459,7 +1459,7 @@ Desktop/ Documents/ Downloads/
   </variablelist>
 
   <sect2>
-   <title>Examples for Searching</title>
+   <title>Examples for searching</title>
    <itemizedlist>
     <listitem>
      <para>
@@ -1493,7 +1493,7 @@ Desktop/ Documents/ Downloads/
   </sect2>
  </sect1>
  <sect1 xml:id="sec-new-bash-view">
-  <title>Viewing Text Files</title>
+  <title>Viewing text files</title>
 
   <para>
    When searching for the contents of a file with <command>grep</command>,
@@ -1570,7 +1570,7 @@ Desktop/ Documents/ Downloads/
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-new-bash-redir">
-  <title>Redirection and Pipes</title>
+  <title>Redirection and pipes</title>
   <para>
    Sometimes it would be useful if you could write the output of a command
    to a file for further editing or if you could combine several commands,
@@ -1611,7 +1611,7 @@ Desktop/ Documents/ Downloads/
   </variablelist>
 
   <sect2 xml:id="sec-new-bash-redir-ex">
-   <title>Examples for Redirection and Pipe</title>
+   <title>Examples for redirection and pipe</title>
    <procedure>
     <step>
      <para>
@@ -1676,7 +1676,7 @@ Desktop/ Documents/ Downloads/
   </sect2>
  </sect1>
  <sect1 xml:id="sec-new-bash-jobs">
-  <title>Starting Programs and Handling Processes</title>
+  <title>Starting programs and handling processes</title>
 
   <para>
    As you have seen in <xref linkend="sec-new-bash-edit"/>, programs can be
@@ -1785,7 +1785,7 @@ PID TTY          TIME CMD
  </sect1>
 
  <sect1 xml:id="sec-bash-tar">
-  <title>Archives and Data Compression</title>
+  <title>Archives and data compression</title>
   <para>
    On Linux, there are two types of commands that make data easier to
    transfer:
@@ -1817,7 +1817,7 @@ PID TTY          TIME CMD
    <filename>testarchive.tar</filename>, do the following:
   </para>
   <procedure xml:id="pro-bash-archive">
-   <title>Archiving Files</title>
+   <title>Archiving files</title>
    <step>
     <para>
      Open a shell.
@@ -1868,7 +1868,7 @@ PID TTY          TIME CMD
    compression, <command>bzip2</command>.
   </para>
   <procedure xml:id="pro-bash-compress">
-   <title>Compressing a File</title>
+   <title>Compressing a file</title>
    <step>
     <para>
      For this example, reuse the archive

--- a/xml/newbie_bash_commands_i.xml
+++ b/xml/newbie_bash_commands_i.xml
@@ -487,7 +487,7 @@
       </para>
       <variablelist>
        <varlistentry>
-        <term></term>
+        <term>-n</term>
         <listitem>
          <para>
           Numbers the output on the left margin

--- a/xml/newbie_bash_commands_i.xml
+++ b/xml/newbie_bash_commands_i.xml
@@ -8,7 +8,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Important Linux Commands</title>
+ <title>Important Linux commands</title>
  <para>
   This section provides an overview of the most important Linux commands. There are
   many more commands than listed in this chapter. Along with the individual
@@ -23,14 +23,14 @@
  </para>
 
  <sect2 xml:id="sec-commands-file">
-  <title>File Commands</title>
+  <title>File commands</title>
   <para>
    The following section lists the most important commands for file
    management. It covers everything from general file administration to the
    manipulation of file system ACLs.
   </para>
   <sect3 xml:id="sec-shell-fileadmin">
-   <title>File Administration</title>
+   <title>File administration</title>
    <variablelist>
     <varlistentry>
      <term><command>ls</command>&#x20;<replaceable>OPTIONS</replaceable>&#x20;<replaceable>FILES</replaceable></term>
@@ -453,7 +453,7 @@
    </variablelist>
   </sect3>
   <sect3 xml:id="sec-commands-filecontents">
-   <title>Commands to Access File Contents</title>
+   <title>Commands to access file contents</title>
    <variablelist>
     <varlistentry>
      <term><command>file</command>&#x20;<replaceable>OPTIONS</replaceable>&#x20;<replaceable>FILES</replaceable></term>
@@ -487,7 +487,7 @@
       </para>
       <variablelist>
        <varlistentry>
-        <term>-n</term>
+        <term></term>
         <listitem>
          <para>
           Numbers the output on the left margin
@@ -592,7 +592,7 @@
   </sect3>
 <!-- ** -->
   <sect3 xml:id="sec-commands-filesystems">
-   <title>File Systems</title>
+   <title>File systems</title>
    <variablelist>
     <varlistentry>
      <term><command>mount</command>&#x20;<replaceable>OPTIONS</replaceable>&#x20;<replaceable>DEVICE</replaceable>&#x20;<replaceable>MOUNT_POINT</replaceable></term>
@@ -655,14 +655,14 @@
  </sect2>
 
  <sect2 xml:id="sec-commands-system">
-  <title>System Commands</title>
+  <title>System commands</title>
   <para>
    The following section lists a few of the most important commands needed
    for retrieving system information and controlling processes and the
    network.
   </para>
   <sect3 xml:id="sec-commands-systeminfo">
-   <title>System Information</title>
+   <title>System information</title>
    <variablelist>
     <varlistentry>
      <term><command>df</command>&#x20;<replaceable>OPTIONS</replaceable>&#x20;<replaceable>DIRECTORY</replaceable></term>
@@ -983,7 +983,7 @@
  </sect2>
 
  <sect2 xml:id="sec-shell-commands-info">
-  <title>For More Information</title>
+  <title>For more information</title>
   <para>
    There are many more commands than listed in this chapter. For information
    about other commands or more detailed information, also see the

--- a/xml/newbie_perm_i.xml
+++ b/xml/newbie_perm_i.xml
@@ -8,7 +8,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>File Access Permissions</title>
+ <title>File access permissions</title>
 
  <para>
   In Linux, objects such as files or folders or processes generally belong
@@ -34,7 +34,7 @@
  </para>
 
  <sect2 xml:id="sec-new-bash-accperm-ugo">
-  <title>Permissions for User, Group and Others</title>
+  <title>Permissions for user, group and others</title>
   <para>
    Three permission sets are defined for each file object on a Linux system.
    These sets include the read, write, and execute permissions for each of
@@ -47,7 +47,7 @@
    that directory.
   </para>
   <example xml:id="ex-new-users-accperm-ugo">
-   <title>Access Permissions For Files and Folders</title>
+   <title>Access permissions for files and folders</title>
 <screen>-rw-r----- 1 &exampleuser_plain; &examplegroup_plain;      0 2015-06-23 16:08 checklist.txt
 -rw-r--r-- 1 &exampleuser_plain; &examplegroup_plain;  53279 2015-06-21 13:16 gnome_quick.xml
 -rw-rw---- 1 &exampleuser_plain; &examplegroup_plain;      0 2015-06-23 16:08 index.htm
@@ -142,14 +142,14 @@ drwxr-xr-x 2 &exampleuser_plain; &examplegroup_plain;     48 2015-06-23 16:09 lo
  </sect2>
 
  <sect2 xml:id="sec-new-bash-accperm-impact">
-  <title>Files and Folders</title>
+  <title>Files and folders</title>
   <para>
    Access permissions have a slightly different impact depending on the type
    of object they apply to: file or directory. The following table shows the
    details:
   </para>
   <table xml:id="tab-new-users-accperm-impact">
-   <title>Access Permissions For Files And Directories</title>
+   <title>Access permissions for files and directories</title>
    <tgroup cols="3">
     <thead>
      <row>
@@ -249,7 +249,7 @@ drwxr-xr-x 2 &exampleuser_plain; &examplegroup_plain;     48 2015-06-23 16:09 lo
  </sect2>
 
  <sect2 xml:id="sec-new-bash-perm">
-  <title>Modifying File Permissions</title>
+  <title>Modifying file permissions</title>
   <para>
    In Linux, objects such as files or folder or processes generally belong
    to the user who created or initiated them. The group which is associated
@@ -299,13 +299,13 @@ drwxr-xr-x 2 &exampleuser_plain; &examplegroup_plain;     48 2015-06-23 16:09 lo
    (change owner) you can transfer ownership to a new user.
   </para>
   <sect3 xml:id="sec-new-bash-perm-ex">
-   <title>Examples for Changing Access Permissions and Ownership</title>
+   <title>Examples for changing access permissions and ownership</title>
    <para>
     The following example shows the output of an <command>ls</command>
     <option>-l</option> command in a shell.
    </para>
    <example xml:id="ex-new-bash-accperm-ugo">
-    <title>Access Permissions For Files and Folders</title>
+    <title>Access permissions for files and folders</title>
 <screen>-rw-r----- 1 &exampleuser_plain; &examplegroup_plain;      0 2015-06-23 16:08 checklist.txt
 -rw-r--r-- 1 &exampleuser_plain; &examplegroup_plain;  53279 2015-06-21 13:16 gnome_quick.xml
 -rw-rw---- 1 &exampleuser_plain; &examplegroup_plain;      0 2015-06-23 16:08 index.htm
@@ -323,7 +323,7 @@ drwxr-xr-x 2 &exampleuser_plain; &examplegroup_plain;     48 2015-06-23 16:09 lo
     third block of characters.
    </para>
    <procedure>
-    <title>Changing Access Permissions</title>
+    <title>Changing access permissions</title>
     <para>
      Suppose you are &exampleuser; and want to
      modify the access permissions to your files:
@@ -372,7 +372,7 @@ drwxr-xr-x 2 &exampleuser_plain; &examplegroup_plain;     48 2015-06-23 16:09 lo
     </step>
    </procedure>
    <procedure>
-    <title>Changing Ownership</title>
+    <title>Changing ownership</title>
     <para>
      Suppose you are &exampleuser; and want to
      transfer the ownership of the file <filename>kde_quick.xml</filename>

--- a/xml/opensuse_reference_intro.xml
+++ b/xml/opensuse_reference_intro.xml
@@ -8,7 +8,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>About This Guide</title>
+ <title>About this guide</title>
  <para>
   This manual gives you a general understanding of &productnamereg;. It is
   intended mainly for system administrators and home users with basic system
@@ -18,7 +18,7 @@
  </para>
  <variablelist>
   <varlistentry>
-   <term>Advanced Administration</term>
+   <term>Advanced administration</term>
    <listitem>
     <para>
      Learn about advanced adminstrations tasks such as using &yast; in text
@@ -47,7 +47,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>Mobile Computers</term>
+   <term>Mobile computers</term>
    <listitem>
     <para>
      Get an introduction to mobile computing with &productname;, get to know

--- a/xml/opensuse_startup_intro.xml
+++ b/xml/opensuse_startup_intro.xml
@@ -8,7 +8,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>About This Guide</title>
+ <title>About this guide</title>
  <para>
   &abstract_osuse_startup;
  </para>
@@ -35,7 +35,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>Managing and Updating Software</term>
+   <term>Managing and updating software</term>
    <listitem>
     <para>
      Understand how to install or remove software with either &yast; or
@@ -45,7 +45,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>The Bash Shell</term>
+   <term>The Bash shell</term>
    <listitem>
     <para>
      Learn how to work with the bash shell, the default command line
@@ -55,7 +55,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>Help and Troubleshooting</term>
+   <term>Help and troubleshooting</term>
    <listitem>
     <para>
      Provides an overview of where to find help and additional documentation

--- a/xml/opensuse_update.xml
+++ b/xml/opensuse_update.xml
@@ -8,7 +8,7 @@
        xmlns:xi="http://www.w3.org/2001/XInclude"
        xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0"
        xml:id="cha-update-osuse">
- <title>Upgrading the System and System Changes</title>
+ <title>Upgrading the system and system changes</title>
  <info>
   <abstract>
    <para>
@@ -24,7 +24,7 @@
   </abstract>
  </info>
  <sect1 xml:id="sec-update-suselinux">
-  <title>Upgrading the System</title>
+  <title>Upgrading the system</title>
  <important>
   <title>
    &productname; &productnumber; is only available as
@@ -90,7 +90,7 @@ udev           252M  124K  252M   1% /dev
   </sect2>
 
   <sect2>
-   <title>Possible Problems</title>
+   <title>Possible problems</title>
    <para>
     If you upgrade a default system from the previous version to this
     version, &yast; works out the necessary changes and performs them.
@@ -111,7 +111,7 @@ udev           252M  124K  252M   1% /dev
     </para>
    </sect3>
    <sect3>
-    <title>Shut Down Virtual Machines</title>
+    <title>Shut down virtual machines</title>
     <para>
      If your machine serves as a &vmhost; for &kvm; or &xen;, make sure to
      properly shut down all running &vmguest;s prior to the update. Otherwise
@@ -211,7 +211,7 @@ udev           252M  124K  252M   1% /dev
      </para>
      <!-- cwickert 2016-03-23: This seems no longer necessary or possible -->
      <!-- <warning>
-      <title>Persistent Device Names</title>
+      <title>Persistent device names</title>
       <para>
        All entries in <filename>/etc/fstab</filename> that specify
        partitions to be mounted using the kernel-device name must be changed
@@ -233,7 +233,7 @@ udev           252M  124K  252M   1% /dev
       </mediaobject>
      </informalfigure>
      <tip>
-      <title>Release Notes</title>
+      <title>Release notes</title>
       <para>
        From this point on, the Release Notes can be viewed from any screen
        during the installation process by selecting <guimenu>Release
@@ -369,7 +369,7 @@ udev           252M  124K  252M   1% /dev
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term><guimenu>Update Options</guimenu>
+       <term><guimenu>Update options</guimenu>
        </term>
        <listitem>
         <para>
@@ -426,7 +426,7 @@ udev           252M  124K  252M   1% /dev
        </listitem>
       </varlistentry>
       <varlistentry>
-       <term><guimenu>Keyboard Layout</guimenu>
+       <term><guimenu>Keyboard layout</guimenu>
        </term>
        <listitem>
         <para>
@@ -501,7 +501,7 @@ udev           252M  124K  252M   1% /dev
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="zypper_upgrade.xml"/>
 
   <sect2 xml:id="sec-update-packages" os="osuse">
-   <title>Updating Individual Packages</title>
+   <title>Updating individual packages</title>
    <para>
     Regardless of your overall updated environment, you can always update
     individual packages. From this point on, however, it is your
@@ -522,7 +522,7 @@ udev           252M  124K  252M   1% /dev
   </sect2>
  </sect1>
  <sect1 xml:id="sec-update-version" os="osuse">
-  <title>Additional Information</title>
+  <title>Additional information</title>
 
   <para>
    Problems and special issues of the various versions are published online

--- a/xml/yast2_sw_addon_osuse.xml
+++ b/xml/yast2_sw_addon_osuse.xml
@@ -8,7 +8,7 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Installing Add-On Products</title>
+ <title>Installing add-on products</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker>
@@ -32,7 +32,7 @@
   </abstract>
  </info>
  <sect1 xml:id="sec-add-ons-addon">
-  <title>Add-Ons</title>
+  <title>Add-ons</title>
 
   <para>
    To install a new add-on, proceed as follows:
@@ -109,7 +109,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-add-ons-drivers">
-  <title>Binary Drivers</title>  <para>
+  <title>Binary drivers</title>  <para>
    Some hardware needs binary-only drivers to function properly. If you have
    such hardware, refer to the release notes for more information about
    availability of binary drivers for your system. To read the release

--- a/xml/zypper_upgrade.xml
+++ b/xml/zypper_upgrade.xml
@@ -8,7 +8,7 @@
  xmlns="http://docbook.org/ns/docbook"
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Distribution Upgrade with Zypper</title>
+ <title>Distribution upgrade with Zypper</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -24,7 +24,7 @@
   upgrades or upgrades on many similarly configured systems.
  </para>
  <sect3 xml:id="sec-update-zypper-prep">
-  <title>Preparing the Upgrade with Zypper</title>
+  <title>Preparing the upgrade with Zypper</title>
   <para>
    To avoid unexpected errors during the upgrade process using
    <command>zypper</command>, minimize risky constellations.
@@ -48,9 +48,9 @@
   </itemizedlist>
  </sect3>
  <sect3 xml:id="sec-update-zypper-proc">
-  <title>The Upgrade Procedure</title>
+  <title>The upgrade procedure</title>
   <warning>
-   <title>Check Your System Backup</title>
+   <title>Check your system backup</title>
    <para>
     Before actually starting the upgrade procedure, check that your system
     backup is up-to-date and restorable. This is especially important
@@ -131,7 +131,7 @@ zypper rr <replaceable>Leap-15.1-Update</replaceable>
        Alternatively, you can lower the priority of these repositories.
       </para>
       <note>
-       <title>Handling of Unresolved Dependencies</title>
+       <title>Handling of unresolved dependencies</title>
        <para>
         <command>zypper dup</command> will remove all packages having
         unresolved dependencies, but it keeps packages of disabled


### PR DESCRIPTION
### Description

* The new capitalization rules are documented at https://documentation.suse.com/style/current/single-html/docu_styleguide/#sec-capitalization, read carefully
* This is the result of an automatic conversion and will most likely need further adjustments
  * Make sure to review the entire diff
  * Entity files have not been changed and need to be updated manually
  * Some product/project names may have been inadvertently changed to the wrong capitalization
  * Some titles may have been missed, either because they're split across multiple source lines or because of improper markup
* Update the conversion commit and remove the (WIP) from the commit message before merging
* This is the thirteenth PR in a series of 14 PRs


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [x] 15 SP3  | (`master` only)   
| [ ] 15 SP2  | [ ] 
| [ ] 15 SP1  | [ ] 
| [ ] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
