### PR TITLE
  Move sapconf section of SLES4SAP to the SLE Tuning Guide

### DIFF
--- a/xml/book_tuning.xml
+++ b/xml/book_tuning.xml
@@ -8,28 +8,7 @@
     %entities;
 ]>
 
-<!-- fs 2011-10-11:
 
-Still missing - check with PM if wanted:
-
-* benchmark tools (desireable)
-  - bonnie
-    http://www.textuality.com/bonnie/
-  - any other benchmarks shipping with SLE??
-  - any other tools to use for benchmarking?
-  - QA should know
-* tools to simulate mixed workloads (desireable)
-
-* green IT: things we can do to save power (mandatory)
-  - isn't that already covered elsewhere?
-
-Tuning (not mentioned in FATE)
-===================================================
- - large page support
- - ethtool?
- - hdparm?
-
--->
 <!-- ##################################################################### -->
 <!-- SLE System Analysis and Tuning Guide                                  -->
 <!-- ##################################################################### -->
@@ -104,6 +83,7 @@ Tuning (not mentioned in FATE)
   <xi:include href="tuning_taskscheduler.xml"/>
   <xi:include href="tuning_memory.xml"/>
   <xi:include href="tuning_network.xml"/>
+  <xi:include href="tuning_sapconf.xml"/>
  </part>
 
 <!-- ===================================================================== -->

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -232,6 +232,11 @@
 <!ENTITY caasp         "&suse; CaaS Platform">
 <!ENTITY caaspa        "SUSE-CaaSP">
 <!ENTITY caspa         "&caaspa;">
+<!ENTITY sapconf       "<literal xmlns='http://docbook.org/ns/docbook'>sapconf</literal>">
+<!ENTITY tuned          "<systemitem xmlns='http://docbook.org/ns/docbook' class='daemon'>tuned</systemitem>">
+<!ENTITY hana           "&sap; HANA">
+<!ENTITY netweaver      "&sap; NetWeaver">
+<!ENTITY saptune        "<command xmlns='http://docbook.org/ns/docbook'>saptune</command>">
 
 
 <!-- ============================================================= -->

--- a/xml/tuning_sapconf.xml
+++ b/xml/tuning_sapconf.xml
@@ -12,8 +12,9 @@
  <title>Tuning &sle; for &sap;</title>
 
  <para>
-  This chapter presents information about tuning &productname; to work optimally with &sap; applications with &sapconf;. &sapconf; is for &sle;
-  systems that install &sap; applications post-deployment. Customers who have
+  This chapter presents information about preparing and tuning &productname;
+  to work optimally with &sap; applications with &sapconf;. &sapconf; is for 
+  &sle; systems that install &sap; applications. Customers who have
   &sles4sap; should use &saptune;.
  </para>
 

