### PR TITLE
Convert too-large tables in AY Guide to variablelists

### DIFF
--- a/xml/ay_country_settings.xml
+++ b/xml/ay_country_settings.xml
@@ -24,11 +24,10 @@
 
    <example>
      <title>Language</title>
-     <screen>
-       &lt;language&gt;
-         &lt;language&gt;en_GB&lt;/language&gt;
-         &lt;languages&gt;de_DE,en_US&lt;/languages&gt;
-       &lt;/language&gt;
+     <screen>&lt;language&gt;
+  &lt;language&gt;en_GB&lt;/language&gt;
+  &lt;languages&gt;de_DE,en_US&lt;/languages&gt;
+&lt;/language&gt;
      </screen>
    </example>
 

--- a/xml/ay_fiber_channel.xml
+++ b/xml/ay_fiber_channel.xml
@@ -53,101 +53,39 @@
      </screen>
    </example>
 
-   <informaltable>
-      <tgroup cols="3">
-       <thead>
-        <row>
-         <entry>
-          <para>
-           Attribute
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Description
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Values
-          </para>
-         </entry>
-        </row>
-       </thead>
-       <tbody>
-        <row>
-         <entry>
-          <para>
-           <literal>fcoe_cfg</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           <literal>DEBUG</literal> is used to enable or disable debugging
+<variablelist>
+  <title>Attribute, Description</title>
+  <varlistentry><term><literal>fcoe_cfg</literal></term>
+<listitem><para><literal>DEBUG</literal> is used to enable or disable debugging
            messages from the fcoe service script and fcoemon.
-          </para>
-          <para>
-           <literal>USE_SYSLOG</literal> messages are sent to the system log
+          </para><para><literal>USE_SYSLOG</literal> messages are sent to the system log
            if set to yes.
-          </para>
-         </entry>
-         <entry>
-          <para>
+          </para><para>
            yes/no
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>interfaces</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
+          </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>interfaces</literal></term>
+<listitem><para>
            List of network cards including the status of VLAN and FCoE
            configuration.
-          </para>
-         </entry>
-         <entry>
-          <para>
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>service_start</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Enable or disable the start of the services <systemitem
-            class="service">fcoe</systemitem> and <systemitem
-            class="service">lldpad</systemitem> boot time.
-          </para>
-          <para>
+          </para><para/></listitem>
+</varlistentry>
+  <varlistentry><term><literal>service_start</literal></term>
+<listitem><para>
+           Enable or disable the start of the services <systemitem class="service">fcoe</systemitem> and <systemitem class="service">lldpad</systemitem> boot time.
+          </para><para>
            Starting the <systemitem class="service">fcoe</systemitem> service
            means starting the Fibre Channel over Ethernet service daemon
            <systemitem class="daemon">fcoemon</systemitem> which controls the
-           FCoE interfaces and establishes a connection with the <systemitem
-            class="daemon">lldpad</systemitem> daemon.
-          </para>
-          <para>
+           FCoE interfaces and establishes a connection with the <systemitem class="daemon">lldpad</systemitem> daemon.
+          </para><para>
            The <systemitem class="service">lldpad</systemitem> service provides
