### PR TITLE
Document the new backend element in the networking section

### DIFF
--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -194,6 +194,17 @@
 
     <variablelist>
      <varlistentry>
+      <term>backend</term>
+      <listitem>
+       <para>
+         Selects the network backend to be used. Supported values are <literal>wicked</literal>,
+         <literal>network_manager</literal> or <literal>none</literal> which will disable the
+         network service.
+       </para>
+<screen>&lt;backend&gt;network_manager&lt;backend&gt;</screen>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
       <term>keep_install_network</term>
       <listitem>
        <para>
@@ -211,7 +222,10 @@
        <para>
         Determines whether to use NetworkManager instead of Wicked.
        </para>
-<screen>&lt;managed config:type="boolean"&gt;true&gt;managed&lt;</screen>
+       <para>
+        Deprecated. Use <literal>backend</literal> instead.
+       </para>
+<screen>&lt;managed config:type="boolean"&gt;true&lt;managed&gt;</screen>
       </listitem>
      </varlistentry>
      <varlistentry>


### PR DESCRIPTION
### Description

Document the new AutoYaST profile element (**backend**) in the **networking** section. This option will be available **only** in TW / SLE-15-SP4 since yast2-network-4.4.9.

- Implemented by https://github.com/yast/yast-network/pull/1215

### Are there any relevant issues/feature requests?

* https://bugzilla.suse.com/show_bug.cgi?id=1183886

### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [x ] 15 SP4  | *(no backport necessary)*
| [ ] 15 SP3  | [ ]
| [ ] 15 SP2  | [ ]
| [ ] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
