### PR TITLE
Convert too-large tables in AY Guide to variablelists

### DIFF
--- a/xml/ay_kernel_dumps.xml
+++ b/xml/ay_kernel_dumps.xml
@@ -173,74 +173,27 @@
     <para>
      The following table shows the settings necessary to reserve memory:
     </para>
-    <table>
-     <title>Kdump memory reservation settings:XML representation</title>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>add_crash_kernel</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Kdump memory reservation settings:XML representation</title>
+  <varlistentry><term><literal>add_crash_kernel</literal></term>
+<listitem><para>
           Set to <literal>true</literal> if memory should be reserved and
           Kdump enabled.
-         </para>
-<screen>&lt;add_crash_kernel config:type="boolean"&gt;true&lt;/add_crash_kernel&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;add_crash_kernel config:type="boolean"&gt;true&lt;/add_crash_kernel&gt;</screen><para>
           required
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>crash_kernel</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>crash_kernel</literal></term>
+<listitem><para>
           Use the syntax of the crashkernel command line as discussed above.
-         </para>
-<screen>&lt;crash_kernel&gt;256M:64M&lt;/crash_kernel&gt;</screen>
-        <para>A list of values is also supported.</para>
-<screen>&lt;crash_kernel config:type="list"&gt;
+         </para><screen>&lt;crash_kernel&gt;256M:64M&lt;/crash_kernel&gt;</screen><para>A list of values is also supported.</para><screen>&lt;crash_kernel config:type="list"&gt;
   &lt;listentry&gt;72M,low&lt;/listentry&gt;
   &lt;listentry&gt;256M,high&lt;/listentry&gt;
-&lt;/crash_kernel&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+&lt;/crash_kernel&gt;</screen><para>
           required
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </table>
+         </para></listitem>
+</varlistentry>
+</variablelist>
    </sect2>
 
    <sect2 xml:id="CreateProfile-kdump-saving">
@@ -330,113 +283,46 @@
     </sect3>
     <sect3 xml:id="CreateProfile-kdump-saving-summary">
      <title>Summary</title>
-     <table>
-      <title>Dump target settings: XML representation</title>
-      <tgroup cols="3">
-       <thead>
-        <row>
-         <entry>
-          <para>
-           Element
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Description
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Comment
-          </para>
-         </entry>
-        </row>
-       </thead>
-       <tbody>
-        <row>
-         <entry>
-          <para>
-           <literal>KDUMP_SAVEDIR</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
+<variablelist>
+  <title>Dump target settings: XML representation</title>
+  <varlistentry><term><literal>KDUMP_SAVEDIR</literal></term>
+<listitem><para>
            A URL that specifies the target to which the dump and related
            files will be saved.
-          </para>
-<screen>&lt;KDUMP_SAVEDIR&gt;file:///var/crash/&lt;/KDUMP_SAVEDIR&gt;</screen>
-         </entry>
-         <entry>
-          <para>
+          </para><screen>&lt;KDUMP_SAVEDIR&gt;file:///var/crash/&lt;/KDUMP_SAVEDIR&gt;</screen><para>
            required
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>KDUMP_COPY_KERNEL</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
+          </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KDUMP_COPY_KERNEL</literal></term>
+<listitem><para>
            Set to <literal>true</literal>, if not only the dump should be
            saved to <literal>KDUMP_SAVEDIR</literal> but also the kernel and
            its debugging information (if installed).
-          </para>
-<screen>&lt;KDUMP_COPY_KERNEL&gt;false&lt;/KDUMP_COPY_KERNEL&gt;</screen>
-         </entry>
-         <entry>
-          <para>
+          </para><screen>&lt;KDUMP_COPY_KERNEL&gt;false&lt;/KDUMP_COPY_KERNEL&gt;</screen><para>
            optional
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>KDUMP_FREE_DISK_SIZE</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
+          </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KDUMP_FREE_DISK_SIZE</literal></term>
+<listitem><para>
            Disk space in megabytes that must remain free after saving the
            dump. If not enough space is available, the dump will not be
            saved.
