### PR TITLE
Ay backports

### DIFF
--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -21,83 +21,67 @@
    <sect2 xml:id="CreateProfile-Network-Workflow">
     <title>Configuration Workflow</title>
 
-   <para>
-    Network configuration is used to connect a single workstation to an
-    Ethernet-based LAN or to configure a dial-up connection. More complex
-    configurations (multiple network cards, routing, etc.) are also
-    provided.
-   </para>
-
-   <para>
-    If the following setting is set to <literal>true</literal>, &yast;
-    will keep network settings created during the installation (via
-    <command>linuxrc</command>) and/or merge it with network settings from the
-    &ay; control file (if defined).
-   </para>
-   <note>
-    <title>The <command>linuxrc</command> program</title>
     <para>
-     For a detailed description of how <command>linuxrc</command> works and its
-     keywords, see <xref linkend="appendix-linuxrc"/>.
+     Network configuration is mainly used to connect a single workstation to an
+     Ethernet-based LAN. It is commonly configured before &ay; starts,
+     to fetch the profile from a network location. This network
+     configuration is usually done through <command>linuxrc</command>
     </para>
-   </note>
-   <para>
-    &ay; settings have higher priority than any configuration files already
-    present. &yast; will write ifcfg-* files based on the entries in the control
-    file without removing old ones. If there is an empty or absent DNS and
-    routing section, &yast; will keep any pre-existing values. Otherwise,
-    settings from the control file will be applied.
-   </para>
 
-<screen>&lt;keep_install_networkconfig:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
-    
+    <note>
+     <title>The <command>linuxrc</command> program</title>
+     <para>
+      For a detailed description of how <command>linuxrc</command> works and its
+      keywords, see <xref linkend="appendix-linuxrc"/>.
+     </para>
+    </note>
+
     <para>
-    By default, &yast; copies the network settings that were used during the
-    installation into the final, installed system. This configuration is merged with the
-    one defined in the &ay; profile.
-   </para>
-   <para>
-    During the second stage, installation of additional packages will take
-    place before the network, as described in the profile, is configured.
-    <literal>keep_install_network</literal> is set by default to
-    <literal>true</literal> to ensure that a network is available
-    in case it is needed to install those packages. If all packages
-    are installed during the first stage and the network is not needed early
-    during the second one, setting <literal>keep_install_network</literal>
-    to <literal>false</literal> will avoid copying the configuration.
-   </para>
+     By default, &yast; copies the network settings that were used during the
+     installation into the final, installed system. This configuration is merged with the
+     one defined in the &ay; profile.
+    </para>
 
-   <note>
+    <para>
+     &ay; settings have higher priority than any existing configuration files.
+     &yast; will write <filename>ifcfg-*</filename> files based on the entries in the profile
+     without removing old ones. If the DNS and routing section is empty or missing,
+     &yast; will keep any pre-existing values. Otherwise, it applies the settings from
+     the profile file.
+    </para>
+
+    <note>
      <title>Use &ay; network settings during installation</title>
-    <para>
-      If network settings are needed during the installation, you
-      can force &ay; to write and apply them before registration takes
-      place by setting the <literal>setup_before_proposal</literal> option to
-      <literal>true</literal>.
-      Asking &ay; to set up the network in the early stages is useful when
-      installation on a network is needed, but the configuration is too complex to
-      define it using linuxrc (see <xref linkend="autoinstall-singlesystem"/>).
-    </para>
+
+     <para> 
+       If network settings are needed during the installation, you
+       can force &ay; to write and apply them before registration takes
+       place by setting the <literal>setup_before_proposal</literal> option to
+       <literal>true</literal>.
+       Asking &ay; to set up the network in the early stages is useful when
+       installation on a network is needed, but the configuration is too complex to
+       define it using linuxrc (see <xref linkend="autoinstall-singlesystem"/>).
+     </para>
 
 <screen>&lt;setup_before_proposal config:type="boolean"&gt;true&lt;/setup_before_proposal&gt;</screen>
 
+     <para>
+       If the configuration is written at the end of installation, it will
+       not be applied until the system is rebooted.
+     </para>
+    </note>
+
     <para>
-      If the configuration is written at the end of installation, it will
-      not be applied until the system is rebooted.
+     Network settings and service activation are defined under the <literal>profile</literal>
+     <literal>networking</literal> global resource.
     </para>
-   </note>
-   <para>
-    To configure network settings and activate networking automatically, one
-    global resource, <literal>&lt;networking&gt;</literal> is used to store the
-    whole network configuration.
-   </para>
-  </sect2>
+   </sect2>
 
    <sect2 xml:id="CreateProfile-Network-Resource">
     <title>The Network Resource</title>
