### PR TITLE
wide tables in AY Guide do not render well

### DIFF
--- a/xml/ay_apache_server.xml
+++ b/xml/ay_apache_server.xml
@@ -377,252 +377,101 @@
 </screen>
    </example>
 
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          List Name
-         </para>
-        </entry>
-        <entry>
-         <para>
-          List Elements
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
+<variablelist>
+  <title>List Name, List Elements, Description</title>
+  <varlistentry><term>
           Listen
-         </para>
-        </entry>
-        <entry>
-         <para>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </term>
+<listitem><para/><para>
           List of host <literal>Listen</literal> settings
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term/>
+<listitem><para>
           PORT
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           port address
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term/>
+<listitem><para>
           ADDRESS
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Network address. All addresses will be taken if this entry is empty.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term>
           hosts
-         </para>
-        </entry>
-        <entry>
-         <para>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </term>
+<listitem><para/><para>
           List of Hosts configuration
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term/>
+<listitem><para>
           KEY
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Host name; <literal>&lt;KEY&gt;main&lt;/KEY&gt;</literal> defines the main hosts,
-          for example <literal>&lt;KEY&gt;192.168.43.2/secondserver.suse.de&lt;/KEY&gt;</literal>
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-         </para>
-        </entry>
-        <entry>
-         <para>
+          for example <literal>&lt;KEY&gt;192.168.43.2/secondserver.suse.de&lt;/KEY&gt;</literal></para></listitem>
+</varlistentry>
+  <varlistentry><term/>
+<listitem><para>
           VALUE
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           List of different values describing the host.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term>
           modules
-         </para>
-        </entry>
-        <entry>
-         <para>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </term>
+<listitem><para/><para>
           Module list. Only user-defined modules need to be described.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term/>
+<listitem><para>
           name
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
          Module name
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term/>
+<listitem><para>
           userdefined
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           For historical reasons, it is always set to <literal>true</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term/>
+<listitem><para>
           change
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           For historical reasons, it is always set to <literal>enable</literal>.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+         </para></listitem>
+</varlistentry>
+</variablelist>
 
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
+<variablelist>
+  <title>Element, Description, Comment</title>
+  <varlistentry><term>
           version
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </term>
+<listitem><para>
           Version of used Apache server
-         </para>
-        </entry>
-        <entry>
-          <para>
+         </para><para>
           Only for information. Default 2.9
-          </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
+          </para></listitem>
+</varlistentry>
+  <varlistentry><term>
           service
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </term>
+<listitem><para>
           Enable Apache service
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
          Optional. Default: false
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+         </para></listitem>
+</varlistentry>
+</variablelist>
 
     <note>
       <title>Firewall</title>

--- a/xml/ay_ask_user_values.xml
+++ b/xml/ay_ask_user_values.xml
@@ -40,114 +40,42 @@
   &lt;/ask-list&gt;
 &lt;/general&gt;</screen>
 
-   <table>
+<variablelist>
     <title>Ask the user for values: XML representation</title>
-    <tgroup cols="3">
-     <thead>
-      <row>
-       <entry>
-        <para>
-         Element
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Description
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Comment
-        </para>
-       </entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>
-        <para>
-         <literal>question</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+  <varlistentry><term><literal>question</literal></term>
+<listitem><para>
          The question you want to ask the user.
-        </para>
-<screen>&lt;question&gt;Enter the LDAP server&lt;/question&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;question&gt;Enter the LDAP server&lt;/question&gt;</screen><para>
          The default value is the path to the element (the path often looks
          strange, so we recommend entering a question).
-        </para>
-        <remark>emap 2011-11-04: not sure I understand this.</remark>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>default</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para><remark>emap 2011-11-04: not sure I understand this.</remark></listitem>
+</varlistentry>
+  <varlistentry><term><literal>default</literal></term>
+<listitem><para>
          Set a preselection for the user. A text entry will be filled out
          with this value. A check box will be true or false and a selection
          will have the given value preselected.
-        </para>
-<screen>&lt;default&gt;dc=suse,dc=de&lt;/default&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;default&gt;dc=suse,dc=de&lt;/default&gt;</screen><para>
          Optional.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>help</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>help</literal></term>
+<listitem><para>
          An optional help text that is shown on the left side of the
          question.
-        </para>
-<screen>&lt;help&gt;Enter the LDAP server address.&lt;/help&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;help&gt;Enter the LDAP server address.&lt;/help&gt;</screen><para>
          Optional.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>title</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>title</literal></term>
+<listitem><para>
          An optional title that is shown above the questions.
-        </para>
-<screen>&lt;title&gt;LDAP server&lt;/title&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;title&gt;LDAP server&lt;/title&gt;</screen><para>
          Optional.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>type</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>type</literal></term>
