### PR TITLE
Document missing zFCP options, wwpn and fcp_lun, in AY Guide

### DIFF
--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -2478,6 +2478,7 @@ as per ancorgs' comment on Github-->
       
      </variablelist>
     </sect3>
+    
     <sect3 xml:id="ay-partition-s390-zfcp">
      <title>Configuring zFCP disks</title>
      <para>
@@ -2510,6 +2511,50 @@ as per ancorgs' comment on Github-->
       </varlistentry>
      </variablelist>
      
+     <para>
+       The <literal>controller_id</literal> element is required.
+     </para>
+     <para>
+       There are two optional elements, <literal>wwpn</literal> 
+       (Worldwide Port Number, the target port through which the SCSI device 
+       is attached), and <literal>fzp_lun</literal>
+       (logical unit number of the SCSI device). It is not necessary to 
+       specify these for FCP devices running in NPIV (Node Port ID 
+       Virtualization) mode, and when the kernel boot parameter 
+       <literal>allow_lun_scan</literal> is set to 1 (the default setting), 
+       which enables automatic LUN scanning by the kernel.
+     </para>
+     <para>
+       If automatic LUN scanning is not available, set the 
+       <literal>wwpn</literal> and <literal>fzp_lun</literal> options 
+       manually.
+     </para>
+
+     <variablelist>
+      <varlistentry>
+        <term>wwpn</term>
+       <listitem>
+       <para>
+        Worldwide port number
+       </para>
+<screen>&lt;wwpn&gt;0x500507630300c562&lt;/wwpn&gt;</screen>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>fzp_lun</term>
+       <listitem>
+       <para>
+        Logical unit number
+       </para>
+<screen>&lt;fzp_lun&gt;0x4010403200000000&lt;/fzp_lun&gt;</screen>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+     
+     <para>
+       See the IBM documentation for more information,
+       <link xlink:href="https://www.ibm.com/docs/en/linux-on-systems?topic=cd-manually-configured-fcp-luns"/>.
+     </para>
     </sect3>
    </sect2>
   </sect1>

--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -2517,16 +2517,16 @@ as per ancorgs' comment on Github-->
      <para>
        There are two optional elements, <literal>wwpn</literal> 
        (Worldwide Port Number, the target port through which the SCSI device 
-       is attached), and <literal>fzp_lun</literal>
+       is attached), and <literal>fcp_lun</literal>
        (logical unit number of the SCSI device). It is not necessary to 
        specify these for FCP devices running in NPIV (Node Port ID 
-       Virtualization) mode, and when the kernel boot parameter 
+       Virtualization) mode, and when the zfcp module parameter 
        <literal>allow_lun_scan</literal> is set to 1 (the default setting), 
-       which enables automatic LUN scanning by the kernel.
+       which enables automatic LUN scanning by the zfcp device driver.
      </para>
      <para>
        If automatic LUN scanning is not available, set the 
-       <literal>wwpn</literal> and <literal>fzp_lun</literal> options 
+       <literal>wwpn</literal> and <literal>fcp_lun</literal> options 
        manually.
      </para>
 
@@ -2541,19 +2541,19 @@ as per ancorgs' comment on Github-->
        </listitem>
       </varlistentry>
       <varlistentry>
-        <term>fzp_lun</term>
+        <term>fcp_lun</term>
        <listitem>
        <para>
         Logical unit number
        </para>
-<screen>&lt;fzp_lun&gt;0x4010403200000000&lt;/fzp_lun&gt;</screen>
+<screen>&lt;fcp_lun&gt;0x4010403200000000&lt;/fcp_lun&gt;</screen>
        </listitem>
       </varlistentry>
      </variablelist>
      
      <para>
        See the IBM documentation for more information,
-       <link xlink:href="https://www.ibm.com/docs/en/linux-on-systems?topic=cd-manually-configured-fcp-luns"/>.
+       <link xlink:href=" https://www.ibm.com/docs/en/linux-on-systems?topic=wsd-configuring-devices"/>.
      </para>
     </sect3>
    </sect2>


### PR DESCRIPTION
resolves Jira https://jira.suse.com/browse/DOCTEAM-171 and
BSC #https://bugzilla.suse.com/show_bug.cgi?id=1185231

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [x ] 15 SP3  | *(no backport necessary)*
| [x ] 15 SP2  | [ ]
| [x ] 15 SP1  | [ ]
| [x ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