-
-   <example xml:id="ex-ay-network-config-general">
-    <title>Network Configuration</title>
+ 
+    <example xml:id="ex-ay-network-config-general">
+     <title>Network configuration</title>
 <screen>&lt;networking&gt;
   &lt;dns&gt;
     &lt;dhcp_hostname config:type="boolean"&gt;true&lt;/dhcp_hostname&gt;
@@ -160,12 +144,12 @@
     &lt;/routes&gt;
   &lt;/routing&gt;
 &lt;/networking&gt;</screen>
-   </example>
+    </example>
 
-   <para>
-    As shown in the example above, the <literal>&lt;networking&gt;</literal> section can be
-    composed of a few subsections:
-   </para>
+    <para>
+     As shown in the example above, the <literal>&lt;networking&gt;</literal> section can be
+     composed of a few subsections:
+    </para>
 
    <itemizedlist>
     <listitem>
@@ -199,39 +183,8 @@
     </listitem>
    </itemizedlist>
 
-   <example xml:id="ex-ay-network-config-bridge">
-     <title>Bridge Interface Configuration</title>
-<screen>
-&lt;interfaces config:type="list"&gt;
-  &lt;interface&gt;
-    &lt;device&gt;br0&lt;/device&gt;
-    &lt;bootproto&gt;static&lt;/bootproto&gt;
-    &lt;bridge&gt;yes&lt;/bridge&gt;
-    &lt;bridge_forwarddelay&gt;0&lt;/bridge_forwarddelay&gt;
-    &lt;bridge_ports&gt;eth0 eth1&lt;/bridge_ports&gt;
-    &lt;bridge_stp&gt;off&lt;/bridge_stp&gt;
-    &lt;ipaddr&gt;&subnetI;.100&lt;/ipaddr&gt;
-    &lt;netmask&gt;&subnetmask;&lt;/netmask&gt;
-    &lt;network&gt;&subnetI;.0&lt;/network&gt;
-    &lt;prefixlen&gt;24&lt;/prefixlen&gt;
-    &lt;startmode&gt;auto&lt;/startmode&gt;
-  &lt;/interface&gt;
-  &lt;interface&gt;
-    &lt;device&gt;eth0&lt;/device&gt;
-    &lt;bootproto&gt;none&lt;/bootproto&gt;
-    &lt;startmode&gt;hotplug&lt;/startmode&gt;
-  &lt;/interface&gt;
-  &lt;interface&gt;
-    &lt;device&gt;eth1&lt;/device&gt;
-    &lt;bootproto&gt;none&lt;/bootproto&gt;
-    &lt;startmode&gt;hotplug&lt;/startmode&gt;
-  &lt;/interface&gt;
-&lt;/interfaces&gt;
-</screen>
-   </example>
    <para>
-    Additionally, there are a few elements that allow modifying how the network configuration is
-    applied:
+    Additionally, there are a few elements that allow modifying how the network configuration is applied:
    </para>
 
     <variablelist>
@@ -286,16 +239,16 @@
 <screen>&lt;strict_IP_check_timeout config:type="integer"&gt;5&lt;strict_IP_check_timeout&gt;</screen>
       </listitem>
      </varlistentry>
-   </variablelist>
+    </variablelist>
 
-   <tip>
-    <title>IPv6 Address Support</title>
-    <para>
-     Using IPv6 addresses in &ay; is fully supported. To disable IPv6
-     Address Support, set &lt;ipv6
-     config:type="boolean"&gt;false&lt;/ipv6&gt;
-    </para>
-   </tip>
+    <tip>
+     <title>IPv6 address support</title>
+     <para>
+      Using IPv6 addresses in &ay; is fully supported. To disable IPv6
+      Address Support, set &lt;ipv6
+      config:type="boolean"&gt;false&lt;/ipv6&gt;
+     </para>
+    </tip>
    </sect2>
 
    <sect2 xml:id="CreateProfile-Network-Interfaces">
@@ -502,6 +455,83 @@
 </varlistentry>
   <!-- TODO: all wireless attributes, but not so many users configure wireless with autoyast -->
 </variablelist>
