### PR TITLE
Fixed typo in QEMU config path (bsc#1180139)

### DIFF
--- a/xml/libvirt_configuration_virsh.xml
+++ b/xml/libvirt_configuration_virsh.xml
@@ -25,7 +25,7 @@
 
   <para>
    The configuration of a VM is stored in an XML file in
-   <filename>/etc/libvirtd/qemu/</filename> and looks like this:
+   <filename>/etc/libvirt/qemu/</filename> and looks like this:
   </para>
 
   <example>


### PR DESCRIPTION
### Are there any relevant issues/feature requests?

* bsc#1180139
* jsc#DOCTEAM-66


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [x] 15 SP3  | *(no backport necessary)*
| [x] 15 SP2  | [ ]
| [x] 15 SP1  | [ ]
| [x] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [x] 12 SP5  | [ ]
| [x] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
