### PR TITLE
convert large tables in AY Guide to lists

### DIFF
--- a/xml/ay_ftp_server.xml
+++ b/xml/ay_ftp_server.xml
@@ -60,551 +60,226 @@
 </screen>
     </example>
 
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>AnonAuthen</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Element, Description, Comment </title>
+  <varlistentry><term><literal>AnonAuthen</literal></term>
+<listitem><para>
           Enable/disable anonymous and local users.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Authenticated Users Only: 1; Anonymous Only: 0; Both: 2
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>AnonCreatDirs</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>AnonCreatDirs</literal></term>
+<listitem><para>
          Anonymous users can create directories.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
          Values: YES/NO
-        </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>AnonReadOnly</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>AnonReadOnly</literal></term>
+<listitem><para>
          Anonymous users can upload.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Values: YES/NO
-          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>AnonMaxRate</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+          </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>AnonMaxRate</literal></term>
+<listitem><para>
           The maximum data transfer rate permitted for anonymous clients.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           KB/s
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>AntiWarez</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>AntiWarez</literal></term>
+<listitem><para>
           Disallow downloading of files that were uploaded but not validated by
           a local admin.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Values: YES/NO
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>Banner</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>Banner</literal></term>
+<listitem><para>
           Specify the name of a file containing the text to display when someone
           connects to the server.
-         </para>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>CertFile</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para/></listitem>
+</varlistentry>
+  <varlistentry><term><literal>CertFile</literal></term>
+<listitem><para>
           DSA certificate to use for SSL-encrypted connections
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           This option specifies the location of the DSA certificate to use for
           SSL-encrypted connections.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>ChrootEnable</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>ChrootEnable</literal></term>
+<listitem><para>
           When enabled, local users will by default be placed in a <literal>chroot</literal>
           jail in their home directory after login.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Warning: This option has security implications.
           Values: YES/NO
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>EnableUpload</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>EnableUpload</literal></term>
+<listitem><para>
           If enabled, FTP users can upload.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           To allow anonymous users to upload, enable <literal>AnonReadOnly</literal>.
           Values: YES/NO
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>FTPUser</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>FTPUser</literal></term>
+<listitem><para>
           Defines the anonymous FTP user.
-         </para>
-        </entry>
-        <entry>
-         <para>
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>FtpDirAnon</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para/></listitem>
+</varlistentry>
+  <varlistentry><term><literal>FtpDirAnon</literal></term>
+<listitem><para>
           FTP directory for anonymous users.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Specify a directory which is used for anonymous FTP users.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>FtpDirLocal</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>FtpDirLocal</literal></term>
+<listitem><para>
           FTP directory for authenticated users.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Specify a directory which is used for FTP authenticated users.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>LocalMaxRate</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>LocalMaxRate</literal></term>
+<listitem><para>
           The maximum data transfer rate permitted for local authenticated users.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           KB/s
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>MaxClientsNumber</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>MaxClientsNumber</literal></term>
+<listitem><para>
           The maximum number of clients allowed to connect.
-         </para>
-        </entry>
-        <entry>
-         <para>
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>MaxClientsPerIP</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para/></listitem>
+</varlistentry>
+  <varlistentry><term><literal>MaxClientsPerIP</literal></term>
+<listitem><para>
           Defines the maximum number of clients for one IP.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           This limits the number of clients allowed to connect from a single
           source Internet address.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>MaxIdleTime</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>MaxIdleTime</literal></term>
+<listitem><para>
           The maximum time (timeout) a remote client may wait between FTP
           commands.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Minutes
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>PasMaxPort</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>PasMaxPort</literal></term>
+<listitem><para>
           Maximum value for a port range for passive connection replies.
-         </para>
-        </entry>
-        <entry>
-         <para>
-          <literal>PassiveMode</literal> needs to be set to YES.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>PasMinPort</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para><literal>PassiveMode</literal> needs to be set to YES.
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>PasMinPort</literal></term>
+<listitem><para>
           Minimum value for a port range for passive connection replies.
-         </para>
-        </entry>
-        <entry>
-         <para>
-          <literal>PassiveMode</literal> needs to be set to YES.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>PassiveMode</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para><literal>PassiveMode</literal> needs to be set to YES.
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>PassiveMode</literal></term>
+<listitem><para>
           Enable Passive Mode
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
          Value: YES/NO
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>SSL</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>SSL</literal></term>
+<listitem><para>
           Security Settings
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
          Disable TLS/SSL: 0; Accept TLS and SSL: 1; Refuse Connections Without
          TLS/SSL: 2
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>SSLEnable</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>SSLEnable</literal></term>
+<listitem><para>
           If enabled, SSL connections are allowed.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Value: YES/NO
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>SSLv2</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>SSLv2</literal></term>
+<listitem><para>
           If enabled, SSL version 2 connections are allowed.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Value: YES/NO
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>SSLv3</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>SSLv3</literal></term>
+<listitem><para>
           If enabled, SSL version 3 connections are allowed.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Value: YES/NO
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>StartDaemon</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>StartDaemon</literal></term>
+<listitem><para>
           How the FTP daemon will be started.
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Manually: 0; when booting: 1; via &systemd; socket: 2
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>TLS</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
+          Manually: 0; when booting: 1; via systemd socket: 2
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>TLS</literal></term>
+<listitem><para>
           If enabled, TLS connections are allowed.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Value: YES/NO
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>Umask</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>Umask</literal></term>
+<listitem><para>
           File creation mask, in the format (umask for files):(umask for
           directories).
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           For example <literal>177:077</literal> if you feel paranoid.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>UmaskAnon</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>UmaskAnon</literal></term>
+<listitem><para>
           The value to which the umask for file creation is set for anonymous
           users.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           To specify octal values, remember the "0" prefix, otherwise the value
           will be treated as a base-10 integer.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>UmaskLocal</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>UmaskLocal</literal></term>
+<listitem><para>
           Umask for authenticated users.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           To specify octal values, remember the "0" prefix, otherwise the value
           will be treated as a base-10 integer.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>VerboseLogging</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>VerboseLogging</literal></term>
+<listitem><para>
           When enabled, all FTP requests and responses are logged.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Value: YES/NO
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>VirtualUser</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>VirtualUser</literal></term>
+<listitem><para>
           By using virtual users, FTP accounts can be administrated without
           affecting system accounts.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para> 
+        <para>
           Value: YES/NO
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+         </para></listitem>
+</varlistentry>
+</variablelist>
 
     <note>
       <title>Firewall</title>


### PR DESCRIPTION
wide tables do not render well. Using convert-table2variablelist.xsl
in DAPS to make the conversion https://github.com/openSUSE/daps

Thank you Thomas Schraitle!

### Description

Describe the overall goals of this pull request.


### Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [ x] 15 SP3  | *(no backport necessary)*
| [ ] 15 SP2  | [ ]
| [ ] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
