### PR TITLE
Convert too-large tables in AY Guide to variablelists

### DIFF
--- a/xml/ay_ask_user_values.xml
+++ b/xml/ay_ask_user_values.xml
@@ -40,114 +40,42 @@
   &lt;/ask-list&gt;
 &lt;/general&gt;</screen>
 
-   <table>
-    <title>Ask the User for Values: XML representation</title>
-    <tgroup cols="3">
-     <thead>
-      <row>
-       <entry>
-        <para>
-         Element
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Description
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Comment
-        </para>
-       </entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>
-        <para>
-         <literal>question</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+<variablelist>
+  <title>Ask the User for Values: XML representation</title>
+  <varlistentry><term><literal>question</literal></term>
+<listitem><para>
          The question you want to ask the user.
-        </para>
-<screen>&lt;question&gt;Enter the LDAP server&lt;/question&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;question&gt;Enter the LDAP server&lt;/question&gt;</screen><para>
          The default value is the path to the element (the path often looks
          strange, so we recommend entering a question).
-        </para>
-        <remark>emap 2011-11-04: not sure I understand this.</remark>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>default</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para><remark>emap 2011-11-04: not sure I understand this.</remark></listitem>
+</varlistentry>
+  <varlistentry><term><literal>default</literal></term>
+<listitem><para>
          Set a preselection for the user. A text entry will be filled out
          with this value. A check box will be true or false and a selection
          will have the given value preselected.
-        </para>
-<screen>&lt;default&gt;dc=suse,dc=de&lt;/default&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;default&gt;dc=suse,dc=de&lt;/default&gt;</screen><para>
          Optional.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>help</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>help</literal></term>
+<listitem><para>
          An optional help text that is shown on the left side of the
          question.
-        </para>
-<screen>&lt;help&gt;Enter the LDAP server address.&lt;/help&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;help&gt;Enter the LDAP server address.&lt;/help&gt;</screen><para>
          Optional.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>title</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>title</literal></term>
+<listitem><para>
          An optional title that is shown above the questions.
-        </para>
-<screen>&lt;title&gt;LDAP server&lt;/title&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;title&gt;LDAP server&lt;/title&gt;</screen><para>
          Optional.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>type</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>type</literal></term>
+<listitem><para>
          The type of the element you want to change. Possible values are
          <literal>symbol</literal>, <literal>boolean</literal>,
          <literal>string</literal> and <literal>integer</literal>. The file
@@ -159,46 +87,24 @@
          A <literal>static_text</literal> is a text that does not
          require any user input and can be used to show information not
          included in the help text.
-        </para>
-<screen>&lt;type&gt;symbol&lt;/type&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;type&gt;symbol&lt;/type&gt;</screen><para>
          Optional. The default is <literal>string</literal>. If type is
          <literal>symbol</literal>, you must provide the selection element
          too (see below).
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>password</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>password</literal></term>
+<listitem><para>
          If this boolean is set to <literal>true</literal>, a password
          dialog pops up instead of a simple text entry. Setting this to
          <literal>true</literal> only makes sense if <literal>type</literal>
          is string.
-        </para>
-<screen>&lt;password config:type="boolean"&gt;true&lt;/password&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;password config:type="boolean"&gt;true&lt;/password&gt;</screen><para>
          Optional. The default is <literal>false</literal>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>pathlist</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>pathlist</literal></term>
+<listitem><para>
          A list of <literal>path</literal> elements. A path is a comma
          separated list of elements that describes the path to the element
          you want to change. For example, the LDAP server element can be
@@ -206,20 +112,17 @@
          <literal>&lt;ldap&gt;&lt;ldap_server&gt;</literal> section.
          So if you want to change that value, you need to set the path to
          <literal>ldap,ldap_server</literal>.
-        </para>
-        <screen>&lt;pathlist config:type="list"&gt;
+        </para><screen>&lt;pathlist config:type="list"&gt;
   &lt;path&gt;networking,dns,hostname&lt;/path&gt;
   &lt;path&gt;...&lt;/path&gt;
 &lt;/pathlist&gt;
-        </screen>
-        <para>To change the
+        </screen><para>To change the
          password of the first user in the control file, you need to set the
          path to <literal>users,0,user_password</literal>. The
          <literal>0</literal> indicates the first user in the &lt;users
          config:type="list"&gt; list of users in the control file.
          <literal>1</literal> would be the second one, and so on.
-        </para>
-        <screen>&lt;users config:type="list"&gt;
+        </para><screen>&lt;users config:type="list"&gt;
   &lt;user&gt;
     &lt;username&gt;root&lt;/username&gt;
     &lt;user_password&gt;password to change&lt;/user_password&gt;
@@ -231,24 +134,13 @@
     &lt;encrypted config:type="boolean"&gt;false&lt;/encrypted&gt;
   &lt;/user&gt;
 &lt;/users&gt;
-        </screen>
-
-       </entry>
-       <entry>
-        <para>
+        </screen><para>
          This information is optional but you should at least provide
          <literal>path</literal> or <literal>file</literal>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>file</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>file</literal></term>
+<listitem><para>
          You can store the answer to a question in a file, to use it in one
          of your scripts later. If you ask during
          <literal>stage=initial</literal> and you want to use the answer in
@@ -258,24 +150,15 @@
          is that <filename>/tmp</filename> in stage&nbsp;1 is in the RAM disk
          and will be lost after the reboot, but the installed system is
          already mounted at <filename>/mnt/</filename>.
-        </para>
-<screen>&lt;file&gt;/tmp/answer_hostname&lt;/file&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;file&gt;/tmp/answer_hostname&lt;/file&gt;</screen><para>
          This information is optional, but you should at least provide
          <literal>path</literal> or <literal>file</literal>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term>
          stage
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </term>
+<listitem><para>
          Stage configures the installation stage in which the question pops
          up. You can set this value to <literal>cont</literal> or
          <literal>initial</literal>. <literal>initial</literal> means the
@@ -289,29 +172,17 @@
          it does not make sense to ask for the file system to use during the
          <literal>cont</literal> phase. The hard disk is already partitioned
          at that stage and the question will have no effect.
-        </para>
-<screen>&lt;stage&gt;cont&lt;/stage&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;stage&gt;cont&lt;/stage&gt;</screen><para>
          Optional. The default is <literal>initial</literal>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>selection</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>selection</literal></term>
+<listitem><para>
          The selection element contains a list of <literal>entry</literal>
          elements. Each entry represents a possible option for the user to
          choose. The user cannot enter a value in a text box, but they can
          choose from a list of values.
-        </para>
-<screen>&lt;selection config:type="list"&gt;
+        </para><screen>&lt;selection config:type="list"&gt;
   &lt;entry&gt;
     &lt;value&gt;
         btrfs
@@ -328,223 +199,107 @@
         Extended3 File System
     &lt;/label&gt;
   &lt;/entry&gt;
-&lt;/selection&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+&lt;/selection&gt;</screen><para>
          Optional for <literal>type=string</literal>, not possible for
          <literal>type=boolean</literal> and mandatory for
          <literal>type=symbol</literal>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>dialog</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>dialog</literal></term>
+<listitem><para>
          You can ask more than one question per dialog. To do so, specify
          the dialog-id with an integer. All questions with the same
          dialog-id belong to the same dialog. The dialogs are sorted by the
          id too.
-        </para>
-<screen>&lt;dialog config:type="integer"&gt;3&lt;/dialog&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;dialog config:type="integer"&gt;3&lt;/dialog&gt;</screen><para>
          Optional.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>element</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>element</literal></term>
+<listitem><para>
          You can have more than one question per dialog. To make that
          possible you need to specify the <literal>element-id</literal> with an
          integer. The questions in a dialog are sorted by ID.
