### PR TITLE
AutoYaST: add missing elements

### DIFF
--- a/xml/ay_bootloader.xml
+++ b/xml/ay_bootloader.xml
@@ -351,7 +351,7 @@
       <listitem>
        <para>
         If set to <literal>true</literal>, then &ay; adds an NVRAM entry for the bootloader
-        in the firmware. This is the desiderable behavior unless you want to preserve some
+        in the firmware. This is the desirable behavior unless you want to preserve some
         specific setting or you need to work around firmware issues.
        </para>
 <screen>&lt;update_nvram&gt;true&lt;/update_nvram&gt;</screen>

--- a/xml/ay_bootloader.xml
+++ b/xml/ay_bootloader.xml
@@ -347,6 +347,18 @@
      </varlistentry>
      
      <varlistentry>
+      <term>update_nvram</term>
+      <listitem>
+       <para>
+        If set to <literal>true</literal>, then &ay; adds an NVRAM entry for the bootloader
+        in the firmware. This is the desiderable behavior unless you want to preserve some
+        specific setting or you need to work around firmware issues.
+       </para>
+<screen>&lt;update_nvram&gt;true&lt;/update_nvram&gt;</screen>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry>
       <term>vgamode</term>
       <listitem>
        <para>

--- a/xml/ay_control_file.xml
+++ b/xml/ay_control_file.xml
@@ -225,10 +225,10 @@ exit 0
     </para>
 
    <tip>
-    <title>Using emacs as an XML editor</title>
+     <title>Using sorter type annotations</title>
     <para>
-     Starting with in &productname; <phrase os="sles;sled">15 SP3</phrase>
-     <phrase os="osuse">15.3</phrase>, it is posible to use the attribute
+     Starting with &productname; <phrase os="sles;sled">15 SP3</phrase>
+     <phrase os="osuse">15.3</phrase>, it is possible to use the attribute
      <literal>t</literal> instead of <literal>config:type</literal> to specify
      the element type.
     </para>

--- a/xml/ay_control_file.xml
+++ b/xml/ay_control_file.xml
@@ -223,6 +223,19 @@ exit 0
      <literal>symbol</literal>, and <literal>integer</literal> can be used,
      the default being a string.
     </para>
+
+   <tip>
+    <title>Using emacs as an XML editor</title>
+    <para>
+     Starting with in &productname; <phrase os="sles;sled">15 SP3</phrase>
+     <phrase os="osuse">15.3</phrase>, it is posible to use the attribute
+     <literal>t</literal> instead of <literal>config:type</literal> to specify
+     the element type.
+    </para>
+
+<screen>&lt;mode t="boolean"&gt;true&lt;/mode&gt;</screen>
+   </tip>
+    
     <para>
      Attributes are not optional. It may appear that attributes are optional,
      because various parts of the schema are not very consistent in their usage

--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -238,8 +238,8 @@
       <listitem>
        <para>
         After setting up the network, &ay; checks whether the assigned IP address is duplicated. In
-        that, it shows a warning whose timeout is controlled by this element. If it is set to
-        <literal>0</literal>, the installation is stopped.
+        that case, it shows a warning whose timeout in seconds is controlled by this element. If it
+        is set to <literal>0</literal>, the installation is stopped.
        </para>
 <screen>&lt;strict_IP_check_timeout config:type="integer"&gt;5&lt;strict_IP_check_timeout&gt;</screen>
       </listitem>

--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -244,7 +244,18 @@
 <screen>&lt;strict_IP_check_timeout config:type="integer"&gt;5&lt;strict_IP_check_timeout&gt;</screen>
       </listitem>
      </varlistentry>
-    </variablelist>
+     <varlistentry>
+      <term>virt_bridge_proposal</term>
+       <listitem>
+        <para>
+         &ay; configures a bridge when a virtualization package is selected to be installed (e.g.,
+         Xen, QEMU or KVM). You can disable such a behaviour by setting this element to
+         <literal>false</literal>.
+        </para>
+<screen>&lt;virt_bridge_proposal config:type="boolean"&gt;false&gt;virt_bridge_proposal&gt;</screen>
+       </listitem>
+      </varlistentry>
+     </variablelist>
 
     <tip>
      <title>IPv6 address support</title>

--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -18,6 +18,9 @@
   </dm:docmanager>
  </info>
 
