### PR TITLE
Streamlining the book introductions 

### DIFF
--- a/xml/ay_intro.xml
+++ b/xml/ay_intro.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE preface
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+    %entities;
+]>
+
+<preface version="5.0" xml:id="ay-preface"
+  xmlns="http://docbook.org/ns/docbook"
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Preface</title>
+ <info>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker></dm:bugtracker>
+   <dm:translation>yes</dm:translation>
+  </dm:docmanager>
+ </info>
+
+ <xi:include href="common_intro_available_doc_i.xml"/>
+ <xi:include href="common_intro_feedback_i.xml"/>
+ <xi:include href="common_intro_typografie_i.xml"/>
+ <xi:include href="common_intro_lifecycle_support_i.xml" os="sles;sled"/>
+</preface>

--- a/xml/book_autoyast.xml
+++ b/xml/book_autoyast.xml
@@ -26,14 +26,10 @@
   </date>
   <xi:include href="common_copyright_gfdl.xml"/>
   <abstract>
-   <para>
-   &ay; is a system for unattended mass deployment of &productname;
-   systems. &ay; installations are performed using an &ay; control file (also
-   called a <quote>profile</quote>) with your customized installation 
-   and configuration data.
-   </para>
+   <para>&abstract_autoyast;</para>
   </abstract>
  </info>
+ <xi:include href="ay_intro.xml"/>
  <xi:include href="ay_introduction.xml"/>
  
 <!-- ===================================================================== -->

--- a/xml/book_sles_containers.xml
+++ b/xml/book_sles_containers.xml
@@ -22,6 +22,7 @@
   <xi:include href="common_copyright_gfdl.xml"/>
   <abstract>
    <para>
+    This guide provides an introduction to the &suse; container ecosystem.
     This document is a work in progress. The content in this document is
     subject to change without notice.
    </para>

--- a/xml/book_sles_rmt.xml
+++ b/xml/book_sles_rmt.xml
@@ -22,7 +22,13 @@
   <productnumber>&productnumber;</productnumber>
   <date><?dbtimestamp format="B d, Y" ?></date>
   <xi:include href="common_copyright_gfdl.xml"/>
+  <abstract>
+   <para>
+    &abstract_smt;
+   </para>
+  </abstract>
  </info>
+ <xi:include href="rmt_intro.xml"/>
  <xi:include href="rmt_overview.xml"/>
  <xi:include href="rmt_install.xml"/>
  <xi:include href="rmt_migrate_from_smt.xml"/>

--- a/xml/containers-intro.xml
+++ b/xml/containers-intro.xml
@@ -8,15 +8,16 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>About this guide</title>
- <para>
-  This guide provides an introduction to the &suse; container ecosystem.
-<!-- This needs more content, look in
-       documentation.suse.com/sles/15-SP1/single-html/SLES-dockerquick/#cha-docker-overview
-       for inspiration. -->
- </para>
+ <title>Preface</title>
+ <info>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker>
+   </dm:bugtracker>
+  </dm:docmanager>
+ </info>
+
  <xi:include href="common_intro_target_audience_i.xml"/>
-<!-- <xi:include href="common_intro_available_doc_i.xml"/> -->
+ <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>
 </preface>

--- a/xml/deployment_intro.xml
+++ b/xml/deployment_intro.xml
@@ -9,77 +9,14 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>About this guide</title>
+ <title>Preface</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
- <para>
-  Installations of &productname; are possible in different ways. It is
-  impossible to cover all combinations of boot, or installation server,
-  automated installations or deploying images. This manual should help with
-  selecting the appropriate method of deployment for your installation.
- </para>
- <variablelist>
-  <varlistentry os="sles">
-   <term><xref linkend="part-prep"/>
-   </term>
-   <listitem>
-    <para>
-     The standard deployment instructions differ depending on the architecture
-     used. For differences and requirements regarding the architecture, see
-     this part.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-   <term><xref linkend="part-deployment"/>
-   </term>
-   <listitem>
-    <para>
-     Most tasks that are needed during installations are described here. This
-     includes the manual setup of your computer and installation of additional
-     software, and cloning disk images and performing the setup remotely.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-   <term><xref linkend="part-customize-media"/>
-   </term>
-   <listitem>
-    <para>
-     If you need or want to modify the regular &slereg; installation images
-     (for virtual environments, to create minimal boot images, or to customize
-     modules, extensions, and repositories), this part describes how to do so.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-   <term><xref linkend="part-installserver"/>
-   </term>
-   <listitem>
-    <para>
-     &productnamereg; can be installed in different ways. Apart from the usual
-     media installation, you can choose from various network-based approaches.
-     This part describes setting up an installation server and how to prepare
-     the boot of the target system for installation.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-   <term><xref linkend="part-sysconfig"/>
-   </term>
-   <listitem>
-    <para>
-     Learn how to configure your system after installation. This part covers
-     common tasks like setting up hardware components, installing or removing
-     software, managing users, or changing settings with &yast;.
-    </para>
-   </listitem>
-  </varlistentry>
- </variablelist>
+
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>