+
+    <example xml:id="ex-ay-network-config-bond">
+     <title>Bonding interface configuration</title>
+<screen>
+&lt;networking&gt;
+  &lt;setup_before_proposal config:type="boolean"&gt;false&lt;/setup_before_proposal&gt;
+  &lt;keep_install_network config:type="boolean"&gt;false&lt;/keep_install_network&gt;
+  &lt;interfaces config:type="list"&gt;
+    &lt;interface&gt;
+      &lt;bonding_master&gt;yes&lt;/bonding_master&gt;
+      &lt;bonding_module_opts&gt;mode=active-backup miimon=100&lt;/bonding_module_opts&gt;
+      &lt;bonding_slave0&gt;eth1&lt;/bonding_slave0&gt;
+      &lt;bonding_slave0&gt;eth2&lt;/bonding_slave0&gt;
+      &lt;bondoption&gt;mode=balance-rr miimon=100&lt;/bondoption&gt;
+      &lt;bootproto&gt;static&lt;/bootproto&gt;
+      &lt;name&gt;bond0&lt;/name&gt;
+      &lt;ipaddr&gt;&subnetI;.61&lt;/ipaddr&gt;
+      &lt;prefixlen&gt;24&lt;/prefixlen&gt;
+      &lt;startmode&gt;auto&lt;/startmode&gt;
+    &lt;/interface&gt;
+    &lt;interface&gt;
+      &lt;bootproto&gt;none&lt;/bootproto&gt;
+      &lt;name&gt;eth1&lt;/name&gt;
+      &lt;startmode&gt;auto&lt;/startmode&gt;
+    &lt;/interface&gt;
+    &lt;interface&gt;
+      &lt;bootproto&gt;none&lt;/bootproto&gt;
+      &lt;name&gt;eth2&lt;/name&gt;
+      &lt;startmode&gt;auto&lt;/startmode&gt;
+    &lt;/interface&gt;
+  &lt;/interfaces&gt;
+  &lt;net-udev config:type="list"&gt;
+    &lt;rule&gt;
+      &lt;name&gt;eth1&lt;/name&gt;
+      &lt;rule&gt;ATTR{address}&lt;/rule&gt;
+      &lt;value&gt;dc:e4:cc:27:94:c7&lt;/value&gt;
+    &lt;/rule&gt;
+    &lt;rule&gt;
+      &lt;name&gt;eth2&lt;/name&gt;
+      &lt;rule&gt;ATTR{address}&lt;/rule&gt;
+      &lt;value&gt;dc:e4:cc:27:94:c8&lt;/value&gt;
+    &lt;/rule&gt;
+  &lt;/net-udev&gt;
+&lt;/networking&gt;
+</screen>
+    </example>
+
+   <example xml:id="ex-ay-network-config-bridge">
+     <title>Bridge Interface Configuration</title>
+<screen>
+&lt;interfaces config:type="list"&gt;
+  &lt;interface&gt;
+    &lt;device&gt;br0&lt;/device&gt;
+    &lt;bootproto&gt;static&lt;/bootproto&gt;
+    &lt;bridge&gt;yes&lt;/bridge&gt;
+    &lt;bridge_forwarddelay&gt;0&lt;/bridge_forwarddelay&gt;
+    &lt;bridge_ports&gt;eth0 eth1&lt;/bridge_ports&gt;
+    &lt;bridge_stp&gt;off&lt;/bridge_stp&gt;
+    &lt;ipaddr&gt;&subnetI;.100&lt;/ipaddr&gt;
+    &lt;netmask&gt;&subnetmask;&lt;/netmask&gt;
+    &lt;network&gt;&subnetI;.0&lt;/network&gt;
+    &lt;prefixlen&gt;24&lt;/prefixlen&gt;
+    &lt;startmode&gt;auto&lt;/startmode&gt;
+  &lt;/interface&gt;
+  &lt;interface&gt;
+    &lt;device&gt;eth0&lt;/device&gt;
+    &lt;bootproto&gt;none&lt;/bootproto&gt;
+    &lt;startmode&gt;hotplug&lt;/startmode&gt;
+  &lt;/interface&gt;
+  &lt;interface&gt;
+    &lt;device&gt;eth1&lt;/device&gt;
+    &lt;bootproto&gt;none&lt;/bootproto&gt;
+    &lt;startmode&gt;hotplug&lt;/startmode&gt;
+  &lt;/interface&gt;
+&lt;/interfaces&gt;
+</screen>
+   </example>
    </sect2>
 
    <sect2 xml:id="CreateProfile-Network-names">

--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -18,6 +18,9 @@
   </dm:docmanager>
  </info>
 
+   <sect2 xml:id="CreateProfile-Network-Workflow">
+    <title>Configuration Workflow</title>
+
    <para>
     Network configuration is used to connect a single workstation to an
     Ethernet-based LAN or to configure a dial-up connection. More complex
