### PR TITLE
Extend/fixes the description of some Autoyast parameter

### DIFF
--- a/xml/ay_bootloader.xml
+++ b/xml/ay_bootloader.xml
@@ -96,9 +96,8 @@
      file.
     </para>
 <screen>&lt;global&gt;
-  &lt;activate config:type="boolean"&gt;true&lt;/activate&gt;
+  &lt;activate&gt;true&lt;/activate&gt;
   &lt;timeout config:type="integer"&gt;10&lt;/timeout&gt;
-  &lt;suse_btrfs config:type="boolean"&gt;true&lt;/suse_btrfs&gt;
   &lt;terminal&gt;gfxterm&lt;/terminal&gt;
   &lt;gfxmode&gt;1280x1024x24&lt;/gfxmode&gt;
 &lt;/global&gt;</screen>
@@ -115,7 +114,7 @@
         partition. If the boot partition is on a logical partition, the boot
         flag is set to the extended partition.
        </para>
-<screen>&lt;activate config:type="boolean"&gt;true&lt;/activate&gt;</screen>
+<screen>&lt;activate&gt;true&lt;/activate&gt;</screen>
        
       </listitem>
      </varlistentry>
@@ -227,7 +226,7 @@
         systems already installed and generates boot entries for them during the
         installation.
        </para>
-<screen>&lt;os_prober config:type="boolean"&gt;false&lt;/os_prober&gt;</screen>
+<screen>&lt;os_prober&gt;false&lt;/os_prober&gt;</screen>
       </listitem>
      </varlistentry>
      

--- a/xml/ay_kernel_dumps.xml
+++ b/xml/ay_kernel_dumps.xml
@@ -19,12 +19,18 @@
  </info>
 
 <!-- {{{ Kdump -->
-
-   <note os="sles">
+   <note os="sles,sled">
     <title>Availability</title>
     <para>
-     This feature is not available on the &zseries; (s390x)
-     architecture.
+     This feature is not available on &aarch64;, or on systems with less than
+     1 GB of RAM.
+    </para>
+   </note>
+
+    <note os="osuse">
+    <title>Availability</title>
+    <para>
+     This feature is available only on the S/390 architecture.
     </para>
    </note>
 

--- a/xml/ay_kernel_dumps.xml
+++ b/xml/ay_kernel_dumps.xml
@@ -90,6 +90,18 @@
 &lt;/kdump&gt; </screen>
    </example>
 
+   <para>
+    Kdump is enabled by default. The following configuration show how it disable it.
+   </para>
+
+   <example>
+    <title>Disabled Kdump configuration</title>
+<screen>&lt;kdump&gt;
+  &lt;add_crash_kernel config:type="boolean"&gt;false&lt;/add_crash_kernel&gt;
+&lt;/kdump&gt; </screen>
+   </example>
+
+
 <!-- {{{ Memory Reservation -->
 
    <sect2 xml:id="CreateProfile-kdump-reservation">

--- a/xml/ay_linuxrc_options.xml
+++ b/xml/ay_linuxrc_options.xml
@@ -500,12 +500,14 @@
       <row>
        <entry>
         <para>
-         <literal>proxy: 10.10.0.1</literal>
+         <literal>proxy: http://10.10.0.1:3128</literal>
         </para>
        </entry>
        <entry>
         <para>
-         Proxy (either FTP or HTTP).
+         Defines a HTTP proxy server.
+         For the full paramter syntax refer to <link
+         xlink:href="https://en.opensuse.org/SDB:Linuxrc#p_proxy"/>.
         </para>
        </entry>
       </row>


### PR DESCRIPTION
### Description

When adapting my Autoyast configuration for SLES 15,
I run into some issues
as some items in the documentation are either incomplete or even wrong.

This PR fixes this.

### Are there any relevant issues/feature requests?


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

I guess this is wrong for all releases. However, nobody will start an auto-installation on old releases. So no fix is required there. Even 15 SP2 is optional.

| Code 15     | Backport Done
| ----------  | ---------- 
| [X] 15 SP3  | (`master` only)   
| [X] 15 SP2  | [ ] 
| [ ] 15 SP1  | [ ] 
| [ ] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