-        </para>
-<screen>&lt;element config:type="integer"&gt;1&lt;/element&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;element config:type="integer"&gt;1&lt;/element&gt;</screen><para>
          Optional (see dialog).
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>width</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>width</literal></term>
+<listitem><para>
          You can increase the default width of the dialog. If there are multiple
          width specifications per dialog, the largest one is used. The
          number is roughly equivalent to the number of characters.
-        </para>
-<screen>&lt;width config:type="integer"&gt;50&lt;/width&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;width config:type="integer"&gt;50&lt;/width&gt;</screen><para>
          Optional.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>height</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>height</literal></term>
+<listitem><para>
          You can increase the default height of the dialog. If there are
          multiple height specifications per dialog, the largest one is used. The
          number is roughly equivalent to the number of lines.
-        </para>
-<screen>&lt;height config:type="integer"&gt;15&lt;/height&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;height config:type="integer"&gt;15&lt;/height&gt;</screen><para>
          Optional.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>frametitle</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>frametitle</literal></term>
+<listitem><para>
          You can have more than one question per dialog. Each question on a
          dialog has a frame that can have a frame title, a small caption for
          each question. You can put multiple elements into one frame. They
          need to have the same frame title.
-        </para>
-<screen>&lt;frametitle&gt;User data&lt;/frametitle&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;frametitle&gt;User data&lt;/frametitle&gt;</screen><para>
          Optional; default is no frame title.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>script</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>script</literal></term>
+<listitem><para>
          You can run scripts after a question has been answered. See the
          table below for detailed instructions about scripts.
-        </para>
-<screen>&lt;script&gt;...&lt;/script&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;script&gt;...&lt;/script&gt;</screen><para>
          Optional; default is no script.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>ok_label</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>ok_label</literal></term>
+<listitem><para>
          You can change the label on the <guimenu>Ok</guimenu> button. The
          last element that specifies the label for a dialog wins.
-        </para>
-<screen>&lt;ok_label&gt;Finish&lt;/ok_label&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;ok_label&gt;Finish&lt;/ok_label&gt;</screen><para>
          Optional.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>back_label</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>back_label</literal></term>
+<listitem><para>
          You can change the label on the <guimenu>Back</guimenu> button. The
          last element that specifies the label for a dialog wins.
-        </para>
-<screen>&lt;back_label&gt;change values&lt;/back_label&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;back_label&gt;change values&lt;/back_label&gt;</screen><para>
          Optional.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>timeout</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>timeout</literal></term>
+<listitem><para>
          You can specify an integer here that is used as timeout in seconds.
          If the user does not answer the question before the timeout, the
          default value is taken as answer. When the user touches or changes
          any widget in the dialog, the timeout is turned off and the dialog
          needs to be confirmed via <guimenu>Ok</guimenu>.
-        </para>
-<screen>&lt;timeout config:type="integer"&gt;30&lt;/timeout&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;timeout config:type="integer"&gt;30&lt;/timeout&gt;</screen><para>
          Optional; a missing value is interpreted as <literal>0</literal>,
          which means that there is no timeout.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <literal>default_value_script</literal>
-        </para>
-       </entry>
-       <entry>
-        <para>
+        </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>default_value_script</literal></term>
+<listitem><para>
          You can run scripts to set the default value for a question (see
          <xref linkend="CreateProfile-Ask-default-value"/> for detailed
          instructions about default value scripts). This feature is useful
          if you can <literal>calculate</literal> a default value, especially
          in combination with the <literal>timeout</literal> option.
-        </para>
-<screen>&lt;default_value_script&gt;...&lt;/default_value_script&gt;</screen>
-       </entry>
-       <entry>
-        <para>
+        </para><screen>&lt;default_value_script&gt;...&lt;/default_value_script&gt;</screen><para>
          Optional; default is no script.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </table>
+        </para></listitem>
+</varlistentry>
+</variablelist>
 
    <sect2 xml:id="CreateProfile-Ask-default-value">
     <title>Default Value Scripts</title>
@@ -567,37 +322,10 @@
     &lt;/ask&gt;
   &lt;/ask-list&gt;
 &lt;/general&gt;</screen>
-    <table>
-     <title>Default Value Scripts: XML representation</title>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>source</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Default Value Scripts: XML representation</title>
+  <varlistentry><term><literal>source</literal></term>
+<listitem><para>
           The source code of the script. Whatever you
           <command>echo</command> to STDOUT will be used as default value
           for the ask-dialog. If your script has an exit code other than 0,
@@ -605,37 +333,19 @@
           <command>echo -n</command> to suppress the <literal>\n</literal>
           and that you echo reasonable values and not <quote>okay</quote>
           for a boolean
-         </para>
-<screen>&lt;source&gt;...&lt;/source&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;source&gt;...&lt;/source&gt;</screen><para>
           This value is required, otherwise nothing would be executed.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>interpreter</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>interpreter</literal></term>
+<listitem><para>
           The interpreter to use.
-         </para>
-<screen>&lt;interpreter&gt;perl&lt;/interpreter&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;interpreter&gt;perl&lt;/interpreter&gt;</screen><para>
           The default value is <literal>shell</literal>. You can also set
           <filename>/bin/myinterpreter</filename> as value.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </table>
+         </para></listitem>
+</varlistentry>
+</variablelist>
    </sect2>
 
    <sect2 xml:id="CreateProfile-Ask-script">
@@ -656,55 +366,17 @@
     &lt;/ask&gt;
   &lt;/ask-list&gt;
 &lt;/general&gt;</screen>
-    <table>
-     <title>Scripts: XML representation</title>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>file name</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Scripts: XML representation</title>
+  <varlistentry><term><literal>file name</literal></term>
+<listitem><para>
           The file name of the script.
-         </para>
-<screen>&lt;filename&gt;my_ask_script.sh&lt;/filename&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;filename&gt;my_ask_script.sh&lt;/filename&gt;</screen><para>
           The default is ask_script.sh
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>source</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>source</literal></term>
+<listitem><para>
           The source code of the script. Together with
           <literal>rerun_on_error</literal> activated, you check the value
           that was entered for sanity. Your script can create a file
@@ -712,99 +384,48 @@
           the next dialog &ay; will raise. A value of -1 terminates the
           ask sequence. If that file is not created, &ay; will run the
           dialogs in the normal order (since 11.0 only).
-         </para>
-<screen>&lt;source&gt;...&lt;/source&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;source&gt;...&lt;/source&gt;</screen><para>
           This value is required, otherwise nothing would be executed.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>environment</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>environment</literal></term>
+<listitem><para>
           A boolean that passes the value of the answer to the question as
           an environment variable to the script. The variable is named
           <envar>VAL</envar>.
-         </para>
-<screen>&lt;environment config:type="boolean"&gt;true&lt;/environment&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;environment config:type="boolean"&gt;true&lt;/environment&gt;</screen><para>
           Optional. Default is <literal>false</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>feedback</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>feedback</literal></term>
+<listitem><para>
           A boolean that turns on feedback for the script execution. STDOUT
           will be displayed in a pop-up window that must be confirmed after
           the script execution.
-         </para>
-<screen>&lt;feedback config:type="boolean"&gt;true&lt;/feedback&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;feedback config:type="boolean"&gt;true&lt;/feedback&gt;</screen><para>
           Optional, default is <literal>false</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>debug</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>debug</literal></term>
+<listitem><para>
           A boolean that turns on debugging for the script execution.
-         </para>
-<screen>&lt;debug config:type="boolean"&gt;true&lt;/debug&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;debug config:type="boolean"&gt;true&lt;/debug&gt;</screen><para>
           Optional, default is <literal>true</literal>. This value needs
           <literal>feedback</literal> to be turned on, too.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>rerun_on_error</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>rerun_on_error</literal></term>