+<listitem><para>
          The type of the element you want to change. Possible values are
          <literal>symbol</literal>, <literal>boolean</literal>,
          <literal>string</literal> and <literal>integer</literal>. The file
@@ -159,46 +87,24 @@
          A <literal>static_text</literal> is a text that does not
          require any user input and can show information not
          included in the help text.
-        </para>
-<screen>&lt;type&gt;symbol&lt;/type&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;type&gt;symbol&lt;/type&gt;</screen><para>
          Optional. The default is <literal>string</literal>. If type is
          <literal>symbol</literal>, you must provide the selection element
          too (see below).
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>password</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>password</literal></term>
+<listitem><para>
          If this boolean is set to <literal>true</literal>, a password
          dialog pops up instead of a simple text entry. Setting this to
          <literal>true</literal> only makes sense if <literal>type</literal>
          is string.
-        </para>
-<screen>&lt;password config:type="boolean"&gt;true&lt;/password&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;password config:type="boolean"&gt;true&lt;/password&gt;</screen><para>
          Optional. The default is <literal>false</literal>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>pathlist</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>pathlist</literal></term>
+<listitem><para>
          A list of <literal>path</literal> elements. A path is a comma
          separated list of elements that describes the path to the element
          you want to change. For example, the LDAP server element can be
@@ -206,20 +112,17 @@
          <literal>&lt;ldap&gt;&lt;ldap_server&gt;</literal> section.
          So to change that value, you need to set the path to
          <literal>ldap,ldap_server</literal>.
-        </para>
-        <screen>&lt;pathlist config:type="list"&gt;
+        </para><screen>&lt;pathlist config:type="list"&gt;
   &lt;path&gt;networking,dns,hostname&lt;/path&gt;
   &lt;path&gt;...&lt;/path&gt;
 &lt;/pathlist&gt;
-        </screen>
-        <para>To change the
+        </screen><para>To change the
          password of the first user in the control file, you need to set the
          path to <literal>users,0,user_password</literal>. The
          <literal>0</literal> indicates the first user in the &lt;users
          config:type="list"&gt; list of users in the control file.
          <literal>1</literal> would be the second one, and so on.
-        </para>
-        <screen>&lt;users config:type="list"&gt;
+        </para><screen>&lt;users config:type="list"&gt;
   &lt;user&gt;
     &lt;username&gt;root&lt;/username&gt;
     &lt;user_password&gt;password to change&lt;/user_password&gt;
@@ -231,24 +134,13 @@
     &lt;encrypted config:type="boolean"&gt;false&lt;/encrypted&gt;
   &lt;/user&gt;
 &lt;/users&gt;
-        </screen>
-
-       </entry>
-       <entry>
-        <para>
+        </screen><para>
          This information is optional but you should at least provide
          <literal>path</literal> or <literal>file</literal>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>file</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>file</literal></term>
+<listitem><para>
          You can store the answer to a question in a file, to use it in one
          of your scripts later. If you ask during
          <literal>stage=initial</literal> and you want to use the answer in
@@ -258,24 +150,15 @@
          is that <filename>/tmp</filename> in stage&nbsp;1 is in the RAM disk
          and will be lost after the reboot, but the installed system is
          already mounted at <filename>/mnt/</filename>.
-        </para>
-<screen>&lt;file&gt;/tmp/answer_hostname&lt;/file&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;file&gt;/tmp/answer_hostname&lt;/file&gt;</screen><para>
          This information is optional, but you should at least provide
          <literal>path</literal> or <literal>file</literal>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term>
          stage
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </term>
+<listitem><para>
          Stage configures the installation stage in which the question pops
          up. You can set this value to <literal>cont</literal> or
          <literal>initial</literal>. <literal>initial</literal> means the
@@ -289,29 +172,17 @@
          it does not make sense to ask for the file system to use during the
          <literal>cont</literal> phase. The hard disk is already partitioned
          at that stage and the question will have no effect.
-        </para>
-<screen>&lt;stage&gt;cont&lt;/stage&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;stage&gt;cont&lt;/stage&gt;</screen><para>
          Optional. The default is <literal>initial</literal>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>selection</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>selection</literal></term>
+<listitem><para>
          The selection element contains a list of <literal>entry</literal>
          elements. Each entry represents a possible option for the user to
          choose. The user cannot enter a value in a text box, but they can
          choose from a list of values.
-        </para>
-<screen>&lt;selection config:type="list"&gt;
+        </para><screen>&lt;selection config:type="list"&gt;
   &lt;entry&gt;
     &lt;value&gt;
         btrfs