-          </para>
-<screen>&lt;KDUMP_FREE_DISK_SIZE&gt;64&lt;/KDUMP_FREE_DISK_SIZE&gt;</screen>
-         </entry>
-         <entry>
-          <para>
+          </para><screen>&lt;KDUMP_FREE_DISK_SIZE&gt;64&lt;/KDUMP_FREE_DISK_SIZE&gt;</screen><para>
            optional
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>KDUMP_KEEP_OLD_DUMPS</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
+          </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KDUMP_KEEP_OLD_DUMPS</literal></term>
+<listitem><para>
            The number of dumps that are kept (not deleted) if
            <literal>KDUMP_SAVEDIR</literal> points to a local directory.
            Specify 0 if you do not want any dumps to be automatically
            deleted, specify -1 if all dumps except the current one should be
            deleted.
-          </para>
-<screen>&lt;KDUMP_KEEP_OLD_DUMPS&gt;4&lt;/KDUMP_KEEP_OLD_DUMPS&gt;</screen>
-         </entry>
-         <entry>
-          <para>
+          </para><screen>&lt;KDUMP_KEEP_OLD_DUMPS&gt;4&lt;/KDUMP_KEEP_OLD_DUMPS&gt;</screen><para>
            optional
-          </para>
-         </entry>
-        </row>
-       </tbody>
-      </tgroup>
-     </table>
+          </para></listitem>
+</varlistentry>
+</variablelist>
     </sect3>
    </sect2>
 
@@ -462,134 +348,55 @@
      <literal>KDUMP_SMTP_PASSWORD</literal>. Support for TLS/SSL is not
      available but may be added in the future.
     </para>