--- a/xml/tuning_sapconf.xml
+++ b/xml/tuning_sapconf.xml
@@ -1,0 +1,705 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE chapter
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+    %entities;
+]>
+
+<chapter xmlns="http://docbook.org/ns/docbook" 
+         xmlns:xi="http://www.w3.org/2001/XInclude" 
+         xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-tuning-sapconf">
+  
+ <title>Tuning &sle; for &sap;</title>
+
+ <para>
+  This chapter presents information about tuning &productname; to work optimally with &sap; applications with &sapconf;. &sapconf; is for &sle;
+  systems that install &sap; applications post-deployment. Customers who have
+  &sles4sap; should use &saptune;.
+ </para>
+
+ <note>
+   <title>The <command>sapconf</command> Command Has Been Removed</title>
+   <para>
+    In &sls; and &productname; 11 and 12, the <command>sapconf</command> command
+    was included in the package with the same name.
+  </para>
+  <para>
+    For &sls; and &productname; 15 this has been changed:
+    the command <command>sapconf</command> have been removed from the
+    <package>sapconf</package> package. The package contains a &systemd; service
+    only. There is no &sapconf; command line tool anymore, no &sapconf;/&tuned; profiles,
+    and no &tuned;.
+   </para>
+  </note>
+  
+ <sect1 xml:id="sec-sapconf-4">
+  <title>Tuning &slea; Systems with &sapconf; 4</title>
+  <para>
+   The package <systemitem>sapconf</systemitem> is available in &sls; and &s4s;.
+   This package contains the
+   <systemitem>tuned</systemitem> profile <literal>sapconf</literal>.
+   This single tuning profile sets recommended parameters for the following
+   types of &sap; applications: &netweaver;, &hana; and &hana;-based applications.
+  </para>
+
+  <variablelist xml:id="vl-tune-sapconf4-overview">
+   <title>Overview of &sapconf;4 in &slsreg;&nbsp;12</title>
+   <varlistentry>
+    <term>&sapconf;4 (&tuned; based)</term>
+    <listitem>
+     <itemizedlist>
+      <listitem>
+       <para><systemitem>sap-netweaver</systemitem> (&tuned; profile)</para>
+      </listitem>
+      <listitem>
+       <para><systemitem>sap-hana</systemitem> (&tuned; profile)</para>
+      </listitem>
+      <listitem>
+       <para><systemitem>sap-bobj</systemitem> (&tuned; profile)</para>
+      </listitem>
+      <listitem>
+       <para><systemitem>sap-ase</systemitem> (&tuned; profile)</para>
+      </listitem>
+     </itemizedlist>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+  <variablelist>
+   <title>Overview of &sapconf;4 in &slsreg;&nbsp;15</title>
+   <varlistentry>
+    <term>&sapconf;4 (&tuned; based)</term>
+    <listitem>
+     <para>&sapconf; (&tuned; profile)</para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+  <para>
+   Note that if you previously made changes to the system tuning, those
+   changes may be overwritten by the &sapconf; profile.
+  </para>
+  <para>
+   &sapconf; consists of two primary parts:
+  </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     A &systemd; service that ensures &tuned; and related services are
+     running and the <literal>sapconf</literal> profile is applied.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     The &tuned; profile <literal>sapconf</literal> that applies
+     configured &sapconf; tuning parameters using a script and configuration
+     files.
+    </para>
+   </listitem>
+  </itemizedlist>
+  <para>
+   To use &sapconf;, make sure
+   that the packages <package>tuned</package> and
+   <package>sapconf</package> are installed on your system.
+  </para>
+
+  <note>
+   <title>Unified Profiles in &sls; and &productname; &productnumber;</title>
+   <para>
+    In &sls; and &productname; 15 and above, only a single &tuned; profile,
+    <literal>sapconf</literal>, is shipped. It is equivalent to the profiles
+    <literal>sap-hana</literal>/<literal>sap-netweaver</literal> shipped in
+    earlier versions of &productname;.
+   </para>
+  </note>
+  <sect2 xml:id="sec-sapconf-4-enable">
+   <title>Enabling and Disabling &sapconf; and Viewing Its Status</title>
+   <para>
+    After the installation of &sapconf;, &tuned; is enabled and the
+    <literal>sapconf</literal> profile is activated. However, if
+    another &tuned; profile is already enabled, &sapconf; will not enable its
+    own &tuned; profile.
+   </para>
+   <para>
+    To make sure &sapconf; applies all tuning parameters,
+    reboot the machine after installation.
+   </para>
+   <para>
+    You can inspect or change the status of &sapconf; as described in the
+    following:
+   </para>
+   <itemizedlist>
+    <listitem>
+     <para>
+      To see the status of the service
+      <systemitem class="daemon">sapconf</systemitem>:
+     </para>
+     <screen>&prompt.root;<command>systemctl status sapconf</command></screen>
+     <para>
+      The service should be displayed as <emphasis>active (exited)</emphasis>,
+      as it is only responsible for starting &tuned; and will exit afterward.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      To start the service
+      <systemitem class="daemon">sapconf</systemitem> and with it the service
+      &tuned;:
+     </para>
+     <screen>&prompt.root;<command>systemctl start sapconf</command></screen>
+    </listitem>
+    <listitem>
+     <para>
+      Should <systemitem class="daemon">sapconf</systemitem> be disabled,
+      enable and start it with:
+     </para>
+     <screen>&prompt.root;<command>systemctl enable --now sapconf</command></screen>
+    </listitem>
+    <listitem>
+     <para>
+      To stop the service
+      <systemitem class="daemon">sapconf</systemitem> and with it the service
+      &tuned;:
+     </para>
+     <screen>&prompt.root;<command>systemctl stop sapconf</command></screen>
+     <para>
+      This will terminate &tuned; as well, therefore the vast majority of
+      optimizations will be disabled immediately. The only exceptions from that
+      are options that require a system reboot to enable/disable.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      To disable <systemitem class="daemon">sapconf</systemitem>, use:
+     </para>
+     <screen>&prompt.root;<command>systemctl disable sapconf</command></screen>
+     <para>
+      If you have not specifically enabled any of the services that &sapconf;
+      depends on yourself, this will also disable most tuning parameters and
+      all services used by &sapconf;.
+     </para>
+    </listitem>
+   </itemizedlist>
+   <para>
+    Similarly, you can inspect and change the status of the underlying service
+    &tuned;:
+   </para>
+   <itemizedlist>
+    <listitem>
+     <para>
+      To see the status of the service &tuned;:
+     </para>
+     <screen>&prompt.root;<command>systemctl status tuned</command></screen>
+    </listitem>
+    <listitem>
+     <para>
+      To see which &tuned; profile is currently in use:
+     </para>
+     <screen>&prompt.root;<command>tuned-adm active</command></screen>
+     <para>
+      If this command does not return the name of the currently active profile
+      as <literal>sapconf</literal>, enable that profile:
+     </para>
+     <screen>&prompt.root;<command>tuned-adm profile sapconf</command></screen>
+    </listitem>
+   </itemizedlist>
+   <tip>
+    <title>Additional Services that &sapconf; Relies On</title>
+    <para>
+     In addition to the &sapconf; service itself and the &tuned; service,
+     &sapconf; also relies on the following two services:
+    </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+       <systemitem class="daemon">sysstat</systemitem> which collects data on
+       system activity.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       <systemitem class="daemon">uuidd</systemitem> which generates time-based
+       UUIDs that are guaranteed to be unique even in settings where many
+       processor cores are involved. This is necessary for &sap; applications.
+      </para>
+     </listitem>
+    </itemizedlist>
+   </tip>
+  </sect2>
+  <sect2 xml:id="sec-sapconf-4-configure">
+   <title>Configuring &sapconf;4</title>
+   <para>
+    In general, the default configuration of &sapconf; already uses the
+    parameter values recommended by &sap;. However, if you have special
+    needs, you can configure the tool to better suit those.
+   </para>
+   <para>
+    The configuration of &sapconf; is split into two parts that can be configured
+    in different ways:
+   </para>
+   <variablelist>
+    <varlistentry>
+     <term><filename>/usr/lib/tuned/<replaceable>PROFILE</replaceable>/tuned.conf</filename></term>
+     <listitem>
+      <para>
+       Any file that adheres to this pattern
+       can be edited like in <xref linkend="pro-sapconf-4-configure"/>.
+       To configure parameters from this file, copy it to the custom profile
+       directory of &tuned; under <filename>/etc/tuned</filename> first and
+       then change values in it. If you change the file in place instead, you
+       will lose the changes you make on the next update of the
+       <package>sapconf</package> package.
+      </para>
+      <para>
+       The following procedure shows an example how to adapt the file
+        <filename>/usr/lib/tuned/sapconf/tuned.conf</filename>.
+       However, as written before, this is possible with any profile.
+       Configure the file as described in the following procedure:
+      </para>
+      <procedure xml:id="pro-sapconf-4-configure">
+       <title>Configuring &sapconf;4 Profiles</title>
+       <step>
+        <para>
+         Create a new custom &tuned; profile directory and copy the file
+         <filename>tuned.conf</filename>:
+        </para>
+<screen>&prompt.root;mkdir /etc/tuned/sapconf
+&prompt.root;cp /usr/lib/tuned/sapconf/tuned.conf /etc/tuned/sapconf/</screen>
+       </step>
+       <step>
+        <para>
+         Within the newly copied <filename>tuned.conf</filename>, fix the
+         reference to <filename>script.sh</filename> to use an absolute path
+         that points to the script from the original profile:
+        </para>
+        <screen>script = /usr/lib/tuned/sapconf/script.sh</screen>
+        <para>
+         Do not instead copy <filename>script.sh</filename>, as that
+         provokes update compatibility issues for &sapconf;.
+        </para>
+       </step>
+       <step>
+        <para>
+         Edit the parameters in
+         <filename>/etc/tuned/sapconf/tuned.conf</filename>.
+        </para>
+       </step>
+      </procedure>
+      <para>
+       After each update to &sapconf;, make sure to compare the contents of
+       the original and the custom <filename>tuned.conf</filename>.
+      </para>
+      <para>
+       Log messages related to this file are written to
+       <filename>/var/log/tuned/tuned.log</filename>.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><filename>/etc/sysconfig/sapconf</filename></term>
+     <listitem>
+      <para>
+       This file contains most parameters of &sapconf;. The parameters from
+       this file are applied using the aforementioned script
+       <filename>/usr/lib/tuned/sapconf/script.sh</filename>.
+      </para>
+      <para>
+       This file can be edited directly. All parameters in this file are
+       explained by means of comments and references to &sap; Notes which can
+       be viewed at <link xlink:href="https://launchpad.support.sap.com/"/>.
+      </para>
+      <para>
+       When &sapconf; is updated, all customized parameters from this file will
+       be preserved as much as possible. However, sometimes parameters cannot
+       be transferred cleanly to the new configuration file. Therefore, after
+       updating it is advisable to check the difference between the previous
+       custom configuration which during the update is moved to
+       <filename>/etc/sysconfig/sapconf.rpmsave</filename>
+       and the new version at <filename>/etc/sysconfig/sapconf</filename>.
+      </para>
+      <para>
+       Log messages related to this file are written to
+       <filename>/var/log/sapconf.log</filename>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+   <para>
+    When editing either of these files, you will find that some values are
+    commented by means of a <literal>#</literal> character at the beginning of
+    the line. This means that while the parameter is relevant for tuning, there
+    is no suitable default for it.
+   </para>
+   <para>
+    Conversely, you can add <literal>#</literal> characters to the beginning of
+    the line to comment specific parameters. However, you should avoid this
+    practice, as it can lead to &sapconf; not properly applying the profile.
+   </para>
+   <para>
+    To apply edited configuration, restart &sapconf;:
+   </para>
+   <screen>&prompt.root;<command>systemctl restart sapconf</command></screen>
+   <para>
+    Confirming that a certain parameter value was applied correctly works
+    differently for different parameters. Hence, the following serves as an
+    example only:
+   </para>
+   <example xml:id="ex-sapconf-change-parameter">
+    <title>Checking Parameters</title>
+    <para>
+     To confirm that the setting for <literal>TCP_SLOW_START</literal> was
+     applied, do the following:
+    </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+       View the log file of &sapconf; to see whether it applied the value.
+       Within <filename>/var/log/sapconf.log</filename>, check for a line
+       containing this text:
+      </para>
+      <screen>Change net.ipv4.tcp_slow_start_after_idle from 1 to 0</screen>
+      <para>
+       Alternatively, the parameter may have already been set correctly
+       before &sapconf; was started. In this case, &sapconf; will not change
+       its value:
+      </para>
+      <screen>Leaving net.ipv4.tcp_slow_start_after_idle unchanged at 1</screen>
+     </listitem>
+     <listitem>
+      <para>
+       The underlying option behind <literal>TCP_SLOW_START</literal> can be
+       manually configured at
+       <filename>/proc/sys/net.ipv4.tcp_slow_start_after_idle</filename>.
+       To check its actual current value, use:
+      </para>
+      <screen>&prompt.root;<command>sysctl net.ipv4.tcp_slow_start_after_idle</command></screen>
+     </listitem>
+    </itemizedlist>
+   </example>
+  </sect2>
+  <sect2 xml:id="sec-sapconf-4-remove">
+   <title>Removing &sapconf;</title>
+   <para>
+    To remove &sapconf; from a system, uninstall its package with:
+   </para>
+   <screen>&prompt.root;<command>zypper rm sapconf</command></screen>
+   <para>
+    Note that when doing this, dependencies of &sapconf; will remain installed.
+    However, the services <systemitem class="daemon">sysstat</systemitem> and
+    <systemitem class="daemon">tuned</systemitem> will
+    go into a disabled state. If either is still relevant to you, make sure to
+    enable it again.
+   </para>
+   <para>
+    Certain parameters and files are not removed when &sapconf; is uninstalled.
+    For more information, see the man page <command>man 7
+    sapconf</command>, section <citetitle>PACKAGE REQUIREMENTS</citetitle>.
+   </para>
+  </sect2>
+  <sect2 xml:id="sec-sapconf-4-more">
+   <title>For More Information</title>
+   <para>
+    The following man pages provide additional information about &sapconf;:
+   </para>
+   <itemizedlist>
+    <listitem>
+     <para>
+      High-level overview of tuning parameters used by &sapconf;:
+      <command>man 7 tuned-profiles-sapconf</command>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Detailed description of all tuning parameters set by &sapconf;:
+      <command>man 5 sapconf</command>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Information about configuring and customizing the &sapconf; profile:
+      <command>man 7 sapconf</command>
+     </para>
+    </listitem>
+   </itemizedlist>
+   <para>
+    Also see the blog series detailing the updated version of &sapconf; at
+    <link xlink:href="https://www.suse.com/c/a-new-sapconf-is-available/"/>.
+   </para>
+  </sect2>
+ </sect1>
+
+ <sect1 xml:id="sec-sapconf-5">
+  <title>Tuning &slea; Systems with &sapconf; 5</title>
+  <para>
+   The package <systemitem>sapconf</systemitem> is available in &sls; and &s4s;.
+   It sets recommended parameters for the following types of &sap; applications:
+   &netweaver;, &hana; and &hana;-based applications.
+  </para>
+
+  <variablelist>
+   <title>Overview of &sapconf;5 in &slsreg;&nbsp;12</title>
+   <varlistentry>
+    <term>&sapconf;5 (without &tuned;)</term>
+    <listitem>
+     <itemizedlist>
+      <listitem>
+       <para><systemitem>sapconf-netweaver</systemitem> (&sapconf; profile as a replacement for &tuned; profile)</para>
+      </listitem>
+      <listitem>
+       <para><systemitem>sapconf-hana</systemitem> (&sapconf; profile as a replacement for &tuned; profile)</para>
+      </listitem>
+      <listitem>
+       <para><systemitem>sapconf-bobj</systemitem> (&sapconf; profile as a replacement for &tuned; profile)</para>
+      </listitem>
+      <listitem>
+       <para><systemitem>sapconf-ase</systemitem> (&sapconf; profile as a replacement for &tuned; profile)</para>
+      </listitem>
+     </itemizedlist>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+  <variablelist>
+   <title>Overview of &sapconf;5 in &slsreg;&nbsp;15</title>
+   <varlistentry>
+    <term>&sapconf;5 (without &tuned;)</term>
+    <listitem>
+     <para>no profiles anymore</para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+  <para>
+   Note that if you previously made changes to the system tuning, those
+   changes may be overwritten by &sapconf;.
+  </para>
+  <para>
+   &sapconf;&nbsp;5 ships a &systemd; service which applies the tuning and ensures that
+   related services are running.
+  </para>
+  <para>
+   To use &sapconf;, make sure
+   that the package <package>sapconf</package> is installed on your system.
+  </para>
+
+  <note>
+   <title>No Profiles in &sls; and &productname; &productnumber;</title>
+   <para>
+    In &sls; and &productname; 15, &sapconf; no longer supports profiles.
+   </para>
+  </note>
+
+  <sect2 xml:id="sec-sapconf-5-enable">
+   <title>Enabling and Disabling &sapconf; and Viewing Its Status</title>
+   <para>
+    After the installation of &sapconf;, the &sapconf; service is enabled.
+   </para>
+   <para>
+    You can inspect or change the status of &sapconf; as described in the
+    following:
+   </para>
+   <itemizedlist>
+    <listitem>
+     <para>
+      To see the status of the service
+      <systemitem class="daemon">sapconf</systemitem>:
+     </para>
+     <screen>&prompt.root;<command>systemctl status sapconf</command></screen>
+     <para>
+      The service should be displayed as <emphasis>active (exited)</emphasis>.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      To start the service
+      <systemitem class="daemon">sapconf</systemitem>:
+     </para>
+     <screen>&prompt.root;<command>systemctl start sapconf</command></screen>
+    </listitem>
+    <listitem>
+     <para>
+      Should <systemitem class="daemon">sapconf</systemitem> be disabled,
+      enable and start it with:
+     </para>
+     <screen>&prompt.root;<command>systemctl enable --now sapconf</command></screen>
+    </listitem>
+    <listitem>
+     <para>
+      To stop the service
+      <systemitem class="daemon">sapconf</systemitem>:
+     </para>
+     <screen>&prompt.root;<command>systemctl stop sapconf</command></screen>
+     <para>
+      This command will disable the vast majority of optimizations immediately. The only 
+      exceptions from this rule are options that require a system reboot to enable/disable.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      To disable <systemitem class="daemon">sapconf</systemitem>, use:
+     </para>
+     <screen>&prompt.root;<command>systemctl disable sapconf</command></screen>
+     <para>
+      If you have not specifically enabled any of the services that &sapconf;
+      depends on yourself, this will also disable most tuning parameters and
+      all services used by &sapconf;.
+     </para>
+    </listitem>
+   </itemizedlist>
+
+   <tip>
+    <title>Additional Services that &sapconf; Relies On</title>
+    <para>
+     In addition to the &sapconf; service it also relies on the following two services:
+    </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+       <systemitem class="daemon">sysstat</systemitem> which collects data on
+       system activity.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       <systemitem class="daemon">uuidd</systemitem> which generates time-based
+       UUIDs that are guaranteed to be unique even in settings where many
+       processor cores are involved. This is necessary for &sap; applications.
+      </para>
+     </listitem>
+    </itemizedlist>
+   </tip>
+  </sect2>
+  <sect2 xml:id="sec-sapconf-5-configure">
+   <title>Configuring &sapconf;5</title>
+   <para>
+    In general, the default configuration of &sapconf; already uses the
+    parameter values recommended by &sap;. However, if you have special
+    needs, you can configure the tool to better suit those.
+   </para>
+   <para>
+    All parameters of &sapconf; can be found in the file
+    <filename>/etc/sysconfig/sapconf</filename>.
+    The file can be edited directly. All parameters in this file are
+    explained by means of comments and references to &sap; Notes which can
+    be viewed at <link xlink:href="https://launchpad.support.sap.com/"/>.
+   </para>
+   <para>
+    When &sapconf; is updated, all customized parameters from this file will
+    be preserved as much as possible. However, sometimes parameters cannot
+    be transferred cleanly to the new configuration file. Therefore, after
+    updating it is advisable to check the difference between the previous
+    custom configuration which during the update is moved to
+    <filename>/etc/sysconfig/sapconf.rpmsave</filename>
+    and the new version at <filename>/etc/sysconfig/sapconf</filename>.
+   </para>
+   <para>
+    Log messages related to this file are written to
+    <filename>/var/log/sapconf.log</filename>.
+   </para>
+   <para>
+    When editing either of these files, you will find that some values are
+    commented by means of a <literal>#</literal> character at the beginning of
+    the line. This means that while the parameter is relevant for tuning, there
+    is no suitable default for it.
+   </para>
+   <para>
+    Conversely, you can add <literal>#</literal> characters to the beginning of
+    the line to comment specific parameters. However, you should avoid this
+    practice, as it can lead to &sapconf; not properly applying the profile.
+   </para>
+   <para>
+    To apply edited configuration, restart &sapconf;:
+   </para>
+   <screen>&prompt.root;<command>systemctl restart sapconf</command></screen>
+   <para>
+    Confirming that a certain parameter value was applied correctly works
+    differently for different parameters. Hence, the following serves as an
+    example only:
+   </para>
+   <example xml:id="ex-sapconf-change-parameter-5">
+    <title>Checking Parameters</title>
+    <para>
+     To confirm that the setting for <literal>TCP_SLOW_START</literal> was
+     applied, do the following:
+    </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+       View the log file of &sapconf; to see whether it applied the value.
+       Within <filename>/var/log/sapconf.log</filename>, check for a line
+       containing this text:
+      </para>
+      <screen>Change net.ipv4.tcp_slow_start_after_idle from 1 to 0</screen>
+      <para>
+       Alternatively, the parameter may have already been set correctly
+       before &sapconf; was started. In this case, &sapconf; will not change
+       its value:
+      </para>
+      <screen>Leaving net.ipv4.tcp_slow_start_after_idle unchanged at 1</screen>
+     </listitem>
+     <listitem>
+      <para>
+       The underlying option behind <literal>TCP_SLOW_START</literal> can be
+       manually configured at
+       <filename>/proc/sys/net.ipv4.tcp_slow_start_after_idle</filename>.
+       To check its actual current value, use:
+      </para>
+      <screen>&prompt.root;<command>sysctl net.ipv4.tcp_slow_start_after_idle</command></screen>
+     </listitem>
+    </itemizedlist>
+   </example>
+  </sect2>
+  <sect2 xml:id="sec-sapconf-5-remove">
+   <title>Removing &sapconf;</title>
+   <para>
+    To remove &sapconf; from a system, uninstall its package with:
+   </para>
+   <screen>&prompt.root;<command>zypper rm sapconf</command></screen>
+   <para>
+    Note that when doing this, dependencies of &sapconf; will remain installed.
+    However, the service <systemitem class="daemon">sysstat</systemitem> will
+    go into a disabled state. If it is still relevant to you, make sure to
+    enable it again.
+   </para>
+  </sect2>
+  <sect2 xml:id="sec-sapconf-5-more">
+   <title>For More Information</title>
+   <para>
+    The following man pages provide additional information about &sapconf;:
+   </para>
+   <itemizedlist>
+    <listitem>
+     <para>
+      Detailed description of all tuning parameters set by &sapconf;:
+      <command>man 5 sapconf</command>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Information about configuring and customizing the &sapconf; profile:
+      <command>man 7 sapconf</command>
+     </para>
+    </listitem>
+   </itemizedlist>
+   <para>
+    Also see the blog series detailing the updated version of &sapconf; at
+    <link xlink:href="https://www.suse.com/c/a-new-sapconf-is-available/"/>.
+   </para>
+  </sect2>
+  <sect2 xml:id="sec-sapconf-5-tuned">
+   <title>Using <command>tuned</command> Together with  &sapconf;</title>
+   <para>
+    With version 5 &sapconf; does not rely on &tuned; anymore. This means both tools
+    can be used independently.
+    &sapconf; will print a warning in it's log if <command>tuned</command> service
+    is started.
+   </para>
+   <note>
+    <title>Important: Using <command>tuned</command> and &sapconf; together</title>
+    <para>
+     If you are going to use <command>tuned</command> and &sapconf; simultaneously,
+     be very careful, that both tools do not configure the same system parameters.
+    </para>
+   </note> 
+  </sect2>
+ </sect1>
+</chapter>