@@ -328,223 +199,107 @@
         Extended3 File System
     &lt;/label&gt;
   &lt;/entry&gt;
-&lt;/selection&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+&lt;/selection&gt;</screen><para>
          Optional for <literal>type=string</literal>, not possible for
          <literal>type=boolean</literal> and mandatory for
          <literal>type=symbol</literal>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>dialog</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>dialog</literal></term>
+<listitem><para>
          You can ask more than one question per dialog. To do so, specify
          the dialog-id with an integer. All questions with the same
          dialog-id belong to the same dialog. The dialogs are sorted by the
          id too.
-        </para>
-<screen>&lt;dialog config:type="integer"&gt;3&lt;/dialog&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;dialog config:type="integer"&gt;3&lt;/dialog&gt;</screen><para>
          Optional.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>element</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>element</literal></term>
+<listitem><para>
          You can have more than one question per dialog. To make that
          possible you need to specify the <literal>element-id</literal> with an
          integer. The questions in a dialog are sorted by ID.
-        </para>
-<screen>&lt;element config:type="integer"&gt;1&lt;/element&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;element config:type="integer"&gt;1&lt;/element&gt;</screen><para>
          Optional (see dialog).
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>width</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>width</literal></term>
+<listitem><para>
          You can increase the default width of the dialog. If there are multiple
          width specifications per dialog, the largest one is used. The
          number is roughly equivalent to the number of characters.
-        </para>
-<screen>&lt;width config:type="integer"&gt;50&lt;/width&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;width config:type="integer"&gt;50&lt;/width&gt;</screen><para>
          Optional.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>height</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>height</literal></term>
+<listitem><para>
          You can increase the default height of the dialog. If there are
          multiple height specifications per dialog, the largest one is used. The
          number is roughly equivalent to the number of lines.
-        </para>
-<screen>&lt;height config:type="integer"&gt;15&lt;/height&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;height config:type="integer"&gt;15&lt;/height&gt;</screen><para>
          Optional.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>frametitle</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>frametitle</literal></term>
+<listitem><para>
          You can have more than one question per dialog. Each question on a
          dialog has a frame that can have a frame title, a small caption for
          each question. You can put multiple elements into one frame. They
          need to have the same frame title.
-        </para>
-<screen>&lt;frametitle&gt;User data&lt;/frametitle&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;frametitle&gt;User data&lt;/frametitle&gt;</screen><para>
          Optional; default is no frame title.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>script</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>script</literal></term>
+<listitem><para>
          You can run scripts after a question has been answered. See the
          table below for detailed instructions about scripts.
-        </para>
-<screen>&lt;script&gt;...&lt;/script&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;script&gt;...&lt;/script&gt;</screen><para>
          Optional; default is no script.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>ok_label</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>ok_label</literal></term>
+<listitem><para>
          You can change the label on the <guimenu>Ok</guimenu> button. The
          last element that specifies the label for a dialog wins.
-        </para>
-<screen>&lt;ok_label&gt;Finish&lt;/ok_label&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;ok_label&gt;Finish&lt;/ok_label&gt;</screen><para>
          Optional.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>back_label</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>back_label</literal></term>
+<listitem><para>
          You can change the label on the <guimenu>Back</guimenu> button. The
          last element that specifies the label for a dialog wins.
-        </para>
-<screen>&lt;back_label&gt;change values&lt;/back_label&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;back_label&gt;change values&lt;/back_label&gt;</screen><para>
          Optional.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>timeout</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>timeout</literal></term>
+<listitem><para>
          You can specify an integer here that is used as timeout in seconds.
          If the user does not answer the question before the timeout, the
          default value is taken as answer. When the user touches or changes
          any widget in the dialog, the timeout is turned off and the dialog
          needs to be confirmed via <guimenu>Ok</guimenu>.
-        </para>
-<screen>&lt;timeout config:type="integer"&gt;30&lt;/timeout&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;timeout config:type="integer"&gt;30&lt;/timeout&gt;</screen><para>
          Optional; a missing value is interpreted as <literal>0</literal>,
          which means that there is no timeout.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>default_value_script</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>default_value_script</literal></term>
+<listitem><para>
          You can run scripts to set the default value for a question (see
          <xref linkend="CreateProfile-Ask-default-value"/> for detailed
          instructions about default value scripts). This feature is useful
          if you can <literal>calculate</literal> a default value, especially
          in combination with the <literal>timeout</literal> option.
-        </para>
-<screen>&lt;default_value_script&gt;...&lt;/default_value_script&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;default_value_script&gt;...&lt;/default_value_script&gt;</screen><para>
          Optional; default is no script.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </table>
