### PR TITLE
First batch of tables converted to variablelists in AY Guide

### DIFF
--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -204,524 +204,393 @@ config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
      in <literal>&lt;interfaces&gt;...&lt;/interfaces&gt;</literal>
      tags.
     </para>
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>bootproto</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+
+  <variablelist xml:id="foofoo2">
+  <varlistentry>
+    <term>
+      <literal>bootproto</literal>
+    </term>
+    <listitem>
+      <para>
           Boot protocol used by the interface. Possible values:
          </para>
-          <itemizedlist>
-           <listitem>
-            <para>
-             <literal>static</literal> for statically assigned addresses. It is
+      <itemizedlist>
+        <listitem>
+          <para><literal>static</literal> for statically assigned addresses. It is
              required to specify the IP using the <literal>ipaddr</literal>
              element.
             </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>dhcp4</literal>, <literal>dhcp6</literal> or
+        </listitem>
+        <listitem>
+          <para><literal>dhcp4</literal>, <literal>dhcp6</literal> or
              <literal>dhcp</literal> for setting the IP address with DHCP
              (IPv4, IPv6 or any).
             </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>dhcp+autoip</literal> to get the IPv4 configuration from
+        </listitem>
+        <listitem>
+          <para><literal>dhcp+autoip</literal> to get the IPv4 configuration from
              <emphasis>Zeroconf</emphasis> and get IPv6 from DHCP.
             </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>autoip</literal> to get the IPv4 configuration from
+        </listitem>
+        <listitem>
+          <para><literal>autoip</literal> to get the IPv4 configuration from
              <emphasis>Zeroconf</emphasis>.
             </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>ibft</literal> to get the IP address using the iBFT
+        </listitem>
+        <listitem>
+          <para><literal>ibft</literal> to get the IP address using the iBFT
              protocol.
             </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>none</literal> to skip setting an address. This value is
+        </listitem>
+        <listitem>
+          <para><literal>none</literal> to skip setting an address. This value is
              used for bridges and bonding slaves.
             </para>
-           </listitem>
-          </itemizedlist>
-        </entry>
-        <entry>
-         <para>
+        </listitem>
+      </itemizedlist>
+      <para>
           Required.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>broadcast</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>broadcast</literal>
+    </term>
+    <listitem>
+      <para>
           Broadcast IP address.
          </para>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Used only with <literal>static</literal> boot protocol.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>device</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>device</literal>
+    </term>
+    <listitem>
+      <para>
           Device name.
          </para>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Deprecated. Use <literal>name</literal> instead.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>name</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>name</literal>
+    </term>
+    <listitem>
+      <para>
           Device name, for example: <literal>eth0</literal>.
          </para>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Required.
          </para>
-        </entry>
-      </row>
-      <row>
-        <entry>
-         <para>
-          <literal>lladdr</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>lladdr</literal>
+    </term>
+    <listitem>
+      <para>
           Link layer address (MAC address).
          </para>
-        </entry>
-        <entry>
-          <para>
+      <para>
             Optional.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>ipaddr</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>ipaddr</literal>
+    </term>
+    <listitem>
+      <para>
           IP address assigned to the interface.
          </para>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Used only with <literal>static</literal> boot protocol. It can include a network prefix,
           for example: <literal>192.168.1.1/24</literal>.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>remote_ipaddr</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>remote_ipaddr</literal>
+    </term>
+    <listitem>
+      <para>
           Remote IP address for point-to-point connections.
          </para>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Used only with <literal>static</literal> boot protocol.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>netmask</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>netmask</literal>
+    </term>
+    <listitem>
+      <para>
           Network mask, for example: <literal>255.255.255.0</literal>.
          </para>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Deprecated. Use <literal>prefixlen</literal> instead or include the network prefix in the
           <literal>ipaddr</literal> element.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>network</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>network</literal>
+    </term>
+    <listitem>
+      <para>
           Network IP address.
          </para>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Deprecated. Use <literal>ipaddr</literal> with <literal>prefixlen</literal> instead.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>prefixlen</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>prefixlen</literal>
