### PR TITLE
vt-doc: Add note about PCI topology for QEMU Q35 machines

### DIFF
--- a/xml/libvirt_configuration_gui.xml
+++ b/xml/libvirt_configuration_gui.xml
@@ -1032,7 +1032,23 @@
     autoload the module by adding <literal>install acpiphp /bin/true</literal>
     to the <filename>/etc/modprobe.conf.local</filename> file.
     </para>
-    </important>
+   </important>
+   <important>
+    <title>&kvm; guests using &qemu; Q35 machine type</title>
+    <para>
+    &kvm; guests using the &qemu; Q35 machine type have a PCI topology that
+    includes a <literal>pcie-root</literal> controller and seven
+    <literal>pcie-root-port</literal> controllers. The
+    <literal>pcie-root</literal> controller does not support hotplug. Each
+    <literal>pcie-root-port</literal> controller supports hotplugging a single
+    PCIe device. PCI controllers cannot be hotplugged, so plan accordingly and
+    add more <literal>pcie-root-port</literal>s if more than seven PCIe
+    devices will be hotplugged. A <literal>pcie-to-pci-bridge</literal>
+    controller can be added to support hotplugging legacy PCI devices.
+    See <link xlink:href="https://libvirt.org/pci-hotplug.html"/> for more
+    information about PCI topology between &qemu; machine types.
+    </para>
+   </important>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-libvirt-config-usb">

--- a/xml/libvirt_configuration_virsh.xml
+++ b/xml/libvirt_configuration_virsh.xml
@@ -553,7 +553,23 @@ CPU Affinity:   yy
     autoload the module by adding <literal>install acpiphp /bin/true</literal>
     to the <filename>/etc/modprobe.conf.local</filename> file.
     </para>
-    </important>
+  </important>
+  <important>
+    <title>&kvm; guests using &qemu; Q35 machine type</title>
+    <para>
+    &kvm; guests using the &qemu; Q35 machine type have a PCI topology that
+    includes a <literal>pcie-root</literal> controller and seven
+    <literal>pcie-root-port</literal> controllers. The
+    <literal>pcie-root</literal> controller does not support hotplug. Each
+    <literal>pcie-root-port</literal> controller supports hotplugging a single
+    PCIe device. PCI controllers cannot be hotplugged, so plan accordingly and
+    add more <literal>pcie-root-port</literal>s if more than seven PCIe
+    devices will be hotplugged. A <literal>pcie-to-pci-bridge</literal>
+    controller can be added to support hotplugging legacy PCI devices.
+    See <link xlink:href="https://libvirt.org/pci-hotplug.html"/> for more
+    information about PCI topology between &qemu; machine types.
+    </para>
+  </important>
  </sect1>
  <sect1 xml:id="sec-libvirt-config-usb-virsh">
   <title>Adding a USB device</title>


### PR DESCRIPTION
See https://bugzilla.suse.com/show_bug.cgi?id=1175218 for details.

Signed-off-by: Jim Fehlig <jfehlig@suse.com>

### Description

Improve documentation around device hotplug.


### Are there any relevant issues/feature requests?

* bsc#1175218


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [x ] 15 SP3  | (`master` only)   
| [x ] 15 SP2  | [ ] 
| [ ] 15 SP1  | [ ] 
| [ ] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