+        </para></listitem>
+</varlistentry>
+</variablelist>
 
    <sect2 xml:id="CreateProfile-Ask-default-value">
     <title>Default value scripts</title>
@@ -567,37 +322,10 @@
     &lt;/ask&gt;
   &lt;/ask-list&gt;
 &lt;/general&gt;</screen>
-    <table>
-     <title>Default value scripts: XML representation</title>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>source</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Default value scripts: XML representation</title>
+  <varlistentry><term><literal>source</literal></term>
+<listitem><para>
           The source code of the script. Whatever you
           <command>echo</command> to STDOUT will be used as default value
           for the ask-dialog. If your script has an exit code other than 0,
@@ -605,37 +333,19 @@
           <command>echo -n</command> to suppress the <literal>\n</literal>
           and that you echo reasonable values and not <quote>okay</quote>
           for a boolean
-         </para>
-<screen>&lt;source&gt;...&lt;/source&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;source&gt;...&lt;/source&gt;</screen><para>
           This value is required, otherwise nothing would be executed.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>interpreter</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>interpreter</literal></term>
+<listitem><para>
           The interpreter to use.
-         </para>
-<screen>&lt;interpreter&gt;perl&lt;/interpreter&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;interpreter&gt;perl&lt;/interpreter&gt;</screen><para>
           The default value is <literal>shell</literal>. You can also set
           <filename>/bin/myinterpreter</filename> as value.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </table>
+         </para></listitem>
+</varlistentry>
+</variablelist>
    </sect2>
 
    <sect2 xml:id="CreateProfile-Ask-script">
@@ -656,155 +366,66 @@
     &lt;/ask&gt;
   &lt;/ask-list&gt;
 &lt;/general&gt;</screen>
-    <table>
-     <title>Scripts: XML representation</title>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>file name</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Scripts: XML representation</title>
+  <varlistentry><term><literal>file name</literal></term>
+<listitem><para>
           The file name of the script.
-         </para>
-<screen>&lt;filename&gt;my_ask_script.sh&lt;/filename&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;filename&gt;my_ask_script.sh&lt;/filename&gt;</screen><para>
           The default is ask_script.sh
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>source</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>source</literal></term>
+<listitem><para>
           The source code of the script. Together with
           <literal>rerun_on_error</literal> activated, you check the value
           that was entered for sanity. Your script can create a file
           <filename>/tmp/next_dialog</filename> with a dialog id specifying
-          the next dialog &ay; will raise. A value of -1 terminates the
+          the next dialog &ay;will raise. A value of -1 terminates the
           ask sequence. If that file is not created, &ay; will run the
           dialogs in the normal order (since 11.0 only).
-         </para>
-<screen>&lt;source&gt;...&lt;/source&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;source&gt;...&lt;/source&gt;</screen><para>
           This value is required, otherwise nothing would be executed.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>environment</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>environment</literal></term>
+<listitem><para>
           A boolean that passes the value of the answer to the question as
           an environment variable to the script. The variable is named
           <envar>VAL</envar>.
-         </para>
-<screen>&lt;environment config:type="boolean"&gt;true&lt;/environment&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;environment config:type="boolean"&gt;true&lt;/environment&gt;</screen><para>
           Optional. Default is <literal>false</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>feedback</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>feedback</literal></term>
+<listitem><para>
           A boolean that turns on feedback for the script execution. STDOUT
           will be displayed in a pop-up window that must be confirmed after
           the script execution.
-         </para>
-<screen>&lt;feedback config:type="boolean"&gt;true&lt;/feedback&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;feedback config:type="boolean"&gt;true&lt;/feedback&gt;</screen><para>
           Optional, default is <literal>false</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>debug</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>debug</literal></term>
+<listitem><para>
           A boolean that turns on debugging for the script execution.
-         </para>
-<screen>&lt;debug config:type="boolean"&gt;true&lt;/debug&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;debug config:type="boolean"&gt;true&lt;/debug&gt;</screen><para>
           Optional, default is <literal>true</literal>. This value needs
           <literal>feedback</literal> to be turned on, too.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>rerun_on_error</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>rerun_on_error</literal></term>
+<listitem><para>
           A boolean that keeps the dialog open until the script has an exit
           code of 0 (zero). So you can parse and check the answers the user
           gave in the script and display an error with the
           <literal>feedback</literal> option.
-         </para>
-<screen>&lt;rerun_on_error config:type="boolean"&gt;true&lt;/rerun_on_error&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;rerun_on_error config:type="boolean"&gt;true&lt;/rerun_on_error&gt;</screen><para>
           Optional, default is <literal>false</literal>. This value should
           be used together with the feedback option.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </table>