+<listitem><para>
           A boolean that keeps the dialog open until the script has an exit
           code of 0 (zero). So you can parse and check the answers the user
           gave in the script and display an error with the
           <literal>feedback</literal> option.
-         </para>
-<screen>&lt;rerun_on_error config:type="boolean"&gt;true&lt;/rerun_on_error&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;rerun_on_error config:type="boolean"&gt;true&lt;/rerun_on_error&gt;</screen><para>
           Optional, default is <literal>false</literal>. This value should
           be used together with the feedback option.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </table>
+         </para></listitem>
+</varlistentry>
+</variablelist>
     <para>
      Below you can see an example of the usage of the <literal>ask</literal>
      feature.

--- a/xml/ay_custom_user_scripts.xml
+++ b/xml/ay_custom_user_scripts.xml
@@ -200,122 +200,53 @@
      not executed by &yast;, but after &yast; has finished. For this reason,
      their XML representation is different from other script types.
     </para>
-    <table>
-     <title>Init script XML representation</title>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>location</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Init script XML representation</title>
+  <varlistentry><term><literal>location</literal></term>
+<listitem><para>
           Define a location from where the script gets fetched. Locations
           can be the same as for the profile (HTTP, FTP, NFS, etc.).
-         </para>
-<screen>&lt;location
-&gt;http://10.10.0.1/myInitScript.sh&lt;/location&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;location&gt;http://10.10.0.1/myInitScript.sh&lt;/location&gt;</screen><para>
           Either &lt;location&gt; or &lt;source&gt; must be
           defined.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>source</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>source</literal></term>
+<listitem><para>
           The script itself (source code), encapsulated in a CDATA tag. If
           you do not want to put the whole shell script into the XML
           profile, use the location parameter.
-         </para>
-<screen>&lt;source&gt;
+         </para><screen>&lt;source&gt;
 &lt;![CDATA[
 echo "Testing the init script" &gt;
 /tmp/init_out.txt
 ]]&gt;
-&lt;/source&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+&lt;/source&gt;</screen><para>
           Either &lt;location&gt; or &lt;source&gt; must be
           defined.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>filename</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>filename</literal></term>
+<listitem><para>
           The file name of the script. It will be stored in a temporary
-          directory under <filename>/tmp</filename>
-         </para>
-<screen>&lt;filename&gt;mynitScript5.sh&lt;/filename&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+          directory under <filename>/tmp</filename></para><screen>&lt;filename&gt;mynitScript5.sh&lt;/filename&gt;</screen><para>
           Optional in case you only have a single init script. The default
           name (<filename>init-scripts</filename>) is used in this case. If
           having specified more than one init script, you must set a unique
           name for each script.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>rerun</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>rerun</literal></term>
+<listitem><para>
           Normally, a script is only run once, even if you use <literal>ayast_setup</literal>
           to run an XML file multiple times. Change this default behavior by
           setting this boolean to <literal>true</literal>.
-         </para>
-<screen>&lt;rerun config:type="boolean"&gt;true&lt;/rerun&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;rerun config:type="boolean"&gt;true&lt;/rerun&gt;</screen><para>
           Optional. Default is <literal>false</literal> (scripts only run
           once).
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </table>
+         </para></listitem>
+</varlistentry>
+</variablelist>
     <para>
      When added to the control file manually, scripts need to be included in
      a <emphasis>CDATA</emphasis> element to avoid confusion with the file
@@ -331,275 +262,126 @@ echo "Testing the init script" &gt;
      definitions can contain only a subset of these elements. See <xref
      linkend="init-scripts" /> for further information about them.
     </para>
-    <table>
-     <title>Script XML Representation</title>
-     <tgroup cols="3">
-      <colspec colwidth="1*"/>
-      <colspec colwidth="3*"/>
-      <colspec colwidth="2*"/>
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>location</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Script XML Representation</title>
+  <varlistentry><term><literal>location</literal></term>
+<listitem><para>
           Define a location from where the script gets fetched. Locations
           can be the same as for the control file (HTTP, FTP, NFS, etc.).
-         </para>
-<screen>&lt;location
-&gt;http://10.10.0.1/myPreScript.sh&lt;/location&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;location&gt;http://10.10.0.1/myPreScript.sh&lt;/location&gt;</screen><para>
           Either <literal>location</literal> or <literal>source</literal>
           must be defined.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>source</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>source</literal></term>
+<listitem><para>
           The script itself (source code), encapsulated in a CDATA tag. If
           you do not want to put the whole shell script into the XML control
           file, refer to the location parameter.
-         </para>
-<screen>&lt;source&gt;
+         </para><screen>&lt;source&gt;
 &lt;![CDATA[
 echo "Testing the pre script" &gt; /tmp/pre-script_out.txt
 ]]&gt;
-&lt;/source&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+&lt;/source&gt;</screen><para>
           Either <literal>location</literal> or <literal>source</literal>
           must be defined.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>interpreter</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>interpreter</literal></term>
+<listitem><para>
           Specify the interpreter that must be used for the script.
           Supported options are <literal>shell</literal> and
           <literal>perl</literal>.
-         </para>
-<screen>&lt;interpreter&gt;perl&lt;/interpreter&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;interpreter&gt;perl&lt;/interpreter&gt;</screen><para>
           Optional; default is <literal>shell</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>file name</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>file name</literal></term>
+<listitem><para>
           The file name of the script. It will be stored in a temporary
           directory under <filename>/tmp</filename>.
-         </para>
-<screen>&lt;filename&gt;myPreScript5.sh&lt;/filename&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;filename&gt;myPreScript5.sh&lt;/filename&gt;</screen><para>
           Optional; default is the type of the script (pre-scripts in this
           case). If you have more than one script, you should define
           different names for each script.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>feedback</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>feedback</literal></term>
+<listitem><para>
           If this boolean is <literal>true</literal>, output and error
           messages of the script (STDOUT and STDERR) will be shown in a
           pop-up. The user needs to confirm them via the OK button.
-         </para>
-<screen>&lt;feedback config:type="boolean"&gt;true&lt;/feedback&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;feedback config:type="boolean"&gt;true&lt;/feedback&gt;</screen><para>
           Optional; default is <literal>false</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>feedback_type</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>feedback_type</literal></term>
+<listitem><para>
           This can be <literal>message</literal>, <literal>warning</literal>
           or <literal>error</literal>. Set the timeout for these pop-ups in
           the &lt;report&gt; section.
-         </para>
-<screen>&lt;feedback_type&gt;warning&lt;/feedback_type&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;feedback_type&gt;warning&lt;/feedback_type&gt;</screen><para>
           Optional; if missing, an always-blocking pop-up is used.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>debug</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>debug</literal></term>
+<listitem><para>
           If this is <literal>true</literal>, every single line of a shell
           script is logged. Perl scripts are run with warnings turned on.
-         </para>
-<screen>&lt;debug config:type="boolean"&gt;true&lt;/debug&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;debug config:type="boolean"&gt;true&lt;/debug&gt;</screen><para>
           Optional; default is <literal>true</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>notification</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>notification</literal></term>
+<listitem><para>
           This text will be shown in a pop-up for the time the script is
           running in the background.
-         </para>
-<screen>&lt;notification&gt;Please wait while script is running...&lt;/notification&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;notification&gt;Please wait while script is running...&lt;/notification&gt;</screen><para>
           Optional; if not configured, no notification pop-up will be shown.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>param-list</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>param-list</literal></term>
+<listitem><para>
           It is possible to specify parameters given to the script being
           called. You may have more than one <literal>param</literal> entry.
           They are concatenated by a single space character on the script
           command line. If any shell quoting should be necessary (for
           example to protect embedded spaces) you need to include this.
