### PR TITLE
intro about available docs: reorg as discussed in SLE writers sync

### DIFF
--- a/xml/common_intro_available_doc_i.xml
+++ b/xml/common_intro_available_doc_i.xml
@@ -38,7 +38,8 @@
    <note>
     <title>Latest updates</title>
     <para>
-     The latest documentation updates are usually available in the English version of the documentation.
+     The latest documentation updates are usually available in the English
+     version of the documentation.
     </para>
    </note>
   </listitem>

--- a/xml/common_intro_available_doc_i.xml
+++ b/xml/common_intro_available_doc_i.xml
@@ -20,134 +20,49 @@
   </dm:docmanager>
  </info>
 
- <note>
-  <title>Online documentation and latest updates</title>
-  <para>
-   Documentation for our products is available at
-   <link os="sles;sled" xlink:href="https://documentation.suse.com/"/><link os="osuse" xlink:href="http://doc.opensuse.org/"/>,
-   where you can also find the latest updates, and browse or download the documentation in various formats.
-   The latest documentation updates are usually available in the English version of the documentation.
-  </para>
- </note>
- <note>
-  <title>Manual Pages</title>
-  <para>
-   Many commands are described in detail in their <emphasis>manual
-   pages</emphasis>. You can view manual pages by running the
-   <command>man</command> command followed by a specific command name. If the
-   <command>man</command> command is not installed on your system, install it
-   by running <command>zypper install man</command>.
-  </para>
- </note>
- <para>
-  The following documentation is available for this product:
- </para>
-
- <variablelist>
-  <varlistentry os="sles;sled">
-   <term><xref linkend="art-sle-installquick"/>
-   </term>
-   <listitem>
+<variablelist>
+ <varlistentry>
+  <term>Online documentation</term>
+  <listitem>
+   <para>
+    The online documentation for this product is available at
+<!--taroth 2021-03-18: keep the profiled links in one line,
+    moving them to separate lines would create a whitespace before
+    the full stop-->
+    <link os="sles" xlink:href="https://documentation.suse.com/#sles"/><link os="sled" xlink:href="https://documentation.suse.com/#sled"/><link os="osuse" xlink:href="http://doc.opensuse.org/"/>.
+    Browse or download the documentation in various formats.
+   </para>
+   <para os="sles;sled">
+    Find the online documentation for other products
+    at <link xlink:href="https://documentation.suse.com/"/>.</para>
+   <note>
+    <title>Latest updates</title>
     <para>
-     &abstract_installquick;
+     The latest documentation updates are usually available in the English version of the documentation.
     </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry os="sles;sled">
-   <term><xref linkend="book-sle-deployment"/>
-   </term>
-   <listitem>
-    <para>
-     <remark>taroth 2016-05-20: check with cwickert if abstract is
-     still correct after the DG rewrite </remark>
-     &abstract_deployment;
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry os="osuse">
-   <term><xref linkend="book-opensuse-startup"/>
-   </term>
-   <listitem>
-    <para>
-     &abstract_osuse_startup;
-    </para>
-   </listitem>
-  </varlistentry>
+   </note>
+  </listitem>
+ </varlistentry>
+ <varlistentry os="sles;sled">
+  <term>Release notes</term>
+  <listitem>
+   <para>
+    For release notes, see <link xlink:href="https://www.suse.com/releasenotes/"/>.
+   </para>
+  </listitem>
+ </varlistentry>
   <varlistentry>
-   <term><xref linkend="book-sle-admin" os="sles;sled"/><xref linkend="book-opensuse-reference" os="osuse"/>
-   </term>
+   <term>In your system</term>
    <listitem>
     <para>
-     &abstract_admin;
+     For offline use, find documentation in your installed system under
+     <filename>/usr/share/doc</filename>. Many commands are also
+     described in detail in their <emphasis>manual pages</emphasis>. To view
+     them, run <command>man</command>, followed by a specific command name. If the
+     <command>man</command> command is not installed on your system, install it
+     with <command>sudo zypper install man</command>.
     </para>
    </listitem>
   </varlistentry>
-  <varlistentry os="sles;osuse">
-   <term><xref linkend="book-virt"/>
-   </term>
-   <listitem>
-    <para>
-     &abstract_virtualization;
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry os="sles">
-   <term><xref linkend="book-storage"/>
-   </term>
-   <listitem>
-    <para>
-     &abstract_storage;
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry os="sles;osuse">
-   <term><xref linkend="book-autoyast"/>
-   </term>
-   <listitem>
-    <para>
-     &abstract_autoyast;
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-   <term><xref linkend="book-security"/>
-   </term>
-   <listitem>
-    <para>
-     &abstract_security;
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-   <term><xref linkend="book-sle-tuning"/>
-   </term>
-   <listitem>
-    <para>
-     &abstract_tuning;
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry os="sles">
-   <term><xref linkend="book-rmt"/>
-   </term>
-   <listitem>
-    <para>
-     &abstract_smt;
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-   <term><xref linkend="book-gnomeuser"/>
-   </term>
-   <listitem>
-    <para>
-     &abstract_gnomeuser;
-    </para>
-   </listitem>
-  </varlistentry>
- </variablelist>
-  <para>
-  The release notes for this product are available at
-   <link xlink:href="https://www.suse.com/releasenotes/"/>.
- </para>
+</variablelist>
 </sect1>


### PR DESCRIPTION
### Description

Reorganize and shorten info about available documentation. 

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [x] 15 SP3  | *(no backport necessary)*
| [ ] 15 SP2  | [ ]
| [ ] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
