### PR TITLE
JeOS Quick: fix some URLs

### DIFF
--- a/xml/art_jeos.xml
+++ b/xml/art_jeos.xml
@@ -254,7 +254,7 @@
       </itemizedlist>
       <para>
        For further information, refer to
-       <link xlink:href="https://documentation.suse.com/sles/15-SP3/single-html/SLES-tuning/#cha-tuning-systemd-coredump"/>.
+       <link xlink:href="https://documentation.suse.com/sles/single-html/SLES-tuning/#cha-tuning-systemd-coredump"/>.
       </para>
      </listitem>
     </varlistentry>
@@ -421,7 +421,7 @@ runcmd:
     <para>
      For further information, see
      <link
-xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-register-sle.html"/>.
+xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-register-sle.html"/>.
     </para>
     <para>
      For &rmt;, the configuration is as follows:
@@ -432,7 +432,7 @@ runcmd:
   - sh rmt-client-setup https://<replaceable>RMT_SERVER/</replaceable></screen>
     <para>
      For further information, see
-     <link xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-rmt-client.html"/>.
+     <link xlink:href="https://documentation.suse.com/sles/html/SLES-all/cha-rmt-client.html"/>.
     </para>
     <para>
      For &sumaa;, the configuration is as follows:

--- a/xml/art_jeos.xml
+++ b/xml/art_jeos.xml
@@ -153,7 +153,7 @@
        &jeos; has no channel by default, and you need to register your system
        to access online channels.
 <!-- FIXME Refer to <xref
-       linkend="sec-registering-your-system" /> for further information. -->
+       linkend="sec-registering-your-system"/> for further information. -->
       </para>
      </listitem>
     </varlistentry>
@@ -254,7 +254,7 @@
       </itemizedlist>
       <para>
        For further information, refer to
-       <link xlink:href="https://documentation.suse.com/sles/15-SP3/single-html/SLES-tuning/#cha-tuning-systemd-coredump" />.
+       <link xlink:href="https://documentation.suse.com/sles/15-SP3/single-html/SLES-tuning/#cha-tuning-systemd-coredump"/>.
       </para>
      </listitem>
     </varlistentry>
@@ -421,8 +421,7 @@ runcmd:
     <para>
      For further information, see
      <link
-xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-register-sle.html"
-/>.
+xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-register-sle.html"/>.
     </para>
     <para>
      For &rmt;, the configuration is as follows:
@@ -433,7 +432,7 @@ runcmd:
   - sh rmt-client-setup https://<replaceable>RMT_SERVER/</replaceable></screen>
     <para>
      For further information, see
-     <link xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-rmt-client.html" />.
+     <link xlink:href="https://documentation.suse.com/sles/15-SP2/html/SLES-all/cha-rmt-client.html"/>.
     </para>
     <para>
      For &sumaa;, the configuration is as follows:
@@ -444,7 +443,7 @@ runcmd:
   - /bin/bash bootstrap.sh</screen>
     <para>
      For further information, see
-     <link xlink:href="https://documentation.suse.com/external-tree/en-us/suma/4.0/suse-manager/client-configuration/registration-bootstrap.html" />.
+     <link xlink:href="https://documentation.suse.com/external-tree/en-us/suma/4.0/suse-manager/client-configuration/registration-bootstrap.html"/>.
     </para>
     <para>
      Finally, the following example shows a configuration that installs a


### PR DESCRIPTION
### Description

When building an HTML version of the guide, I noticed additional whitespaces in the text after some links, stemming from whitespaces before the closing tag of the link elements in the source code (did not see this in the SP2 version of the code).

In a separate commit, I also removed the SP-related info from the link pointing to the product documentation on d.s.c - for reasons, see commit message.

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [x] 15 SP3  | *(no backport necessary)*
| [ ] 15 SP2  | [ ]
| [ ] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