+    </term>
+    <listitem>
+      <para>
           Network prefix, for example: <literal>24</literal>.
          </para>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Used only with <literal>static</literal> boot protocol.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>startmode</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>startmode</literal>
+    </term>
+    <listitem>
+      <para>
           When to bring up an interface. Possible values are:
          </para>
-          <itemizedlist>
-           <listitem>
-            <para>
-             <literal>hotplug</literal> when the device is plugged in. Useful
+      <itemizedlist>
+        <listitem>
+          <para><literal>hotplug</literal> when the device is plugged in. Useful
              for USB network cards, for example.
             </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>auto</literal> when the system
+        </listitem>
+        <listitem>
+          <para><literal>auto</literal> when the system
              boots. <literal>onboot</literal> is a deprecated alias.
             </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>ifplugd</literal> when the device is managed by the
+        </listitem>
+        <listitem>
+          <para><literal>ifplugd</literal> when the device is managed by the
              <literal>ifplugd</literal> daemon.
             </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>manual</literal> when the device is supposed to be started
+        </listitem>
+        <listitem>
+          <para><literal>manual</literal> when the device is supposed to be started
              manually.
             </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>nfsroot</literal> when the device is needed to mount the
+        </listitem>
+        <listitem>
+          <para><literal>nfsroot</literal> when the device is needed to mount the
              root file system, for example, when <literal>/</literal> is on an
              NFS volume.
             </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>off</literal> to never start the device.
+        </listitem>
+        <listitem>
+          <para><literal>off</literal> to never start the device.
             </para>
-           </listitem>
-          </itemizedlist>
-        </entry>
-        <entry>
-         <para>
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>ifplugd_priority</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+        </listitem>
+      </itemizedlist>
+      <para/>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>ifplugd_priority</literal>
+    </term>
+    <listitem>
+      <para>
           Priority for <literal>ifplugd</literal> daemon. It determines in which
           order the devices are activated.
          </para>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Used only with <literal>ifplugd</literal> start mode.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>usercontrol</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>usercontrol</literal>
+    </term>
+    <listitem>
+      <para>
           Parameter is no longer used.
          </para>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Deprecated.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>bonding_slaveX</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>bonding_slaveX</literal>
+    </term>
+    <listitem>
+      <para>
           Name of the bonding device.
          </para>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Required for bonding devices. <literal>X</literal> is replaced by a
           number starting from 0, for example <literal>bonding_slave0</literal>. Each
           slave needs to have a unique number.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>bonding_module_opts</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>bonding_module_opts</literal>
+    </term>
+    <listitem>
+      <para>
           Options for bonding device.
          </para>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Used only with <literal>bond</literal> device.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>mtu</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>mtu</literal>
+    </term>
+    <listitem>
+      <para>
           Maximum transmission unit for the interface.
          </para>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Optional.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>ethtool_options</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>ethtool_options</literal>
+    </term>
+    <listitem>
+      <para>
           Ethtool options during device activation.
          </para>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Optional.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>zone</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>zone</literal>
+    </term>
+    <listitem>
+      <para>
           Firewall zone name which the interface is assigned to.
          </para>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Optional.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>vlan_id</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>vlan_id</literal>
+    </term>
+    <listitem>
+      <para>
           Identifier used for this VLAN.
          </para>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Used only with a <literal>vlan</literal> device.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>etherdevice</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>etherdevice</literal>
+    </term>
+    <listitem>
+      <para>
           Device to which VLAN is attached.
          </para>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Used only with a <literal>vlan</literal> device and required for it.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>bridge</literal>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>bridge</literal>
+    </term>
+    <listitem>
+      <para><literal>yes</literal> if interface is a bridge.
          </para>
-        </entry>
-        <entry>
-         <para>
-          <literal>yes</literal> if interface is a bridge.
-         </para>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Deprecated. It is inferred from other attributes.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>bridge_ports</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>bridge_ports</literal>
+    </term>
+    <listitem>
+      <para>
           Space-separated list of bridge ports, for example, <literal>eth0 eth1</literal>.
          </para>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Used only with a <literal>bridge</literal> device and required for
           it.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>bridge_stp</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>bridge_stp</literal>