-         </para>
-<screen>&lt;param-list config:type="list"&gt;
+         </para><screen>&lt;param-list config:type="list"&gt;
   &lt;param&gt;par1&lt;/param&gt;
   &lt;param&gt;par2 par3&lt;/param&gt;
   &lt;param&gt;"par4.1 par4.2"&lt;/param&gt;
-&lt;/param-list&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+&lt;/param-list&gt;</screen><para>
           Optional; if not configured, no parameters get passed to script.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>rerun</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>rerun</literal></term>
+<listitem><para>
           A script is only run once. Even if you use
           <literal>ayast</literal>_setup to run an XML file multiple times,
           the script is only run once. Change this default behavior by
           setting this boolean to <literal>true</literal>.
-         </para>
-<screen>&lt;rerun config:type="boolean"&gt;true&lt;/rerun&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;rerun config:type="boolean"&gt;true&lt;/rerun&gt;</screen><para>
           Optional; default is <literal>false</literal>, meaning that scripts
           only run once.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>chrooted</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>chrooted</literal></term>
+<listitem><para>
           During installation, the new system is mounted at <filename>/mnt</filename>.
-          If this parameter is set to <literal>false</literal>, &ay; does not
+          If this parameter is set to <literal>false</literal>, [[ay]] does not
           run <command>chroot</command> and does not install the boot loader
-          at this stage. If the parameter is set to <literal>true</literal>, &ay;
+          at this stage. If the parameter is set to <literal>true</literal>, [[ay]]
           performs a <command>chroot</command> into <filename>/mnt</filename> and
           installs the boot loader. The result is that if you want to change
           anything in the newly-installed system, you no longer need to use the
           <filename>/mnt</filename> prefix.
-         </para>
-<screen>&lt;chrooted config:type="boolean"
-&gt;true&lt;/chrooted&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;chrooted config:type="boolean"&gt;true&lt;/chrooted&gt;</screen><para>
           Optional; default is <literal>false</literal>. This option is only
           available for chroot environment scripts.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </table>
+         </para></listitem>
+</varlistentry>
+</variablelist>
    </sect2>
 
    <sect2 xml:id="script-examples">

--- a/xml/ay_kernel_dumps.xml
+++ b/xml/ay_kernel_dumps.xml
@@ -153,74 +153,29 @@
     <para>
      The following table shows the settings necessary to reserve memory:
     </para>
-    <table>
-     <title>Kdump Memory Reservation Settings:XML Representation</title>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>add_crash_kernel</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    
+<variablelist>
+  <title>Kdump Memory Reservation Settings:XML Representation</title>
+  <varlistentry><term><literal>add_crash_kernel</literal></term>
+<listitem><para>
           Set to <literal>true</literal> if memory should be reserved and
           Kdump enabled.
-         </para>
-<screen>&lt;add_crash_kernel config:type="boolean"&gt;true&lt;/add_crash_kernel&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;add_crash_kernel config:type="boolean"&gt;true&lt;/add_crash_kernel&gt;</screen><para>
           required
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>crash_kernel</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>crash_kernel</literal></term>
+<listitem><para>
           Use the syntax of the crashkernel command line as discussed above.
-         </para>
-<screen>&lt;crash_kernel&gt;256M:64M&lt;/crash_kernel&gt;</screen>
-        <para>A list of values is also supported.</para>
-<screen>&lt;crash_kernel config:type="list"&gt;
+         </para><screen>&lt;crash_kernel&gt;256M:64M&lt;/crash_kernel&gt;</screen><para>A list of values is also supported.</para><screen>&lt;crash_kernel config:type="list"&gt;
   &lt;listentry&gt;72M,low&lt;/listentry&gt;
   &lt;listentry&gt;256M,high&lt;/listentry&gt;
-&lt;/crash_kernel&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+&lt;/crash_kernel&gt;</screen><para>
           required
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </table>
+         </para></listitem>
+</varlistentry>
+</variablelist>
+
    </sect2>
 
    <sect2 xml:id="CreateProfile-kdump-saving">
@@ -310,113 +265,47 @@
     </sect3>
     <sect3 xml:id="CreateProfile-kdump-saving-summary">
      <title>Summary</title>
-     <table>
-      <title>Dump Target Settings: XML Representation</title>
-      <tgroup cols="3">
-       <thead>
-        <row>
-         <entry>
-          <para>
-           Element
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Description
-          </para>
-         </entry>
-         <entry>
-          <para>
-           Comment
-          </para>
-         </entry>
-        </row>
-       </thead>
-       <tbody>
-        <row>
-         <entry>
-          <para>
-           <literal>KDUMP_SAVEDIR</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
+
+<variablelist>
+  <title>Dump Target Settings: XML Representation</title>
+  <varlistentry><term><literal>KDUMP_SAVEDIR</literal></term>
+<listitem><para>
            A URL that specifies the target to which the dump and related
            files will be saved.
-          </para>
-<screen>&lt;KDUMP_SAVEDIR&gt;file:///var/crash/&lt;/KDUMP_SAVEDIR&gt;</screen>
-         </entry>
-         <entry>
-          <para>
+          </para><screen>&lt;KDUMP_SAVEDIR&gt;file:///var/crash/&lt;/KDUMP_SAVEDIR&gt;</screen><para>
            required
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>KDUMP_COPY_KERNEL</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
+          </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KDUMP_COPY_KERNEL</literal></term>
+<listitem><para>
            Set to <literal>true</literal>, if not only the dump should be
            saved to <literal>KDUMP_SAVEDIR</literal> but also the kernel and
            its debugging information (if installed).
-          </para>
-<screen>&lt;KDUMP_COPY_KERNEL&gt;false&lt;/KDUMP_COPY_KERNEL&gt;</screen>
-         </entry>
-         <entry>
-          <para>
+          </para><screen>&lt;KDUMP_COPY_KERNEL&gt;false&lt;/KDUMP_COPY_KERNEL&gt;</screen><para>
            optional
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>KDUMP_FREE_DISK_SIZE</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
+          </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KDUMP_FREE_DISK_SIZE</literal></term>
+<listitem><para>
            Disk space in megabytes that must remain free after saving the
            dump. If not enough space is available, the dump will not be
            saved.
-          </para>
-<screen>&lt;KDUMP_FREE_DISK_SIZE&gt;64&lt;/KDUMP_FREE_DISK_SIZE&gt;</screen>
-         </entry>
-         <entry>
-          <para>
+          </para><screen>&lt;KDUMP_FREE_DISK_SIZE&gt;64&lt;/KDUMP_FREE_DISK_SIZE&gt;</screen><para>
            optional
-          </para>
-         </entry>
-        </row>
-        <row>
-         <entry>
-          <para>
-           <literal>KDUMP_KEEP_OLD_DUMPS</literal>
-          </para>
-         </entry>
-         <entry>
-          <para>
+          </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KDUMP_KEEP_OLD_DUMPS</literal></term>
+<listitem><para>
            The number of dumps that are kept (not deleted) if
            <literal>KDUMP_SAVEDIR</literal> points to a local directory.
            Specify 0 if you do not want any dumps to be automatically
            deleted, specify -1 if all dumps except the current one should be
            deleted.
-          </para>
-<screen>&lt;KDUMP_KEEP_OLD_DUMPS&gt;4&lt;/KDUMP_KEEP_OLD_DUMPS&gt;</screen>
-         </entry>
-         <entry>
-          <para>
+          </para><screen>&lt;KDUMP_KEEP_OLD_DUMPS&gt;4&lt;/KDUMP_KEEP_OLD_DUMPS&gt;</screen><para>
            optional
-          </para>
-         </entry>
-        </row>
-       </tbody>
-      </tgroup>
-     </table>
+          </para></listitem>
+</varlistentry>
+</variablelist>
     </sect3>
    </sect2>
 
