### PR TITLE
Depl. Guide: remaining proofing corrections

### DIFF
--- a/xml/deployment_boot_parameters.xml
+++ b/xml/deployment_boot_parameters.xml
@@ -304,7 +304,7 @@
     <literal>&grub;</literal> in the following.
    </para>
    <tip>
-    <title>Using additional drivers with secure boot</title>
+    <title>Using additional drivers with Secure Boot</title>
     <para>
      When installing with Secure Boot enabled, you cannot load drivers that
      are not shipped with &productname;. This is also true of drivers shipped

--- a/xml/deployment_expert_partitioner_overview.xml
+++ b/xml/deployment_expert_partitioner_overview.xml
@@ -48,7 +48,7 @@
  </figure>
 
  <tip arch="zseries" os="sles">
-  <title>&zseries;: device names</title>
+  <title>&zseries;: Device names</title>
   <para>
    &zseries; recognizes only DASD and SCSI hard disks. IDE hard disks are
    not supported. This is why these devices appear in the partition table as
@@ -153,7 +153,7 @@
     </listitem>
    </itemizedlist>
    <note>
-    <title>Partitions created with parted 3.1 or earlier mislabeled</title>
+    <title>Partitions created with <productname>Parted</productname> 3.1 or earlier mislabeled</title>
     <para>
      GPT partitions created with Parted 3.1 or earlier used the Microsoft
      Basic Data partition type instead of the newer Linux-specific GPT GUID.
@@ -492,7 +492,7 @@
         &productname;, persistent device names are enabled by default.
        </para>
        <note os="sles" arch="zseries">
-        <title>&zseries;: mounting by path</title>
+        <title>&zseries;: Mounting by path</title>
         <para>
          Since mounting by ID causes problems on &zseries; when using
          disk-to-disk copying for cloning purposes, devices are mounted by path

--- a/xml/deployment_firstboot.xml
+++ b/xml/deployment_firstboot.xml
@@ -23,11 +23,11 @@
   Rolling out customized preinstallations of &productname; to many
   identical machines spares you from installing each one of them
   separately and provides a standardized installation for the end users.
-  With &yast; Firstboot, create customized preinstallation images and
+  With &yast; firstboot, create customized preinstallation images and
   determine the workflow for the final personalization steps that involve
   end user interaction (as opposed to &ay;, which allows completely
-  automated installations; for more information, see the 
-  <citetitle>System Registration and Extension Selection</citetitle>
+  automated installations). For more information, see the
+  <citetitle>System registration and extension selection</citetitle> chapter
   of the &ayguide;.
  </para>
  <para>
@@ -287,7 +287,7 @@
    <title>Customizing the license action</title>
    <para>
     You can customize the way the installation system reacts to a user's
-    refusal to accept the license agreement. There are three different ways
+    refusal to accept the license agreement. There are three different ways in
     which the system could react to this scenario:
    </para>
    <variablelist>
@@ -327,8 +327,8 @@
   <sect2 xml:id="sec-fb-customize-rn">
    <title>Customizing the release notes</title>
    <para>
-    Depending on if you have changed the instance of &productname; you are
-    deploying with firstboot, you probably need to educate the end users
+    Depending on whether you have changed the instance of &productname; you are
+    deploying with firstboot, you might need to educate the end users
     about important aspects of their new operating system. A standard
     installation uses release notes (displayed during one of the final
     stages of the installation) to provide important information to the
@@ -366,7 +366,7 @@
   <sect2 xml:id="sec-fb-customize-wf">
    <title>Customizing the workflow</title>
    <para>
-    The provided <filename>/etc/YaST2/firstboot.xml</filename> example, defines
+    The provided <filename>/etc/YaST2/firstboot.xml</filename> example defines
     a standard workflow which includes the following enabled components:
    </para>
    <itemizedlist>
@@ -408,18 +408,18 @@
     </listitem>
    </itemizedlist>
    <para>
-    Bear in mind that this workflow is a template. You may adjust
-    it properly, manually editing the firstboot configuration file
+    Bear in mind that this workflow is a template. You can adjust
+    it properly by manually editing the firstboot configuration file
     <filename>/etc/YaST2/firstboot.xml</filename>. This XML file is a subset
     of the standard <filename>control.xml</filename> file that is used by
     &yast; to control the installation workflow. See <xref linkend="ex-fb-wf"/>
     to learn more about how to configure the workflow section.
    </para>
    <para>
-    For an overview about proposals, see <xref linkend="ex-fb-proposal"/>.
+    For an overview of proposals, see <xref linkend="ex-fb-proposal"/>.
     This provides you with enough background to modify the firstboot
     installation workflow. The basic syntax of the firstboot configuration