+    </term>
+    <listitem>
+      <para>
           Spanning tree protocol. Possible values are <literal>on</literal>
           (when enabled) and <literal>off</literal> (when disabled).
          </para>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Used only with a <literal>bridge</literal> device.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>bridge_forward_delay</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>bridge_forward_delay</literal>
+    </term>
+    <listitem>
+      <para>
           Forward delay for bridge, for example: <literal>15</literal>.
          </para>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Used only with <literal>bridge</literal> devices. Valid values are between <literal>4</literal> and <literal>30</literal>.
          </para>
-        </entry>
-       </row>
-       <!-- TODO: all wireless attributes, but not so many users configure wireless with autoyast -->
-      </tbody>
-     </tgroup>
-   </informaltable>
+    </listitem>
+  </varlistentry>
+  <!-- TODO: all wireless attributes, but not so many users configure wireless with autoyast -->
+</variablelist>
+
 
     <example xml:id="ex-ay-network-config-bond">
      <title>Bonding interface configuration</title>

--- a/xml/ay_nis_server.xml
+++ b/xml/ay_nis_server.xml
@@ -54,291 +54,203 @@
 </screen>
    </example>
 
-   <informaltable>
-    <tgroup cols="3">
-     <thead>
-      <row>
-       <entry>
-        <para>
-         Attribute
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Values
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Description
-        </para>
-       </entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>
-        <para>
-         <literal>domain</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+<variablelist>
+  <varlistentry>
+    <term>
+      <literal>domain</literal>
+    </term>
+    <listitem>
+      <para>
          NIS domain name.
         </para>
-       </entry>
-       <entry>
-        <para>
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>maps_to_serve</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+      <para/>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>maps_to_serve</literal>
+    </term>
+    <listitem>
+      <para>
          List of maps which are available for the server.
         </para>
-       </entry>
-       <entry>
-        <para>
+      <para>
         Values: auto.master, ethers, group, hosts, netgrp, networks, passwd, protocols, rpc, services, shadow
         </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>merge_passwd</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>merge_passwd</literal>
+    </term>
+    <listitem>
+      <para>
          Select if your passwd file should be merged with the shadow file (only possible if the shadow file exists).
         </para>
-       </entry>
-       <entry>
-        <para>
+      <para>
          Value: true/false
         </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>mingid</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>mingid</literal>
+    </term>
+    <listitem>
+      <para>
          Minimum GID to include in the user maps.
         </para>
-       </entry>
-       <entry>
-        <para>
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>minuid</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+      <para/>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>minuid</literal>
+    </term>
+    <listitem>
+      <para>
          Minimum UID to include in the user maps.
         </para>
-       </entry>
-       <entry>
-        <para>
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>nopush</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+      <para/>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>nopush</literal>
+    </term>
+    <listitem>
+      <para>
          Do not push the changes to slave servers. (Useful if there are none).
         </para>
-       </entry>
-       <entry>
-        <para>
+      <para>
          Value: true/false
         </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>pwd_chfn</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>pwd_chfn</literal>
+    </term>
+    <listitem>
+      <para>
          YPPWD_CHFN - allow changing the full name
         </para>
-       </entry>
-       <entry>
-        <para>
+      <para>
          Value: true/false
         </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>pwd_chsh</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>pwd_chsh</literal>
+    </term>
+    <listitem>
+      <para>
          YPPWD_CHSH - allow changing the login shell
         </para>
-       </entry>
-       <entry>
-        <para>
+      <para>
          Value: true/false
         </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>pwd_srcdir</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>pwd_srcdir</literal>
+    </term>
+    <listitem>
+      <para>
          YPPWD_SRCDIR - source directory for passwd data
         </para>
-       </entry>
-       <entry>
-        <para>
-         Default: <filename>/etc</filename>
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>securenets</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+      <para>
+         Default: <filename>/etc</filename></para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>securenets</literal>
+    </term>
+    <listitem>
+      <para>
          List of allowed hosts to query the NIS server
         </para>
-       </entry>
-       <entry>
-        <para>
-         <remark>Dublin proofreader 2016-09-06: This does not make sense in
+      <para><remark>Dublin proofreader 2016-09-06: This does not make sense in
           the context of the sentence, however I am not sure of the intended
           meaning. Please revise.</remark>
          A host address will be allowed if network is equal to the bitwise
          AND of the host's address and the netmask.
         </para>
