### PR TITLE
typo in net_sync.xml

### DIFF
--- a/xml/net_sync.xml
+++ b/xml/net_sync.xml
@@ -221,7 +221,7 @@
   <para>
    Rsync can run as a daemon
    (<systemitem class="daemon"
-     >rsyncd</systemitem>) listing on default
+     >rsyncd</systemitem>) listening on default
    port 873 for incoming connections. This daemon can receive <quote>copying
    targets</quote>.
   </para>


### PR DESCRIPTION
### Description

Fix a typo.


### Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [x] 15 SP3  | *(no backport necessary)*
| [x] 15 SP2  | [ ]
| [x] 15 SP1  | [ ]
| [x] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [x] 12 SP5  | [ ]
| [x] 12 SP4  | [ ]
| [x] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
