### PR TITLE
Convert too-large tables in AY Guide to variablelists

### DIFF
--- a/xml/ay_bootloader.xml
+++ b/xml/ay_bootloader.xml
@@ -102,147 +102,62 @@
   &lt;terminal&gt;gfxterm&lt;/terminal&gt;
   &lt;gfxmode&gt;1280x1024x24&lt;/gfxmode&gt;
 &lt;/global&gt;</screen>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Attribute
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>activate</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Attribute, Description</title>
+  <varlistentry><term><literal>activate</literal></term>
+<listitem><para>
           Set the boot flag on the boot partition. The boot partition can be
           <filename>/</filename> if there is no separate /boot partition. If
           the boot partition is on a logical partition, the boot flag is set
           to the extended partition.
-         </para>
-<screen>&lt;activate config:type="boolean"&gt;true&lt;/activate&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>append</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;activate config:type="boolean"&gt;true&lt;/activate&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>append</literal></term>
+<listitem><para>
           Kernel parameters added at the end of boot entries for normal and
           recovery mode.
-         </para>
-<screen>&lt;append&gt;nomodeset vga=0x317&lt;/append&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>boot_boot</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;append&gt;nomodeset vga=0x317&lt;/append&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>boot_boot</literal></term>
+<listitem><para>
           Write &grub; to a separate /boot partition. If no separate
           /boot partition exists, &grub; will be written to
           <filename>/</filename>.
-         </para>
-<screen>&lt;boot_boot&gt;false&lt;/boot_boot&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>boot_custom</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;boot_boot&gt;false&lt;/boot_boot&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>boot_custom</literal></term>
+<listitem><para>
           Write &grub; to a custom device.
-         </para>
-<screen>&lt;boot_custom&gt;/dev/sda3&lt;/boot_custom&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>boot_extended</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;boot_custom&gt;/dev/sda3&lt;/boot_custom&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>boot_extended</literal></term>
+<listitem><para>
           Write &grub; to the extended partition (important if you want
           to use generic boot code and the <filename>/boot</filename>
           partition is logical). Note: if the boot partition is logical, you
           should use <literal>boot_mbr</literal> (write &grub; to MBR)
           rather than <literal>generic_mbr</literal>.
-         </para>
-<screen>&lt;boot_extended&gt;false&lt;/boot_extended&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>boot_mbr</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;boot_extended&gt;false&lt;/boot_extended&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>boot_mbr</literal></term>
+<listitem><para>
           Write &grub; to the MBR of the first disk in the order (device.map
           includes order of disks).
-         </para>
-<screen>&lt;boot_mbr&gt;false&lt;/boot_mbr&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>boot_root</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;boot_mbr&gt;false&lt;/boot_mbr&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>boot_root</literal></term>
+<listitem><para>
           Write &grub; to <filename>/</filename> partition.
-         </para>
-<screen>&lt;boot_root&gt;false&lt;/boot_root&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>generic_mbr</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;boot_root&gt;false&lt;/boot_root&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>generic_mbr</literal></term>
+<listitem><para>
           Write generic boot code to the MBR (will be ignored if <literal>boot_mbr</literal>
           is set to <literal>true</literal>).
-         </para>
-<screen>&lt;generic_mbr config:type="boolean"&gt;false&lt;/generic_mbr&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>gfxmode</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;generic_mbr config:type="boolean"&gt;false&lt;/generic_mbr&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>gfxmode</literal></term>
+<listitem><para>
           Graphical resolution of the &grub; screen (requires
           &lt;terminal&gt; to be set to <literal>gfxterm</literal>.
           Valid entries are <literal>auto</literal>,
@@ -253,96 +168,59 @@
           resolutions supported by &grub; on a particular system by
           using the <command>vbeinfo</command> command at the &grub; command line in
           the running system.
-         </para>
-<screen>&lt;gfxmode&gt;1280x1024x24&lt;/gfxmode&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>os_prober</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;gfxmode&gt;1280x1024x24&lt;/gfxmode&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>os_prober</literal></term>
+<listitem><para>
           If set to <literal>true</literal>, automatically searches for
           operating systems already installed and generates boot entries for
           them during the installation
-         </para>
-<screen>&lt;os_prober config:type="boolean"&gt;false&lt;/os_prober&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>cpu_mitigations</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;os_prober config:type="boolean"&gt;false&lt;/os_prober&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>cpu_mitigations</literal></term>
+<listitem><para>
           Allows to choose a default setting of kernel boot command line parameters
           for CPU mitigation (and at the same time strike a balance between security
-          and performance). Possible values are:</para>
-         <formalpara>
-          <title><literal>auto</literal></title>
+          and performance). Possible values are:
+          </para>
+          <formalpara><title><literal>auto</literal></title>
            &kernel_cpu_mitigations_auto;
          </formalpara>
-         <formalpara>
-          <title><literal>nosmt</literal></title>
+         <formalpara><title><literal>nosmt</literal></title>
            &kernel_cpu_mitigations_nosmt;
          </formalpara>
-         <formalpara>
-          <title><literal>off</literal></title>
+         <formalpara><title><literal>off</literal></title>
            &kernel_cpu_mitigations_off;
          </formalpara>
-         <formalpara>
-          <title>
-           <literal>manual</literal>
-          </title>
+         <formalpara><title><literal>manual</literal></title>
           &kernel_cpu_mitigations_manual;
          </formalpara>
 <screen>&lt;cpu_mitigations&gt;auto&lt;/cpu_mitigations&gt;</screen>
-         <para>
+          <para>
           If not set in &ay;, the respective settings can be changed via
           kernel command line. By default, the (product-specific) settings in
           the <filename>/control.xml</filename> file on the installation medium
           are used (if nothing else is specified).
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>suse_btrfs</literal>
-         </para>
-        </entry>
-       <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>suse_btrfs</literal></term>
+<listitem><para>
           Obsolete and no longer used. Booting from Btrfs snapshots is
           automatically enabled since SLES 12 SP2.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>serial</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>serial</literal></term>
+<listitem><para>
           Command to execute if the &grub; terminal mode is set to
           <literal>serial</literal>.
