### PR TITLE
Incorporate proofing corrections from Dublin for GNOME Guide

### DIFF
--- a/xml/apps_evolution.xml
+++ b/xml/apps_evolution.xml
@@ -99,7 +99,7 @@
     </step>
     <step performance="optional">
      <para>
-      (Optional) Type an address in the <guimenu>Reply-To</guimenu> field.
+      Type an address in the <guimenu>Reply-To</guimenu> field.
      </para>
      <para>
       Only use this field if you want replies to e-mails from you to be sent to
@@ -108,7 +108,7 @@
     </step>
     <step performance="optional">
      <para>
-      (Optional) Type your organization name in the
+      Type your organization name in the
       <guimenu>Organization</guimenu> field.
      </para>
      <para>
@@ -140,7 +140,7 @@
     following is a list of available server types:
    </para>
    <formalpara>
-    <title>Exchange web services:</title>
+    <title>Exchange Web services:</title>
     <para>
      Allows you to connect to newer Microsoft Exchange servers to synchronize
      e-mail, calendar, and contact information. This is only available if you
@@ -201,7 +201,7 @@
     </para>
    </formalpara>
    <formalpara>
-    <title>Standard unix mbox spool file or directory:</title>
+    <title>Standard Unix mbox spool file or directory:</title>
     <para>
      To read and store e-mail in the mail spool on your local system, select
      this option. You need to provide the path to the mail spool you want to
@@ -266,7 +266,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gnome-evolution-first-start-setup-assistant-receiving-exchange">
-    <title>Configuration options for exchange web services</title>
+    <title>Configuration options for Exchange Web Services</title>
     <para>
      If you selected Exchange Web Services as the server type, you need to
      specify additional information.
@@ -738,7 +738,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gnome-evolution-first-start-setup-assistant-receiving-opts-mbox">
-    <title>Standard unix mbox spool or directory receiving options</title>
+    <title>Standard Unix mbox spool or directory receiving options</title>
     <para>
      If you selected that you want to receive mail through a Unix mbox Spool
      File or Directories, you will now see a page of options to specify the
@@ -881,7 +881,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gnome-evolution-usage">
-  <title>Using evolution</title>
+  <title>Using Evolution</title>
 
   <para>
    Now that the first-run configuration has finished, you are ready to begin

--- a/xml/apps_firefox.xml
+++ b/xml/apps_firefox.xml
@@ -325,7 +325,7 @@
      </step>
     </procedure>
     <tip>
-     <title>Keywords for regular web sites</title>
+     <title>Keywords for regular Web sites</title>
      <para>
       Using keywords is not restricted to search engines. You can also add a
       keyword to a bookmark (via the bookmark's properties). For example, if

--- a/xml/apps_libreoffice.xml
+++ b/xml/apps_libreoffice.xml
@@ -1397,8 +1397,8 @@
    </step>
    <step>
     <para>
-     Seelct the type (e.g. <guimenu>Text</guimenu>) and insert the name of the
-     owner in the <guimenu>Value</guimenu> column.
+     Select the type (for example, <guimenu>Text</guimenu>) and insert the name
+     of the owner in the <guimenu>Value</guimenu> column.
     </para>
    </step>
    <step>

--- a/xml/apps_librevarious.xml
+++ b/xml/apps_librevarious.xml
@@ -5,7 +5,7 @@
     %entities;
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-lo-various">
- <title>&libo; <guimenu>Impress</guimenu>, <guimenu>Base</guimenu>, <guimenu>Draw</guimenu>, and <guimenu>Math</guimenu></title>
+ <title>&libo; Impress, Base, Draw, and Math</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>

--- a/xml/apps_librewriter.xml
+++ b/xml/apps_librewriter.xml
@@ -6,7 +6,7 @@
   <!ENTITY libo-insert-icon "<inlinemediaobject xmlns='http://docbook.org/ns/docbook'><textobject role='description'><phrase>Insert</phrase></textobject><imageobject role='fo'><imagedata fileref='libreoffice-writer-master-insert.png' width='0.8em' format='PNG'/></imageobject><imageobject role='html'><imagedata fileref='libreoffice-writer-master-insert.png' width='1em' format='PNG'/></imageobject></inlinemediaobject>">
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-lo-writer">
- <title><guimenu>&libo; Writer</guimenu></title>
+ <title>&libo; Writer</title>
  <info>
   <abstract>
    <para>
@@ -900,7 +900,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-lo-writer-html">
-  <title>Using writer as an HTML editor</title>
+  <title>Using Writer as an HTML editor</title>
 
   <para>
    In addition to being a full-featured word processor, Writer also functions

--- a/xml/common_intro_lifecycle_support_i.xml
+++ b/xml/common_intro_lifecycle_support_i.xml
@@ -24,7 +24,7 @@
  <xref linkend="cha-upgrade-background"/>.
 </para>
 <para>
- If you are entitled to support, find details how to collect information
+ If you are entitled to support, find details on how to collect information
  for a support ticket in <xref linkend="cha-adm-support"/>.
 </para>
 

--- a/xml/gnome_custom.xml
+++ b/xml/gnome_custom.xml
@@ -144,7 +144,7 @@
    </itemizedlist>
    <note>
     <title>
-     Settings Made Using <command>ibus-setup</command> Do Not Take Effect
+     Settings made using <command>ibus-setup</command> do not take effect
     </title>
     <para>
      On GNOME, settings made using <command>ibus-setup</command> do not take

--- a/xml/gnome_use.xml
+++ b/xml/gnome_use.xml
@@ -893,7 +893,7 @@
     </step>
     <step>
      <para>
-      Specify the directory where Archive Manager will extracts the files.
+      Specify the directory where Archive Manager will extract the files.
      </para>
     </step>
     <step>


### PR DESCRIPTION
### Description

First batch of proofing corrections are for the smallest PDF: the GNOME Guide.

I have made a few additional corrections as well, e.g. "Seelct" -> "Select".


### Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [ ] 15 SP4  |*(no backport necessary)*
| [ ] 15 SP3  | [ ]
| [ ] 15 SP2  | [ ]
| [ ] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