+   <sect2 xml:id="CreateProfile-Network-Workflow">
+    <title>Configuration Workflow</title>
+
    <para>
     Network configuration is mainly used to connect a single workstation to an
     Ethernet-based LAN. It is commonly configured before &ay; starts,
@@ -36,12 +39,8 @@
    <para>
     By default, &yast; copies the network settings that were used during the
     installation into the final, installed system. This configuration is merged with the
-    one defined in the &ay; profile. To skip copying the network configuration,
-    set the <literal>keep_install_network</literal> option to <literal>false</literal>.
+    one defined in the &ay; profile.
    </para>
-
-<screen>&lt;keep_install_network
-config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
 
    <para>
     &ay; settings have higher priority than any existing configuration files.
@@ -68,8 +67,7 @@ config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
       define it using linuxrc (see <xref linkend="autoinstall-singlesystem"/>).
     </para>
 
-<screen>&lt;setup_before_proposal
-  config:type="boolean"&gt;true&lt;/setup_before_proposal&gt;</screen>
+<screen>&lt;setup_before_proposal config:type="boolean"&gt;true&lt;/setup_before_proposal&gt;</screen>
 
     <para>
       If the configuration is written at the end of installation, it will
@@ -81,6 +79,10 @@ config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
     Network settings and service activation are defined under the <literal>profile</literal>
     <literal>networking</literal> global resource.
    </para>
+  </sect2>
+
+   <sect2 xml:id="CreateProfile-Network-Resource">
+    <title>The Network Resource</title>
 
    <example xml:id="ex-ay-network-config-general">
     <title>Network configuration</title>
@@ -185,6 +187,65 @@ config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
     </listitem>
    </itemizedlist>
 
+   <para>
+    Additionally, there are a few elements that allow modyfing how the network configuration is
+    applied:
+   </para>
+
+    <variablelist>
+     <varlistentry>
+      <term>keep_install_network</term>
+      <listitem>
+       <para>
+        As described in <xref linkend="CreateProfile-Network-Workflow"/>, by default, &ay;
+        merges the network configuration from the running system with the one defined in the
+        profile. If you want to use just the configuration from the profile, set this element to
+        <literal>false</literal>. The value is <literal>true</literal> by default.
+       </para>
+<screen>&lt;keep_install_network config:type="boolean"&gt;false&lt;keep_install_network&gt;</screen>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>managed</term>
+      <listitem>
+       <para>
+        Determines whether to use NetworkManager instead of Wicked.
+       </para>
+<screen>&lt;managed config:type="boolean"&gt;true&gt;managed&lt;</screen>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>start_immediately</term>
+      <listitem>
+       <para>
+        Forces &ay; to restart the network just after writing the configuration.
+       </para>
+<screen>&lt;start_immediately config:type="boolean"&gt;true&lt;start_immediately&gt;</screen>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>setup_before_proposal</term>
+      <listitem>
+       <para>
+        Use the network configuration defined in the profile during the installation process.
+        Otherwise, &ay; relies on the configuration set by <command>linuxrc</command>.
+       </para>
+<screen>&lt;setup_before_proposal config:type="boolean"&gt;true&lt;setup_before_proposal&gt;</screen>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>strict_IP_check_timeout</term>
+      <listitem>
+       <para>
+        After setting up the network, &ay; checks whether the assigned IP address is duplicated. In
+        that, it shows a warning whose timeout is controlled by this element. If it is set to
+        <literal>0</literal>, the installation is stopped.
+       </para>
+<screen>&lt;strict_IP_check_timeout config:type="integer"&gt;5&lt;strict_IP_check_timeout&gt;</screen>
+      </listitem>
+     </varlistentry>
+   </variablelist>
+
    <tip>
     <title>IPv6 address support</title>
     <para>
@@ -193,6 +254,7 @@ config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
      config:type="boolean"&gt;false&lt;/ipv6&gt;
     </para>
    </tip>
+   </sect2>
 
    <sect2 xml:id="CreateProfile-Network-Interfaces">
     <title>Interfaces</title>

--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -21,71 +21,71 @@
    <sect2 xml:id="CreateProfile-Network-Workflow">
     <title>Configuration Workflow</title>
 
-   <para>
-    Network configuration is mainly used to connect a single workstation to an
-    Ethernet-based LAN. It is commonly configured before &ay; starts,
-    to fetch the profile from a network location. This network
-    configuration is usually done through <command>linuxrc</command>
-   </para>
-
-   <note>
-    <title>The <command>linuxrc</command> program</title>
     <para>