-         </para>
-<screen>&lt;serial&gt;
+         </para><screen>&lt;serial&gt;
   serial --speed=115200 --unit=0 --word=8 --parity=no --stop=1
-&lt;/serials&gt;</screen>
-        </entry>
-       </row>
-       <!-- secure_boot disable added to SLE 15 SP2 oct 1 2019, uncomment
+&lt;/serials&gt;</screen></listitem>
+</varlistentry>
+  <!-- secure_boot disable added to SLE 15 SP2 oct 1 2019, uncomment
        if it is ever backported to earlier releases, see
        https://github.com/SUSE/doc-sle/pull/481 (cjs) -->
-       <!--<row>
+  <!--<row>
         <entry>
          <para>
           <literal>secure_boot</literal>
@@ -356,98 +234,48 @@
 <screen>&lt;secure_boot&gt;false&lt;/secure_boot&gt;</screen>
         </entry>
        </row>-->
-       <row>
-        <entry>
-         <para>
-          <literal>terminal</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+  <varlistentry><term><literal>terminal</literal></term>
+<listitem><para>
           Specify the &grub; terminal mode to use, Valid entries are
           <literal>console</literal>, <literal>gfxterm</literal>, and
           <literal>serial</literal>. If set to <literal>serial</literal>,
           the serial command needs to be specified with
           &lt;serial&gt;, too.
-         </para>
-<screen>&lt;terminal&gt;serial&lt;/terminal&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>timeout</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;terminal&gt;serial&lt;/terminal&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>timeout</literal></term>
+<listitem><para>
           The timeout in seconds until the default boot entry is booted
           automatically.
-         </para>
-<screen>&lt;timeout config:type="integer"&gt;10&lt;/timeout&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>trusted_boot</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;timeout config:type="integer"&gt;10&lt;/timeout&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>trusted_boot</literal></term>
+<listitem><para>
           If set to <literal>true</literal>, then Trusted GRUB is used.
           Trusted GRUB supports Trusted Platform Module (TPM).
           Works only for <literal>grub2</literal> bootloader.
-         </para>
-<screen>&lt;trusted_boot&gt;true&lt;/trusted_boot&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>vgamode</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;trusted_boot&gt;true&lt;/trusted_boot&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>vgamode</literal></term>
+<listitem><para>
           Adds the kernel parameter
           <literal>vga=<replaceable>VALUE</replaceable></literal> to the
           boot entries.
-         </para>
-<screen>&lt;vgamode&gt;0x317&lt;/vgamode&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>xen_append</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;vgamode&gt;0x317&lt;/vgamode&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>xen_append</literal></term>
+<listitem><para>
           Kernel parameters added at the end of boot entries for &xen;
           guests.
-         </para>
-<screen>&lt;xen_append&gt;nomodeset vga=0x317&lt;/xen_append&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>xen_kernel_append</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;xen_append&gt;nomodeset vga=0x317&lt;/xen_append&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>xen_kernel_append</literal></term>
+<listitem><para>
           Kernel parameters added at the end of boot entries for &xen;
           kernels on the &vmhost;.
-         </para>
-<screen>&lt;xen_kernel_append&gt;dom0_mem=768M&lt;/xen_kernel_append&gt;</screen>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+         </para><screen>&lt;xen_kernel_append&gt;dom0_mem=768M&lt;/xen_kernel_append&gt;</screen></listitem>
+</varlistentry>
+</variablelist>
 </sect2>
 
    <sect2 xml:id="CreateProfile-Bootloader-dev-map">

--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -35,301 +35,124 @@
     &lt;/drive&gt;
   &lt;/partitioning&gt;
 &lt;/profile&gt;</screen>
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Attribute
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Values
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>device</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Attribute, Values, Description</title>
+  <varlistentry><term><literal>device</literal></term>
+<listitem><para>
           The device you want to configure in this section. You can use persistent
           device names via ID, like
           <filename>/dev/disk/by-id/ata-WDC_WD3200AAKS-75L9A0_WD-WMAV27368122</filename>
           or <emphasis>by-path</emphasis>, like
           <filename>/dev/disk/by-path/pci-0001:00:03.0-scsi-0:0:0:0</filename>.
-         </para>
-<screen>&lt;device&gt;/dev/sda&lt;/device&gt;</screen>
-        <para>
+         </para><screen>&lt;device&gt;/dev/sda&lt;/device&gt;</screen><para>
           In case of volume groups, software RAID or &bcache; devices, the name in the installed
           system may be different (to avoid clashes with existing devices).
-        </para>
-        </entry>
-        <entry>
-         <para>
+        </para><para>
           Optional. If left out, &ay; tries to guess the device. See
           <xref linkend="ay-partitioning-skip-devices"/> on how to influence
           guessing.
-         </para>
-         <para>
+         </para><para>
           If set to <literal>ask</literal>, &ay; will ask the user which device to use
           during installation.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>initialize</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>initialize</literal></term>
+<listitem><para>
           If set to <literal>true</literal>, the partition table gets wiped
           out before &ay; starts the partition calculation.
-         </para>
-<screen>&lt;initialize config:type="boolean"&gt;true&lt;/initialize&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;initialize config:type="boolean"&gt;true&lt;/initialize&gt;</screen><para>
           Optional. The default is <literal>false</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>partitions</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>partitions</literal></term>
+<listitem><para>
           A list of &lt;partition&gt; entries (see
           <xref linkend="ay-partition-configuration"/>).
-         </para>
-<screen>&lt;partitions config:type="list"&gt;
+         </para><screen>&lt;partitions config:type="list"&gt;
   &lt;partition&gt;...&lt;/partition&gt;
   ...
-&lt;/partitions&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+&lt;/partitions&gt;</screen><para>
           Optional. If no partitions are specified, &ay; will create a
           reasonable partitioning (see
           <xref linkend="ay-auto-partitioning"/>).
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>pesize</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>pesize</literal></term>
+<listitem><para>
           This value only makes sense with LVM.
-         </para>
-<screen>&lt;pesize&gt;8M&lt;/pesize&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;pesize&gt;8M&lt;/pesize&gt;</screen><para>
           Optional. Default is 4M for LVM volume groups.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>use</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>use</literal></term>