+         </para></listitem>
+</varlistentry>
+</variablelist>
     <para>
      Below you can see an example of the usage of the <literal>ask</literal>
      feature.

--- a/xml/ay_audit_framework.xml
+++ b/xml/ay_audit_framework.xml
@@ -42,148 +42,56 @@
 </screen>
    </example>
 
-   <informaltable>
-    <tgroup cols="3">
-     <thead>
-      <row>
-       <entry>
-        <para>
-         Attribute
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Values
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Description
-        </para>
-       </entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>
-        <para>
-         <literal>auditd/flush</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+<variablelist>
+  <title>Attribute, Values, Description</title>
+  <varlistentry><term><literal>auditd/flush</literal></term>
+<listitem><para>
          Describes how to write the data to disk.
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para><para>
          If set to <literal>INCREMENTAL</literal> the Frequency parameter tells
          how many records to write before issuing an explicit flush to disk.
          <literal>NONE</literal> means: no special effort is made to flush data,
          <literal>DATA</literal>: keep data portion synchronized,
          <literal>SYNC</literal>: keep data and metadata fully synchronized.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>auditd/freq</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>auditd/freq</literal></term>
+<listitem><para>
          This parameter tells how many records to write before issuing an explicit flush to disk.
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para><para>
          The parameter <literal>flush</literal> needs to be set to <literal>INCREMENTAL</literal>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>auditd/log_file</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>auditd/log_file</literal></term>
+<listitem><para>
          The full path name to the log file.
-        </para>
-       </entry>
-       <entry>
-        <para>
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>auditd/log_fomat</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para><para/></listitem>
+</varlistentry>
+  <varlistentry><term><literal>auditd/log_fomat</literal></term>
+<listitem><para>
          How much information needs to be logged.
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para><para>
          Set <literal>RAW</literal> to log all data (store in a format exactly as the kernel sends it)
          or <literal>NOLOG</literal> to discard all audit information instead of writing it to disk
          (does not affect data sent to the dispatcher).
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>auditd/max_log_file</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>auditd/max_log_file</literal></term>
+<listitem><para>
          How much information needs to be logged.
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para><para>
          Unit: Megabytes
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>auditd/num_logs</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>auditd/num_logs</literal></term>
+<listitem><para>
          Number of log files.
-        </para>
-       </entry>
-       <entry>
-        <para>
-         <literal>max_log_file_action</literal> needs to be set to <literal>ROTATE</literal>
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>auditd/max_log_file_action</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para><para><literal>max_log_file_action</literal> needs to be set to <literal>ROTATE</literal></para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>auditd/max_log_file_action</literal></term>
+<listitem><para>
          What happens if the log capacity has been reached.
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para><para>
          If the action is set to <literal>ROTATE</literal> the Number of Log
          Files specifies the number of files to keep. Set to
          <literal>SYSLOG</literal>, the audit daemon will write a warning to
@@ -191,49 +99,26 @@
          stops writing records to disk. <literal>IGNORE</literal> means do
          nothing, <literal>KEEP_LOGS</literal> is similar to
          <literal>ROTATE</literal>, but log files are not overwritten.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>auditd/name_format</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>auditd/name_format</literal></term>
+<listitem><para>
          Computer Name Format describes how to write the computer name to the log file.
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para><para>
          If <literal>USER</literal> is set, the user-defined name is used.
          <literal>NONE</literal> means no computer name is inserted.
          <literal>HOSTNAME</literal> uses the name returned by the 'gethostname' syscall.
          <literal>FQD</literal> uses the fully qualified domain name.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>rules</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>rules</literal></term>
+<listitem><para>
          Rules for auditctl
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para><para>
          You can edit the rules manually, which we only recommend for
          advanced users.  For more information about all options, see
          <command>man auditctl</command>.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
+        </para></listitem>
+</varlistentry>
+</variablelist>
   </sect1>

--- a/xml/ay_custom_user_scripts.xml
+++ b/xml/ay_custom_user_scripts.xml
@@ -200,122 +200,49 @@
      not executed by &yast;, but after &yast; has finished. For this reason,
      their XML representation is different from other script types.
     </para>
-    <table>
-     <title>Init script XML representation</title>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>location</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Init script XML representation</title>
+  <varlistentry><term><literal>location</literal></term>
+<listitem><para>
           Define a location from where the script gets fetched. Locations
           can be the same as for the profile (HTTP, FTP, NFS, etc.).
-         </para>
-<screen>&lt;location
-&gt;http://10.10.0.1/myInitScript.sh&lt;/location&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;location&gt;http://10.10.0.1/myInitScript.sh&lt;/location&gt;</screen><para>
           Either &lt;location&gt; or &lt;source&gt; must be
           defined.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>source</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>source</literal></term>