-           the Link Layer Discovery Protocol agent daemon <systemitem
-            class="daemon">lldpad</systemitem>, which informs <systemitem
-            class="daemon">fcoemon</systemitem> about DCB (Data Center
+           the Link Layer Discovery Protocol agent daemon <systemitem class="daemon">lldpad</systemitem>, which informs <systemitem class="daemon">fcoemon</systemitem> about DCB (Data Center
            Bridging) features and configuration of the interfaces.
-          </para>
-         </entry>
-         <entry>
-          <para>
+          </para><para>
            yes/no
-          </para>
-         </entry>
-        </row>
-       </tbody>
-      </tgroup>
-   </informaltable>
+          </para></listitem>
+</varlistentry>
+</variablelist>
+
   </sect1>

--- a/xml/ay_iscsi_client.xml
+++ b/xml/ay_iscsi_client.xml
@@ -42,78 +42,29 @@
      </screen>
    </example>
 
-   <informaltable>
-      <tgroup cols="2">
-       <thead>
-        <row>
-         <entry>
-          <para>
-           Attribute
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Description
-          </para>
-         </entry>
-        </row>
-       </thead>
-       <tbody>
-        <row>
-         <entry>
-          <para>
-           <literal>initiatorname</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           <literal>InitiatorName</literal> is a value from
+<variablelist>
+  <title>Attribute, Description</title>
+  <varlistentry><term><literal>initiatorname</literal></term>
+<listitem><para><literal>InitiatorName</literal> is a value from
            <filename>/etc/iscsi/initiatorname.iscsi</filename>. In case you
            have iBFT, this value will be added from there and you are only able
            to change it in the BIOS setup.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>version</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
+          </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>version</literal></term>
+<listitem><para>
            Version of the &yast; module. Default: 1.0
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>targets</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
+          </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>targets</literal></term>
+<listitem><para>
            List of targets. Each entry contains:
-          </para>
-          <para>
-           <literal>authmethod</literal> Authentication method: None/CHAP
-          </para>
-          <para>
-           <literal>portal</literal> Portal address
-          </para>
-          <para>
-           <literal>startup</literal> Value: manual/onboot
-          </para>
-          <para>
-           <literal>target</literal> Target name
-          </para>
-          <para>
-           <literal>iface</literal> Interface name
-          </para>
-         </entry>
-        </row>
-       </tbody>
-      </tgroup>
-   </informaltable>
+          </para><para><literal>authmethod</literal> Authentication method: None/CHAP
+          </para><para><literal>portal</literal> Portal address
+          </para><para><literal>startup</literal> Value: manual/onboot
+          </para><para><literal>target</literal> Target name
+          </para><para><literal>iface</literal> Interface name
+          </para></listitem>
+</varlistentry>
+</variablelist>
   </sect1>

--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -219,507 +219,201 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
      in <literal>&lt;interfaces&gt;...&lt;/interfaces&gt;</literal>
      tags.
     </para>
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>bootproto</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Element, Description, Comment</title>
+  <varlistentry><term><literal>bootproto</literal></term>
+<listitem><para>
           Boot protocol used by the interface. Possible values:
-         </para>
-          <itemizedlist>
-           <listitem>
-            <para>
-             <literal>static</literal> for statically assigned addresses. It is
+         </para><itemizedlist><listitem><para><literal>static</literal> for statically assigned addresses. It is
              required to specify the IP using the <literal>ipaddr</literal>
              element.
-            </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>dhcp4</literal>, <literal>dhcp6</literal> or
+            </para></listitem><listitem><para><literal>dhcp4</literal>, <literal>dhcp6</literal> or
              <literal>dhcp</literal> for setting the IP address with DHCP
              (IPv4, IPv6 or any).
-            </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>dhcp+autoip</literal> to get the IPv4 configuration from
+            </para></listitem><listitem><para><literal>dhcp+autoip</literal> to get the IPv4 configuration from
              <emphasis>Zeroconf</emphasis> and get IPv6 from DHCP.
-            </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>autoip</literal> to get the IPv4 configuration from
+            </para></listitem><listitem><para><literal>autoip</literal> to get the IPv4 configuration from
              <emphasis>Zeroconf</emphasis>.
-            </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>ibft</literal> to get the IP address using the iBFT
+            </para></listitem><listitem><para><literal>ibft</literal> to get the IP address using the iBFT
              protocol.
-            </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>none</literal> to skip setting an address. This value is
+            </para></listitem><listitem><para><literal>none</literal> to skip setting an address. This value is
              used for bridges and bonding slaves.
-            </para>
-           </listitem>
-          </itemizedlist>
-        </entry>
-        <entry>
-         <para>
+            </para></listitem></itemizedlist><para>
           Required.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>broadcast</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>broadcast</literal></term>
+<listitem><para>
           Broadcast IP address.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Used only with <literal>static</literal> boot protocol.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>device</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>device</literal></term>
+<listitem><para>
           Device name.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Deprecated. Use <literal>name</literal> instead.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>name</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>name</literal></term>
+<listitem><para>
           Device name, for example: <literal>eth0</literal>.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Required.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>ipaddr</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>ipaddr</literal></term>
+<listitem><para>
           IP address assigned to the interface.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Used only with <literal>static</literal> boot protocol. It can include a network prefix,
           for example: <literal>192.168.1.1/24</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>remote_ipaddr</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>remote_ipaddr</literal></term>
+<listitem><para>
           Remote IP address for point-to-point connections.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Used only with <literal>static</literal> boot protocol.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>netmask</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>netmask</literal></term>
+<listitem><para>
           Network mask, for example: <literal>255.255.255.0</literal>.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Deprecated. Use <literal>prefixlen</literal> instead or include the network prefix in the
           <literal>ipaddr</literal> element.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>network</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>network</literal></term>
+<listitem><para>
           Network IP address.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Deprecated. Use <literal>ipaddr</literal> with <literal>prefixlen</literal> instead.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>prefixlen</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>prefixlen</literal></term>
+<listitem><para>
           Network prefix, for example: <literal>24</literal>.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Used only with <literal>static</literal> boot protocol.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>startmode</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>startmode</literal></term>
+<listitem><para>
           When to bring up an interface. Possible values are:
-         </para>
-          <itemizedlist>
-           <listitem>
-            <para>
-             <literal>hotplug</literal> when the device is plugged in. Useful
+         </para><itemizedlist><listitem><para><literal>hotplug</literal> when the device is plugged in. Useful
              for USB network cards, for example.
-            </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>auto</literal> when the system
+            </para></listitem><listitem><para><literal>auto</literal> when the system
              boots. <literal>onboot</literal> is a deprecated alias.
-            </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>ifplugd</literal> when the device is managed by the
+            </para></listitem><listitem><para><literal>ifplugd</literal> when the device is managed by the
              <literal>ifplugd</literal> daemon.
-            </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>manual</literal> when the device is supposed to be started
+            </para></listitem><listitem><para><literal>manual</literal> when the device is supposed to be started
              manually.
-            </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>nfsroot</literal> when the device is needed to mount the
+            </para></listitem><listitem><para><literal>nfsroot</literal> when the device is needed to mount the
              root file system, for example, when <literal>/</literal> is on an
              NFS volume.
-            </para>
-           </listitem>
-           <listitem>
-            <para>
-             <literal>off</literal> to never start the device.
-            </para>
-           </listitem>
-          </itemizedlist>
-        </entry>
-        <entry>
-         <para>
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>ifplugd_priority</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+            </para></listitem><listitem><para><literal>off</literal> to never start the device.
+            </para></listitem></itemizedlist><para/></listitem>
+</varlistentry>
+  <varlistentry><term><literal>ifplugd_priority</literal></term>
+<listitem><para>
           Priority for <literal>ifplugd</literal> daemon. It determines in which
           order the devices are activated.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Used only with <literal>ifplugd</literal> start mode.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>usercontrol</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>usercontrol</literal></term>
+<listitem><para>
           Parameter is no longer used.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Deprecated.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>bonding_slaveX</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>bonding_slaveX</literal></term>
+<listitem><para>
           Name of the bonding device.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Required for bonding devices. <literal>X</literal> is replaced by a
           number starting from 0, for example <literal>bonding_slave0</literal>. Each
           slave needs to have a unique number.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>bonding_module_opts</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>bonding_module_opts</literal></term>
+<listitem><para>
           Options for bonding device.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Used only with <literal>bond</literal> device.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>mtu</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>mtu</literal></term>
+<listitem><para>
           Maximum transmission unit for the interface.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Optional.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>ethtool_options</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>ethtool_options</literal></term>
+<listitem><para>
           Ethtool options during device activation.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Optional.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>zone</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>zone</literal></term>
+<listitem><para>
           Firewall zone name which the interface is assigned to.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Optional.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>vlan_id</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>vlan_id</literal></term>
+<listitem><para>
           Identifier used for this VLAN.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Used only with a <literal>vlan</literal> device.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>etherdevice</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>etherdevice</literal></term>
+<listitem><para>
           Device to which VLAN is attached.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Used only with a <literal>vlan</literal> device and required for it.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>bridge</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          <literal>yes</literal> if interface is a bridge.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>bridge</literal></term>
+<listitem><para><literal>yes</literal> if interface is a bridge.
+         </para><para>
           Deprecated. It is inferred from other attributes.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>bridge_ports</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>bridge_ports</literal></term>
+<listitem><para>
           Space-separated list of bridge ports, for example, <literal>eth0 eth1</literal>.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Used only with a <literal>bridge</literal> device and required for
           it.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>bridge_stp</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>bridge_stp</literal></term>
+<listitem><para>
           Spanning tree protocol. Possible values are <literal>on</literal>
           (when enabled) and <literal>off</literal> (when disabled).
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Used only with a <literal>bridge</literal> device.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>bridge_forward_delay</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>bridge_forward_delay</literal></term>
+<listitem><para>
           Forward delay for bridge, for example: <literal>15</literal>.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           Used only with <literal>bridge</literal> devices. Valid values are between <literal>4</literal> and <literal>30</literal>.
-         </para>
-        </entry>
-       </row>
-       <!-- TODO: all wireless attributes, but not so many users configure wireless with autoyast -->
-      </tbody>
-     </tgroup>
-    </informaltable>
+         </para></listitem>
+</varlistentry>
+  <!-- TODO: all wireless attributes, but not so many users configure wireless with autoyast -->
+</variablelist>
    </sect2>
 
    <sect2 xml:id="CreateProfile-Network-names">
@@ -838,107 +532,40 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
      settings, such as the host name or name servers.
     </para>
 
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>hostname</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Element, Description</title>
+  <varlistentry><term><literal>hostname</literal></term>
+<listitem><para>
           Host name, excluding the domain name part. For example:
           <literal>foo</literal> (instead of <literal>foo.bar</literal>).
-          </para>
-        </entry>
-        <entry>
-         <para>
+          </para><para>
           If a host name is not specified and is not taken from a DHCP server (see <literal>dhcp_hostname</literal>),
           &ay; will generate a random one.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>nameservers</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>nameservers</literal></term>
+<listitem><para>
           List of name servers. Example:
-        </para>
-<screen>&lt;nameservers config:type="list"&gt;
+        </para><screen>&lt;nameservers config:type="list"&gt;
   &lt;nameserver&gt;&dnsip;&lt;/nameserver&gt;
   &lt;nameserver&gt;&dnsip117;&lt;/nameserver&gt;
-&lt;/nameservers&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>searchlist</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+&lt;/nameservers&gt;</screen><para/></listitem>
+</varlistentry>
+  <varlistentry><term><literal>searchlist</literal></term>
+<listitem><para>
           Search list for host name lookup.
-         </para>
-<screen>&lt;searchlist config:type="list"&gt;
+         </para><screen>&lt;searchlist config:type="list"&gt;
   &lt;search&gt;&exampledomain;&lt;/search&gt;
-&lt;/searchlist&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+&lt;/searchlist&gt;</screen><para>
           Optional.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>dhcp_hostname</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>dhcp_hostname</literal></term>
+<listitem><para>
           Specifies whether the host name must be taken from DHCP or not.
-         </para>
-<screen>&lt;dhcp_hostname config:type="boolean"&gt;true&lt;/dhcp_hostname&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+         </para><screen>&lt;dhcp_hostname config:type="boolean"&gt;true&lt;/dhcp_hostname&gt;</screen><para/></listitem>
+</varlistentry>
+</variablelist>
    </sect2>
 
    <sect2 xml:id="CreateProfile-Network-Routing">
@@ -1104,127 +731,54 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
      The following elements must be between the
      &lt;s390-devices&gt;...&lt;/s390-devices&gt; tags.
     </para>
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
+<variablelist>
+  <title>Element, Description, Comment</title>
+  <varlistentry><term>
           type
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </term>
+<listitem><para>
           qeth, ctc or iucv
-         </para>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
+         </para><para/></listitem>
+</varlistentry>
+  <varlistentry><term>
           chanids
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </term>
+<listitem><para>
           channel ids separated by a colon (preferred) or a space
-         </para>
-<screen>&lt;chanids&gt;0.0.0700:0.0.0701:0.0.0702&lt;/chanids&gt;</screen>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
+         </para><screen>&lt;chanids&gt;0.0.0700:0.0.0701:0.0.0702&lt;/chanids&gt;</screen><para/></listitem>
+</varlistentry>
+  <varlistentry><term>
           layer2
-         </para>
-        </entry>
-        <entry>
-         <para/>
-<screen>&lt;layer2 config:type="boolean"&gt;true&lt;/layer2&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </term>
+<listitem><para/><screen>&lt;layer2 config:type="boolean"&gt;true&lt;/layer2&gt;</screen><para>
           boolean; default: false
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term>
           portname
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </term>
+<listitem><para>
           QETH port name (deprecated since <phrase os="sles;sled">SLE 12
           SP2</phrase><phrase os="osuse">openSUSE 42.2</phrase>)
-         </para>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
+         </para><para/></listitem>
+</varlistentry>
+  <varlistentry><term>
           protocol
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </term>
+<listitem><para>
           CTC / LCS protocol, a small number (as a string)
-         </para>
-<screen>&lt;protocol&gt;1&lt;/protocol&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;protocol&gt;1&lt;/protocol&gt;</screen><para>
           optional
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term>
           router
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </term>
+<listitem><para>
           IUCV router/user
-         </para>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+         </para><para/></listitem>
+</varlistentry>
+</variablelist>
 
     <para>
      In addition to the options mentioned above, &ay; also supports

--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -1555,7 +1555,7 @@ size=40G features='0' hwhandler='0' wp=rw
    </para>
 
    <para>
-    For more information about bcache on &productname;, also see the blog post
+    For more information about &bcache; on &productname;, also see the blog post
     at <link xlink:href="https://www.suse.com/c/combine-the-performance-of-solid-state-drive-with-the-capacity-of-a-hard-drive-with-bcache-and-yast/"/>.
    </para>
 
@@ -1669,48 +1669,15 @@ size=40G features='0' hwhandler='0' wp=rw
     section is <literal>cache_mode</literal>, described in the table below.
    </para>
 
-   <informaltable>
-    <tgroup cols="3">
-     <thead>
-      <row>
-       <entry>
-        <para>
-         Attribute
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Values
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Description
-        </para>
-       </entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>
-        <para>
-         <literal>cache_mode</literal>
-        </para>
-       </entry>
-       <entry>
-        <para/>
-        <screen>&lt;cache_mode&gt;writethrough&lt;/cache_mode&gt;</screen>
-       </entry>
-       <entry>
-        <para>
-         Cache mode for &bcache;. Possible values are <literal>writethrough</literal>,
+<variablelist>
+  <title>Attribute, Values, Description</title>
+  <varlistentry><term><literal>cache_mode</literal></term>
+<listitem><para/><screen>&lt;cache_mode&gt;writethrough&lt;/cache_mode&gt;</screen><para>
+         Cache mode for bcache. Possible values are <literal>writethrough</literal>,
          <literal>writeback</literal>, <literal>writearound</literal> and <literal>none</literal>.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
+        </para></listitem>
+</varlistentry>
+</variablelist>
   </sect2>
 
   <sect2 xml:id="ay-multidevice-btrfs">
@@ -1881,15 +1848,13 @@ as per ancorgs' comment on Github-->
   <title>Attribute, Description, Values</title>
   <varlistentry><term><literal>device</literal></term>
 <listitem><para><literal>DASD</literal> is the only value allowed
-          </para><screen>&lt;device
-&gt;DASD&lt;/dev_name&gt;</screen><para/></listitem>
+          </para><screen>&lt;device&gt;DASD&lt;/dev_name&gt;</screen><para/></listitem>
 </varlistentry>
   <varlistentry><term><literal>dev_name</literal></term>
 <listitem><para>
            The device (<literal>dasd<replaceable>N</replaceable></literal>)
            you want to configure in this section.
-          </para><screen>&lt;dev_name
-&gt;/dev/dasda&lt;/dev_name&gt;</screen><para>
+          </para><screen>&lt;dev_name&gt;/dev/dasda&lt;/dev_name&gt;</screen><para>
            Optional but recommended. If left out, &ay; tries to guess the
            device.
           </para></listitem>
@@ -1906,8 +1871,9 @@ as per ancorgs' comment on Github-->
            Enable or disable the use of <literal>DIAG</literal>. Possible
            values are <literal>true</literal> (enable) or
            <literal>false</literal> (disable).
-          </para><screen>&lt;diag
-config:type="boolean"&gt;true&lt;/diag&gt;</screen><para>
+          </para>
+  <screen>&lt;diagconfig:type="boolean"&gt;true&lt;/diag&gt;</screen>
+      <para>
            Optional.
           </para></listitem>
 </varlistentry>
@@ -1932,40 +1898,16 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen><para>
       Each disk needs to be configured in a separate
       <literal>listentry</literal> section.
      </para>
-     <informaltable>
-      <tgroup cols="2">
-       <thead>
-        <row>
-         <entry>
-          <para>
-           Attribute
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Values
-          </para>
-         </entry>
-        </row>
-       </thead>
-       <tbody>
-        <row>
-         <entry>
-          <para>
-           <literal>controller_id</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
+<variablelist>
+  <title>Attribute, Values</title>
+  <varlistentry><term><literal>controller_id</literal></term>
+<listitem><para>
            Channel number
           </para>
-<screen>&lt;controller_id
-&gt;0.0.fc00&lt;/controller_id&gt;</screen>
-         </entry>
-        </row>
-       </tbody>
-      </tgroup>
-     </informaltable>
+<screen>&lt;controller_id&gt;0.0.fc00&lt;/controller_id&gt;</screen>
+</listitem>
+</varlistentry>
+</variablelist>
     </sect3>
    </sect2>
   </sect1>

--- a/xml/ay_software.xml
+++ b/xml/ay_software.xml
@@ -391,44 +391,45 @@
 <listitem><para>
           If set to <literal>true</literal>, &ay; will accept unsigned
           files like the content file.
-         </para><screen>&lt;accept_unsigned_file config:type="boolean"
-&gt;true&lt;/accept_unsigned_file&gt;</screen></listitem>
+         </para>
+<screen>&lt;accept_unsigned_file config:type="boolean"&gt;true&lt;/accept_unsigned_file&gt;</screen></listitem>
 </varlistentry>
   <varlistentry><term><literal>accept_file_without_checksum</literal></term>
 <listitem><para>
           If set to <literal>true</literal>, &ay; will accept files
           without a checksum in the content file.
-         </para><screen>&lt;accept_file_without_checksum config:type="boolean"
-&gt;true&lt;/accept_file_without_checksum&gt;</screen></listitem>
+         </para>
+<screen>&lt;accept_file_without_checksum config:type="boolean"&gt;true&lt;/accept_file_without_checksum&gt;</screen>
+</listitem>
 </varlistentry>
   <varlistentry><term><literal>accept_verification_failed</literal></term>
 <listitem><para>
           If set to <literal>true</literal>, &ay; will accept signed
           files even when the verification of the signature failed.
-         </para><screen>&lt;accept_verification_failed config:type="boolean"
-&gt;true&lt;/accept_verification_failed&gt;</screen></listitem>
+         </para>
+<screen>&lt;accept_verification_failed config:type="boolean"&gt;true&lt;/accept_verification_failed&gt;</screen></listitem>
 </varlistentry>
   <varlistentry><term><literal>accept_unknown_gpg_key</literal></term>
 <listitem><para>
           If set to <literal>true</literal>, &ay; will accept new GPG
           keys of the installation sources, for example the key used to sign
           the content file.
-         </para><screen>&lt;accept_unknown_gpg_key config:type="boolean"
-&gt;true&lt;/accept_unknown_gpg_key&gt;</screen></listitem>
+         </para>
+<screen>&lt;accept_unknown_gpg_key config:type="boolean"&gt;true&lt;/accept_unknown_gpg_key&gt;</screen></listitem>
 </varlistentry>
   <varlistentry><term><literal>accept_non_trusted_gpg_key</literal></term>
 <listitem><para>
           Set this option to <literal>true</literal> to accept known keys you
           have not yet trusted.
-         </para><screen>&lt;accept_non_trusted_gpg_key config:type="boolean"
-&gt;true&lt;/accept_non_trusted_gpg_key&gt;</screen></listitem>
+         </para>
+<screen>&lt;accept_non_trusted_gpg_key config:type="boolean"&gt;true&lt;/accept_non_trusted_gpg_key&gt;</screen></listitem>
 </varlistentry>
   <varlistentry><term><literal>import_gpg_key</literal></term>
 <listitem><para>
           If set to <literal>true</literal>, &ay; will accept and import
           new GPG keys on the installation source in its database.
-         </para><screen>&lt;import_gpg_key config:type="boolean"
-&gt;true&lt;/import_gpg_key&gt;</screen></listitem>
+         </para>
+<screen>&lt;import_gpg_key config:type="boolean"&gt;true&lt;/import_gpg_key&gt;</screen></listitem>
 </varlistentry>
 </variablelist>
     <para>
@@ -445,22 +446,22 @@
 <listitem><para>
           If set to <literal>true</literal>, &ay; will accept unsigned
           files like the content file for this add-on product.
-         </para><screen>&lt;accept_unsigned_file config:type="boolean"
-&gt;true&lt;/accept_unsigned_file&gt;</screen></listitem>
+         </para>
+<screen>&lt;accept_unsigned_file config:type="boolean"&gt;true&lt;/accept_unsigned_file&gt;</screen></listitem>
 </varlistentry>
   <varlistentry><term><literal>accept_file_without_checksum</literal></term>
 <listitem><para>
           If set to <literal>true</literal>, &ay; will accept files
           without a checksum in the content file for this add-on.
-         </para><screen>&lt;accept_file_without_checksum config:type="boolean"
-&gt;true&lt;/accept_file_without_checksum&gt;</screen></listitem>
+         </para>
+<screen>&lt;accept_file_without_checksum config:type="boolean"&gt;true&lt;/accept_file_without_checksum&gt;</screen></listitem>
 </varlistentry>
   <varlistentry><term><literal>accept_verification_failed</literal></term>
 <listitem><para>
           If set to <literal>true</literal>, &ay; will accept signed
           files even when the verification of the signature fails.
-         </para><screen>&lt;accept_verification_failed config:type="boolean"
-&gt;true&lt;/accept_verification_failed&gt;</screen></listitem>
+         </para>
+<screen>&lt;accept_verification_failed config:type="boolean"&gt;true&lt;/accept_verification_failed&gt;</screen></listitem>
 </varlistentry>
   <varlistentry><term><literal>accept_unknown_gpg_key</literal></term>
 <listitem><para>


### PR DESCRIPTION
some tables are too large and do not render well in HTML
or PDF, converted with wondrous stylesheet by Thomas Schraitle



### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [ ] 15 SP3  | *(no backport necessary)*
| [x ] 15 SP2  | [ ]
| [ ] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