--- a/xml/gnomeuser_intro.xml
+++ b/xml/gnomeuser_intro.xml
@@ -5,89 +5,14 @@
     %entities;
 ]>
 <preface xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="pre-gnome-about">
- <title>About this guide</title>
+ <title>Preface</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
- <para>
-  This manual introduces you to the &gnome; graphical desktop environment as
-  implemented in &productnamereg;, and shows you how to configure it to meet
-  your personal needs and preferences. It also introduces you to several
-  programs and services. It is intended for users who have experience
-  using a graphical desktop environment such as macOS&thrdmrk;,
-  Windows&thrdmrk;, or other Linux desktops.
- </para>
- <para>
-  The manual is divided into the following parts:
- </para>
- <variablelist>
-  <varlistentry>
-   <term>Introduction</term>
-   <listitem>
-    <para>
-     Get to know your &gnome; desktop, learn how to cope with basic and daily
-     tasks using the central &gnome; applications and various small utilities.
-     Get an overview of the possibilities that &gnome; offers for modifying and
-     individualizing the desktop according to your needs and wishes. Learn how
-     to use assistive technologies to improve accessibility in case of vision
-     or mobility impairment.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-   <term>Connectivity, files and resources</term>
-   <listitem>
-    <para>
-     Learn how to manage and exchange data on your system or on a network:
-     connecting to a network and sharing files, managing printers, or creating
-     backups of your data. This part also shows how to sign and encrypt your
-     mails and documents and how to use file transfer clients to transfer data
-     from or to the Internet.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-   <term>&libo;</term>
-   <listitem>
-    <para>
-     Introduces the &libo; suite, including Writer, Calc, Impress, Base, Draw,
-     and Math.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-   <term>Internet, communication and collaboration</term>
-   <listitem>
-    <para>
-     Use a Web browser and get to know the e-mailing and calendaring software.
-     Communicate with others using Instant Messaging or Voice over IP.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-   <term>Graphics and multimedia</term>
-   <listitem>
-    <para>
-     Get to know GIMP, an image manipulation program that meets the needs of
-     both amateurs and professionals. Get introduced to your desktop's
-     applications for playing movies. Learn how to create data or audio CDs and
-     DVDs for archiving your data.
-    </para>
-   </listitem>
-  </varlistentry>
-<!--<remark>
-     SLED used to ship with Banshee. Banshee has been nixed from the repos.
-     SLED now ships with Rhythmbox which is not yet documented here. Documenting
-     Rhythmbox for a later SLE 12 Service Pack, however, might be little more
-     than a waste of time. Like Banshee, Rhythmbox has been barely maintained
-     for years. There is no "hot new thing", but GNOME Music is starting to
-     become a contender. (A seriously feature-reduced one, though.)
-     - sknorr, 2015-09-16
-    </remark>-->
- </variablelist>
+
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>

--- a/xml/kvm_intro.xml
+++ b/xml/kvm_intro.xml
@@ -9,22 +9,14 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>About this manual</title>
+ <title>Preface</title>
  <info>
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           </dm:bugtracker>
       </dm:docmanager>
  </info>
