### PR TITLE
A few style corrections to the AY Guide before proofing drop

### DIFF
--- a/xml/ay_auto_installation.xml
+++ b/xml/ay_auto_installation.xml
@@ -95,7 +95,7 @@ xml:id="Invoking">
     directory of the boot medium or the initrd upon start-up and switch to
     an automated installation if it was found. In case the control file is
     named differently or located elsewhere, specify its location on the
-    kernel command-line with the parameter
+    kernel command line with the parameter
     <literal>&ay;=<replaceable>URL</replaceable></literal>.
    </para>
 

--- a/xml/ay_bootloader.xml
+++ b/xml/ay_bootloader.xml
@@ -350,7 +350,7 @@
       <term>update_nvram</term>
       <listitem>
        <para>
-        If set to <literal>true</literal>, then &ay; adds an NVRAM entry for the bootloader
+        If set to <literal>true</literal>, then &ay; adds an NVRAM entry for the boot loader
         in the firmware. This is the desirable behavior unless you want to preserve some
         specific setting or you need to work around firmware issues.
        </para>

--- a/xml/ay_dynamic_profiles.xml
+++ b/xml/ay_dynamic_profiles.xml
@@ -62,7 +62,7 @@ xml:id="dynamic-profiles">
       <para>
        As an alternative, &ay; can ask the user for values to use in the profile
        at runtime. The installation is not fully unattended in that case, but it
-       can be rather useful to set usernames, passwords, IP addresses and so on.
+       can be rather useful to set user names, passwords, IP addresses and so on.
        You can find more information about this feature in the
        <xref linkend="CreateProfile-Ask"/> section.
       </para>

--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -199,7 +199,7 @@
        <para>
         As described in <xref linkend="CreateProfile-Network-Workflow"/>, by default, &ay;
         merges the network configuration from the running system with the one defined in the
-        profile. If you want to use just the configuration from the profile, set this element to
+        profile. If you want to use only the configuration from the profile, set this element to
         <literal>false</literal>. The value is <literal>true</literal> by default.
        </para>
 <screen>&lt;keep_install_network config:type="boolean"&gt;false&lt;keep_install_network&gt;</screen>

--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -408,7 +408,7 @@
             <literal>CT_BTRFS</literal> for multi-device Btrfs file systems.
            </para>
            <para>
-            <literal>CT_NFS</literal> for NFS file systems.
+            <literal>CT_NFS</literal> for NFS.
            </para>
            <para>
             <literal>CT_TMPFS</literal> for <literal>tmpfs</literal> file systems.


### PR DESCRIPTION


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.
Some last minute corrections before the May 5 proofing drop

| Code 15     | Backport Done
| ----------  | ----------
| [ x] 15 SP3  | *(no backport necessary)*
| [ ] 15 SP2  | [ ]
| [ ] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
