### PR TITLE
Clarify SLES extensions lookup

### DIFF
--- a/xml/ay_registration_extensions.xml
+++ b/xml/ay_registration_extensions.xml
@@ -288,16 +288,13 @@ x509 -noout -fingerprint -sha256</screen>
      that can be included as additional sources during the installation.
      Extensions can be added via the <literal>addons</literal> property within
      the <literal>suse_register</literal> block.
-     <!-- Below is a list of all extensions available for &productname;
-          on x86_64: -->
+
     </para>
     <note>
      <title>Availability of extensions</title>
      <para>
       The availability of extensions is product and architecture dependent,
       not all extensions are available on all architectures.
-      <!-- All listed extensions are available for &sls; on the x86_64
-           architecture. -->
      </para>
      <para>
       Some extensions, such as <literal>sle-ha</literal>,
@@ -348,11 +345,5 @@ x509 -noout -fingerprint -sha256</screen>
    registration workflow will evaluate the right one.
  </para> 
 </note>
-
-    <para>
-     For background information and add-on listings for &slsa; see <link
-     xlink:href="https://github.com/yast/yast-registration/wiki/Available-SCC-Extensions-for-Use-in-Autoyast"/>.
-     The listings will get updated from time to time.
-    </para>
    </sect2>
   </sect1>


### PR DESCRIPTION
Remove link to unmaintained Github page, SUSEConnect --list-extensions
is the authoritative source
https://jira.suse.com/browse/DOCTEAM-151
https://bugzilla.suse.com/show_bug.cgi?id=1185014


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [x] 15 SP3  | *(no backport necessary)*
| [x] 15 SP2  | [ ]
| [x] 15 SP1  | [ ]
| [x] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