+<listitem><para>
           Specifies the strategy &ay; will use to partition the hard
           disk.
-         </para>
-         <para>
+         </para><para>
           Choose between:
-         </para>
-         <itemizedlist mark="bullet" spacing="normal">
-          <listitem>
-           <para>
-            <literal>all</literal> (uses the whole device while calculating
+         </para><itemizedlist mark="bullet" spacing="normal"><listitem><para><literal>all</literal> (uses the whole device while calculating
             the new partitioning),
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>linux</literal> (only existing Linux partitions are
+           </para></listitem><listitem><para><literal>linux</literal> (only existing Linux partitions are
             used),
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>free</literal> (only unused space on the device is
+           </para></listitem><listitem><para><literal>free</literal> (only unused space on the device is
             used, no other partitions are touched),
-           </para>
-          </listitem>
-          <listitem>
-           <para>
+           </para></listitem><listitem><para>
             1,2,3 (a list of comma separated partition numbers to use).
-           </para>
-          </listitem>
-         </itemizedlist>
-        </entry>
-        <entry>
-         <para>
+           </para></listitem></itemizedlist><para>
           This parameter should be provided.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>type</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>type</literal></term>
+<listitem><para>
           Specify the type of the <literal>drive</literal>,
-         </para>
-         <para>
+         </para><para>
           Choose between:
-         </para>
-         <itemizedlist mark="bullet" spacing="normal">
-          <listitem>
-           <para>
-            <literal>CT_DISK</literal> for physical hard disks (default),
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>CT_LVM</literal> for LVM volume groups,
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>CT_RAID</literal> for software RAID devices,
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>CT_BCACHE</literal> for software &bcache; devices.
-           </para>
-          </listitem>
-         </itemizedlist>
-<screen>&lt;type config:type="symbol"&gt;CT_LVM&lt;/type&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><itemizedlist mark="bullet" spacing="normal"><listitem><para><literal>CT_DISK</literal> for physical hard disks (default),
+           </para></listitem><listitem><para><literal>CT_LVM</literal> for LVM volume groups,
+           </para></listitem><listitem><para><literal>CT_RAID</literal> for software RAID devices,
+           </para></listitem><listitem><para><literal>CT_BCACHE</literal> for software &bcache; devices.
+           </para></listitem></itemizedlist><screen>&lt;type config:type="symbol"&gt;CT_LVM&lt;/type&gt;</screen><para>
           Optional. Default is <literal>CT_DISK</literal> for a normal
           physical hard disk.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>disklabel</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>disklabel</literal></term>
+<listitem><para>
           Describes the type of the partition table.
-         </para>
-         <para>
+         </para><para>
           Choose between:
-         </para>
-         <itemizedlist mark="bullet" spacing="normal">
-          <listitem>
-           <para>
-            <literal>msdos</literal>
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>gpt</literal>
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>none</literal>
-           </para>
-          </listitem>
-         </itemizedlist>
-<screen>&lt;disklabel&gt;gpt&lt;/disklabel&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><itemizedlist mark="bullet" spacing="normal"><listitem><para><literal>msdos</literal></para></listitem><listitem><para><literal>gpt</literal></para></listitem><listitem><para><literal>none</literal></para></listitem></itemizedlist><screen>&lt;disklabel&gt;gpt&lt;/disklabel&gt;</screen><para>
           Optional. By default &yast; decides what makes sense. If a partition
           table of a different type already exists, it will be recreated with
           the given type only if it does not include any partition that should
           be kept or reused. To use the disk without creating any partition, set
           this element to <literal>none</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>keep_unknown_lv</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>keep_unknown_lv</literal></term>
+<listitem><para>
           This value only makes sense for type=CT_LVM drives. If you are
           reusing a logical volume group and you set this to
           <literal>true</literal>, all existing logical volumes in that
           group will not be touched unless they are specified in the
           &lt;partitioning&gt; section. So you can keep existing
           logical volumes without specifying them.
-         </para>
-<screen>&lt;keep_unknown_lv config:type="boolean"
-&gt;false&lt;/keep_unknown_lv&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;keep_unknown_lv config:type="boolean"
+&gt;false&lt;/keep_unknown_lv&gt;</screen><para>
           Optional. The default is <literal>false</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>enable_snapshots</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>enable_snapshots</literal></term>
+<listitem><para>
           Enables snapshots on Btrfs file systems mounted at <literal>/</literal>
           (does not apply to other file systems, or Btrfs file systems not mounted
           at <literal>/</literal>).
-         </para>
-<screen>&lt;enable_snapshots config:type="boolean"
-&gt;false&lt;/enable_snapshots&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;enable_snapshots config:type="boolean"
+&gt;false&lt;/enable_snapshots&gt;</screen><para>
           Optional. The default is <literal>true</literal>.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+         </para></listitem>
+</varlistentry>
+</variablelist>
     <tip xml:id="ay-partitioning-skip-devices">
      <title>Skipping Devices</title>
      <para>
@@ -382,413 +205,172 @@
     &lt;/partition&gt;
   &lt;/partitions&gt;
 &lt;/drive&gt;</screen>
-    <informaltable>
-     <tgroup cols="3">
-      <colspec colwidth="1*"/>
-      <colspec colwidth="3*"/>
-      <colspec colwidth="2*"/>
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Attribute
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Values
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>create</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Attribute, Values, Description</title>
+  <varlistentry><term><literal>create</literal></term>
+<listitem><para>
           Specify if this partition or logical volume must be created or if it already exists.
-         </para>
-<screen>&lt;create config:type="boolean" &gt;false&lt;/create&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;create config:type="boolean"&gt;false&lt;/create&gt;</screen><para>
           If set to <literal>false</literal>, you also need to set one of
           <literal>partition_nr</literal>, <literal>lv_name</literal>, <literal>label</literal>
           or <literal>uuid</literal> to tell &ay; which device to use.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>crypt_fs</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>crypt_fs</literal></term>
+<listitem><para>
           Partition will be encrypted.
-         </para>
-<screen>&lt;crypt_fs config:type="boolean"&gt;false&lt;/crypt_fs&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;crypt_fs config:type="boolean"&gt;false&lt;/crypt_fs&gt;</screen><para>
           Default is <literal>false</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>crypt_key</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>crypt_key</literal></term>
+<listitem><para>
           Encryption key
-         </para>
-<screen>&lt;crypt_key&gt;xxxxxxxx&lt;/crypt_key&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;crypt_key&gt;xxxxxxxx&lt;/crypt_key&gt;</screen><para>
           Needed if <literal>crypt_fs</literal> has been set to <literal>true</literal>,
           as well as to open and reuse an existing encrypted device.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>mount</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>mount</literal></term>
+<listitem><para>
           The mount point of this partition.
-         </para>
-<screen>&lt;mount&gt;/&lt;/mount&gt;
-&lt;mount&gt;swap&lt;/mount&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;mount&gt;/&lt;/mount&gt;
+&lt;mount&gt;swap&lt;/mount&gt;</screen><para>
           You should have at least a root partition (/) and a swap
           partition.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>fstopt</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>fstopt</literal></term>
+<listitem><para>
           Mount options for this partition.
-         </para>
-<screen>&lt;fstopt&gt;
+         </para><screen>&lt;fstopt&gt;
   ro,noatime,user,data=ordered,acl,user_xattr
-&lt;/fstopt&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+&lt;/fstopt&gt;</screen><para>
           See <command>man mount</command> for available mount options.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>label</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>label</literal></term>
+<listitem><para>
           The label of the partition. Useful when formatting the device
           (especially if the <literal>mountby</literal> parameter is set to
           <literal>label</literal>) and for identifying a device that already
           exists (see <literal>create</literal> above).
-         </para>
-<screen>&lt;label&gt;mydata&lt;/label&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;label&gt;mydata&lt;/label&gt;</screen><para>
           See <command>man e2label</command> for an example.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>uuid</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>uuid</literal></term>
+<listitem><para>
           The uuid of the partition. Only useful for indentifying an
           existing device (see <literal>create</literal> above),
           the uuid cannot be enforced for new devices.
          </para>
-<screen>&lt;uuid
-&gt;1b4e28ba-2fa1-11d2-883f-b9a761bde3fb&lt;/uuid&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+<screen>&lt;uuid&gt;1b4e28ba-2fa1-11d2-883f-b9a761bde3fb&lt;/uuid&gt;</screen><para>
           See <command>man uuidgen</command>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>size</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>size</literal></term>
+<listitem><para>
           The size of the partition, for example 4G, 4500M, etc. The /boot
           partition and the swap partition can have <literal>auto</literal>
           as size. Then &ay; calculates a reasonable size. One partition
           can have the value <literal>max</literal> to use all remaining
           space.
-         </para>
-         <para>
+         </para><para>
           You can also specify the size in percentage. So 10% will use 10%
           of the size of the hard disk or volume group. You can mix auto,
           max, size, and percentage as you like.
-         </para>
-<screen>&lt;size&gt;10G&lt;/size&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;size&gt;10G&lt;/size&gt;</screen><para>
           Starting with &productname; 15, all values (including
           <literal>auto</literal> and <literal>max</literal>) can be used for
           resizing partitions as well.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>format</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>format</literal></term>
+<listitem><para>
           Specify if &ay; should format the partition.
-         </para>
-<screen>&lt;format config:type="boolean"&gt;false&lt;/format&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;format config:type="boolean"&gt;false&lt;/format&gt;</screen><para>
           If you set <literal>create</literal> to <literal>true</literal>,
           then you likely want this option set to <literal>true</literal> as
           well.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>file system</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>file system</literal></term>
+<listitem><para>
           Specify the file system to use on this partition:
-         </para>
-         <itemizedlist mark="bullet" spacing="normal">
-          <listitem>
-           <para>
-            <literal>btrfs</literal>
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>ext2</literal>
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>ext3</literal>
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>ext4</literal>
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>fat</literal>
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>xfs</literal>
-           </para>
-          </listitem>
-          <listitem>
-           <para>
-            <literal>swap</literal>
-           </para>
-          </listitem>
-         </itemizedlist>
-<screen>&lt;filesystem config:type="symbol"
-&gt;ext3&lt;/filesystem&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><itemizedlist mark="bullet" spacing="normal"><listitem><para><literal>btrfs</literal></para></listitem><listitem><para><literal>ext2</literal></para></listitem><listitem><para><literal>ext3</literal></para></listitem><listitem><para><literal>ext4</literal></para></listitem><listitem><para><literal>fat</literal></para></listitem><listitem><para><literal>xfs</literal></para></listitem><listitem><para><literal>swap</literal></para></listitem></itemizedlist>
+<screen>&lt;filesystem config:type="symbol"&gt;ext3&lt;/filesystem&gt;</screen><para>
           Optional. The default is <literal>btrfs</literal> for the root
           partition (<filename>/</filename>) and <literal>xfs</literal> for
           data partitions.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>mkfs_options</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>mkfs_options</literal></term>
+<listitem><para>
           Specify an option string that is added to the mkfs command.
-         </para>
-<screen>&lt;mkfs_options&gt;-I 128&lt;/mkfs_options&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;mkfs_options&gt;-I 128&lt;/mkfs_options&gt;</screen><para>
           Optional. Only use this when you know what you are doing.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>partition_nr</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>partition_nr</literal></term>
+<listitem><para>
           The partition number of this partition. If you have set
           <literal>create=false</literal> or if you use LVM, then you can
           specify the partition via <literal>partition_nr</literal>. You can
           force &ay; to only create primary partitions by assigning
           numbers below 5.
          </para>
-<screen>&lt;partition_nr config:type="integer"
-&gt;2&lt;/partition_nr&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+<screen>&lt;partition_nr config:type="integer"&gt;2&lt;/partition_nr&gt;</screen><para>
           Usually, numbers 1 to 4 are primary partitions while 5 and higher
           are logical partitions.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>partition_id</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>partition_id</literal></term>
+<listitem><para>
           The <literal>partition_id</literal> sets the id of the partition.
           If you want different identifiers than 131 for Linux partition or
           130 for swap, configure them with partition_id.
          </para>
-<screen>&lt;partition_id config:type="integer"
-&gt;131&lt;/partition_id&gt;</screen>
-         <para>
+<screen>&lt;partition_id config:type="integer"&gt;131&lt;/partition_id&gt;</screen><para>
           Possible values are:
-         </para>
-         <simplelist>
-          <member>Swap: <literal>130</literal></member>
-          <member>Linux: <literal>131</literal></member>
-          <member>LVM: <literal>142</literal></member>
-          <member>MD RAID: <literal>253</literal></member>
-          <member>EFI partition: <literal>259</literal></member>
-         </simplelist>
-        </entry>
-        <entry>
-         <para>
+         </para><simplelist><member>Swap: <literal>130</literal></member><member>Linux: <literal>131</literal></member><member>LVM: <literal>142</literal></member><member>MD RAID: <literal>253</literal></member><member>EFI partition: <literal>259</literal></member></simplelist><para>
           The default is <literal>131</literal> for Linux partition and
           <literal>130</literal> for swap.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>partition_type</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>partition_type</literal></term>
+<listitem><para>
           When using an <literal>msdos</literal> partition table, this
           element sets the type of the partition. The value can be
           <literal>primary</literal> or <literal>logical</literal>.
           This value is ignored when using a <literal>gpt</literal>
           partition table, because such a distinction does not exist in
           that case.
-         </para>
-<screen>&lt;partition_type&gt;primary&lt;/partition_type&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;partition_type&gt;primary&lt;/partition_type&gt;</screen><para>
           Optional. Allowed values are <literal>primary</literal> (default) and
           <literal>logical</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>mountby</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>mountby</literal></term>
+<listitem><para>
           Instead of a partition number, you can tell &ay; to mount a
           partition by <literal>device</literal>, <literal>label</literal>,
           <literal>uuid</literal>, <literal>path</literal> or
           <literal>id</literal>, which are the udev path and udev id (see
           <filename>/dev/disk/...</filename>).
          </para>
-<screen>&lt;mountby config:type="symbol"
-&gt;label&lt;/mountby&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+<screen>&lt;mountby config:type="symbol"&gt;label&lt;/mountby&gt;</screen><para>
           See <literal>label</literal> and <literal>uuid</literal>
           documentation above. The default depends on &yast; and usually
           is <literal>id</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>subvolumes</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>subvolumes</literal></term>
+<listitem><para>
           List of subvolumes to create for a file system of type Btrfs. This
           key only makes sense for file systems of type Btrfs. See
           <xref linkend="ay-btrfs-subvolumes"/> for more information.
-         </para>
-<screen>&lt;subvolumes config:type="list"&gt;
+         </para><screen>&lt;subvolumes config:type="list"&gt;
   &lt;path&gt;tmp&lt;/path&gt;
   &lt;path&gt;opt&lt;/path&gt;
   &lt;path&gt;srv&lt;/path&gt;
@@ -798,258 +380,113 @@
   &lt;path&gt;var/tmp&lt;/path&gt;
   &lt;path&gt;var/spool&lt;/path&gt;
   ...
-&lt;/subvolumes&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+&lt;/subvolumes&gt;</screen><para>
           If no <tag>subvolumes</tag> section has been defined for a partition
           description, &ay; will create a predefined set of subvolumes for the
           given mount point.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>create_subvolumes</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>create_subvolumes</literal></term>
+<listitem><para>
           Determine whether Btrfs subvolumes should be created or not.
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><para>
           It is set to <literal>true</literal> by default. When set to
           <literal>false</literal>, no subvolumes will be created.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>subvolumes_prefix</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>subvolumes_prefix</literal></term>
+<listitem><para>
           Set the Btrfs subvolumes prefix name. If no prefix is wanted,
           it must be set to an empty value:
-         </para>
-         <screen>&lt;subvolumes_prefix&gt;&lt;![CDATA[]]&gt;&lt;/subvolumes_prefix&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;subvolumes_prefix&gt;&lt;![CDATA[]]&gt;&lt;/subvolumes_prefix&gt;</screen><para>
           It is set to <literal>@</literal> by default.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>lv_name</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>lv_name</literal></term>
+<listitem><para>
           If this partition is on a logical volume in a volume group, specify
           the logical volume name here (see the <literal>type</literal>
           parameter in the drive configuration).
-         </para>
-<screen>&lt;lv_name&gt;opt_lv&lt;/lv_name&gt;</screen>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>stripes</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;lv_name&gt;opt_lv&lt;/lv_name&gt;</screen><para/></listitem>
+</varlistentry>
+  <varlistentry><term><literal>stripes</literal></term>
+<listitem><para>
           An integer that configures LVM striping. Specify across how many
           devices you want to stripe (spread data).
-         </para>
-<screen>&lt;stripes config:type="integer"&gt;2&lt;/stripes&gt;</screen>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>stripesize</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;stripes config:type="integer"&gt;2&lt;/stripes&gt;</screen><para/></listitem>
+</varlistentry>
+  <varlistentry><term><literal>stripesize</literal></term>
+<listitem><para>
           Specify the size of each block in KB.
-         </para>
-<screen>&lt;stripesize config:type="integer"
-&gt;4&lt;/stripesize&gt;</screen>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>lvm_group</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;stripesize config:type="integer"
+&gt;4&lt;/stripesize&gt;</screen><para/></listitem>
+</varlistentry>
+  <varlistentry><term><literal>lvm_group</literal></term>
+<listitem><para>
           If this is a physical partition used by (part of) a volume group
           (LVM), you need to specify the name of the volume group here.
-         </para>
-<screen>&lt;lvm_group&gt;system&lt;/lvm_group&gt;</screen>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>pool</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          <literal>pool</literal> must be set to <literal>true</literal> if
+         </para><screen>&lt;lvm_group&gt;system&lt;/lvm_group&gt;</screen><para/></listitem>
+</varlistentry>
+  <varlistentry><term><literal>pool</literal></term>
+<listitem><para><literal>pool</literal> must be set to <literal>true</literal> if
           the LVM logical volume should be an LVM thin pool.
-         </para>
-<screen>&lt;pool config:type="boolean"&gt;false&lt;/pool&gt;</screen>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>used_pool</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;pool config:type="boolean"&gt;false&lt;/pool&gt;</screen><para/></listitem>
+</varlistentry>
+  <varlistentry><term><literal>used_pool</literal></term>
+<listitem><para>
           The name of the LVM thin pool that is used as a data store for
           this thin logical volume. If this is set to something non-empty,
           it implies that the volume is a so-called thin logical volume.
-         </para>
-<screen>&lt;used_pool&gt;my_thin_pool&lt;/used_pool&gt;</screen>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>raid_name</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;used_pool&gt;my_thin_pool&lt;/used_pool&gt;</screen><para/></listitem>
+</varlistentry>
+  <varlistentry><term><literal>raid_name</literal></term>
+<listitem><para>
           If this physical volume is part of a RAID, specify the name of the
           RAID.
-         </para>
-<screen>&lt;raid_name&gt;/dev/md/0&lt;/raid_name&gt;</screen>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>raid_options</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;raid_name&gt;/dev/md/0&lt;/raid_name&gt;</screen><para/></listitem>
+</varlistentry>
+  <varlistentry><term><literal>raid_options</literal></term>
+<listitem><para>
           Specify RAID options, see below.
-         </para>
-<screen>&lt;raid_options&gt;...&lt;/raid_options&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;raid_options&gt;...&lt;/raid_options&gt;</screen><para>
           Setting the RAID options at <literal>partition</literal> level is deprecated.
           See <xref linkend="ay-partition-sw-raid"/>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term>
           bcache_backing_for
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </term>
+<listitem><para>
           If this device is used as a <emphasis>&bcache; backing device</emphasis>, specify the name
           of the &bcache; device.
-         </para>
-<screen>&lt;bcache_backing_for&gt;/dev/bcache0&lt;/bcache_backing_for&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;bcache_backing_for&gt;/dev/bcache0&lt;/bcache_backing_for&gt;</screen><para>
           See <xref linkend="ay-partition-bcache"/> for further details.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term>
           bcache_caching_for
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </term>
+<listitem><para>
           If this device is used as a <emphasis>&bcache; caching device</emphasis>, specify the names
           of the &bcache; devices.
-         </para>
-<screen>&lt;bcache_caching_for config:type="list"&gt;
+         </para><screen>&lt;bcache_caching_for config:type="list"&gt;
   &lt;listentry&gt;/dev/bcache0&lt;/listentry&gt;
-&lt;/bcache_caching_for&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+&lt;/bcache_caching_for&gt;</screen><para>
           See <xref linkend="ay-partition-bcache"/> for further details.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>resize</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>resize</literal></term>
+<listitem><para>
           This boolean must be <literal>true</literal> if an existing
           partition should be resized. In this case, you need to tell &ay;
           to reuse the device (see <literal>create</literal>) and specify
           a <literal>size</literal>.
-         </para>
-<screen>&lt;resize config:type="boolean"&gt;false&lt;/resize&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;resize config:type="boolean"&gt;false&lt;/resize&gt;</screen><para>
           Starting with &productname; 15 resizing works with physical disk
           partitions and with LVM volumes.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+         </para></listitem>
+</varlistentry>
+</variablelist>
 
     <important>
      <title>Creating Boot Partitions Automatically</title>
@@ -1991,121 +1428,49 @@
      ...
      &lt;/raid_options&gt;
      &lt;/partition&gt;</screen>
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Attribute
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Values
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>chunk_size</literal>
-         </para>
-        </entry>
-        <entry>
-         <para/>
-         <screen>&lt;chunk_size&gt;4&lt;/chunk_size&gt;</screen>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>parity_algorithm</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Attribute, Values, Description</title>
+  <varlistentry><term><literal>chunk_size</literal></term>
+<listitem><para/><screen>&lt;chunk_size&gt;4&lt;/chunk_size&gt;</screen><para/></listitem>
+</varlistentry>
+  <varlistentry><term><literal>parity_algorithm</literal></term>
+<listitem><para>
           Possible values are:
-         </para>
-         <para>
-          <literal>left_asymmetric</literal>, <literal>left_symmetric,
+         </para><para><literal>left_asymmetric</literal>, <literal>left_symmetric,
            right_asymmetric</literal>, <literal>right_symmetric</literal>.
-         </para>
-         <para>
+         </para><para>
           For RAID6 and RAID10 the following values can be used:
-         </para>
-         <para>
-          <literal>parity_first</literal>, <literal>parity_last</literal>,
+         </para><para><literal>parity_first</literal>, <literal>parity_last</literal>,
           <literal>left_asymmetric_6, left_symmetric_6</literal>,
           <literal>right_asymmetric_6</literal>,
           <literal>right_symmetric_6</literal>,
           <literal>parity_first_6</literal>, <literal>n2</literal>,
           <literal>o2</literal>, <literal>f2</literal>,
           <literal>n3</literal>, <literal>o3</literal>,
-          <literal>f3</literal>
-         </para>
-         <screen>&lt;parity_algorithm
-          &gt;left_asymmetric&lt;/parity_algorithm&gt;</screen>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>raid_type</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+          <literal>f3</literal></para><screen>&lt;parity_algorithm
+          &gt;left_asymmetric&lt;/parity_algorithm&gt;</screen><para/></listitem>
+</varlistentry>
+  <varlistentry><term><literal>raid_type</literal></term>
+<listitem><para>
           Possible values are: <literal>raid0</literal>,
           <literal>raid1</literal>, <literal>raid5</literal>,
           <literal>raid6</literal> and <literal>raid10</literal>.
-         </para>
-         <screen>&lt;raid_type&gt;raid1&lt;/raid_type&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;raid_type&gt;raid1&lt;/raid_type&gt;</screen><para>
           The default is <literal>raid1</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>device_order</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>device_order</literal></term>
+<listitem><para>
           This list contains the order of the physical devices:
-         </para>
-         <screen>&lt;device_order config:type="list"&gt;
+         </para><screen>&lt;device_order config:type="list"&gt;
           &lt;device&gt;/dev/sdb2&lt;/device&gt;
           &lt;device&gt;/dev/sda1&lt;/device&gt;
           ...
-          &lt;/device_order&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+          &lt;/device_order&gt;</screen><para>
           This is optional and the default is alphabetical order.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+         </para></listitem>
+</varlistentry>
+</variablelist>
    </sect3>
   </sect2>
 
@@ -2316,48 +1681,15 @@ size=40G features='0' hwhandler='0' wp=rw
     section is <literal>cache_mode</literal>, described in the table below.
    </para>
 
-   <informaltable>
-    <tgroup cols="3">
-     <thead>
-      <row>
-       <entry>
-        <para>
-         Attribute
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Values
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Description
-        </para>
-       </entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>
-        <para>
-         <literal>cache_mode</literal>
-        </para>
-       </entry>
-       <entry>
-        <para/>
-        <screen>&lt;cache_mode&gt;writethrough&lt;/cache_mode&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+<variablelist>
+  <title>Attribute, Values, Description</title>
+  <varlistentry><term><literal>cache_mode</literal></term>
+<listitem><para/><screen>&lt;cache_mode&gt;writethrough&lt;/cache_mode&gt;</screen><para>
          Cache mode for &bcache;. Possible values are <literal>writethrough</literal>,
          <literal>writeback</literal>, <literal>writearound</literal> and <literal>none</literal>.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
+        </para></listitem>
+</varlistentry>
+</variablelist>
   </sect2>
 
   <sect2 xml:id="ay-partition-nfs">
@@ -2418,108 +1750,41 @@ size=40G features='0' hwhandler='0' wp=rw
       configured in a separate &lt;listentry&gt; ...
       &lt;/listentry&gt; section.
      </para>
-     <informaltable>
-      <tgroup cols="3">
-       <thead>
-        <row>
-         <entry>
-          <para>
-           Attribute
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Description
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Values
-          </para>
-         </entry>
-        </row>
-       </thead>
-       <tbody>
-        <row>
-         <entry>
-          <para>
-           <literal>device</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
-           <literal>DASD</literal> is the only value allowed
-          </para>
-<screen>&lt;device
-&gt;DASD&lt;/dev_name&gt;</screen>
-         </entry>
-         <entry>
-          <para/>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>dev_name</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
+<variablelist>
+  <title>Attribute, Description, Values</title>
+  <varlistentry><term><literal>device</literal></term>
+<listitem><para><literal>DASD</literal> is the only value allowed
+          </para><screen>&lt;device
+&gt;DASD&lt;/dev_name&gt;</screen><para/></listitem>
+</varlistentry>
+  <varlistentry><term><literal>dev_name</literal></term>
+<listitem><para>
            The device (<literal>dasd<replaceable>N</replaceable></literal>)
            you want to configure in this section.
-          </para>
-<screen>&lt;dev_name
-&gt;/dev/dasda&lt;/dev_name&gt;</screen>
-         </entry>
-         <entry>
-          <para>
-           Optional but recommended. If left out, &ay; tries to guess the
+          </para><screen>&lt;dev_name
+&gt;/dev/dasda&lt;/dev_name&gt;</screen><para>
+           Optional but recommended. If left out, ay tries to guess the
            device.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>channel</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
+          </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>channel</literal></term>
+<listitem><para>
            Channel by which the disk is accessed.
-          </para>
-<screen>&lt;channel&gt;0.0.0150&lt;/channel&gt;</screen>
-         </entry>
-         <entry>
-          <para>
+          </para><screen>&lt;channel&gt;0.0.0150&lt;/channel&gt;</screen><para>
            Mandatory.
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>diag</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
+          </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>diag</literal></term>
+<listitem><para>
            Enable or disable the use of <literal>DIAG</literal>. Possible
            values are <literal>true</literal> (enable) or
            <literal>false</literal> (disable).
-          </para>
-<screen>&lt;diag
-config:type="boolean"&gt;true&lt;/diag&gt;</screen>
-         </entry>
-         <entry>
-          <para>
+          </para><screen>&lt;diag
+config:type="boolean"&gt;true&lt;/diag&gt;</screen><para>
            Optional.
-          </para>
-         </entry>
-        </row>
-       </tbody>
-      </tgroup>
-     </informaltable>
+          </para></listitem>
+</varlistentry>
+</variablelist>
     </sect3>
     <sect3 xml:id="ay-partition-s390-zfcp">
      <title>Configuring zFCP Disks</title>
@@ -2540,40 +1805,15 @@ config:type="boolean"&gt;true&lt;/diag&gt;</screen>
       Each disk needs to be configured in a separate
       <literal>listentry</literal> section.
      </para>
-     <informaltable>
-      <tgroup cols="2">
-       <thead>
-        <row>
-         <entry>
-          <para>
-           Attribute
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Values
-          </para>
-         </entry>
-        </row>
-       </thead>
-       <tbody>
-        <row>
-         <entry>
-          <para>
-           <literal>controller_id</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
+<variablelist>
+  <title>Attribute, Values</title>
+  <varlistentry><term><literal>controller_id</literal></term>
+<listitem><para>
            Channel number
           </para>
-<screen>&lt;controller_id
-&gt;0.0.fc00&lt;/controller_id&gt;</screen>
-         </entry>
-        </row>
-       </tbody>
-      </tgroup>
-     </informaltable>
+<screen>&lt;controller_id&gt;0.0.fc00&lt;/controller_id&gt;</screen></listitem>
+</varlistentry>
+</variablelist>
     </sect3>
    </sect2>
   </sect1>

--- a/xml/ay_registration_extensions.xml
+++ b/xml/ay_registration_extensions.xml
@@ -75,260 +75,123 @@
 &lt;/networking&gt;</screen>
    </tip>
 
-   <informaltable>
-    <tgroup cols="3">
-     <thead>
-      <row>
-       <entry>
-        <para>
-         Element
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Description
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Comment
-        </para>
-       </entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>
-        <para>
-         <literal>do_registration</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+<variablelist>
+  <title>Element, Description, Comment</title>
+  <varlistentry><term><literal>do_registration</literal></term>
+<listitem><para>
          Boolean
-        </para>
-<screen>&lt;do_registration config:type="boolean"
-&gt;true&lt;/do_registration&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;do_registration config:type="boolean"
+&gt;true&lt;/do_registration&gt;</screen><para>
          Specify whether the system should be registered or not. If set to
          <literal>false</literal> all other options are ignored and the system
          is not registered.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>e-mail</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>e-mail</literal></term>
+<listitem><para>
          E-mail address
-        </para>
-<screen>&lt;email&gt;&exampleuser_plain;@&exampledomain;&lt;/email&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;email&gt;&exampleuser_plain;@&exampledomain;&lt;/email&gt;</screen><para>
          Optional. The e-mail address matching the registration code.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>reg_code</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>reg_code</literal></term>
+<listitem><para>
          Text
-        </para>
-<screen>&lt;reg_code&gt;<replaceable>SECRET_REGCODE</replaceable>&lt;/reg_code&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;reg_code&gt;<replaceable>SECRET_REGCODE</replaceable>&lt;/reg_code&gt;</screen><para>
          Required. Registration code.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>install_updates</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>install_updates</literal></term>
+<listitem><para>
          Boolean
-        </para>
-<screen>&lt;install_updates config:type="boolean"
-&gt;true&lt;/install_updates&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;install_updates config:type="boolean"
+&gt;true&lt;/install_updates&gt;</screen><para>
          Optional. Determines if updates from the Updates channels should be
          installed. The default value is to not install them (<literal>false</literal>).
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>slp_discovery</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>slp_discovery</literal></term>
+<listitem><para>
          Boolean
-        </para>
-<screen>&lt;slp_discovery config:type="boolean"
-&gt;true&lt;/slp_discovery&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;slp_discovery config:type="boolean"
+&gt;true&lt;/slp_discovery&gt;</screen><para>
          Optional. Search for a registration server via SLP. The default value
          is <literal>false</literal>.
-        </para>
-        <para>
+        </para><para>
          Expects to find a single server. If more than one server is found,
          the installation will fail. In case there is more than one
          registration server available, you need to specify one with
          <literal>reg_server</literal>.
-        </para>
-        <para>
+        </para><para>
          If neither <literal>slp_discovery</literal> nor
          <literal>reg_server</literal> are set, the system is registered
          with the &scc;.
-        </para>
-        <para>
+        </para><para>
          This setting also affects the self-update feature: If it is disabled,
          no SLP search will be performed.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>reg_server</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>reg_server</literal></term>
+<listitem><para>
          URL
-        </para>
-<screen>&lt;reg_server&gt;
+        </para><screen>&lt;reg_server&gt;
   https://smt.&exampledomain;
-&lt;/reg_server&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+&lt;/reg_server&gt;</screen><para>
          Optional. &rmt; server URL. If neither <literal>slp_discovery</literal>
          nor <literal>reg_server</literal> are set, the system is registered with
          the &scc;.
-        </para>
-        <para>
+        </para><para>
          The &rmt; server is queried for a URL of the self-update repository. So if
          <literal>self_update_url</literal> is not set, the &rmt; server influences
          where the self-updates are downloaded from. Check out the &deploy;
          to find further information about this feature.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>reg_server_cert_fingerprint_type</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         <literal>SHA1</literal> or <literal>SHA256</literal>
-        </para>
-<screen>&lt;reg_server_cert_fingerprint_type&gt;
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>reg_server_cert_fingerprint_type</literal></term>
+<listitem><para><literal>SHA1</literal> or <literal>SHA256</literal></para><screen>&lt;reg_server_cert_fingerprint_type&gt;
   SHA1
-&lt;/reg_server_cert_fingerprint_type&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+&lt;/reg_server_cert_fingerprint_type&gt;</screen><para>
          Optional. Requires a checksum value provided with
          <literal>reg_server_cert_fingerprint</literal>. Using the fingerprint is
          recommended, since it ensures the SSL certificate is verified. The matching
          certificate will be automatically imported when the SSL communication fails
          because of a verification error.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>reg_server_cert_fingerprint</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>reg_server_cert_fingerprint</literal></term>
+<listitem><para>
          Server Certificate Fingerprint value in hexadecimal notion (case-insensitive).
-        </para>
-<screen>&lt;reg_server_cert_fingerprint&gt;
+        </para><screen>&lt;reg_server_cert_fingerprint&gt;
   <replaceable>01:AB...:EF</replaceable>
-&lt;/reg_server_cert_fingerprint&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+&lt;/reg_server_cert_fingerprint&gt;</screen><para>
          Optional. Requires a fingerprint type value provided with
          <literal>reg_server_cert_fingerprint_type</literal>. Using the fingerprint is
          recommended, since it ensures the SSL certificate is verified. The matching
          certificate will be automatically imported when the SSL communication fails
          because of a verification error.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>reg_server_cert</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>reg_server_cert</literal></term>
+<listitem><para>
          URL
-        </para>
-<screen>&lt;reg_server_cert&gt;
+        </para><screen>&lt;reg_server_cert&gt;
   http://smt.&exampledomain;/smt.crt
-&lt;/reg_server_cert&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+&lt;/reg_server_cert&gt;</screen><para>
          Optional. URL of the SSL certificate on the server. Using this option is
          not recommended, since the certificate that is downloaded is not verified.
          Use <literal>reg_server_cert_fingerprint</literal> instead.
-        </para>
-       </entry>
-      </row>
-      <row os="sles;sled">
-       <entry>
-        <para>
-         <literal>addons</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>addons</literal></term>
+<listitem><para>
          Add-ons list
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para><para>
          Specify an extension from the registration server that should be
          added to the installation repositories. See
          <xref linkend="CreateProfile-Register-Extension"/> for details.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
+        </para></listitem>
+</varlistentry>
+</variablelist>
 
    <tip>
     <title>Obtaining a Server Certificate Fingerprint</title>


### PR DESCRIPTION
some tables are too large and do not render well in HTML
or PDF, converted with wondrous stylesheet by Thomas Schraitle


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [ ] 15 SP3  | *(no backport necessary)*
| [ ] 15 SP2  | [ ]
| [ x] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
