### PR TITLE
Enable custom repo attached to a product (jsc#DOCTEAM-57)

### DIFF
--- a/xml/rmt_mirroring.xml
+++ b/xml/rmt_mirroring.xml
@@ -378,7 +378,7 @@ Clean finished. An estimated 157 MB were removed.
     <important>
      <para>
       When custom repositories are attached to a product, clients registering to that product will have such repository added in a disabled state.
-      To enable the repository, find its ID with the <command>zypper lr</command> and run:
+      To enable the repository, find its ID with the command <command>zypper lr</command> and run:
      </para>
 <screen>&prompt.root;zypper mr -e <replaceable>REPO_ID</replaceable></screen>
     </important>

--- a/xml/rmt_mirroring.xml
+++ b/xml/rmt_mirroring.xml
@@ -377,7 +377,7 @@ Clean finished. An estimated 157 MB were removed.
     </para>
     <important>
      <para>
-      When custom repositories are attached to a product, clients registering to that product will have such repo added in a disabled state.
+      When custom repositories are attached to a product, clients registering to that product will have such repository added in a disabled state.
       To enable the repository, find its ID with the <command>zypper lr</command> and run:
      </para>
 <screen>&prompt.root;zypper mr -e <replaceable>REPO_ID</replaceable></screen>

--- a/xml/rmt_mirroring.xml
+++ b/xml/rmt_mirroring.xml
@@ -351,7 +351,8 @@ Clean finished. An estimated 157 MB were removed.
   <procedure>
    <step>
     <para>
-     Add the remote repository to the &rmt; server. Replace <replaceable>URL</replaceable> with the URL to the repository.
+     Add the remote repository to the &rmt; server.
+     Replace <replaceable>URL</replaceable> with the URL to the repository.
      Replace <replaceable>NAME</replaceable> with a name of your choice for the repository.
     </para>
     <screen>&prompt.root;<command>rmt-cli repos custom add <replaceable>URL</replaceable> <replaceable>NAME</replaceable></command></screen>
@@ -370,13 +371,17 @@ Clean finished. An estimated 157 MB were removed.
     </para>
     <screen>&prompt.root;<command>rmt-cli repos custom attach <replaceable>REPOSITORY_ID</replaceable> <replaceable>PRODUCT_ID</replaceable></command></screen>
     <para>
-     Replace <replaceable>REPOSITORY_ID</replaceable> with the ID of
-     the new custom repository. Replace
-     <replaceable>PRODUCT_ID</replaceable> with the ID of a product you
-     want the repository to be attached to. If you need to retrieve the
-     <replaceable>PRODUCT_ID</replaceable>, use the command
-     <command>rmt-cli products list --all</command>.
+     Replace <replaceable>REPOSITORY_ID</replaceable> with the ID of the new custom repository.
+     Replace <replaceable>PRODUCT_ID</replaceable> with the ID of a product you want the repository to be attached to.
+     If you need to retrieve the <replaceable>PRODUCT_ID</replaceable>, use the command <command>rmt-cli products list --all</command>.
     </para>
+    <important>
+     <para>
+      When custom repositories are attached to a product, clients registering to that product will have such repo added in a disabled state.
+      To enable the repository, find its ID with the <command>zypper lr</command> and run:
+     </para>
+<screen>&prompt.root;zypper mr -e <replaceable>REPO_ID</replaceable></screen>
+    </important>
    </step>
    <step>
     <para>


### PR DESCRIPTION
### Description

User needs to enable newly added custom repos attached to a product.


### Are there any relevant issues/feature requests?

* jsc#DOCTEAM-57


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [x] 15 SP3  | *(no backport necessary)*
| [x] 15 SP2  | [ ]
| [x] 15 SP1  | [ ]
| [x] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