-    file (plus how the key elements are configured) is explained with this
+    file (plus how the key elements are configured) is explained via this
     example.
    </para>
    <example xml:id="ex-fb-proposal">
@@ -631,7 +631,7 @@
        <para>
         To change the order of proposals, move the respective
         <literal>module</literal> elements containing the proposal screens
-        around in the workflow. Note that there may be dependencies to other
+        around in the workflow. Note that there may be dependencies on other
         installation steps that require a certain order of proposals and
         workflow components.
        </para>
@@ -645,7 +645,7 @@
     </step>
    </procedure>
    <para>
-    You can always change the workflow of the configuration steps when the
+    You can always change the workflow of the configuration steps if the
     default does not meet your needs. Enable or disable certain modules in
     the workflow (or add your own custom ones).
    </para>
@@ -701,7 +701,7 @@
     <step>
      <para>
       Determine at which point in the workflow your new module should be
-      run. In doing so, make sure that possible dependencies to other steps
+      run. In doing so, make sure that any dependencies on other steps
       in the workflow are taken into account and resolved.
      </para>
     </step>
@@ -752,7 +752,7 @@
    <tip>
     <title>Finding connected network interface for auto-configuration</title>
     <para>
-     If the target hardware may feature more than one network interface add
+     If the target hardware could feature more than one network interface, add
      the <systemitem>network-autoconfig</systemitem> package to the
      application image. <systemitem>network-autoconfig</systemitem> cycles
      through all available Ethernet interfaces until one is successfully configured via DHCP.
@@ -791,7 +791,7 @@
    <title>Providing translations of the installation workflow</title>
    <para>
     Depending on the end user it could be desirable to offer translations of
-    the customized workflow. Those translations could be necessary, if you
+    the customized workflow. Those translations could be necessary if you
     customized the workflow by changing the
     <filename>/etc/YaST2/firstboot.xml</filename> file, as described in
     <xref linkend="sec-fb-customize-wf" />. <!--This is different from the
@@ -810,11 +810,11 @@
    <procedure>
     <step>
      <para>
-      Change the <systemitem>textdomain</systemitem> setting from:
+      For example, change the <systemitem>textdomain</systemitem> setting from:
      </para>
 <screen><![CDATA[<textdomain>firstboot</textdomain>]]></screen>
      <para>
-      to, for example,
+      to the following:
      </para>
 <screen><![CDATA[<textdomain>firstboot-oem</textdomain>]]></screen>
     </step>

--- a/xml/deployment_installserver.xml
+++ b/xml/deployment_installserver.xml
@@ -383,7 +383,7 @@ description=NFS Repository</screen>
   <para os="sles">
    For more information about OpenSLP, refer to the package documentation
    located under <filename>/usr/share/doc/packages/openslp/</filename> or refer
-   to <xref linkend="cha-slp"/>. For more Information about NFS, refer to
+   to <xref linkend="cha-slp"/>. For more information about NFS, refer to
    <xref linkend="cha-nfs"/>.
   </para>
  </sect1>

--- a/xml/deployment_pxe.xml
+++ b/xml/deployment_pxe.xml
@@ -731,25 +731,25 @@ F10 <replaceable>FILENAME</replaceable></screen>
    </para>
   </warning>
  </sect1>
- 
+
  <sect1 xml:id="sec-deployment-prep-boot-wol">
   <title>Using wake-on-LAN for remote wakeups</title>
    <para>
        Wake-on-LAN (WOL) is an Ethernet standard for remotely waking up a computer 
        by sending it a wakeup signal over a network. This signal is called the 
-       "magic packet". Install WOL on client machines to enable remote wakeups, 
+       <quote>magic packet</quote>. Install WOL on client machines to enable remote wakeups,
        and on every machine you want to use for sending the wakeup signal. The
        magic packet is broadcast over UDP port 9 to the MAC address of the network 
        interface on the client machine.
    </para>
    <para>
-       When computers are shutdown they usually are not turned all the way off, 
-       but remain in a low power mode. When the network interface supports WOL it 
-       listens for the magic packet wakeup signal when the machine is powered off. 
+       When computers are shut down they usually are not turned all the way off,
+       but remain in a low power mode. When the network interface supports WOL, it
+       listens for the magic packet wakeup signal when the machine is powered off.
        You can send the magic packet manually, or schedule wakeups in a cron job
        on the sending machine.
    </para>
-   
+
   <sect2 xml:id="sec-deployment-prep-boot-wol-prereqs">
        <title>Prerequisites</title>
    <para>
@@ -767,31 +767,31 @@ F10 <replaceable>FILENAME</replaceable></screen>
        Adjust your firewall to allow traffic over UDP port 9.
    </para>
   </sect2>