-        <para>
+      <para>
          The entry with netmask 255.0.0.0 and network 127.0.0.0 must exist
          to allow connections from the local host.
         </para>
-        <para>
+      <para>
          Entering netmask 0.0.0.0 and network 0.0.0.0 gives access to all hosts.
         </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>server_type</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>server_type</literal>
+    </term>
+    <listitem>
+      <para>
          Select whether to configure the NIS server as a master or a slave or not to configure a NIS server.
         </para>
-       </entry>
-       <entry>
-        <para>
+      <para>
          Values: master, slave, none
         </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>slaves</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>slaves</literal>
+    </term>
+    <listitem>
+      <para>
          List of host names to configure as NIS server slaves.
         </para>
-       </entry>
-       <entry>
-        <para>
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>start_ypbind</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+      <para/>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>start_ypbind</literal>
+    </term>
+    <listitem>
+      <para>
          This host is also a NIS client (only when client is configured locally).
         </para>
-       </entry>
-       <entry>
-        <para>
+      <para>
          Value: true/false
         </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>start_yppasswdd</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>start_yppasswdd</literal>
+    </term>
+    <listitem>
+      <para>
          Also start the password daemon.
         </para>
-       </entry>
-       <entry>
-        <para>
+      <para>
          Value: true/false
         </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>start_ypxfrd</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>start_ypxfrd</literal>
+    </term>
+    <listitem>
+      <para>
          Also start the map transfer daemon. Fast Map distribution; it will speed up the transfer of maps to the slaves.
         </para>
-       </entry>
-       <entry>
-        <para>
+      <para>
          Value: true/false
         </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
+    </listitem>
+  </varlistentry>
+</variablelist>
+
   </sect1>

--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -1076,92 +1076,44 @@
 
      </para>
 
-     <informaltable>
-      <tgroup cols="3">
-       <colspec colwidth="1*"/>
-       <colspec colwidth="3*"/>
-       <colspec colwidth="2*"/>
-       <thead>
-        <row>
-         <entry>
-          <para>
-           Attribute
+<variablelist xml:id="foofoo">
+  <varlistentry>
+    <term>
+      <literal>path</literal>
+    </term>
+    <listitem>
+      <para> Mount point for the subvolume. </para>
+      <screen>&lt;path&gt;tmp&lt;/tmp&gt;</screen>
+      <para> Required. AutoYaST will ignore the subvolume if the
+              <literal>path</literal> is not specified. </para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>copy-on-write</literal>
+    </term>
+    <listitem>
+      <para> Whether copy-on-write should be enabled for the subvolume. </para>
+      <screen>&lt;copy-on-write config:type="boolean"&gt;false&lt;/copy-on-write&gt;</screen>
+      <para> Optional. The default value is <literal>false</literal>.
           </para>
