### PR TITLE
Integrating proofreading changes into Deployment (& other) guides

### DIFF
--- a/xml/book_sle_deployment.xml
+++ b/xml/book_sle_deployment.xml
@@ -49,7 +49,7 @@
  <part xml:id="part-deployment">
   <title>Installation procedure</title>
   <xi:include href="deployment_boot_parameters.xml"/>
-  <xi:include href="deployment_yast_installer.xml"/>
+  <xi:include href="deployment_yast_inscommtaller.xml"/>
   <xi:include href="deployment_register.xml"/>
   <xi:include href="deployment_expert_partitioner.xml"/>
   <xi:include href="deployment_remote.xml"/>

--- a/xml/book_sle_deployment.xml
+++ b/xml/book_sle_deployment.xml
@@ -49,7 +49,7 @@
  <part xml:id="part-deployment">
   <title>Installation procedure</title>
   <xi:include href="deployment_boot_parameters.xml"/>
-  <xi:include href="deployment_yast_inscommtaller.xml"/>
+  <xi:include href="deployment_yast_installer.xml"/>
   <xi:include href="deployment_register.xml"/>
   <xi:include href="deployment_expert_partitioner.xml"/>
   <xi:include href="deployment_remote.xml"/>

--- a/xml/deployment_prep_zseries_prep_i.xml
+++ b/xml/deployment_prep_zseries_prep_i.xml
@@ -684,8 +684,7 @@ DIRM USER WITHPASS</screen>
 <screen>RECEIVE &lt;number&gt; USER DIRECT A (REPL)</screen>
     <para>
      You can now log in on the guest as user
-     <systemitem
-      class="username">LINUX1</systemitem>.
+     <systemitem class="username">LINUX1</systemitem>.
     </para>
     <para>
      If you do not have the <literal>dirmaint</literal> option available, refer

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -437,17 +437,17 @@
 
  <sect1 xml:id="sec-yast-install-welcome">
   <title>
-   <phrase os="sles;sled">Language, Keyboard, and Product Selection</phrase>
-   <phrase os="osuse">Language, Keyboard, and License Agreement</phrase>
+   <phrase os="sles;sled">Language, keyboard, and product selection</phrase>
+   <phrase os="osuse">Language, keyboard, and license agreement</phrase>
   </title>
   <figure>
   <title>
-   <phrase os="sles;sled">Language, Keyboard, and Product Selection</phrase>
-   <phrase os="osuse">Language, Keyboard, and License Agreement</phrase>
+   <phrase os="sles;sled">Language, keyboard, and product selection</phrase>
+   <phrase os="osuse">Language, keyboard, and license agreement</phrase>
   </title>
    <mediaobject>
     <textobject role="description">
-     <phrase>Language, Keyboard, and Product Selection</phrase>
+     <phrase>Language, keyboard, and product selection</phrase>
     </textobject>
     <imageobject role="fo">
      <imagedata os="sled" fileref="install_product_sled.png" width="100%"/>
@@ -2658,7 +2658,7 @@ sle-live-patching 8c541494</screen>
    </variablelist>
   </sect2>
   <sect2 xml:id="sec-s390-inst-reipl-reconnect" arch="zseries" os="sles">
-   <title>&zseries;: connecting to the installed system</title>
+   <title>&zseries;: Connecting to the installed system</title>
    <para>
     After IPLing the system, establish a connection via VNC, SSH, or X to log
     in to the installed system. Using either VNC or SSH is recommended. To

--- a/xml/planning.xml
+++ b/xml/planning.xml
@@ -269,7 +269,7 @@
   </sect2>
 
   <sect2 xml:id="sec-planning-qu-media">
-   <title>Quarterly update media</title>
+   <title>Quarterly updated media</title>
 <!-- cwickert 2020-11-18: The following is based on the text from
     https://www.suse.com/download/sles/ -->
    <para>
@@ -280,7 +280,7 @@
     <listitem>
      <para>
       The first, containing <literal>GM</literal> in the file name, consists of
-      the package set as shipped at first customer shipment date.
+      the package set as shipped on the first customer shipment date.
      </para>
     </listitem>
     <listitem>
@@ -288,8 +288,8 @@
       The second, identified by a <literal>QU</literal> followed by a number in
       the file name, contains the same package set but includes all maintenance
       updates of the packages that have been released in the meantime.
-      Quarterly updated media are refreshed every 3 months, with the first
-      coming three month after the <literal>GM</literal> release.
+      Quarterly updated media are refreshed every three months, with the first
+      coming three months after the <literal>GM</literal> release.
      </para>
     </listitem>
    </itemizedlist>

--- a/xml/snapper.xml
+++ b/xml/snapper.xml
@@ -9,7 +9,7 @@
          xmlns:xi="http://www.w3.org/2001/XInclude"
          xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0"
          xml:id="cha-snapper">
- <title>System recovery and snapshot management with snapper</title>
+ <title>System recovery and snapshot management with Snapper</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -97,7 +97,7 @@
   </para>
 
   <tip>
-   <title>Enabling snapper in the installed system</title>
+   <title>Enabling Snapper in the installed system</title>
    <para>
     If you disabled Snapper during the installation, you can enable it at
     any time later. To do so, create a default Snapper configuration for the