-     For a detailed description of how <command>linuxrc</command> works and its
-     keywords, see <xref linkend="appendix-linuxrc"/>.
+     Network configuration is mainly used to connect a single workstation to an
+     Ethernet-based LAN. It is commonly configured before &ay; starts,
+     to fetch the profile from a network location. This network
+     configuration is usually done through <command>linuxrc</command>
     </para>
-   </note>
 
-   <para>
-    By default, &yast; copies the network settings that were used during the
-    installation into the final, installed system. This configuration is merged with the
-    one defined in the &ay; profile.
-   </para>
+    <note>
+     <title>The <command>linuxrc</command> program</title>
+     <para>
+      For a detailed description of how <command>linuxrc</command> works and its
+      keywords, see <xref linkend="appendix-linuxrc"/>.
+     </para>
+    </note>
 
-   <para>
-    &ay; settings have higher priority than any existing configuration files.
-    &yast; will write <filename>ifcfg-*</filename> files based on the entries in the profile
-    without removing old ones. If the DNS and routing section is empty or missing,
-    &yast; will keep any pre-existing values. Otherwise, it applies the settings from
-    the profile file.
-   </para>
+    <para>
+     By default, &yast; copies the network settings that were used during the
+     installation into the final, installed system. This configuration is merged with the
+     one defined in the &ay; profile.
+    </para>
 
-   <note>
+    <para>
+     &ay; settings have higher priority than any existing configuration files.
+     &yast; will write <filename>ifcfg-*</filename> files based on the entries in the profile
+     without removing old ones. If the DNS and routing section is empty or missing,
+     &yast; will keep any pre-existing values. Otherwise, it applies the settings from
+     the profile file.
+    </para>
+
+    <note>
      <title>Use &ay; network settings during installation</title>
 
-    <para>
-      Since &productname; 15.3, writing the configuration based on the
-      profile happens at the end of the first stage.
-    </para>
-    <para>
-      However, if network settings are needed during the installation, you
-      can force &ay; to write and apply them before registration takes
-      place by setting the <literal>setup_before_proposal</literal> option to
-      <literal>true</literal>.
-      Asking &ay; to set up the network in the early stages is useful when
-      installation on a network is needed, but the configuration is too complex to
-      define it using linuxrc (see <xref linkend="autoinstall-singlesystem"/>).
-    </para>
+     <para>
+       Since &productname; 15.3, writing the configuration based on the
+       profile happens at the end of the first stage.
+     </para>
+     <para>
+       However, if network settings are needed during the installation, you
+       can force &ay; to write and apply them before registration takes
+       place by setting the <literal>setup_before_proposal</literal> option to
+       <literal>true</literal>.
+       Asking &ay; to set up the network in the early stages is useful when
+       installation on a network is needed, but the configuration is too complex to
+       define it using linuxrc (see <xref linkend="autoinstall-singlesystem"/>).
+     </para>
 
 <screen>&lt;setup_before_proposal config:type="boolean"&gt;true&lt;/setup_before_proposal&gt;</screen>
 
-    <para>
-      If the configuration is written at the end of installation, it will
-      not be applied until the system is rebooted.
-    </para>
-   </note>
+     <para>
+       If the configuration is written at the end of installation, it will
+       not be applied until the system is rebooted.
+     </para>
+    </note>
 
-   <para>
-    Network settings and service activation are defined under the <literal>profile</literal>
-    <literal>networking</literal> global resource.
-   </para>
-  </sect2>
+    <para>
+     Network settings and service activation are defined under the <literal>profile</literal>
+     <literal>networking</literal> global resource.
+    </para>
+   </sect2>
 
    <sect2 xml:id="CreateProfile-Network-Resource">
     <title>The Network Resource</title>
 
-   <example xml:id="ex-ay-network-config-general">
-    <title>Network configuration</title>
+    <example xml:id="ex-ay-network-config-general">
+     <title>Network configuration</title>
 <screen>&lt;networking&gt;
   &lt;dns&gt;
     &lt;dhcp_hostname config:type="boolean"&gt;true&lt;/dhcp_hostname&gt;
@@ -148,49 +148,49 @@
     &lt;/routes&gt;
   &lt;/routing&gt;
 &lt;/networking&gt;</screen>
