### PR TITLE
Raspberry Pi Quick: fix some URLs

### DIFF
--- a/xml/art_raspberry-pi.xml
+++ b/xml/art_raspberry-pi.xml
@@ -200,7 +200,7 @@
      If you want to try out &productnamearch; &productnumber; on the &rpi;,
      &suse; will provide you with a trial version. This gives you access to
      free patches and updates for a period of 60 days. You must sign in to the
-     &scc; at <link xlink:href="&sccurl;" />
+     &scc; at <link xlink:href="&sccurl;"/>
      using your Customer Center account credentials to receive this free offer.
      If you do not have a Customer Center account, you must create one to take
      advantage of the trial version.
@@ -381,7 +381,7 @@
     </variablelist>
     <para>
      For other limitations refer to the online version of the Release Notes at
-     <link xlink:href="https://www.suse.com/releasenotes/aarch64/SUSE-SLES/&product-ga;-SP&product-sp;/" />.
+     <link xlink:href="https://www.suse.com/releasenotes/aarch64/SUSE-SLES/&product-ga;-SP&product-sp;/"/>.
     </para>
    </sect3>
   </sect2>
@@ -455,13 +455,13 @@
     <listitem>
      <para>
       Easy 7-Zip from
-      <link xlink:href="http://www.e7z.org/" />
+      <link xlink:href="http://www.e7z.org/"/>
      </para>
     </listitem>
     <listitem>
      <para>
       Win32 Disk Imager from
-      <link xlink:href="http://sourceforge.net/projects/win32diskimager/" />
+      <link xlink:href="http://sourceforge.net/projects/win32diskimager/"/>
      </para>
     </listitem>
    </itemizedlist>
@@ -524,7 +524,7 @@
     <listitem>
      <para>
       The Unarchiver from
-      <link xlink:href="http://unarchiver.c3.cx/unarchiver" />
+      <link xlink:href="http://unarchiver.c3.cx/unarchiver"/>
      </para>
     </listitem>
    </itemizedlist>
@@ -895,7 +895,7 @@ Password:
     <title>Evaluation code</title>
     <para>
      Sixty day evaluation subscriptions may be requested at the following page:
-     <link xlink:href="https://www.suse.com/products/arm/" />
+     <link xlink:href="https://www.suse.com/products/arm/"/>
     </para>
    </note>
    <para>
@@ -904,7 +904,7 @@ Password:
     at:</emphasis>
    </para>
    <para>
-    <link xlink:href="&sccurl;" />
+    <link xlink:href="&sccurl;"/>
    </para>
    <para>
     To register your subscription, perform the following steps:
@@ -1259,14 +1259,14 @@ Device setup complete</screen>
     A valid and activated subscription entitles you to receive bug and security
     fixes, feature updates, and technical assistance from &suse;'s support
     organization. Learn more at
-    <link xlink:href="https://www.suse.com/support/" />.
-    Via the &scc; at <link xlink:href="&sccurl;" />
+    <link xlink:href="https://www.suse.com/support/"/>.
+    Via the &scc; at <link xlink:href="&sccurl;"/>
     you can open an incident.
    </para>
    <para>
     In addition, &suse; has provided conversation forums where you can get
     answers to questions. Go to
-    <link xlink:href="https://forums.suse.com/" />.
+    <link xlink:href="https://forums.suse.com/"/>.
     Under the main forum category <emphasis role="strong">SUSE Linux Enterprise
     Server</emphasis> select the sub-forum <emphasis role="strong">SLES for
     Raspberry Pi</emphasis>.
@@ -1284,7 +1284,7 @@ Device setup complete</screen>
     </para>
     <para>
      Visit
-     <link xlink:href="https://www.suse.com/support/" />
+     <link xlink:href="https://www.suse.com/support/"/>
      for more information about official support options.
     </para>
    </important>
@@ -1327,7 +1327,7 @@ https://www.bluetooth.com/develop-with-bluetooth/marketing-branding/
   <para>
    &suse;, the &suse; logo and &yast; are registered trademarks of SUSE LLC in the
    United States and other countries. For &suse; trademarks, see
-   <link xlink:href="http://www.suse.com/company/legal/" />.
+   <link xlink:href="http://www.suse.com/company/legal/"/>.
    Linux is a registered trademark of Linus Torvalds. Other names or trademarks
    mentioned in this document may be trademarks or registered trademarks of
    their respective owners.

--- a/xml/art_raspberry-pi.xml
+++ b/xml/art_raspberry-pi.xml
@@ -1166,7 +1166,7 @@ Successfully registered system</screen>
     &productnamearch;, consult the respective sections of the
     <citetitle>&sls; Deployment</citetitle> and
     <citetitle>Administration</citetitle> guides at
-    <link xlink:href="https://documentation.suse.com/sles/15-SP2/"/>.
+    <link xlink:href="https://documentation.suse.com/sles/"/>.
    </para>
   </sect2>
  </sect1>


### PR DESCRIPTION
### Description

When building an HTML version of the guide, I noticed additional whitespaces in the text after some links, stemming from whitespaces before the closing tag of the link elements in the source code (did not see this in the SP2 version of the code).

In a separate commit, I also removed the SP-related info from the link pointing to the product documentation on d.s.c - for reasons, see commit message. 

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [x] 15 SP3  | *(no backport necessary)*
| [ ] 15 SP2  | [ ]
| [ ] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