@@ -443,133 +332,53 @@
      available but may be added in the future.
     </para>
 <!-- {{{ Table: XML representation of the e-mail notification settings -->
-    <table>
-     <title>E-Mail Notification Settings: XML Representation</title>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>KDUMP_NOTIFICATION_TO</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>E-Mail Notification Settings: XML Representation</title>
+  <varlistentry><term><literal>KDUMP_NOTIFICATION_TO</literal></term>
+<listitem><para>
           Exactly one e-mail address to which the e-mail should be sent.
           Additional recipients can be specified in
           <literal>KDUMP_NOTIFICATION_CC</literal>.
-         </para>
-<screen>&lt;KDUMP_NOTIFICATION_TO
-&gt;&exampleuser_plain;@&exampledomain;&lt;/KDUMP_NOTIFICATION_TO&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KDUMP_NOTIFICATION_TO&gt;&exampleuser_plain;@&exampledomain;&lt;/KDUMP_NOTIFICATION_TO&gt;</screen><para>
           optional (notification disabled if empty)
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>KDUMP_NOTIFICATION_CC</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KDUMP_NOTIFICATION_CC</literal></term>
+<listitem><para>
           Zero, one or more recipients that are in the cc line of the
           notification e-mail.
-         </para>
-<screen>&lt;KDUMP_NOTIFICATION_CC
-&gt;&exampleuserII_plain;@&exampledomain; &exampleuserIII_plain;@&exampledomain;&lt;/KDUMP_NOTIFICATION_CC&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KDUMP_NOTIFICATION_CC&gt;&exampleuserII_plain;@&exampledomain; &exampleuserIII_plain;@&exampledomain;&lt;/KDUMP_NOTIFICATION_CC&gt;</screen><para>
           optional
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>KDUMP_SMTP_SERVER</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KDUMP_SMTP_SERVER</literal></term>
+<listitem><para>
           Host name of the SMTP server used for mail delivery. SMTP
           authentication is supported (see
           <literal>KDUMP_SMTP_USER</literal> and
           <literal>KDUMP_SMTP_PASSWORD</literal>) but TLS/SSL are
           not.
-         </para>
-<screen>&lt;KDUMP_SMTP_SERVER&gt;email.suse.de&lt;/KDUMP_SMTP_SERVER&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KDUMP_SMTP_SERVER&gt;email.suse.de&lt;/KDUMP_SMTP_SERVER&gt;</screen><para>
           optional (notification disabled if empty)
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>KDUMP_SMTP_USER</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KDUMP_SMTP_USER</literal></term>
+<listitem><para>
           User name used together with
           <literal>KDUMP_SMTP_PASSWORD</literal> for SMTP authentication.
-         </para>
-<screen>&lt;KDUMP_SMTP_USER&gt;bwalle&lt;/KDUMP_SMTP_USER&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KDUMP_SMTP_USER&gt;bwalle&lt;/KDUMP_SMTP_USER&gt;</screen><para>
           optional
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>KDUMP_SMTP_PASSWORD</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KDUMP_SMTP_PASSWORD</literal></term>
+<listitem><para>
           Password used together with <literal>KDUMP_SMTP_USER</literal> for
           SMTP authentication.
-         </para>
-<screen>&lt;KDUMP_SMTP_PASSWORD&gt;geheim&lt;/KDUMP_SMTP_PASSWORD&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KDUMP_SMTP_PASSWORD&gt;geheim&lt;/KDUMP_SMTP_PASSWORD&gt;</screen><para>
           optional
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </table>
+         </para></listitem>
+</varlistentry>
+</variablelist>
    </sect2>
 
    <sect2 xml:id="CreateProfile-kdump-kernel">
@@ -594,181 +403,66 @@
      know what you are doing and you want to specify the entire command line,
      set <literal>KDUMP_COMMANDLINE</literal>.
     </para>
-    <table>
-     <title>Kernel Settings: XML Representation</title>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>KDUMP_KERNELVER</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    
+<variablelist>
+  <title>Kernel Settings: XML Representation</title>
+  <varlistentry><term><literal>KDUMP_KERNELVER</literal></term>
+<listitem><para>
           Version string for the kernel used for Kdump. Leave it empty to
           use the auto-detection mechanism (strongly recommended).
-         </para>
-<screen>&lt;KDUMP_KERNELVER
-&gt;2.6.27-default&lt;/KDUMP_KERNELVER&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KDUMP_KERNELVER&gt;2.6.27-default&lt;/KDUMP_KERNELVER&gt;</screen><para>
           optional (auto-detection if empty)
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>KDUMP_COMMANDLINE_APPEND</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KDUMP_COMMANDLINE_APPEND</literal></term>
+<listitem><para>
           Additional command line parameters for the Kdump kernel.
-         </para>
-<screen>&lt;KDUMP_COMMANDLINE_APPEND
-&gt;console=ttyS0,57600&lt;/KDUMP_COMMANDLINE_APPEND&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KDUMP_COMMANDLINE_APPEND&gt;console=ttyS0,57600&lt;/KDUMP_COMMANDLINE_APPEND&gt;</screen><para>
           optional
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>KDUMP_Command Line</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KDUMP_Command Line</literal></term>
+<listitem><para>
           Overwrite the automatically generated Kdump command line. Use with
           care. Usually, <literal>KDUMP_COMMANDLINE_APPEND</literal> should
           suffice.
-         </para>
-<screen>&lt;KDUMP_COMMANDLINE_APPEND
-&gt;root=/dev/sda5 maxcpus=1 irqpoll&lt;/KDUMP_COMMANDLINE&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KDUMP_COMMANDLINE_APPEND&gt;root=/dev/sda5 maxcpus=1 irqpoll&lt;/KDUMP_COMMANDLINE&gt;</screen><para>
           optional
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </table>
+         </para></listitem>
+</varlistentry>
+</variablelist>
+
    </sect2>
 
    <sect2 xml:id="CreateProfile-kdump-expert">
     <title>Expert Settings</title>
-    <table>
-     <title>Expert Settings: XML Representations</title>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>KDUMP_IMMEDIATE_REBOOT</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
-          <literal>true</literal> if the system should be rebooted
+<variablelist>
+  <title>Expert Settings: XML Representations</title>
+  <varlistentry><term><literal>KDUMP_IMMEDIATE_REBOOT</literal></term>
+<listitem><para><literal>true</literal> if the system should be rebooted
           automatically after the dump has been saved,
           <literal>false</literal> otherwise. The default is to reboot the
           system automatically.
-         </para>
-<screen>&lt;KDUMP_IMMEDIATE_REBOOT
-&gt;true&lt;/KDUMP_IMMEDIATE_REBOOT&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KDUMP_IMMEDIATE_REBOOT&gt;true&lt;/KDUMP_IMMEDIATE_REBOOT&gt;</screen><para>
           optional
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>KDUMP_VERBOSE</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KDUMP_VERBOSE</literal></term>
+<listitem><para>
           Bitmask that specifies how verbose the Kdump process should be.
           Read kdump(5) for details.
-         </para>
-<screen>&lt;KDUMP_VERBOSE&gt;3&lt;/KDUMP_VERBOSE&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KDUMP_VERBOSE&gt;3&lt;/KDUMP_VERBOSE&gt;</screen><para>
           optional
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>KEXEC_OPTIONS</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>KEXEC_OPTIONS</literal></term>
+<listitem><para>
           Additional options that are passed to kexec when loading the Kdump
           kernel. Normally empty.
-         </para>
-<screen>&lt;KEXEC_OPTIONS&gt;--noio&lt;/KEXEC_OPTIONS&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;KEXEC_OPTIONS&gt;--noio&lt;/KEXEC_OPTIONS&gt;</screen><para>
           optional
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </table>
+         </para></listitem>
+</varlistentry>
+</variablelist>
    </sect2>
   </sect1>

--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -292,127 +292,55 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
      The following elements must be between the
      &lt;s390-devices&gt;...&lt;/s390-devices&gt; tags.
     </para>
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Element
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Comment
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
+    
+<variablelist>
+  <title>Element, Description, Comment</title>
+  <varlistentry><term>
           type
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </term>
+<listitem><para>
           qeth, ctc or iucv
-         </para>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
+         </para><para/></listitem>
+</varlistentry>
+  <varlistentry><term>
           chanids
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </term>
+<listitem><para>
           channel ids separated by spaces
-         </para>
-<screen>&lt;chanids&gt;0.0.0700 0.0.0701 0.0.0702&lt;/chanids&gt;</screen>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
+         </para><screen>&lt;chanids&gt;0.0.0700 0.0.0701 0.0.0702&lt;/chanids&gt;</screen><para/></listitem>
+</varlistentry>
+  <varlistentry><term>
           layer2
-         </para>
-        </entry>
-        <entry>
-         <para/>
-<screen>&lt;layer2 config:type="boolean"&gt;true&lt;/layer2&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </term>
+<listitem><para/><screen>&lt;layer2 config:type="boolean"&gt;true&lt;/layer2&gt;</screen><para>
           boolean; default: false
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term>
           portname
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </term>
+<listitem><para>
           QETH port name (deprecated since <phrase os="sles;sled">SLE 12
           SP2</phrase><phrase os="osuse">openSUSE 42.2</phrase>)
-         </para>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
+         </para><para/></listitem>
+</varlistentry>
+  <varlistentry><term>
           protocol
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </term>
+<listitem><para>
           CTC / LCS protocol, a small number (as a string)
-         </para>
-<screen>&lt;protocol&gt;1&lt;/protocol&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;protocol&gt;1&lt;/protocol&gt;</screen><para>
           optional
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term>
           router
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </term>
+<listitem><para>
           IUCV router/user
-         </para>
-        </entry>
-        <entry>
-         <para/>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+         </para><para/></listitem>
+</varlistentry>
+</variablelist>
 
     <para>
      In addition to the options mentioned above, &ay; also supports

--- a/xml/ay_software.xml
+++ b/xml/ay_software.xml
@@ -456,117 +456,47 @@
      <literal>true</literal> is a potential security risk. Never do it when
      using packages or repositories from third party sources.
     </para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Attribute
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Values
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>accept_unsigned_file</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Attribute, Values</title>
+  <varlistentry><term><literal>accept_unsigned_file</literal></term>
+<listitem><para>
           If set to <literal>true</literal>, &ay; will accept unsigned
           files like the content file.
-         </para>
-<screen>&lt;accept_unsigned_file config:type="boolean"
-&gt;true&lt;/accept_unsigned_file&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>accept_file_without_checksum</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;accept_unsigned_file config:type="boolean"&gt;true&lt;/accept_unsigned_file&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>accept_file_without_checksum</literal></term>
+<listitem><para>
           If set to <literal>true</literal>, &ay; will accept files
           without a checksum in the content file.
-         </para>
-<screen>&lt;accept_file_without_checksum config:type="boolean"
-&gt;true&lt;/accept_file_without_checksum&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>accept_verification_failed</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;accept_file_without_checksum config:type="boolean"&gt;true&lt;/accept_file_without_checksum&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>accept_verification_failed</literal></term>
+<listitem><para>
           If set to <literal>true</literal>, &ay; will accept signed
           files even when the verification of the signature failed.
-         </para>
-<screen>&lt;accept_verification_failed config:type="boolean"
-&gt;true&lt;/accept_verification_failed&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>accept_unknown_gpg_key</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;accept_verification_failed config:type="boolean"&gt;true&lt;/accept_verification_failed&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>accept_unknown_gpg_key</literal></term>
+<listitem><para>
           If set to <literal>true</literal>, &ay; will accept new GPG
           keys of the installation sources, for example the key used to sign
           the content file.
-         </para>
-         <screen>&lt;accept_unknown_gpg_key config:type="boolean"
-&gt;true&lt;/accept_unknown_gpg_key&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>accept_non_trusted_gpg_key</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;accept_unknown_gpg_key config:type="boolean"&gt;true&lt;/accept_unknown_gpg_key&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>accept_non_trusted_gpg_key</literal></term>
+<listitem><para>
           Set this option to <literal>true</literal> to accept known keys you
           have not yet trusted.
-         </para>
-         <screen>&lt;accept_non_trusted_gpg_key config:type="boolean"
-&gt;true&lt;/accept_non_trusted_gpg_key&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>import_gpg_key</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;accept_non_trusted_gpg_key config:type="boolean"&gt;true&lt;/accept_non_trusted_gpg_key&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>import_gpg_key</literal></term>
+<listitem><para>
           If set to <literal>true</literal>, &ay; will accept and import
           new GPG keys on the installation source in its database.
-         </para>
-         <screen>&lt;import_gpg_key config:type="boolean"
-&gt;true&lt;/import_gpg_key&gt;</screen>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+         </para><screen>&lt;import_gpg_key config:type="boolean"&gt;true&lt;/import_gpg_key&gt;</screen></listitem>
+</varlistentry>
+</variablelist>
+
     <para>
      It is possible to configure the signature handling for each add-on
      product, module, or extension individually. The following elements must
@@ -575,148 +505,73 @@
      optional. If not configured, the global signature-handling from the
      <literal>general</literal> section is used.
     </para>
-    <informaltable>
-     <tgroup cols="2">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Attribute
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Values
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>accept_unsigned_file</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+    
+<variablelist>
+  <title>Attribute, Values</title>
+  <varlistentry><term><literal>accept_unsigned_file</literal></term>
+<listitem><para>
           If set to <literal>true</literal>, &ay; will accept unsigned
           files like the content file for this add-on product.
-         </para>
-         <screen>&lt;accept_unsigned_file config:type="boolean"
-&gt;true&lt;/accept_unsigned_file&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>accept_file_without_checksum</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;accept_unsigned_file config:type="boolean"&gt;true&lt;/accept_unsigned_file&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>accept_file_without_checksum</literal></term>
+<listitem><para>
           If set to <literal>true</literal>, &ay; will accept files
           without a checksum in the content file for this add-on.
-         </para>
-<screen>&lt;accept_file_without_checksum config:type="boolean"
-&gt;true&lt;/accept_file_without_checksum&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>accept_verification_failed</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;accept_file_without_checksum config:type="boolean"&gt;true&lt;/accept_file_without_checksum&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>accept_verification_failed</literal></term>
+<listitem><para>
           If set to <literal>true</literal>, &ay; will accept signed
           files even when the verification of the signature fails.
-         </para>
-<screen>&lt;accept_verification_failed config:type="boolean"
-&gt;true&lt;/accept_verification_failed&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>accept_unknown_gpg_key</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;accept_verification_failed config:type="boolean"&gt;true&lt;/accept_verification_failed&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>accept_unknown_gpg_key</literal></term>
+<listitem><para>
           If <literal>all</literal> is set to <literal>true</literal>, &ay; will accept new GPG
           keys on the installation source.
-         </para>
-<screen>&lt;accept_unknown_gpg_key&gt;
-  &lt;all config:type="boolean"&gt;true&lt;/all&gt;
-&lt;/accept_unknown_gpg_key&gt;</screen>
-         <para>
+         </para><screen>&lt;accept_unknown_gpg_key&gt;
+  &lt;all config:type="boolean"&gt;true&lt;/all&gt;&lt;/accept_unknown_gpg_key&gt;</screen><para>
           Otherwise you can define single keys too.
-         </para>
-<screen>&lt;accept_unknown_gpg_key&gt;
+         </para><screen>&lt;accept_unknown_gpg_key&gt;
   &lt;all config:type="boolean"&gt;false&lt;/all&gt;
   &lt;keys config:type="list"&gt;
     &lt;keyid&gt;3B3011B76B9D6523&lt;/keyid&gt;
   &lt;/keys&gt;
-&lt;/accept_unknown_gpg_key&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>accept_non_trusted_gpg_key</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+&lt;/accept_unknown_gpg_key&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>accept_non_trusted_gpg_key</literal></term>
+<listitem><para>
           This means, the key is known, but it is not trusted by you.
-         </para>
-         <para>
+         </para><para>
           You can trust all keys by adding:
-         </para>
-<screen>&lt;accept_non_trusted_gpg_key&gt;
+         </para><screen>&lt;accept_non_trusted_gpg_key&gt;
   &lt;all config:type="boolean"&gt;true&lt;/all&gt;
-&lt;/accept_non_trusted_gpg_key&gt;</screen>
-         <para>
+&lt;/accept_non_trusted_gpg_key&gt;</screen><para>
           Or you can trust specific keys:
-         </para>
-<screen>&lt;accept_non_trusted_gpg_key&gt;
+         </para><screen>&lt;accept_non_trusted_gpg_key&gt;
   &lt;all config:type="boolean"&gt;false&lt;/all&gt;
   &lt;keys config:type="list"&gt;
     &lt;keyid&gt;3B3011B76B9D6523&lt;/keyid&gt;
   &lt;/keys&gt;
-&lt;/accept_non_trusted_gpg_key&gt;</screen>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>import_gpg_key</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+&lt;/accept_non_trusted_gpg_key&gt;</screen></listitem>
+</varlistentry>
+  <varlistentry><term><literal>import_gpg_key</literal></term>
+<listitem><para>
           If <literal>all</literal> is set to <literal>true</literal>, &ay; will accept and import
           all new GPG keys on the installation source into its database.
-         </para>
-<screen>&lt;import_gpg_key&gt;
+         </para><screen>&lt;import_gpg_key&gt;
   &lt;all config:type="boolean"&gt;true&lt;/all&gt;
-&lt;/import_gpg_key&gt;</screen>
-         <para>
+&lt;/import_gpg_key&gt;</screen><para>
           This can be done for specific keys only:
-         </para>
-<screen>&lt;import_gpg_key&gt;
+         </para><screen>&lt;import_gpg_key&gt;
   &lt;all config:type="boolean"&gt;false&lt;/all&gt;
   &lt;keys config:type="list"&gt;
     &lt;keyid&gt;3B3011B76B9D6523&lt;/keyid&gt;
   &lt;/keys&gt;
-&lt;/import_gpg_key&gt;</screen>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+&lt;/import_gpg_key&gt;</screen></listitem>
+</varlistentry>
+</variablelist>
    </sect2>
 
    <sect2 xml:id="Software-Selections-kernel">

--- a/xml/ay_users_groups.xml
+++ b/xml/ay_users_groups.xml
@@ -175,216 +175,86 @@
      </para>
     </note>
 
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Attribute
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Values
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>username</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Attribute, Values</title>
+  <varlistentry><term><literal>username</literal></term>
+<listitem><para>
           Text
-         </para>
-<screen>&lt;username&gt;lukesw&lt;/username&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;username&gt;lukesw&lt;/username&gt;</screen><para>
           Required. It should be a valid user name. Check <literal>man 8 useradd</literal>
           if you are not sure.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>fullname</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>fullname</literal></term>
+<listitem><para>
           Text
-         </para>
-<screen>&lt;fullname&gt;Tux Torvalds&lt;/fullname&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;fullname&gt;Tux Torvalds&lt;/fullname&gt;</screen><para>
           Optional. User's full name.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>forename</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>forename</literal></term>
+<listitem><para>
           Text
-         </para>
-<screen>&lt;forname&gt;Tux&lt;/forename&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;forname&gt;Tux&lt;/forename&gt;</screen><para>
           Optional. User's forename.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>surname</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>surname</literal></term>
+<listitem><para>
           Text
-         </para>
-<screen>&lt;surname&gt;Skywalker&lt;/surname&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;surname&gt;Skywalker&lt;/surname&gt;</screen><para>
           Optional. User's surname.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>uid</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>uid</literal></term>
+<listitem><para>
           Number
-         </para>
-<screen>&lt;uid&gt;1001&lt;/uid&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;uid&gt;1001&lt;/uid&gt;</screen><para>
           Optional. User ID. It should be a unique and must be a non-negative
           number. If not specified, &ay; will automatically choose a user
-          ID. Also refer to <xref
-          linkend="ann-Configuration-Security-users-uid"/> for additional
+          ID. Also refer to <xref linkend="ann-Configuration-Security-users-uid"/> for additional
           information.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>gid</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>gid</literal></term>
+<listitem><para>
           Number
-         </para>
-<screen>&lt;gid&gt;100&lt;/gid&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;gid&gt;100&lt;/gid&gt;</screen><para>
           Optional. Initial group ID. It must be a unique and non-negative
           number. Moreover it must refer to an existing group.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>home</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>home</literal></term>
+<listitem><para>
           Path
-         </para>
-<screen>&lt;home&gt;/home/luke&lt;/home&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;home&gt;/home/luke&lt;/home&gt;</screen><para>
           Optional. Absolute path to the user's home directory. By default,
           <literal>/home/username</literal> will be used (for example,
           <literal>alice</literal>'s home directory will be
           <literal>/home/alice</literal>).
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>home_btrfs_subvolume</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>home_btrfs_subvolume</literal></term>
+<listitem><para>
           Boolean
-         </para>
-<screen>&lt;home_btrfs_subvolume config:type="boolean"&gt;true&lt;/home_btrfs_subvolume&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;home_btrfs_subvolume config:type="boolean"&gt;true&lt;/home_btrfs_subvolume&gt;</screen><para>
           Optional. Generates the home directory in a Btrfs subvolume. Disabled
           by default.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>shell</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>shell</literal></term>
+<listitem><para>
           Path
-         </para>
-<screen>&lt;shell&gt;/usr/bin/zsh&lt;/shell&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;shell&gt;/usr/bin/zsh&lt;/shell&gt;</screen><para>
           Optional. <literal>/bin/bash</literal> is the default value. If you
           choose another one, make sure that it's installed (adding the corresponding
           package to the <literal>software</literal> section).
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>user_password</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>user_password</literal></term>
+<listitem><para>
           Text
-         </para>
-<screen>&lt;user_password&gt;some-password&lt;/user_password&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;user_password&gt;some-password&lt;/user_password&gt;</screen><para>
           Optional. If you enter an exclamation mark (<literal>!</literal>), a
           random password will be generated. A user's password can be written in
           plain text (not recommended) or in encrypted form. To create an
@@ -392,48 +262,26 @@
           as written in <filename>/etc/shadow</filename> (second column).
           To enable or disable the use of encrypted passwords in the profile, see
           the <literal>encrypted</literal> parameter.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>encrypted</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>encrypted</literal></term>
+<listitem><para>
           Boolean
-         </para>
-<screen>&lt;encrypted config:type="boolean"&gt;true&lt;/encrypted&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;encrypted config:type="boolean"&gt;true&lt;/encrypted&gt;</screen><para>
           Optional. Considered <literal>false</literal> if not present.
           Indicates if the user's password in the profile is encrypted or not.
           &ay; supports standard encryption algorithms (see <command>man 3
           crypt)</command>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>password_settings</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>password_settings</literal></term>
+<listitem><para>
           Password settings
-         </para>
-         <screen>&lt;password_settings&gt;
+         </para><screen>&lt;password_settings&gt;
   &lt;expire/&gt;
   &lt;max&gt;60&lt;/max&gt;
   &lt;warn&gt;7&lt;/warn&gt;
-&lt;/password_settings&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+&lt;/password_settings&gt;</screen><para>
           Optional. Some password settings can be customized:
           <literal>expire</literal> (account expiration date in format
           <literal>YYYY-MM-DD</literal>), <literal>flag</literal>
@@ -444,33 +292,19 @@
           change password after it has expired) and <literal>warn</literal>
           (number of days before expiration when the password change reminder
           starts).
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>authorized_keys</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>authorized_keys</literal></term>
+<listitem><para>
           List of authorized keys
-         </para>
-         <screen>&lt;authorized_keys config:type="list"&gt;
+         </para><screen>&lt;authorized_keys config:type="list"&gt;
   &lt;listentry&gt;ssh-rsa ...&lt;/listentry&gt;
-&lt;/authorized_keys&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+&lt;/authorized_keys&gt;</screen><para>
           A list of authorized keys to be written to <literal>$HOME/.ssh/authorized_keys</literal>.
           See example below.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+         </para></listitem>
+</varlistentry>
+</variablelist>
 
    </sect2>
 
@@ -485,199 +319,78 @@
      <literal>useradd</literal>.
     </para>
 
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Attribute
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Values
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>group</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Attribute, Values, Description</title>
+  <varlistentry><term><literal>group</literal></term>
+<listitem><para>
           Text
-         </para>
-<screen>&lt;group&gt;100&lt;/group&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;group&gt;100&lt;/group&gt;</screen><para>
           Optional. Default initial login group.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>groups</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>groups</literal></term>
+<listitem><para>
           Text
-         </para>
-<screen>&lt;groups&gt;users&lt;/groups&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;groups&gt;users&lt;/groups&gt;</screen><para>
           Optional. List of additional groups.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>home</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>home</literal></term>
+<listitem><para>
           Path
-         </para>
-<screen>&lt;home&gt;/home&lt;/home&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;home&gt;/home&lt;/home&gt;</screen><para>
           Optional. User's home directory prefix.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>expire</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>expire</literal></term>
+<listitem><para>
           Date
-         </para>
-<screen>&lt;expire&gt;2017-12-31&lt;/expire&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;expire&gt;2017-12-31&lt;/expire&gt;</screen><para>
           Optional. Default password expiration date in <literal>YYYY-MM-DD</literal> format.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>inactive</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>inactive</literal></term>
+<listitem><para>
           Number
-         </para>
-<screen>&lt;inactive&gt;3&lt;/inactive&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;inactive&gt;3&lt;/inactive&gt;</screen><para>
           Optional. Number of days after which an expired account is disabled.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>no_groups</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>no_groups</literal></term>
+<listitem><para>
           Boolean
-         </para>
-<screen>&lt;no_groups config:type="boolean"&gt;true&lt;/no_groups&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;no_groups config:type="boolean"&gt;true&lt;/no_groups&gt;</screen><para>
           Optional. Do not use secondary groups.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>shell</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>shell</literal></term>
+<listitem><para>
           Path
-         </para>
-<screen>&lt;shell&gt;/usr/bin/fish&lt;/shell&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;shell&gt;/usr/bin/fish&lt;/shell&gt;</screen><para>
           Default login shell. <literal>/bin/bash</literal> is the default value. If you
           choose another one, make sure that it is installed (adding the corresponding
           package to the <literal>software</literal> section).
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>skel</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>skel</literal></term>
+<listitem><para>
           Path
-         </para>
-<screen>&lt;skel&gt;/etc/skel&lt;/skel&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;skel&gt;/etc/skel&lt;/skel&gt;</screen><para>
           Optional. Location of the files to be used as skeleton when adding a new
           user. You can find more information in <literal>man 8
           useradd</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>umask</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>umask</literal></term>
+<listitem><para>
           File creation mode mask
-         </para>
-<screen>&lt;umask&gt;022&lt;/umask&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;umask&gt;022&lt;/umask&gt;</screen><para>
           Set the file creation mode mask for the home directory. By default
           <literal>useradd</literal> will use <literal>022</literal>. Check <literal>man 8 useradd</literal>
           and <literal>man 1 umask</literal> for further information.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+         </para></listitem>
+</varlistentry>
+</variablelist>
    </sect2>
 
    <sect2 xml:id="Configuration-Security-groups">
@@ -699,124 +412,47 @@
 &lt;/groups&gt;</screen>
     </example>
 
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Attribute
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Values
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>groupname</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Attribute, Values, Description</title>
+  <varlistentry><term><literal>groupname</literal></term>
+<listitem><para>
           Text
-         </para>
-<screen>&lt;groupname&gt;users&lt;/groupname&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;groupname&gt;users&lt;/groupname&gt;</screen><para>
           Required. It should be a valid group name. Check <literal>man 8 groupadd</literal>
           if you are not sure.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>gid</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>gid</literal></term>
+<listitem><para>
           Number
-         </para>
-<screen>&lt;gid&gt;100&lt;/gid&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;gid&gt;100&lt;/gid&gt;</screen><para>
           Optional. Group ID. It must be a unique and non-negative number.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>group_password</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>group_password</literal></term>
+<listitem><para>
           Text
-         </para>
-<screen>&lt;group_password&gt;password&lt;/group_password&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;group_password&gt;password&lt;/group_password&gt;</screen><para>
           Optional. The group's password can be written in plain text (not
           recommended) or in encrypted form. Check the <literal>encrypted</literal> to
           select the desired behavior.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>encrypted</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>encrypted</literal></term>