-<!-- {{{ Table: XML representation of the e-mail notification settings -->
-    <table>
-     <title>E-mail notification settings: XML representation</title>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>KDUMP_NOTIFICATION_TO</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>E-mail notification settings: XML representation</title>
+  <varlistentry><term><literal>KDUMP_NOTIFICATION_TO</literal></term>
+<listitem><para>
           Exactly one e-mail address to which the e-mail should be sent.
           Additional recipients can be specified in
           <literal>KDUMP_NOTIFICATION_CC</literal>.
-         </para>
-<screen>&lt;KDUMP_NOTIFICATION_TO
-&gt;&exampleuser_plain;@&exampledomain;&lt;/KDUMP_NOTIFICATION_TO&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KDUMP_NOTIFICATION_TO
+&gt;&exampleuser_plain;@&exampledomain;&lt;/KDUMP_NOTIFICATION_TO&gt;</screen><para>
           optional (notification disabled if empty)
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>KDUMP_NOTIFICATION_CC</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KDUMP_NOTIFICATION_CC</literal></term>
+<listitem><para>
           Zero, one or more recipients that are in the cc line of the
           notification e-mail.
-         </para>
-<screen>&lt;KDUMP_NOTIFICATION_CC
-&gt;&exampleuserII_plain;@&exampledomain; &exampleuserIII_plain;@&exampledomain;&lt;/KDUMP_NOTIFICATION_CC&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KDUMP_NOTIFICATION_CC
+&gt;&exampleuserII_plain;@&exampledomain; &exampleuserIII_plain;@&exampledomain;&lt;/KDUMP_NOTIFICATION_CC&gt;</screen><para>
           optional
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>KDUMP_SMTP_SERVER</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KDUMP_SMTP_SERVER</literal></term>
+<listitem><para>
           Host name of the SMTP server used for mail delivery. SMTP
           authentication is supported (see
           <literal>KDUMP_SMTP_USER</literal> and
           <literal>KDUMP_SMTP_PASSWORD</literal>) but TLS/SSL are
           not.
-         </para>
-<screen>&lt;KDUMP_SMTP_SERVER&gt;email.suse.de&lt;/KDUMP_SMTP_SERVER&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KDUMP_SMTP_SERVER&gt;email.suse.de&lt;/KDUMP_SMTP_SERVER&gt;</screen><para>
           optional (notification disabled if empty)
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>KDUMP_SMTP_USER</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KDUMP_SMTP_USER</literal></term>
+<listitem><para>
           User name used together with
           <literal>KDUMP_SMTP_PASSWORD</literal> for SMTP authentication.
-         </para>
-<screen>&lt;KDUMP_SMTP_USER&gt;bwalle&lt;/KDUMP_SMTP_USER&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KDUMP_SMTP_USER&gt;bwalle&lt;/KDUMP_SMTP_USER&gt;</screen><para>
           optional
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>KDUMP_SMTP_PASSWORD</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KDUMP_SMTP_PASSWORD</literal></term>
+<listitem><para>
           Password used together with <literal>KDUMP_SMTP_USER</literal> for
           SMTP authentication.
-         </para>
-<screen>&lt;KDUMP_SMTP_PASSWORD&gt;geheim&lt;/KDUMP_SMTP_PASSWORD&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KDUMP_SMTP_PASSWORD&gt;geheim&lt;/KDUMP_SMTP_PASSWORD&gt;</screen><para>
           optional
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </table>
+         </para></listitem>
+</varlistentry>
+</variablelist>
    </sect2>
 
    <sect2 xml:id="CreateProfile-kdump-kernel">
@@ -614,181 +421,68 @@
      know what you are doing and you want to specify the entire command line,
      set <literal>KDUMP_COMMANDLINE</literal>.
     </para>
-    <table>
-     <title>Kernel settings: XML representation</title>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>KDUMP_KERNELVER</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Kernel settings: XML representation</title>
+  <varlistentry><term><literal>KDUMP_KERNELVER</literal></term>
+<listitem><para>
           Version string for the kernel used for Kdump. Leave it empty to
           use the auto-detection mechanism (strongly recommended).
-         </para>
-<screen>&lt;KDUMP_KERNELVER
-&gt;2.6.27-default&lt;/KDUMP_KERNELVER&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KDUMP_KERNELVER
+&gt;2.6.27-default&lt;/KDUMP_KERNELVER&gt;</screen><para>
           optional (auto-detection if empty)
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>KDUMP_COMMANDLINE_APPEND</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KDUMP_COMMANDLINE_APPEND</literal></term>
+<listitem><para>
           Additional command line parameters for the Kdump kernel.
-         </para>
-<screen>&lt;KDUMP_COMMANDLINE_APPEND
-&gt;console=ttyS0,57600&lt;/KDUMP_COMMANDLINE_APPEND&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KDUMP_COMMANDLINE_APPEND
+&gt;console=ttyS0,57600&lt;/KDUMP_COMMANDLINE_APPEND&gt;</screen><para>
           optional
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>KDUMP_Command Line</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KDUMP_Command Line</literal></term>
+<listitem><para>
           Overwrite the automatically generated Kdump command line. Use with
           care. Usually, <literal>KDUMP_COMMANDLINE_APPEND</literal> should
           suffice.
-         </para>
-<screen>&lt;KDUMP_COMMANDLINE_APPEND
-&gt;root=/dev/sda5 maxcpus=1 irqpoll&lt;/KDUMP_COMMANDLINE&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KDUMP_COMMANDLINE_APPEND
+&gt;root=/dev/sda5 maxcpus=1 irqpoll&lt;/KDUMP_COMMANDLINE&gt;</screen><para>
           optional
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </table>
+         </para></listitem>
+</varlistentry>
+</variablelist>
    </sect2>
 
    <sect2 xml:id="CreateProfile-kdump-expert">
     <title>Expert settings</title>
-    <table>
-     <title>Expert settings: XML representations</title>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>KDUMP_IMMEDIATE_REBOOT</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          <literal>true</literal> if the system should be rebooted
+<variablelist>
+  <title>Expert settings: XML representations</title>
+  <varlistentry><term><literal>KDUMP_IMMEDIATE_REBOOT</literal></term>
+<listitem><para><literal>true</literal> if the system should be rebooted
           automatically after the dump has been saved,
           <literal>false</literal> otherwise. The default is to reboot the
           system automatically.
-         </para>
-<screen>&lt;KDUMP_IMMEDIATE_REBOOT
-&gt;true&lt;/KDUMP_IMMEDIATE_REBOOT&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KDUMP_IMMEDIATE_REBOOT
+&gt;true&lt;/KDUMP_IMMEDIATE_REBOOT&gt;</screen><para>
           optional
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>KDUMP_VERBOSE</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KDUMP_VERBOSE</literal></term>
+<listitem><para>
           Bitmask that specifies how verbose the Kdump process should be.
           Read kdump(5) for details.
-         </para>
-<screen>&lt;KDUMP_VERBOSE&gt;3&lt;/KDUMP_VERBOSE&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KDUMP_VERBOSE&gt;3&lt;/KDUMP_VERBOSE&gt;</screen><para>
           optional
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>KEXEC_OPTIONS</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KEXEC_OPTIONS</literal></term>
+<listitem><para>
           Additional options that are passed to kexec when loading the Kdump
           kernel. Normally empty.
-         </para>
-<screen>&lt;KEXEC_OPTIONS&gt;--noio&lt;/KEXEC_OPTIONS&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KEXEC_OPTIONS&gt;--noio&lt;/KEXEC_OPTIONS&gt;</screen><para>
           optional
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </table>
+         </para></listitem>
+</varlistentry>
+</variablelist>
    </sect2>
   </sect1>

--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -111,6 +111,7 @@
     </example>
 
     <variablelist>
+      <title></title>
      <varlistentry>
       <term>lvm</term>
       <listitem>
@@ -286,6 +287,7 @@
 &lt;/profile&gt;</screen>
 
 <variablelist>
+  <title>Attribute, Values, Description</title>
     <varlistentry>
         <term>device</term>
         <listitem>

--- a/xml/ay_rules_classes.xml
+++ b/xml/ay_rules_classes.xml
@@ -805,160 +805,72 @@ fi;
     &lt;/dialog&gt;
   &lt;/rule&gt;
 &lt;/rules&gt;</screen>
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Attribute
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Values
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>dialog_nr</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Attribute, Values, Description </title>
+  <varlistentry><term><literal>dialog_nr</literal></term>
+<listitem><para>
           All rules with the same <literal>dialog_nr</literal> are presented
           in the same pop-up dialog. The same <literal>dialog_nr</literal>
           can appear in multiple rules.
-         </para>
-<screen>&lt;dialog_nr config:type="integer"&gt;3&lt;/dialog_nr&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;dialog_nr config:type="integer"&gt;3&lt;/dialog_nr&gt;</screen><para>
           This element is optional and the default for a missing dialog_nr
           is always <literal>0</literal>. To use one pop-up for
           all rules, you do not need to specify the
           <literal>dialog_nr</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>element</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>element</literal></term>
+<listitem><para>
           Specify a unique ID. Even if you have more than one dialog, you
           must not use the same id twice. Using id <literal>1</literal> on
           dialog 1 and id <literal>1</literal> on dialog 2 is not supported.
           (This behavior is contrary to the <literal>ask</literal> dialog,
           where you can have the same ID for multiple dialogs.)
-         </para>
-<screen>&lt;element config:type="integer"&gt;3&lt;/element&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;element config:type="integer"&gt;3&lt;/element&gt;</screen><para>
           Optional. If omitted, &ay; adds its own IDs internally. Then
           you cannot specify conflicting rules (see below).
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>title</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>title</literal></term>
+<listitem><para>
           Caption of the pop-up dialog
-         </para>
-<screen>&lt;title&gt;Desktop Selection&lt;/title&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;title&gt;Desktop Selection&lt;/title&gt;</screen><para>
           Optional
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>question</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>question</literal></term>
+<listitem><para>
           Question shown in the pop-up behind the check box.
-         </para>
-<screen>&lt;question&gt;GNOME Desktop&lt;/question&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;question&gt;GNOME Desktop&lt;/question&gt;</screen><para>
           Optional. If you do not configure a text here, the name of the XML
           file that is triggered by this rule will be shown instead.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>timeout</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>timeout</literal></term>
+<listitem><para>
           Timeout in seconds after which the dialog will automatically
           <quote>press</quote> the okay button. Useful for a non-blocking
           installation in combination with rules dialogs.
-         </para>
-<screen>&lt;timeout config:type="integer"&gt;30&lt;/timeout&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;timeout config:type="integer"&gt;30&lt;/timeout&gt;</screen><para>
           Optional. A missing timeout will stop the installation process
           until the dialog is confirmed by the user.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>conflicts</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>conflicts</literal></term>
+<listitem><para>
           A list of element ids (rules) that conflict with this rule. If
           this rule matches or is selected by the user, all conflicting
           rules are deselected and disabled in the pop-up. Take care that
           you do not create deadlocks.
-         </para>
-<screen>&lt;conflicts config:type="list"&gt;
+         </para><screen>&lt;conflicts config:type="list"&gt;
   &lt;element config:type="integer"&gt;1&lt;/element&gt;
   &lt;element config:type="integer"&gt;5&lt;/element&gt;
   ...
-&lt;/conflicts&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+&lt;/conflicts&gt;</screen><para>
           Optional
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+         </para></listitem>
+</varlistentry>
+</variablelist>
     <para>
      Here is an example of how to use dialogs with rules:
     </para>


### PR DESCRIPTION
some tables are too large and do not render well in HTML
or PDF


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [x ] 15 SP3  | *(no backport necessary)*
| [ ] 15 SP2  | [ ]
| [ ] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