-         </entry>
-         <entry>
-          <para>
-           Values
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Description
-          </para>
-         </entry>
-        </row>
-       </thead>
-       <tbody>
-        <row>
-         <entry>
-          <para>
-           <literal>path</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Mount point for the subvolume.
-          </para>
-          <screen>&lt;path&gt;tmp&lt;/tmp&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           Required. &ay; will ignore the subvolume if the
-           <literal>path</literal> is not specified.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>copy-on-write</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Whether copy-on-write should be enabled for the subvolume.
-          </para>
-          <screen>&lt;copy-on-write config:type="boolean"&gt;false&lt;/copy-on-write&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           Optional. The default value is <literal>false</literal>.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>referenced_limit</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Set a quota for the subvolume.
-          </para>
-          <screen>&lt;referenced_limit&gt;1 GiB&lt;/referenced_limit&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           Optional. The default value is <literal>unlimited</literal>. Btrfs
-           supports two kinds of limits: <literal>referenced</literal> and
-           <literal>exclusive</literal>. At this point, only the former is
-           supported.
-          </para>
-         </entry>
-        </row>
-       </tbody>
-      </tgroup>
-     </informaltable>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>referenced_limit</literal>
+    </term>
+    <listitem>
+      <para> Set a quota for the subvolume. </para>
+      <screen>&lt;referenced_limit&gt;1 GiB&lt;/referenced_limit&gt;</screen>
+      <para> Optional. The default value is <literal>unlimited</literal>.
+            Btrfs supports two kinds of limits: <literal>referenced</literal>
+            and <literal>exclusive</literal>. At this point, only the former is
+            supported. </para>
+    </listitem>
+  </varlistentry>
+</variablelist>
+
 
      <para>
       If there is a default subvolume used for the distribution (for example

--- a/xml/ay_squid_server.xml
+++ b/xml/ay_squid_server.xml
@@ -292,111 +292,70 @@
 </screen>
    </example>
 
-   <informaltable>
-    <tgroup cols="3">
-     <thead>
-      <row>
-       <entry>
-        <para>
-         Attribute
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Values
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Description
-        </para>
-       </entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>
-        <para>
-         <literal>acls</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+<variablelist>
+  <varlistentry>
+    <term>
+      <literal>acls</literal>
+    </term>
+    <listitem>
+      <para>
          List of Access Control Settings (ACLs).
         </para>
-       </entry>
-       <entry>
-        <para>
+      <para>
          Each list entry contains the name, type, and additional options.
          Use the &yast; Squid configuration module to get an overview
          of possible entries.
         </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>http_accesses</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>http_accesses</literal>
+    </term>
+    <listitem>
+      <para>
          In the Access Control table, access can be denied or allowed to ACL
          Groups.
         </para>
-        <para>
-        </para>
-       </entry>
-       <entry>
-        <para>
+      <para/>
+      <para>
          If there are more ACL Groups in one definition, access will be allowed or denied to members who belong to all ACL
          Groups at the same time.
        </para>
-        <para>
+      <para>
          The Access Control table is checked in the order listed here. The
          first matching entry is used.
         </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>http_ports</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>http_ports</literal>
+    </term>
+    <listitem>
+      <para>
          Define all ports where Squid will listen for clients' HTTP requests.
         </para>
-       </entry>
-       <entry>
-        <para>
-         <literal>Host</literal> can contain a host name or IP address or
+      <para><literal>Host</literal> can contain a host name or IP address or
          remain empty.
         </para>
-        <para>
-         <literal>transparent</literal> disables PMTU discovery when transparent.
+      <para><literal>transparent</literal> disables PMTU discovery when transparent.
         </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>refresh_patterns</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>refresh_patterns</literal>
+    </term>
+    <listitem>
+      <para>
          Refresh patterns define how Squid treats the objects in the cache.
         </para>
-       </entry>
-       <entry>
-        <para>
+      <para>
          The refresh patterns are checked in the order listed here. The first
          matching entry is used.
         </para>
-        <para>
-         <literal>Min</literal> determines how long (in minutes) an object
+      <para><literal>Min</literal> determines how long (in minutes) an object
          should be considered fresh if no explicit expiry time is given.
          <literal>Max</literal> is the upper limit of how long objects without
          an explicit expiry time will be considered fresh.
@@ -404,44 +363,34 @@
          (time since last modification). An object without an explicit expiry
          time will be considered fresh.
         </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>settings</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>settings</literal>
+    </term>
+    <listitem>
+      <para>
          Map of all available general parameters with default values.
         </para>
-       </entry>
-       <entry>
-        <para>
+      <para>
          Use the &yast; Squid configuration module to get an overview
          about possible entries.
         </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>service_enabled_on_startup</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>service_enabled_on_startup</literal>
+    </term>
+    <listitem>
+      <para>
          Squid service start when booting.
         </para>
-       </entry>
-       <entry>
-        <para>
+      <para>
          Value: true/false
         </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </sect1>
+    </listitem>
+  </varlistentry>
+</variablelist> 
+</sect1>

--- a/xml/ay_users_groups.xml
+++ b/xml/ay_users_groups.xml
@@ -127,216 +127,154 @@
      </para>
     </note>
 
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Attribute
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Values
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>username</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <varlistentry>
+    <term>
+      <literal>username</literal>
+    </term>
+    <listitem>
+      <para>
           Text
          </para>
-<screen>&lt;username&gt;lukesw&lt;/username&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <screen>&lt;username&gt;lukesw&lt;/username&gt;</screen>
+      <para>
           Required. It should be a valid user name. Check <literal>man 8 useradd</literal>
           if you are not sure.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>fullname</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>fullname</literal>
+    </term>
+    <listitem>
+      <para>
           Text
          </para>
-<screen>&lt;fullname&gt;Tux Torvalds&lt;/fullname&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <screen>&lt;fullname&gt;Tux Torvalds&lt;/fullname&gt;</screen>
+      <para>
           Optional. User's full name.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>forename</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>forename</literal>
+    </term>
+    <listitem>
+      <para>
           Text
          </para>
-<screen>&lt;forname&gt;Tux&lt;/forename&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <screen>&lt;forname&gt;Tux&lt;/forename&gt;</screen>
+      <para>
           Optional. User's forename.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>surname</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>surname</literal>
+    </term>
+    <listitem>
+      <para>
           Text
          </para>
-<screen>&lt;surname&gt;Skywalker&lt;/surname&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <screen>&lt;surname&gt;Skywalker&lt;/surname&gt;</screen>
+      <para>
           Optional. User's surname.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>uid</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>uid</literal>
+    </term>
+    <listitem>
+      <para>
           Number
          </para>
-<screen>&lt;uid&gt;1001&lt;/uid&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <screen>&lt;uid&gt;1001&lt;/uid&gt;</screen>
+      <para>
           Optional. User ID. It should be a unique and must be a non-negative
           number. If not specified, &ay; will automatically choose a user
-          ID. Also refer to <xref
-          linkend="ann-Configuration-Security-users-uid"/> for additional
+          ID. Also refer to <xref linkend="ann-Configuration-Security-users-uid"/> for additional
           information.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>gid</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>gid</literal>
+    </term>
+    <listitem>
+      <para>
           Number
          </para>
-<screen>&lt;gid&gt;100&lt;/gid&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <screen>&lt;gid&gt;100&lt;/gid&gt;</screen>
+      <para>
           Optional. Initial group ID. It must be a unique and non-negative
           number. Moreover it must refer to an existing group.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>home</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>home</literal>
+    </term>
+    <listitem>
+      <para>
           Path
          </para>
-<screen>&lt;home&gt;/home/luke&lt;/home&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <screen>&lt;home&gt;/home/luke&lt;/home&gt;</screen>
+      <para>
           Optional. Absolute path to the user's home directory. By default,
           <literal>/home/username</literal> will be used (for example,
           <literal>alice</literal>'s home directory will be
           <literal>/home/alice</literal>).
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>home_btrfs_subvolume</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>home_btrfs_subvolume</literal>
+    </term>
+    <listitem>
+      <para>
           Boolean
          </para>
-<screen>&lt;home_btrfs_subvolume config:type="boolean"&gt;true&lt;/home_btrfs_subvolume&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <screen>&lt;home_btrfs_subvolume config:type="boolean"&gt;true&lt;/home_btrfs_subvolume&gt;</screen>
+      <para>
           Optional. Generates the home directory in a Btrfs subvolume. Disabled
           by default.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>shell</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>shell</literal>
+    </term>
+    <listitem>
+      <para>
           Path
          </para>
-<screen>&lt;shell&gt;/usr/bin/zsh&lt;/shell&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <screen>&lt;shell&gt;/usr/bin/zsh&lt;/shell&gt;</screen>
+      <para>
           Optional. <literal>/bin/bash</literal> is the default value. If you
           choose another one, make sure that it is installed (adding the corresponding
           package to the <literal>software</literal> section).
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>user_password</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>user_password</literal>
+    </term>
+    <listitem>
+      <para>
           Text
          </para>
-<screen>&lt;user_password&gt;some-password&lt;/user_password&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <screen>&lt;user_password&gt;some-password&lt;/user_password&gt;</screen>
+      <para>
           Optional. If you enter an exclamation mark (<literal>!</literal>), a
           random password will be generated. A user's password can be written in
           plain text (not recommended) or in encrypted form. To create an
@@ -345,47 +283,39 @@
           To enable or disable the use of encrypted passwords in the profile, see
           the <literal>encrypted</literal> parameter.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>encrypted</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>encrypted</literal>
+    </term>
+    <listitem>
+      <para>
           Boolean
          </para>
-<screen>&lt;encrypted config:type="boolean"&gt;true&lt;/encrypted&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <screen>&lt;encrypted config:type="boolean"&gt;true&lt;/encrypted&gt;</screen>
+      <para>
           Optional. Considered <literal>false</literal> if not present.
           Indicates if the user's password in the profile is encrypted or not.
           &ay; supports standard encryption algorithms (see <command>man 3
           crypt)</command>.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>password_settings</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>password_settings</literal>
+    </term>
+    <listitem>
+      <para>
           Password settings
          </para>
-         <screen>&lt;password_settings&gt;
+      <screen>&lt;password_settings&gt;
   &lt;expire/&gt;
   &lt;max&gt;60&lt;/max&gt;
   &lt;warn&gt;7&lt;/warn&gt;
 &lt;/password_settings&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <para>
           Optional. Some password settings can be customized:
           <literal>expire</literal> (account expiration date in format
           <literal>YYYY-MM-DD</literal>), <literal>flag</literal>
@@ -397,34 +327,27 @@
           (number of days before expiration when the password change reminder
           starts).
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>authorized_keys</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>authorized_keys</literal>
+    </term>
+    <listitem>
+      <para>
           List of authorized keys
          </para>
-         <screen>&lt;authorized_keys config:type="list"&gt;
+      <screen>&lt;authorized_keys config:type="list"&gt;
   &lt;listentry&gt;ssh-rsa ...&lt;/listentry&gt;
 &lt;/authorized_keys&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <para>
           A list of authorized keys to be written to <literal>$HOME/.ssh/authorized_keys</literal>.
           See example below.
          </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-
-   </sect2>
+    </listitem>
+  </varlistentry>
+</variablelist>
+</sect2>
 
    <sect2 xml:id="Configuration-Security-user-defaults">
     <title>User defaults</title>
@@ -437,200 +360,141 @@
      <literal>useradd</literal>.
     </para>
 
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Attribute
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Values
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>group</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <varlistentry>
+    <term>
+      <literal>group</literal>
+    </term>
+    <listitem>
+      <para>
           Text
          </para>
-<screen>&lt;group&gt;100&lt;/group&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <screen>&lt;group&gt;100&lt;/group&gt;</screen>
+      <para>
           Optional. Default initial login group.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>groups</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>groups</literal>
+    </term>
+    <listitem>
+      <para>
           Text
          </para>
-<screen>&lt;groups&gt;users&lt;/groups&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <screen>&lt;groups&gt;users&lt;/groups&gt;</screen>
+      <para>
           Optional. List of additional groups.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>home</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>home</literal>
+    </term>
+    <listitem>
+      <para>
           Path
          </para>
-<screen>&lt;home&gt;/home&lt;/home&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <screen>&lt;home&gt;/home&lt;/home&gt;</screen>
+      <para>
           Optional. User's home directory prefix.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>expire</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>expire</literal>
+    </term>
+    <listitem>
+      <para>
           Date
          </para>
-<screen>&lt;expire&gt;2017-12-31&lt;/expire&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <screen>&lt;expire&gt;2017-12-31&lt;/expire&gt;</screen>
+      <para>
           Optional. Default password expiration date in <literal>YYYY-MM-DD</literal> format.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>inactive</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>inactive</literal>
+    </term>
+    <listitem>
+      <para>
           Number
          </para>
-<screen>&lt;inactive&gt;3&lt;/inactive&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <screen>&lt;inactive&gt;3&lt;/inactive&gt;</screen>
+      <para>
           Optional. Number of days after which an expired account is disabled.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>no_groups</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>no_groups</literal>
+    </term>
+    <listitem>
+      <para>
           Boolean
          </para>
-<screen>&lt;no_groups config:type="boolean"&gt;true&lt;/no_groups&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <screen>&lt;no_groups config:type="boolean"&gt;true&lt;/no_groups&gt;</screen>
+      <para>
           Optional. Do not use secondary groups.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>shell</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>shell</literal>
+    </term>
+    <listitem>
+      <para>
           Path
          </para>
-<screen>&lt;shell&gt;/usr/bin/fish&lt;/shell&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <screen>&lt;shell&gt;/usr/bin/fish&lt;/shell&gt;</screen>
+      <para>
           Default login shell. <literal>/bin/bash</literal> is the default value. If you
           choose another one, make sure that it is installed (adding the corresponding
           package to the <literal>software</literal> section).
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>skel</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>skel</literal>
+    </term>
+    <listitem>
+      <para>
           Path
          </para>
-<screen>&lt;skel&gt;/etc/skel&lt;/skel&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <screen>&lt;skel&gt;/etc/skel&lt;/skel&gt;</screen>
+      <para>
           Optional. Location of the files to be used as skeleton when adding a new
           user. You can find more information in <literal>man 8
           useradd</literal>.
          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>umask</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>umask</literal>
+    </term>
+    <listitem>
+      <para>
           File creation mode mask
          </para>
-<screen>&lt;umask&gt;022&lt;/umask&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+      <screen>&lt;umask&gt;022&lt;/umask&gt;</screen>
+      <para>
           Set the file creation mode mask for the home directory. By default
           <literal>useradd</literal> will use <literal>022</literal>. Check <literal>man 8 useradd</literal>
           and <literal>man 1 umask</literal> for further information.
          </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
-   </sect2>
+    </listitem>
+  </varlistentry>
+</variablelist>
+</sect2>
 
    <sect2 xml:id="Configuration-Security-groups">
     <title>Groups</title>

--- a/xml/ay_windows_domain_client.xml
+++ b/xml/ay_windows_domain_client.xml
@@ -39,130 +39,82 @@
 </screen>
    </example>
 
-   <informaltable>
-    <tgroup cols="3">
-     <thead>
-      <row>
-       <entry>
-        <para>
-         Attribute
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Values
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Description
-        </para>
-       </entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>
-        <para>
-         <literal>disable_dhcp_hostname</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+<variablelist>
+  <varlistentry>
+    <term>
+      <literal>disable_dhcp_hostname</literal>
+    </term>
+    <listitem>
+      <para>
          Do not allow DHCP to change the host name.
         </para>
-       </entry>
-       <entry>
-        <para>
+      <para>
         Value: true/false
         </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>global/security</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>global/security</literal>
+    </term>
+    <listitem>
+      <para>
          Kind of authentication regime (domain technology or Active Directory server (ADS)).
         </para>
-       </entry>
-       <entry>
-        <para>
+      <para>
         Value: ADS/domain
         </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>global/usershare_allow_guests</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>global/usershare_allow_guests</literal>
+    </term>
+    <listitem>
+      <para>
          Sharing guest access is allowed.
         </para>
-       </entry>
-       <entry>
-        <para>
+      <para>
         Value: No/Yes
         </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>global/usershare_max_shares</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>global/usershare_max_shares</literal>
+    </term>
+    <listitem>
+      <para>
          Max. number of shares from <filename>smb.conf</filename>.
         </para>
-       </entry>
-       <entry>
-        <para>
+      <para>
          0 means that shares are not enabled.
         </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>global/workgroup</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>global/workgroup</literal>
+    </term>
+    <listitem>
+      <para>
          Workgroup or domain name.
         </para>
-       </entry>
-       <entry>
-        <para>
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>winbind</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+      <para/>
+    </listitem>
+  </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>winbind</literal>
+    </term>
+    <listitem>
+      <para>
          Using winbind.
         </para>
-       </entry>
-       <entry>
-        <para>
+      <para>
          Value: true/false
         </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </sect1>
+    </listitem>
+  </varlistentry>
+</variablelist>
+</sect1>


### PR DESCRIPTION
Some of the tables are so large they do not render well, especially in PDF.
Using convert-table2variablelist.xsl in DAPS to make the conversion
https://github.com/openSUSE/daps

### Description

Describe the overall goals of this pull request.


### Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [ x] 15 SP3  | *(no backport necessary)*
| [ ] 15 SP2  | [ ]
| [ ] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
