### PR TITLE
Document the 'lladdr' element (AY networking section)

### DIFF
--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -341,6 +341,23 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
           Required.
          </para>
         </entry>
+      </row>
+      <row>
+        <entry>
+         <para>
+          <literal>lladdr</literal>
+         </para>
+        </entry>
+        <entry>
+         <para>
+          Link layer address (MAC address).
+         </para>
+        </entry>
+        <entry>
+          <para>
+            Optional.
+         </para>
+        </entry>
        </row>
        <row>
         <entry>


### PR DESCRIPTION
### Description

Add the `lladdr`element to the interfaces list as it was missing there although it is mentioned by the s390 device documentation (https://doc.opensuse.org/projects/autoyast/#CreateProfile-Network-s390)

### Are there any relevant issues/feature requests?

* https://bugzilla.suse.com/show_bug.cgi?id=1179876

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [X] 15 SP3  | (`master` only)   
| [ ] 15 SP2  | [ ] 
| [ ] 15 SP1  | [ ] 
| [ ] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [ ] 12 SP5  | [ ] 
| [ ] 12 SP4  | [ ] 
| [ ] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