-   </example>
+    </example>
 
-   <para>
-    As shown in the example above, the <literal>&lt;networking&gt;</literal> section can be
-    composed of a few subsections:
-   </para>
+    <para>
+     As shown in the example above, the <literal>&lt;networking&gt;</literal> section can be
+     composed of a few subsections:
+    </para>
 
-   <itemizedlist>
-    <listitem>
-     <para>
-      <literal>interfaces</literal> describes the configuration of the
-     network interfaces, including their IP addresses, how they are started,
-     etc.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <literal>dns</literal> specifies DNS related settings, such as the
-     host name, the list of name servers, etc.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <literal>routing</literal> defines the routing rules.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <literal>s390-devices</literal> covers z Systems-specific device settings.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <literal>net-udev</literal> enumerates the udev rules used to set
-     persistent names.
-     </para>
-    </listitem>
-   </itemizedlist>
+    <itemizedlist>
+     <listitem>
+      <para>
+       <literal>interfaces</literal> describes the configuration of the
+      network interfaces, including their IP addresses, how they are started,
+      etc.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       <literal>dns</literal> specifies DNS related settings, such as the
+      host name, the list of name servers, etc.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       <literal>routing</literal> defines the routing rules.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       <literal>s390-devices</literal> covers z Systems-specific device settings.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       <literal>net-udev</literal> enumerates the udev rules used to set
+      persistent names.
+      </para>
+     </listitem>
+    </itemizedlist>
 
-   <para>
-    Additionally, there are a few elements that allow modyfing how the network configuration is
-    applied:
-   </para>
+    <para>
+     Additionally, there are a few elements that allow modyfing how the network configuration is
+     applied:
+    </para>
 
     <variablelist>
      <varlistentry>
@@ -244,16 +244,16 @@
 <screen>&lt;strict_IP_check_timeout config:type="integer"&gt;5&lt;strict_IP_check_timeout&gt;</screen>
       </listitem>
      </varlistentry>
-   </variablelist>
+    </variablelist>
 
-   <tip>
-    <title>IPv6 address support</title>
-    <para>
-     Using IPv6 addresses in &ay; is fully supported. To disable IPv6
-     Address Support, set &lt;ipv6
-     config:type="boolean"&gt;false&lt;/ipv6&gt;
-    </para>
-   </tip>
+    <tip>
+     <title>IPv6 address support</title>
+     <para>
+      Using IPv6 addresses in &ay; is fully supported. To disable IPv6
+      Address Support, set &lt;ipv6
+      config:type="boolean"&gt;false&lt;/ipv6&gt;
+     </para>
+    </tip>
    </sect2>
 
    <sect2 xml:id="CreateProfile-Network-Interfaces">

--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -87,7 +87,6 @@ config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
 <screen>&lt;networking&gt;
   &lt;dns&gt;
     &lt;dhcp_hostname config:type="boolean"&gt;true&lt;/dhcp_hostname&gt;
-    &lt;domain&gt;site&lt;/domain&gt;
     &lt;hostname&gt;linux-bqua&lt;/hostname&gt;
     &lt;nameservers config:type="list"&gt;
       &lt;nameserver&gt;&dnsip;&lt;/nameserver&gt;


### PR DESCRIPTION
### Description

This PR adds documentation for some elements that were missing in the AutoYaST guide. I have tried to organize them in different commits, so it is easy to review and even backport them.

* 1a9e644: add "update_nvram" (**new in SLE 15 SP3**).
* 197257f: add "virt_bridge_proposal" (**new in SLE 15 SP3**).
* 797c3aa: explaining that it is possible to use `t` instead of `config:type` (**new in SLE 15 SP3**).
* 309b4b0: drop the `domain` element from an example. It was deprecated a few releases ago, but we forgot to update the example. **Backport to SP2 if possible**.
* 73d5d16 and 8d30ce6: the introduction of the networking section was somehow confusing. Some elements were not documented while others were just mentioned in the examples. I am not 100% happy with the new text, but I think it is a step in the right direction. **Backport to SP2 if possible**.

If needed, I can take care of creating the PRs with the changes to backport.

Thanks!

### Are there any relevant issues/feature requests?

* [bsc#1183606](https://bugzilla.suse.com/show_bug.cgi?id=1183606)

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [ ] 15 SP3  | *(no backport necessary)*
| [ ] 15 SP2  | [ ]
| [ ] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
