### PR TITLE
Enable TLS for libvirtd the systemd way (bsc#1180527)

### DIFF
--- a/xml/libvirt_connect.xml
+++ b/xml/libvirt_connect.xml
@@ -1038,11 +1038,13 @@ dynamic_ownership = 1</screen>
      </step>
      <step>
       <para>
-       Enable TLS support by editing
-       <filename>/etc/libvirt/libvirtd.conf</filename> and setting
-       <literal>listen_tls = 1</literal>. Restart &libvirtd;:
+       Enable TLS support by enabling the relevant socket and restarting
+       &libvirtd;:
       </para>
-<screen>&prompt.sudo;systemctl restart libvirtd</screen>
+<screen>
+&prompt.sudo;systemctl enable libvirtd-tls.socket
+&prompt.sudo;systemctl restart libvirtd.service
+</screen>
      </step>
      <step>
       <para>


### PR DESCRIPTION
### Description

Our docs still described enabling secure libvirtd connection the old traditional way instead of systemd one.
This update fixes it.


### Are there any relevant issues/feature requests?

* bsc#1180527


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ---------- 
| [x] 15 SP3  | (`master` only)   
| [x] 15 SP2  | [ ] 
| [x] 15 SP1  | [ ] 
| [x] 15 SP0  | [ ] 

| Code 12     | Backport Done
| ----------  | ---------- 
| [x] 12 SP5  | [ ] 
| [x] 12 SP4  | [ ] 
| [x] 12 SP3  | [ ] 
| [ ] 12 SP2  | [ ] 
