### PR TITLE
final conversion of wide tables to variablelists for SLE15SP1

### DIFF
--- a/xml/ay_rules_classes.xml
+++ b/xml/ay_rules_classes.xml
@@ -804,160 +804,69 @@ fi;
     &lt;/dialog&gt;
   &lt;/rule&gt;
 &lt;/rules&gt;</screen>
-    <informaltable>
-     <tgroup cols="3">
-      <thead>
-       <row>
-        <entry>
-         <para>
-          Attribute
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Values
-         </para>
-        </entry>
-        <entry>
-         <para>
-          Description
-         </para>
-        </entry>
-       </row>
-      </thead>
-      <tbody>
-       <row>
-        <entry>
-         <para>
-          <literal>dialog_nr</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+<variablelist>
+  <varlistentry><term><literal>dialog_nr</literal></term>
+<listitem><para>
           All rules with the same <literal>dialog_nr</literal> are presented
           in the same pop-up dialog. The same <literal>dialog_nr</literal>
           can appear in multiple rules.
-         </para>
-<screen>&lt;dialog_nr config:type="integer"&gt;3&lt;/dialog_nr&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;dialog_nr config:type="integer"&gt;3&lt;/dialog_nr&gt;</screen><para>
           This element is optional and the default for a missing dialog_nr
           is always <literal>0</literal>. To use one pop-up for
           all rules, you do not need to specify the
           <literal>dialog_nr</literal>.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>element</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>element</literal></term>
+<listitem><para>
           Specify a unique ID. Even if you have more than one dialog, you
           must not use the same id twice. Using id <literal>1</literal> on
           dialog 1 and id <literal>1</literal> on dialog 2 is not supported.
           (This behavior is contrary to the <literal>ask</literal> dialog,
           where you can have the same ID for multiple dialogs.)
-         </para>
-<screen>&lt;element config:type="integer"&gt;3&lt;/element&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;element config:type="integer"&gt;3&lt;/element&gt;</screen><para>
           Optional. If left out, &ay; adds its own ids internally. Then
           you cannot specify conflicting rules (see below).
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>title</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>title</literal></term>
+<listitem><para>
           Caption of the pop-up dialog
-         </para>
-<screen>&lt;title&gt;Desktop Selection&lt;/title&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;title&gt;Desktop Selection&lt;/title&gt;</screen><para>
           Optional
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>question</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>question</literal></term>
+<listitem><para>
           Question shown in the pop-up behind the check box.
-         </para>
-<screen>&lt;question&gt;GNOME Desktop&lt;/question&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;question&gt;GNOME Desktop&lt;/question&gt;</screen><para>
           Optional. If you do not configure a text here, the name of the XML
           file that is triggered by this rule will be shown instead.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>timeout</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>timeout</literal></term>
+<listitem><para>
           Timeout in seconds after which the dialog will automatically
           <quote>press</quote> the okay button. Useful for a non-blocking
           installation in combination with rules dialogs.
-         </para>
-<screen>&lt;timeout config:type="integer"&gt;30&lt;/timeout&gt;</screen>
-        </entry>
-        <entry>
-         <para>
+         </para><screen>&lt;timeout config:type="integer"&gt;30&lt;/timeout&gt;</screen><para>
           Optional. A missing timeout will stop the installation process
           until the dialog is confirmed by the user.
-         </para>
-        </entry>
-       </row>
-       <row>
-        <entry>
-         <para>
-          <literal>conflicts</literal>
-         </para>
-        </entry>
-        <entry>
-         <para>
+         </para></listitem>
+</varlistentry>
+  <varlistentry><term><literal>conflicts</literal></term>
+<listitem><para>
           A list of element ids (rules) that conflict with this rule. If
           this rule matches or is selected by the user, all conflicting
           rules are deselected and disabled in the pop-up. Take care that
           you do not create deadlocks.
-         </para>
-<screen>&lt;conflicts config:type="list"&gt;
+         </para><screen>&lt;conflicts config:type="list"&gt;
   &lt;element config:type="integer"&gt;1&lt;/element&gt;
   &lt;element config:type="integer"&gt;5&lt;/element&gt;
   ...
-&lt;/conflicts&gt;</screen>
-        </entry>
-        <entry>
-         <para>
-          <literal>optional</literal>
-         </para>
-        </entry>
-       </row>
-      </tbody>
-     </tgroup>
-    </informaltable>
+&lt;/conflicts&gt;</screen><para><literal>optional</literal></para></listitem>
+</varlistentry>
+</variablelist>
     <para>
      Here is an example of how to use dialogs with rules:
     </para>


### PR DESCRIPTION
https://jira.suse.com/browse/DOCTEAM-67

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [ ] 15 SP3  | *(no backport necessary)*
| [ ] 15 SP2  | [ ]
| [ x] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