+<listitem><para>
           The script itself (source code), encapsulated in a CDATA tag. If
           you do not want to put the whole shell script into the XML
           profile, use the location parameter.
-         </para>
-<screen>&lt;source&gt;
-&lt;![CDATA[
-echo "Testing the init script" &gt;
-/tmp/init_out.txt
-]]&gt;
-&lt;/source&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;source&gt;
+&lt;![CDATA[echo "Testing the init script" &gt;/tmp/init_out.txt]]&gt;&lt;/source&gt;</screen><para>
           Either &lt;location&gt; or &lt;source&gt; must be
           defined.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>filename</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>filename</literal></term>
+<listitem><para>
           The file name of the script. It will be stored in a temporary
-          directory under <filename>/tmp</filename>
-         </para>
-<screen>&lt;filename&gt;mynitScript5.sh&lt;/filename&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+          directory under <filename>/tmp</filename></para><screen>&lt;filename&gt;mynitScript5.sh&lt;/filename&gt;</screen><para>
           Optional in case you only have a single init script. The default
           name (<filename>init-scripts</filename>) is used in this case. If
           having specified more than one init script, you must set a unique
           name for each script.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>rerun</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>rerun</literal></term>
+<listitem><para>
           Normally, a script is only run once, even if you use <literal>ayast_setup</literal>
           to run an XML file multiple times. Change this default behavior by
           setting this boolean to <literal>true</literal>.
-         </para>
-<screen>&lt;rerun config:type="boolean"&gt;true&lt;/rerun&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;rerun config:type="boolean"&gt;true&lt;/rerun&gt;</screen><para>
           Optional. Default is <literal>false</literal> (scripts only run
           once).
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </table>
+         </para></listitem>
+</varlistentry>
+</variablelist>
     <para>
      When added to the control file manually, scripts need to be included in
      a <emphasis>CDATA</emphasis> element to avoid confusion with the file
@@ -341,264 +268,123 @@ echo "Testing the init script" &gt;
        as having enabled the <literal>debug</literal> flag.
       </para>
     </important>
-    <table>
-     <title>Script XML representation</title>
-     <tgroup cols="3">
-      <colspec colwidth="1*"/>
-      <colspec colwidth="3*"/>
-      <colspec colwidth="2*"/>
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>location</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Script XML representation</title>
+  <varlistentry><term><literal>location</literal></term>
+<listitem><para>
           Define a location from where the script gets fetched. Locations
           can be the same as for the control file (HTTP, FTP, NFS, etc.).
           Additionally a relative URL can be used that defines a path relative to
           the directory with the control file, using the
           syntax <literal>relurl://script.sh</literal>.
-         </para>
-<screen>&lt;location
-&gt;http://10.10.0.1/myPreScript.sh&lt;/location&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;location&gt;http://10.10.0.1/myPreScript.sh&lt;/location&gt;</screen><para>
           Either <literal>location</literal> or <literal>source</literal>
           must be defined.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>source</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>source</literal></term>
+<listitem><para>
           The script itself (source code), encapsulated in a CDATA tag. If
           you do not want to put the whole shell script into the XML control
           file, refer to the location parameter.
-         </para>
-<screen>&lt;source&gt;
+         </para><screen>&lt;source&gt;
 &lt;![CDATA[
 echo "Testing the pre script" &gt; /tmp/pre-script_out.txt
 ]]&gt;
-&lt;/source&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+&lt;/source&gt;</screen><para>
           Either <literal>location</literal> or <literal>source</literal>
           must be defined.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>interpreter</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>interpreter</literal></term>
+<listitem><para>
           Specify the interpreter that must be used for the script. Any
           interpreter available in the given environment can be specified. It is
           possible to provide a full path to the interpreter, including
           parameters. There are also deprecated keywords interpreter "shell",
           "perl" and "python" that are supported by the <literal>debug</literal>
           flag.
-         </para>
-<screen>&lt;interpreter&gt;/bin/bash -x&lt;/interpreter&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;interpreter&gt;/bin/bash -x&lt;/interpreter&gt;</screen><para>
           Optional; default is <literal>shell</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>file name</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>file name</literal></term>
+<listitem><para>
           The file name of the script. It will be stored in a temporary
           directory under <filename>/tmp</filename>.
-         </para>
-<screen>&lt;filename&gt;myPreScript5.sh&lt;/filename&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;filename&gt;myPreScript5.sh&lt;/filename&gt;</screen><para>
           Optional; default is the type of the script (pre-scripts in this
           case). If you have more than one script, you should define
           different names for each script. If <literal>filename</literal>
           is not defined and <literal>location</literal> is defined,
           the file name from the location path will be used.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>feedback</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>feedback</literal></term>