-  
+
   <sect2 xml:id="sec-deployment-prep-boot-wiredethernet">
        <title>Verifying wired Ethernet support</title>
    <para>
-       Run the following command to see if a wired Ethernet interface 
+       Run the following command to see if a wired Ethernet interface
        supports WOL:
    </para>
    <screen>&prompt.sudo;ethtool eth0 | grep -i wake-on
 Supports Wake-on: pumbg
 Wake-on: g</screen>
    <para>
-       The example output shows that eth0 supports WOL, indicated by the 
-       <literal>g</literal> flag on the <literal>Supports Wake-on</literal> line. 
+       The example output shows that eth0 supports WOL, indicated by the
+       <literal>g</literal> flag on the <literal>Supports Wake-on</literal> line.
        <literal>Wake-on: g</literal> shows that WOL is already enabled, so this 
-       interface is ready to receive wakeup signals. If WOL is not enabled, 
+       interface is ready to receive wakeup signals. If WOL is not enabled,
        enable it with this command:
    </para>
    <screen>&prompt.sudo;ethtool -s wol g</screen>
   </sect2>
-  
+
    <sect2 xml:id="sec-deployment-prep-boot-wirelessethernet">
        <title>Verifying wireless interface support</title> 
    <para>
        Wakeup-over-wifi, or WoWLAN, requires a wireless network interface that
-       supports WoWLAN. Test it with the <command>iw</command>, command, which 
+       supports WoWLAN. Test it with the <command>iw</command> command, which
        is provided by the <package>iw</package> package:
    </para>
    <screen>&prompt.sudo;zypper in iw</screen>
@@ -807,16 +807,15 @@ phy#0
                 ssid accesspoint
                 type managed
                 channel 11 (2462 MHz), width: 20 MHz, center1: 2462 MHz
-                txpower 20.00 dBm</screen>                
-            
+                txpower 20.00 dBm</screen>
    <para>
-       In this example, the device name to use for querying WoWLAN support is 
+       In this example, the device name to use for querying WoWLAN support is
        <literal>phy#0</literal>. This example shows that it is not supported:
    </para>
        <screen>&prompt.sudo;iw phy#0 wowlan show
 command failed: Operation not supported (-95)</screen>
    <para>
-       This example shows an interface that supports WoWLAN, but it is not enabled:
+       This example shows an interface that supports WoWLAN, but is not enabled:
    </para>
    <screen>&prompt.sudo;iw phy#0 wowlan show
 WoWLAN is disabled</screen>
@@ -831,7 +830,7 @@ WoWLAN is enabled:
 <sect2 xml:id="sec-deployment-prep-boot-wol-install">
     <title>Installing and testing WOL</title>
     <para>
-        To use WOL, install the <package>wol</package> package on the client 
+        To use WOL, install the <package>wol</package> package on the client
         and sending machines:
     </para>
 <screen>&prompt.sudo;zypper in wol</screen>
@@ -845,7 +844,7 @@ WoWLAN is enabled:
    <screen>&prompt.sudo;ip addr show eth0|grep ether
 link/ether 7c:ef:a5:fe:06:7c brd ff:ff:ff:ff:ff:ff</screen>
    <para>
-       In the example output, <literal>7c:ef:a5:fe:06:7c</literal> is the MAC 
+       In the example output, <literal>7c:ef:a5:fe:06:7c</literal> is the MAC
        address.
    </para>
    <para>
@@ -854,18 +853,17 @@ link/ether 7c:ef:a5:fe:06:7c brd ff:ff:ff:ff:ff:ff</screen>
    </para>
    <screen>&prompt.user;wol <replaceable>7c:ef:a5:fe:06:7c</replaceable></screen>
    <para>
-       When your target machine and second device are on the same network but in
+       If your target machine and second device are on the same network but in
        different subnets, specify the broadcast address for your target
        machine:
    </para>
-   <screen>&prompt.user;wol -i <replaceable>192.168.0.63 7c:ef:a5:fe:06:7c</replaceable>
-   </screen>
+   <screen>&prompt.user;wol -i <replaceable>192.168.0.63 7c:ef:a5:fe:06:7c</replaceable></screen>
    <para>
-       Because WOL relies on broadcast domains the sending machine must be on 
+       Because WOL relies on broadcast domains, the sending machine must be on
        the same network, though it can be in a different network segment.
    </para>
    <para>
-       It is possible to send the magic packet from a different network. One way 
+       It is possible to send the magic packet from a different network. One way
        is with port forwarding, if your router supports port forwarding to a 
        broadcast address. A more secure method is to connect to a host inside
        your network via SSH, and send the magic packet from there.

--- a/xml/deployment_troubleshooting.xml
+++ b/xml/deployment_troubleshooting.xml
@@ -58,7 +58,7 @@
 
   <variablelist>
    <varlistentry>