--- a/xml/tuning_storagescheduler.xml
+++ b/xml/tuning_storagescheduler.xml
@@ -5,7 +5,10 @@
     %entities;
 ]>
 
-<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-tuning-io">
+<chapter xmlns="http://docbook.org/ns/docbook" 
+         xmlns:xi="http://www.w3.org/2001/XInclude" 
+         xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-tuning-io">
+  
  <title>Tuning I/O performance</title>
  <info>
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -25,6 +28,7 @@
   network storage systems, for example, each require different tuning
   strategies.
  </para>
+ 
  <sect1 xml:id="cha-tuning-io-switch">
   <title>Switching I/O scheduling</title>
 
@@ -364,6 +368,7 @@
 
   </sect2>
  </sect1>
+ 
  <sect1 xml:id="cha-tuning-io-barrier">
   <title>I/O Barrier tuning</title>
 


### PR DESCRIPTION

        Move sapconf section of SLES4SAP to the SLE Tuning Guide
    
        sapconf is for preparing SLES installations to add SAP applications.
        saptune is for SLES4SAP.
        https://jira.suse.com/browse/SLE-15940


### To which product versions do the changes apply? TBD

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [ ] 15 SP3  | *(no backport necessary)*
| [ ] 15 SP2  | [ ]
| [ ] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