+<listitem><para>
           Boolean
-         </para>
-<screen>&lt;encrypted config:type="boolean"&gt;true&lt;/encrypted&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;encrypted config:type="boolean"&gt;true&lt;/encrypted&gt;</screen><para>
           Optional. Indicates if the group's password in the profile is encrypted or not.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>userlist</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>userlist</literal></term>
+<listitem><para>
           Users list
-         </para>
-<screen>&lt;userlist&gt;bob,alice&lt;/userlist&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;userlist&gt;bob,alice&lt;/userlist&gt;</screen><para>
           Optional. A list of users who belong to the group. User names must be separated by commas.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+         </para></listitem>
+</varlistentry>
+</variablelist>
    </sect2>
 
    <sect2 xml:id="Configuration-Security-login-settings">
@@ -833,67 +469,24 @@
 &lt;/login_settings&gt;</screen>
     </example>
 
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Attribute
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Values
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>password_less_login</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <title>Attribute, Values, Description</title>
+  <varlistentry><term><literal>password_less_login</literal></term>
+<listitem><para>
           Boolean
-         </para>
-<screen>&lt;password_less_login config:type="boolean"&gt;true&lt;/password_less_login&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;password_less_login config:type="boolean"&gt;true&lt;/password_less_login&gt;</screen><para>
           Optional. Enables password-less login. It only affects graphical login.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>autologin_user</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>autologin_user</literal></term>
+<listitem><para>
           Text
-         </para>
-<screen>&lt;autologin_user&gt;alice&lt;/autologin_user&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;autologin_user&gt;alice&lt;/autologin_user&gt;</screen><para>
           Optional. Enables autologin for the given user.
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+         </para></listitem>
+</varlistentry>
+</variablelist>
+
    </sect2>
 
   </sect1>


### PR DESCRIPTION
some tables are too large and do not render well in HTML
or PDF, converted with wondrous stylesheet by Thomas Schraitle

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [ ] 15 SP3  | *(no backport necessary)*
| [ ] 15 SP2  | [ ]
| [x ] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