-    <term>Using an external &usbflashdrivecap; or DVD drive</term>
+    <term>Using an external &usbflashdrive; or DVD drive</term>
     <listitem>
      <para>
       Linux supports most existing &usbflashdrive;s and DVD drives. If the
@@ -86,7 +86,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>&usbflashdrivecap;</term>
+    <term>&usbflashdrive;</term>
     <listitem>
      <para>
       You can use a &usbflashdrive; if your machine lacks a DVD drive and

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -1012,7 +1012,7 @@ sle-live-patching 8c541494</screen>
 
    <tip>
     <title>
-     Copying the Installation Media Image to a Removable Flash Disk
+     Copying the installation media image to a removable flash disk
     </title>
     <para>
      Use the following command to copy the contents of the installation image
@@ -1596,7 +1596,7 @@ sle-live-patching 8c541494</screen>
      </listitem>
     </varlistentry>
     <varlistentry os="sles" arch="zseries">
-     <term>&zseries;: using minidisks in z/VM</term>
+     <term>&zseries;: Using minidisks in z/VM</term>
      <listitem>
       <para>
        If &productname; is installed on minidisks in z/VM, which reside
@@ -1625,7 +1625,7 @@ sle-live-patching 8c541494</screen>
     </varlistentry>
     <varlistentry os="sles" arch="power">
      <!-- this warning is duplicated in sec.power.prep -->
-     <term>IBM &power;: installing on systems with multiple Fibre Channel disks</term>
+     <term>IBM &power;: Installing on systems with multiple Fibre Channel disks</term>
      <listitem>
       <para>
        If more than one disk is available, the partitioning scheme suggested during
@@ -2274,7 +2274,7 @@ sle-live-patching 8c541494</screen>
     By default, &productname; uses the Wayland display server protocol.
    </para>
    <tip os="sles" arch="zseries">
-    <title>&zseries;: hardware cryptography support</title>
+    <title>&zseries;: Hardware cryptography support</title>
     <para>
      The hardware cryptography stack is not installed by default. To install
      it, select <guimenu>System z HW crypto support</guimenu> in the
@@ -2643,7 +2643,7 @@ sle-live-patching 8c541494</screen>
        </step>
       </procedure>
       <note>
-       <title><literal>cio_ignore</literal> Is disabled for KVM installations</title>
+       <title><literal>cio_ignore</literal> is disabled for KVM installations</title>
        <para>
         The kernel parameter <literal>cio_ignore</literal> prevents the kernel
         from looking at all the available hardware devices. However, for KVM

--- a/xml/tuning_multikernel.xml
+++ b/xml/tuning_multikernel.xml
@@ -94,7 +94,7 @@
   </procedure>
 
   <warning>
-   <title>Kernel module packages (KMP)</title>
+   <title>Kernel Module Packages (KMP)</title>
    <para>
     Make sure that required vendor provided kernel modules (Kernel Module
     Packages) are also installed for the new updated kernel. The kernel update

--- a/xml/uefi-httpboot-server.xml
+++ b/xml/uefi-httpboot-server.xml
@@ -76,7 +76,7 @@ addn-hosts=/etc/dnsmasq.d/hosts.conf</screen>
    </para>
 <screen>systemctl start dnsmasq</screen>
    <note>
-    <title>Use the <phrase role="productname">shim</phrase> bootloader</title>
+    <title>Use the <phrase role="productname">shim</phrase> boot loader</title>
     <para>
      Because of a change in UEFI 2.7, we recommend using a shim boot loader from
      &slea; 15 or newer to avoid potential errors caused by the additional DNS
@@ -441,7 +441,7 @@ systemctl restart dhcpd6</screen>
   <title>Booting the client via HTTP boot</title>
 
   <para>
-   If the firmware already supports HTTP Boot, plug in the cable and choose the
+   If the firmware already supports HTTP boot, plug in the cable and choose the
    correct boot option.
   </para>
  </sect1>

--- a/xml/yast2_userman.xml
+++ b/xml/yast2_userman.xml
@@ -467,7 +467,7 @@
      first.
     </para>
     <note os="sles">
-     <title>Quotas Btrfs partitions</title>
+     <title>Quotas for Btrfs partitions</title>
      <para>
 <!-- <remark condition="clarity">
        2014-07-17 - fs: According to aschnell, Btrfs quotas are kaputt; this


### PR DESCRIPTION
### Description

Covers the remaining proofing corrections from p.100-309), see https://github.com/SUSE/doc-sle/pull/792 for the first part.


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [x] 15 SP3  | *(no backport necessary)*
| [ ] 15 SP2  | [ ]
| [ ] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
