### PR TITLE
Small fixes for KLP

### DIFF
--- a/xml/klp.xml
+++ b/xml/klp.xml
@@ -134,7 +134,7 @@
     95% of qualifying fixes are released as live patches. For more information
     on CVSS (the base for the SUSE CVSS rating), see
     <link xlink:href="https://www.first.org/cvss/">Common Vulnerability Scoring
-    System SIG</link>. .
+    System SIG</link>.
    </para>
   </sect2>
 

--- a/xml/klp.xml
+++ b/xml/klp.xml
@@ -230,7 +230,8 @@
 <screen>$ SUSEConnect --list-extensions
 ...
 SUSE Linux Enterprise Live Patching &productnumber; x86_64
-Activate with: SUSEConnect -p sle-module-live-patching/&productnumbershort;/x86_64 -r ADDITIONAL REGCODE</screen>
+Activate with: SUSEConnect -p sle-module-live-patching/&productnumbershort;/x86_64 \
+  -r ADDITIONAL REGCODE</screen>
    </step>
    <step>
     <para>
@@ -239,7 +240,8 @@ Activate with: SUSEConnect -p sle-module-live-patching/&productnumbershort;/x86_
      <replaceable>LIVE_PATCHING_REGISTRATION_CODE</replaceable></option>, for
      example:
     </para>
-<screen>SUSEConnect -p sle-module-live-patching/&productnumbershort;/x86_64 -r <replaceable>LIVE_PATCHING_REGISTRATION_CODE</replaceable></screen>
+<screen>SUSEConnect -p sle-module-live-patching/&productnumbershort;/x86_64 \
+  -r <replaceable>LIVE_PATCHING_REGISTRATION_CODE</replaceable></screen>
    </step>
    <step>
     <para>

--- a/xml/klp.xml
+++ b/xml/klp.xml
@@ -229,8 +229,8 @@
     </para>
 <screen>$ SUSEConnect --list-extensions
 ...
-SUSE Linux Enterprise Live Patching 15 SP3 x86_64
-Activate with: SUSEConnect -p sle-module-live-patching/15.3/x86_64 -r ADDITIONAL REGCODE</screen>
+SUSE Linux Enterprise Live Patching &productnumber; x86_64
+Activate with: SUSEConnect -p sle-module-live-patching/&productnumbershort;/x86_64 -r ADDITIONAL REGCODE</screen>
    </step>
    <step>
     <para>
@@ -239,7 +239,7 @@ Activate with: SUSEConnect -p sle-module-live-patching/15.3/x86_64 -r ADDITIONAL
      <replaceable>LIVE_PATCHING_REGISTRATION_CODE</replaceable></option>, for
      example:
     </para>
-<screen>SUSEConnect -p sle-module-live-patching/15.3/x86_64 -r <replaceable>LIVE_PATCHING_REGISTRATION_CODE</replaceable></screen>
+<screen>SUSEConnect -p sle-module-live-patching/&productnumbershort;/x86_64 -r <replaceable>LIVE_PATCHING_REGISTRATION_CODE</replaceable></screen>
    </step>
    <step>
     <para>


### PR DESCRIPTION
### Description

While looking at https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-klp.html I noticed a few glitches. Most importantly, the maintenance branch for 15 SP2 contained fixed version numbers for 15 SP3.

I inserted entities to avoid this and fixed two minor things I spotted along the way (long code lines in PDF, a duplicated punctuation mark). Please backport the fixes to the appropriate older doc versions, too.  

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [x] 15 SP3  | *(no backport necessary)*
| [x] 15 SP2  | [ ]
| [x] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