+<listitem><para>
           If this boolean is <literal>true</literal>, output and error
           messages of the script (STDOUT and STDERR) will be shown in a
           pop-up. The user needs to confirm them via the OK button.
-         </para>
-<screen>&lt;feedback config:type="boolean"&gt;true&lt;/feedback&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;feedback config:type="boolean"&gt;true&lt;/feedback&gt;</screen><para>
           Optional; default is <literal>false</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>feedback_type</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>feedback_type</literal></term>
+<listitem><para>
           This can be <literal>message</literal>, <literal>warning</literal>
           or <literal>error</literal>. Set the timeout for these pop-ups in
           the &lt;report&gt; section.
-         </para>
-<screen>&lt;feedback_type&gt;warning&lt;/feedback_type&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;feedback_type&gt;warning&lt;/feedback_type&gt;</screen><para>
           Optional; if missing, an always-blocking pop-up is used.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>debug</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>debug</literal></term>
+<listitem><para>
           If this is <literal>true</literal>, every single line of a shell
           script is logged. Perl scripts are run with warnings turned on.
           This only works for the deprecated keyword <literal>interpreter</literal>.
           For other languages, give the path to the interpreter as a parameter in the 
           <literal>interpreter</literal> value, for example "&lt;interpreter&gt;ruby -w&lt;/interpreter&gt;".
-         </para>
-<screen>&lt;debug config:type="boolean"&gt;true&lt;/debug&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;debug config:type="boolean"&gt;true&lt;/debug&gt;</screen><para>
           Optional; default is <literal>true</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>notification</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>notification</literal></term>
+<listitem><para>
           This text will be shown in a pop-up for the time the script is
           running in the background.
-         </para>
-<screen>&lt;notification&gt;Please wait while script is running...&lt;/notification&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;notification&gt;Please wait while script is running...&lt;/notification&gt;</screen><para>
           Optional; if not configured, no notification pop-up will be shown.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>param-list</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>param-list</literal></term>
+<listitem><para>
           It is possible to specify parameters given to the script being
           called. You may have more than one <literal>param</literal> entry.
           They are concatenated by a single space character on the script
           command line. If any shell quoting should be necessary (for
           example to protect embedded spaces) you need to include this.
-         </para>
-<screen>&lt;param-list config:type="list"&gt;
+         </para><screen>&lt;param-list config:type="list"&gt;
   &lt;param&gt;par1&lt;/param&gt;
   &lt;param&gt;par2 par3&lt;/param&gt;
   &lt;param&gt;"par4.1 par4.2"&lt;/param&gt;
-&lt;/param-list&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+&lt;/param-list&gt;</screen><para>
           Optional; if not configured, no parameters get passed to script.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>rerun</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>rerun</literal></term>
+<listitem><para>
           A script is only run once. Even if you use
           <literal>ayast</literal>_setup to run an XML file multiple times,
           the script is only run once. Change this default behavior by
           setting this boolean to <literal>true</literal>.
-         </para>
-<screen>&lt;rerun config:type="boolean"&gt;true&lt;/rerun&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;rerun config:type="boolean"&gt;true&lt;/rerun&gt;</screen><para>
           Optional; default is <literal>false</literal>, meaning that scripts
           only run once.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>chrooted</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>chrooted</literal></term>
+<listitem><para>
           During installation, the new system is mounted at <filename>/mnt</filename>.
           If this parameter is set to <literal>false</literal>, &ay; does not
           run <command>chroot</command> and does not install the boot loader
@@ -607,20 +393,12 @@ echo "Testing the pre script" &gt; /tmp/pre-script_out.txt
           installs the boot loader. The result is that to change
           anything in the newly-installed system, you no longer need to use the
           <filename>/mnt</filename> prefix.
-         </para>
-<screen>&lt;chrooted config:type="boolean"
-&gt;true&lt;/chrooted&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;chrooted config:type="boolean"&gt;true&lt;/chrooted&gt;</screen><para>
           Optional; default is <literal>false</literal>. This option is only
           available for chroot environment scripts.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </table>
+         </para></listitem>
+</varlistentry>
+</variablelist>
    </sect2>
 
    <sect2 xml:id="script-examples">

--- a/xml/ay_nis_server.xml
+++ b/xml/ay_nis_server.xml
@@ -55,6 +55,7 @@
    </example>
 
 <variablelist>
+  <title>Attribute, Values, Description</title>
   <varlistentry>
     <term>
       <literal>domain</literal>

