### PR TITLE
Corrections to title case corrections

### DIFF
--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -226,7 +226,7 @@
  </sect1>
  
  <sect1 xml:id="sec-tuning-cgroups-tasksmax">
-  <title>Preventing fork bombs with tasksMax</title>
+  <title>Preventing fork bombs with <literal>TasksMax</literal></title>
    <para>
     &systemd; 228 shipped with a <literal>DefaultTasksMax</literal>
     limit of 512. This limited the number of processes any system unit
@@ -252,7 +252,7 @@
    </para>
 
    <sect2 xml:id="sec-tasksmax-defaults">
-    <title>Finding the current default tasksMax values</title>
+    <title>Finding the current default <literal>TasksMax</literal> values</title>
     <para>
      &productname; ships with two custom configurations that override the
      upstream defaults for system units and for user slices, and sets them
@@ -279,7 +279,7 @@ TasksMax=infinity
   </sect2>
 
   <sect2 xml:id="sec-edit-taskmax-default">
-   <title>Overriding the defaultTasksMax value</title>
+   <title>Overriding the <literal>DefaultTasksMax</literal> value</title>
    <para>
     Change the global <literal>DefaultTasksMax</literal> value by creating
     a new override file,
@@ -354,7 +354,7 @@ TasksMax=8192
   </sect2>
 
   <sect2>
-   <title>Default tasksMax limit on users</title>
+   <title>Default <literal>TasksMax</literal> limit on users</title>
    <para>
     The default limit on users should be fairly high, because user sessions
     need more resources.
@@ -379,7 +379,8 @@ TasksMax=16284
 </screen>
    <para>
     How do you know what values to use? This varies according to your workloads,
-    system resources, and other resource configurations. When your TasksMax
+    system resources, and other resource configurations. When your 
+    <literal>TasksMax</literal>
     value is too low, you will see error messages such as
     <emphasis>Failed to fork (Resources temporarily unavailable)</emphasis>,
     <emphasis>Can't create thread to handle new connection</emphasis>, and

--- a/xml/tuning_memory.xml
+++ b/xml/tuning_memory.xml
@@ -579,9 +579,9 @@ dd if=/dev/zero of=zerofile ibs=1048576 count=$((MEMTOTAL_MBYTES*30/100))
   </sect2>
 
   <sect2 xml:id="cha-tuning-memory-vm-thp">
-   <title>Transparent huge page parameters</title>
+   <title>Transparent HugePage parameters</title>
     <para>
-     Transparent Huge Pages (THP) provide a way to dynamically allocate huge
+     Transparent HugePages (THP) provide a way to dynamically allocate huge
      pages either on&#x2011;demand by the process or deferring the allocation
      until later via the <command>khugepaged</command> kernel thread. This
      method is distinct from the use of <literal>hugetlbfs</literal> to

--- a/xml/tuning_power.xml
+++ b/xml/tuning_power.xml
@@ -579,7 +579,7 @@ CPU | C0   | Cx   | Freq || POLL | C1   | C2   | C3
   </para>
 
   <sect2 xml:id="sec-tuning-power-options-p-states">
-   <title>Tuning options for p-states</title>
+   <title>Tuning options for P-states</title>
    <para>
     The &cpufreq; subsystem offers several tuning options for P-states:
     You can switch between the different governors, influence minimum or
@@ -640,7 +640,7 @@ CPU | C0   | Cx   | Freq || POLL | C1   | C2   | C3
   because it will only be made available in an online update-->
 
   <!--<sect2 id="sec-tuning-power-options-c-states">
-   <title>Tuning options for c-states</title>
+   <title>Tuning options for C-states</title>
 
 
    <!-\-/etc/sysconfig/cpupower

--- a/xml/tuning_storagescheduler.xml
+++ b/xml/tuning_storagescheduler.xml
@@ -211,7 +211,7 @@
   </sect2>
 
   <sect2 xml:id="sec-tuning-io-schedulers-bfq">
-   <title><systemitem class="resource">BFQ</systemitem> (Budget fair queueing)</title>
+   <title><systemitem class="resource">BFQ</systemitem> (Budget Fair Queueing)</title>
    <para>
      <systemitem class="resource">BFQ</systemitem> is a
      fairness-oriented scheduler. It is described as "a

--- a/xml/tuning_systemresources.xml
+++ b/xml/tuning_systemresources.xml
@@ -158,7 +158,7 @@ Large page support
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><guimenu>X window system</guimenu>
+     <term><guimenu>X Window System</guimenu>
      </term>
      <listitem>
       <para>

--- a/xml/tuning_taskscheduler.xml
+++ b/xml/tuning_taskscheduler.xml
@@ -210,7 +210,7 @@
  </sect1>
  -->
  <sect1 xml:id="sec-tuning-taskscheduler-cfs">
-  <title>Completely fair scheduler</title>
+  <title>Completely Fair Scheduler</title>
 
   <para>
    Since the Linux kernel version 2.6.23, a new approach has been taken to
@@ -234,7 +234,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Completely fair scheduler</term>
+    <term>Completely Fair Scheduler</term>
     <listitem>
      <para>
       Introduced in kernel 2.6.23 and extended in 2.6.24, CFS tries to


### PR DESCRIPTION
Mostly names that should be capitalized:

Transparent HugePage
https://www.kernel.org/doc/html/latest/admin-guide/mm/transhuge.html

C-states and P-states
https://software.intel.com/content/www/us/en/develop/blogs/c-states-and-p-states-are-very-different.html

Budget Fair Queueing
https://www.kernel.org/doc/html/latest/block/bfq-iosched.html

X Window System
http://www.opengroup.org/desktop/x/

Completely Fair Scheduler
https://www.kernel.org/doc/html/latest/scheduler/sched-design-CFS.html

### Description

Describe the overall goals of this pull request.

Review changes in titles to sentence case. A few corrections that are mostly names that should be capitalized a certain way

| Code 15     | Backport Done
| ----------  | ---------- 
| [ x] 15 SP3  | (`master` only)   
| [ ] 15 SP2  | [ ] 
| [ ] 15 SP1  | [ ] 
| [ ] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