@@ -151,7 +151,7 @@
    <title>Default settings</title>
    <variablelist>
     <varlistentry>
-     <term>Disks larger than 16 GB</term>
+     <term>Disks larger than 16&nbsp;GB</term>
      <listitem>
       <itemizedlist>
        <listitem><para>Configuration file: <filename>/etc/snapper/configs/root</filename></para></listitem>
@@ -161,7 +161,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Disks smaller than 16 GB</term>
+     <term>Disks smaller than 16&nbsp;GB</term>
      <listitem>
       <itemizedlist>
        <listitem><para>Configuration file: not created</para></listitem>
@@ -451,7 +451,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-snapper-lvm">
-    <title>Using snapper on thinly-provisioned LVM volumes</title>
+    <title>Using Snapper on thinly-provisioned LVM volumes</title>
     <para>
      Apart from snapshots on <literal>Btrfs</literal> file systems, Snapper
      also supports taking snapshots on thinly-provisioned LVM volumes (snapshots
@@ -476,7 +476,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-snapper-undo">
-  <title>Using snapper to undo changes</title>
+  <title>Using Snapper to undo changes</title>
 
   <para>
    Snapper on &productname; is preconfigured to serve as a tool that lets you
@@ -776,7 +776,7 @@ c..... /var/lib/rpm/Sigmd5</screen>
   </sect2>
 
   <sect2 xml:id="sec-snapper-undo-delete-file">
-   <title>Using snapper to restore files</title>
+   <title>Using Snapper to restore files</title>
    <para>
     Apart from the installation and administration snapshots, Snapper creates
     timeline snapshots. You can use these backup snapshots to restore files
@@ -1267,7 +1267,7 @@ single | 4 |     |         |                       |
  </sect1>
  
  <sect1 xml:id="sec-snapper-homedirs">
-     <title>Enabling snapper in user home directories</title>
+     <title>Enabling Snapper in user home directories</title>
      
      <para>
          You may enable snapshots for users' <filename>/home</filename> 
@@ -1387,7 +1387,7 @@ single | 0 |       |      | root |         | current     |
  </sect1>
  
  <sect1 xml:id="sec-snapper-config">
-  <title>Creating and modifying snapper configurations</title>
+  <title>Creating and modifying Snapper configurations</title>
 
   <para>
    The way Snapper behaves is defined in a configuration file that is specific
@@ -1700,7 +1700,7 @@ local  | /local</screen>
     </variablelist>
    </sect3>
    <sect3 xml:id="sec-snapper-config-user">
-    <title>Using snapper as regular user</title>
+    <title>Using Snapper as regular user</title>
     <para>
      By default Snapper can only be used by &rootuser;. However, there are
      cases in which certain groups or users need to be able to create snapshots
@@ -1727,7 +1727,7 @@ local  | /local</screen>
      set the SYNC_ACL option to <literal>yes</literal>.
     </para>
     <procedure>
-     <title>Enabling regular users to use snapper</title>
+     <title>Enabling regular users to use Snapper</title>
      <para>
       Note that all steps in this procedure need to be run by &rootuser;.
      </para>

--- a/xml/tuning_multikernel.xml
+++ b/xml/tuning_multikernel.xml
@@ -222,7 +222,7 @@
    </procedure>
   </sect2>
   <sect2 xml:id="sec-tuning-multikernel-deleteoldkernel">
-   <title>Use case: deleting an old kernel after reboot only</title>
+   <title>Use case: Deleting an old kernel after reboot only</title>
    <para>
     You want to make sure that an old kernel will only be deleted after the
     system has rebooted successfully with the new kernel.
@@ -238,7 +238,7 @@
   </sect2>
 
   <sect2 xml:id="sec-tuning-multikernel-fallback">
-   <title>Use case: keeping older kernels as fallback</title>
+   <title>Use case: Keeping older kernels as fallback</title>
    <para>
     You want to keep one or more kernel versions to have one or more
     <quote>spare</quote> kernels.
@@ -261,7 +261,7 @@
   </sect2>
 
   <sect2 xml:id="sec-tuning-multikernel-specificversion">
-   <title>Use case: keeping a specific kernel version</title>
+   <title>Use case: Keeping a specific kernel version</title>
    <para>
     You make regular system updates and install new kernel versions. However,
     you are also compiling your own kernel version and want


### PR DESCRIPTION
Part 1… up to page 100

### Description

Integrating Dublin proofreading changes into the SLE Deployment Guide

Note, some of the changes have also touched on chapters in the Tuning Guide, the Admin Guide, the Snapper guide and others, because sections of these are included or referenced in the Dep Guide.

In the Snapper guide, I found that automated transition to sentence case had removed the capital S from "Snapper" in many titles, so I have manually fixed this for consistency. 

Thus, although all these errors were **found** in proofing the DepGuide, not all the changes are in the DepGuide.

The last change is p75. I have stopped before p105:
> Tip: Using additional drives with ~s~ecure ~b~oot

That is where to continue from.

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [X] 15 SP3  | *(no backport necessary)*
| [ ] 15 SP2  | [ ]
| [ ] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