--- a/xml/ay_samba_server.xml
+++ b/xml/ay_samba_server.xml
@@ -47,6 +47,7 @@
    </example>
 
    <variablelist>
+     <title>Attribute, Values, Description</title>
     <varlistentry>
      <term>accounts</term>
      <listitem>

--- a/xml/ay_squid_server.xml
+++ b/xml/ay_squid_server.xml
@@ -293,6 +293,7 @@
    </example>
 
 <variablelist>
+  <title>Attribute, Values, Description</title>
   <varlistentry>
     <term>
       <literal>acls</literal>

--- a/xml/ay_users_groups.xml
+++ b/xml/ay_users_groups.xml
@@ -128,6 +128,7 @@
     </note>
 
 <variablelist>
+  <title>Attribute, Values, Description</title>
   <varlistentry>
     <term>
       <literal>username</literal>
@@ -361,6 +362,7 @@
     </para>
 
 <variablelist>
+  <title>Attribute, Values, Description</title>  
   <varlistentry>
     <term>
       <literal>group</literal>
@@ -515,124 +517,47 @@
 &lt;/groups&gt;</screen>
     </example>
 
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Attribute
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Values
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>groupname</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Attribute, Values, Description</title>  
+  <varlistentry><term><literal>groupname</literal></term>
+<listitem><para>
           Text
-         </para>
-<screen>&lt;groupname&gt;users&lt;/groupname&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;groupname&gt;users&lt;/groupname&gt;</screen><para>
           Required. It should be a valid group name. Check <literal>man 8 groupadd</literal>
           if you are not sure.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>gid</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>gid</literal></term>
+<listitem><para>
           Number
-         </para>
-<screen>&lt;gid&gt;100&lt;/gid&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;gid&gt;100&lt;/gid&gt;</screen><para>
           Optional. Group ID. It must be a unique and non-negative number.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>group_password</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>group_password</literal></term>
+<listitem><para>
           Text
-         </para>
-<screen>&lt;group_password&gt;password&lt;/group_password&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;group_password&gt;password&lt;/group_password&gt;</screen><para>
           Optional. The group's password can be written in plain text (not
           recommended) or in encrypted form. Check the <literal>encrypted</literal> to
           select the desired behavior.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>encrypted</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>encrypted</literal></term>
+<listitem><para>
           Boolean
-         </para>
-<screen>&lt;encrypted config:type="boolean"&gt;true&lt;/encrypted&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;encrypted config:type="boolean"&gt;true&lt;/encrypted&gt;</screen><para>
           Optional. Indicates if the group's password in the profile is encrypted or not.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>userlist</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>userlist</literal></term>
+<listitem><para>
           Users list
-         </para>
-<screen>&lt;userlist&gt;bob,alice&lt;/userlist&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;userlist&gt;bob,alice&lt;/userlist&gt;</screen><para>
           Optional. A list of users who belong to the group. User names must be separated by commas.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+         </para></listitem>
+</varlistentry>
+</variablelist>
    </sect2>
 
    <sect2 xml:id="Configuration-Security-login-settings">
@@ -649,66 +574,22 @@
 &lt;/login_settings&gt;</screen>
     </example>
 
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Attribute
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Values
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>password_less_login</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Attribute, Values, Description</title>
+  <varlistentry><term><literal>password_less_login</literal></term>
+<listitem><para>
           Boolean
-         </para>
-<screen>&lt;password_less_login config:type="boolean"&gt;true&lt;/password_less_login&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;password_less_login config:type="boolean"&gt;true&lt;/password_less_login&gt;</screen><para>
           Optional. Enables password-less login. It only affects graphical login.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>autologin_user</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>autologin_user</literal></term>
+<listitem><para>
           Text
-         </para>
-<screen>&lt;autologin_user&gt;alice&lt;/autologin_user&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;autologin_user&gt;alice&lt;/autologin_user&gt;</screen><para>
           Optional. Enables autologin for the given user.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+         </para></listitem>
+</varlistentry>
+</variablelist>
    </sect2>
   </sect1>   

--- a/xml/ay_windows_domain_client.xml
+++ b/xml/ay_windows_domain_client.xml
@@ -40,6 +40,7 @@
    </example>
 
 <variablelist>
+  <title>Attribute, Values, Description</title>
   <varlistentry>
     <term>
       <literal>disable_dhcp_hostname</literal>


### PR DESCRIPTION
### Description
    wide tables do not render well. Using convert-table2variablelist.xsl
    in DAPS to make the conversion https://github.com/openSUSE/daps
    
    Thank you Thomas Schraitle!


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [ x] 15 SP3  | *(no backport necessary)*
| [ ] 15 SP2  | [ ]
| [ ] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