- <para>
-  This manual offers an introduction to setting up and managing virtualization
-  with &kvm; (Kernel-based Virtual Machine) and &xen; on &productname;. The
-  first part introduces the different virtualization solutions by describing
-  their requirements, their installations and &suse;'s support status. The
-  second part deals with managing &vmguest;s and &vmhost;s with &libvirt;.  The
-  following parts describe topics that are both hypervisor independent, or
-  relate directly &kvm; and &xen; solutions.
- </para>
+
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>

--- a/xml/rmt_intro.xml
+++ b/xml/rmt_intro.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE preface
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+    %entities;
+]>
+
+<preface version="5.0" xml:id="rmt-preface"
+  xmlns="http://docbook.org/ns/docbook"
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Preface</title>
+ <info>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker></dm:bugtracker>
+   <dm:translation>yes</dm:translation>
+  </dm:docmanager>
+ </info>
+
+ <xi:include href="common_intro_available_doc_i.xml"/>
+ <xi:include href="common_intro_feedback_i.xml"/>
+ <xi:include href="common_intro_typografie_i.xml"/>
+ <xi:include href="common_intro_lifecycle_support_i.xml" os="sles;sled"/>
+</preface>

--- a/xml/rmt_overview.xml
+++ b/xml/rmt_overview.xml
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE preface
+<!DOCTYPE chapter
 [
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
 
-<preface xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="pre-rmt">
- <title>About this guide</title>
+<chapter xmlns="http://docbook.org/ns/docbook"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0"
+ xml:id="rmt-overview">
+ <title>Overview</title>
  <info/>
- <sect1>
-  <title>Overview</title>
   <para>
    The &rmtool; (&rmt;) for &sle; &productnumber; allows enterprise
    customers to optimize the management of &sle; software updates and
@@ -73,21 +74,4 @@
    and &slea; 12. For a feature comparison between &rmt; and SMT, see
    <xref linkend="sec-rmt-migrate-notes-features" />.
   </para>
- </sect1>
- <sect1>
-  <title>Additional documentation and resources</title>
-
-  <para>
-   Chapters in this manual contain links to additional documentation resources
-   that are available either on the system or on the Internet.
-  </para>
-
-  <para>
-   For an overview of the documentation available for your product and the
-   latest documentation updates, refer to
-   <link xlink:href="https://documentation.suse.com/"/>.
-  </para>
- </sect1>
- <xi:include href="common_intro_feedback_i.xml"/>
- <xi:include href="common_intro_typografie_i.xml"/>
-</preface>
+</chapter>

--- a/xml/security_intro.xml
+++ b/xml/security_intro.xml
@@ -9,25 +9,14 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>About this guide</title>
- <info>
-      <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-        <dm:bugtracker>
-          </dm:bugtracker>
-      </dm:docmanager>
-    </info>
-    <para>
-  This manual introduces the basic concepts of system security on
-  &productname;. It covers extensive documentation about the
-  authentication mechanisms available on Linux, such as NIS or LDAP. It
-  deals with aspects of local security like access control lists,
-  encryption and intrusion detection. In the network security part you
-  learn how to secure computers with firewalls and masquerading, and how
-  to set up virtual private networks (VPN). This manual shows how to use
-  security software like &aa; (which lets you specify per program which
-  files the program may read, write, and execute) or the auditing system
-  that collects information about security-relevant events.
- </para>
+ <title>Preface</title>
+  <info>
+    <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+      <dm:bugtracker></dm:bugtracker>
+      <dm:translation></dm:translation>
+    </dm:docmanager>
+  </info>
+
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>

--- a/xml/sle_admin_intro.xml
+++ b/xml/sle_admin_intro.xml
@@ -9,92 +9,14 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>About this guide</title>
+ <title>Preface</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
- <para>
-  This guide is intended for use by professional network and system
-  administrators during the operation of &slereg;. As such, it is solely
-  concerned with ensuring that &sle; is properly configured and that the
-  required services on the network are available to allow it to function
-  properly as initially installed. This guide does not cover the process of
-  ensuring that &sle; offers proper compatibility with your enterprise's
-  application software or that its core functionality meets those requirements.
-  It assumes that a full requirements audit has been done and the installation
-  has been requested, or that a test installation for such an audit has been
-  requested.
- </para>
- <para>
-  This guide contains the following:
- </para>
- <variablelist>
-  <varlistentry>
-   <term>Support and common tasks</term>
-   <listitem>
-    <para>
-     &sle; offers a wide range of tools to customize various aspects of the
-     system. This part introduces a few of them. <phrase os="sles">A breakdown
-     of available device technologies, high availability configurations, and
-     advanced administration possibilities introduces the system to the
-     administrator.</phrase>
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-   <term>System</term>
-   <listitem>
-    <para>
-     Learn more about the underlying operating system by studying this part.
-     &sle; supports several hardware architectures and you can use this to
-     adapt your own applications to run on &sle;. The boot loader and boot
-     procedure information assists you in understanding how your Linux system
-     works and how your own custom scripts and applications may blend in with
-     it.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-   <term>Services</term>
-   <listitem>
-    <para>
-     &sle; is designed to be a network operating system. <phrase os="sles">It
-     offers a wide range of network services, such as DNS, DHCP, Web, proxy,
-     and authentication services. It also integrates well into heterogeneous
-     environments, including MS Windows clients and servers.</phrase>
-     <phrase os="sled">&sledreg; includes client support for many network
-     services. It integrates well into heterogeneous environments including MS
-     Windows clients and servers. </phrase>
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-   <term>Mobile computers</term>
-   <listitem>
-    <para>
-     Laptops, and the communication between mobile devices like PDAs, or
-     cellular phones and &sle; need some special attention. Take care for power
-     conservation and for the integration of different devices into a changing
-     network environment. Also get in touch with the background technologies
-     that provide the needed functionality.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-   <term>Troubleshooting</term>
-   <listitem>
-    <para>
-     Provides an overview of finding help and additional documentation
-     when you need more information or want to perform specific tasks. There is
-     also a list of the most frequent problems with explanations of how to
-     fix them.
-    </para>
-   </listitem>
-  </varlistentry>
- </variablelist>
+
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>

--- a/xml/storage_intro.xml
+++ b/xml/storage_intro.xml
@@ -9,19 +9,14 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>About this guide</title>
+ <title>Preface</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
- <para>
-  This guide provides information about how to manage storage devices on
-  &productname; &productnumber;. For information about partitioning and
-  managing devices, see <xref linkend="cha-expert-partitioner"/>. This guide is intended
-  for system administrators.
- </para>
+
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>

--- a/xml/tuning_intro.xml
+++ b/xml/tuning_intro.xml
@@ -9,144 +9,14 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>About this guide</title>
+ <title>Preface</title>
  <info>
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           </dm:bugtracker>
       </dm:docmanager>
     </info>
-    <para>
-  &productname; is used for a broad range of usage scenarios in
-  enterprise and scientific data centers. &suse; has ensured
-  &productname; is set up in a way that it accommodates different
-  operation purposes with optimal performance. However, &productname;
-  must meet very different demands when employed on a number crunching
-  server compared to a file server, for example.
- </para>
- <para>
-  It is not possible to ship a distribution that is optimized for all
-  workloads. Different workloads vary substantially in some aspects. Most
-  important among those are I/O access patterns, memory access patterns, and
-  process scheduling. A behavior that perfectly suits a certain workload
-  might reduce performance of another workload. For example, I/O-intensive
-  tasks, such as handling database requests, usually have completely
-  different requirements than CPU-intensive tasks, such as video encoding.
-  The versatility of Linux makes it possible to configure your system in a
-  way that it brings out the best in each usage scenario.
- </para>
- <para>
-  This manual introduces you to means to monitor and analyze your system. It
-  describes methods to manage system resources and to tune your system. This
-  guide does <emphasis>not</emphasis> offer recipes for special scenarios,
-  because each server has got its own different demands. It rather enables
-  you to thoroughly analyze your servers and make the most out of them.
- </para>
- <variablelist>
-<!--
-  <varlistentry>
-   <term>Understanding the basics</term>
-   <listitem>
-    <para>
-     How does the kernel handle
-     - processes
-     - memory management
-     - I/O
-     - networking
-    </para>
-   </listitem>
-  </varlistentry>
--->
-  <varlistentry>
-   <term><xref linkend="part-tuning-basics"/></term>
-   <listitem>
-    <para>
-     Tuning a system requires a carefully planned proceeding. Learn which
-     steps are necessary to successfully improve your system.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-<!-- System Monitoring -->
-   <term><xref linkend="part-tuning-monitoring"/>
-   </term>
-   <listitem>
-    <para>
-     Linux offers a large variety of tools to monitor almost every aspect of
-     the system. Learn how to use these utilities and how to read and
-     analyze the system log files.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-<!-- Kernel Monitoring -->
-   <term><xref linkend="part-tuning-kerneltrace"/>
-   </term>
-   <listitem>
-    <para>
-     The Linux kernel itself offers means to examine every nut, bolt and
-     screw of the system. This part introduces you to SystemTap, a scripting
-     language for writing kernel modules that can be used to analyze and
-     filter data. Collect debugging information and find bottlenecks by
-     using kernel probes and Perf. Last, monitor applications with
-     Oprofile.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-<!-- Resource Management -->
-   <term><xref linkend="part-tuning-resources"/>
-   </term>
-   <listitem>
-    <para>
-     Learn how to set up a tailor-made system fitting exactly the server's
-     need. Get to know how to use power management while at the same time
-     keeping the performance of a system at a level that matches the current
-     requirements.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-<!--  Kernel Tuning -->
-   <term><xref linkend="part-tuning-kernel"/>
-   </term>
-   <listitem>
-    <para>
-     The Linux kernel can be optimized either by using sysctl, via the
-     <filename>/proc</filename> and <filename>/sys</filename> file systems
-     or by kernel command line parameters. This part covers tuning the I/O
-     performance and optimizing the way how Linux schedules processes. It
-     also describes basic principles of memory management and shows how
-     memory management can be fine-tuned to suit needs of specific
-     applications and usage patterns. Furthermore, it describes how to
-     optimize network performance.
-    </para>
-   </listitem>
-  </varlistentry>
-  <varlistentry>
-<!--  Handling System Dumps -->
-   <term><xref linkend="part-tuning-dumps"/>
-   </term>
-   <listitem>
-    <para>
-     This part enables you to analyze and handle application or system
-     crashes. It introduces tracing tools such as strace or ltrace and
-     describes how to handle system crashes using Kexec and Kdump.
-    </para>
-   </listitem>
-  </varlistentry>
- </variablelist>
- <tip os="sles;sled">
-  <title>Getting the &sle; SDK</title>
-  <para>
-   The SDK is a module for &sle; and is available via an online channel from
-   the &scc;.  Alternatively, go to <link
-   os="sles;sled" xlink:href="http://download.suse.com/"/><link
-   os="osuse" xlink:href="https://doc.opensuse.org/"/>, search for <literal>&sle;
-   Software Development Kit</literal> and download it from there.
-   Refer to <xref linkend="cha-add-ons"/> for details.
-  </para>
- </tip>
+
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>

--- a/xml/upgrade_intro.xml
+++ b/xml/upgrade_intro.xml
@@ -9,33 +9,14 @@
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>About this guide</title>
+ <title>Preface</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
- <para>
-  There are different ways to upgrade &productname;. It is
-  impossible to cover all combinations of boot, or installation server,
-  automated installations or deploying images. This manual should help with
-  selecting the appropriate method of upgrading your installation.
- </para>
- <remark>2021-03-11 jufa: consider removing this varlist incl. content</remark>
- <variablelist>
-  <varlistentry>
-   <term><xref linkend="book-sle-upgrade"/>
-   </term>
-   <listitem>
-    <para>
-     This part will give you some background information on terminology, &suse;
-     product lifecycles and Service Pack releases, and recommended upgrade
-     policies.
-    </para>
-   </listitem>
-  </varlistentry>
- </variablelist>
+
  <xi:include href="common_intro_available_doc_i.xml"/>
  <xi:include href="common_intro_feedback_i.xml"/>
  <xi:include href="common_intro_typografie_i.xml"/>


### PR DESCRIPTION
### Description

Streamlining the book introductions. Removed the info about the book structure (as this can be seen from the TOCs), added missing intros to two books and made sure each book has an abstract. 


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [x] 15 SP3  | *(no backport necessary)*
| [ ] 15 SP2  | [ ]
| [ ] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