@@ -46,9 +49,13 @@
     settings from the control file will be applied.
    </para>
 
-<screen>&lt;keep_install_network
-config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
-
+<screen>&lt;keep_install_networkconfig:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
+    
+    <para>
+    By default, &yast; copies the network settings that were used during the
+    installation into the final, installed system. This configuration is merged with the
+    one defined in the &ay; profile.
+   </para>
    <para>
     During the second stage, installation of additional packages will take
     place before the network, as described in the profile, is configured.
@@ -60,11 +67,34 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
     to <literal>false</literal> will avoid copying the configuration.
    </para>
 
+   <note>
+     <title>Use &ay; network settings during installation</title>
+    <para>
+      If network settings are needed during the installation, you
+      can force &ay; to write and apply them before registration takes
+      place by setting the <literal>setup_before_proposal</literal> option to
+      <literal>true</literal>.
+      Asking &ay; to set up the network in the early stages is useful when
+      installation on a network is needed, but the configuration is too complex to
+      define it using linuxrc (see <xref linkend="autoinstall-singlesystem"/>).
+    </para>
+
+<screen>&lt;setup_before_proposal config:type="boolean"&gt;true&lt;/setup_before_proposal&gt;</screen>
+
+    <para>
+      If the configuration is written at the end of installation, it will
+      not be applied until the system is rebooted.
+    </para>
+   </note>
    <para>
     To configure network settings and activate networking automatically, one
     global resource, <literal>&lt;networking&gt;</literal> is used to store the
     whole network configuration.
    </para>
+  </sect2>
+
+   <sect2 xml:id="CreateProfile-Network-Resource">
+    <title>The Network Resource</title>
 
    <example xml:id="ex-ay-network-config-general">
     <title>Network Configuration</title>
@@ -199,6 +229,64 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
 &lt;/interfaces&gt;
 </screen>
    </example>
+   <para>
+    Additionally, there are a few elements that allow modifying how the network configuration is
+    applied:
+   </para>
+
+    <variablelist>
+     <varlistentry>
+      <term>keep_install_network</term>
+      <listitem>
+       <para>
+        As described in <xref linkend="CreateProfile-Network-Workflow"/>, by default, &ay;
+        merges the network configuration from the running system with the one defined in the
+        profile. If you want to use just the configuration from the profile, set this element to
+        <literal>false</literal>. The value is <literal>true</literal> by default.
+       </para>
+<screen>&lt;keep_install_network config:type="boolean"&gt;false&lt;keep_install_network&gt;</screen>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>managed</term>
+      <listitem>
+       <para>
+        Determines whether to use NetworkManager instead of Wicked.
+       </para>
+<screen>&lt;managed config:type="boolean"&gt;true&gt;managed&lt;</screen>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>start_immediately</term>
+      <listitem>
+       <para>
+        Forces &ay; to restart the network just after writing the configuration.
+       </para>
+<screen>&lt;start_immediately config:type="boolean"&gt;true&lt;start_immediately&gt;</screen>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>setup_before_proposal</term>
+      <listitem>
+       <para>
+        Use the network configuration defined in the profile during the installation process.
+        Otherwise, &ay; relies on the configuration set by <command>linuxrc</command>.
+       </para>
+<screen>&lt;setup_before_proposal config:type="boolean"&gt;true&lt;setup_before_proposal&gt;</screen>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>strict_IP_check_timeout</term>
+      <listitem>
+       <para>
+        After setting up the network, &ay; checks whether the assigned IP address is duplicated. In
+        that, it shows a warning whose timeout is controlled by this element. If it is set to
+        <literal>0</literal>, the installation is stopped.
+       </para>
+<screen>&lt;strict_IP_check_timeout config:type="integer"&gt;5&lt;strict_IP_check_timeout&gt;</screen>
+      </listitem>
+     </varlistentry>
+   </variablelist>
 
    <tip>
     <title>IPv6 Address Support</title>
@@ -208,6 +296,7 @@ config:type="boolean"&gt;true&lt;/keep_install_network&gt;</screen>
      config:type="boolean"&gt;false&lt;/ipv6&gt;
     </para>
    </tip>
+   </sect2>
 
    <sect2 xml:id="CreateProfile-Network-Interfaces">
     <title>Interfaces</title>


### PR DESCRIPTION
cherry-pick 73d5d16 and 8d30ce6b from main, see
https://github.com/SUSE/doc-sle/pull/824
backport updates in Main to SLE15SP2

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [ ] 15 SP3  | *(no backport necessary)*
| [x ] 15 SP2  | [ ]
| [ ] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
