### PR TITLE
Integrate proofing corrections to 15.3 storage guide

### DIFF
--- a/xml/autofs.xml
+++ b/xml/autofs.xml
@@ -127,7 +127,7 @@
      <term>map name</term>
      <listitem>
       <para>
-       The name of a map source to use for mounting. For the syntax of the maps
+       The name of a map source to use for mounting. For the syntax of the map
        files, see <xref linkend="sec-autofs-mapfiles"/>.
       </para>
      </listitem>
@@ -155,7 +155,7 @@
     The following entry in <filename>auto.master</filename> tells
     <systemitem>autofs</systemitem> to look in
     <filename>/etc/auto.smb</filename>, and create mount points in the
-    <filename>/smb</filename> directory.
+    <filename>/smb</filename> directory:
    </para>
 <screen>/smb   /etc/auto.smb</screen>
    <sect3 xml:id="sec-autofs-directmount">
@@ -165,7 +165,7 @@
      relevant map file. Instead of specifying the mount point in
      <filename>auto.master</filename>, replace the mount point field with
      <literal>/-</literal>. For example, the following line tells
-     <systemitem>autofs</systemitem> to create a mount point at the place
+     <systemitem>autofs</systemitem> to create a mount point in the place
      specified in <filename>auto.smb</filename>:
     </para>
 <screen>/-        /etc/auto.smb</screen>
@@ -188,7 +188,7 @@
      Although <emphasis>files</emphasis> are the most common types of maps for
      auto-mounting with <systemitem>autofs</systemitem>, there are other types
      as well. A map specification can be the output of a command, or a result
-     of a query in LDAP or database. For more detailed information on map
+     of a query in LDAP or a database. For more detailed information on map
      types, see the manual page <command>man 5 auto.master</command>.
     </para>
    </important>
@@ -221,9 +221,9 @@
      <term>options</term>
      <listitem>
       <para>
-       Specifies optional comma-separated list of mount options for the
+       Specifies an optional comma-separated list of mount options for the
        relevant entries. If <filename>auto.master</filename> contains options
-       for this map file as well, theses are appended.
+       for this map file as well, these are appended.
       </para>
      </listitem>
     </varlistentry>
@@ -319,7 +319,7 @@
   </sect2>
 
   <sect2 xml:id="sec-autofs-debugging-problems">
-   <title>Debugging the automounter problems</title>
+   <title>Debugging automounter problems</title>
    <para>
     If you experience problems when mounting directories with
     <systemitem>autofs</systemitem>, it is useful to run the
@@ -349,7 +349,7 @@
     <step>
      <para>
       Check the output of <command>automount</command> from the first terminal
-      for more information why the mount failed, or why it was not even
+      for more information on why the mount failed, or why it was not even
       attempted.
      </para>
     </step>
@@ -379,7 +379,7 @@
     </para>
 <screen>/nfs      /etc/auto.nfs      --timeout=10</screen>
     <para>
-     It tells <systemitem>autofs</systemitem> that the base mount point is
+     This tells <systemitem>autofs</systemitem> that the base mount point is
      <filename>/nfs</filename>, the NFS shares are specified in the
      <filename>/etc/auto.nfs</filename> map, and that all shares in this map
      will be automatically unmounted after 10 seconds of inactivity.
@@ -469,8 +469,8 @@ drwxr-xr-x  4 1001 users 4096 Apr 25 08:56 manual/</screen>
    <para>
     If you have a directory with subdirectories that you need to auto-mount
     individually&mdash;the typical case is the <filename>/home</filename>
-    directory with individual users' home directories inside&mdash;
-    <systemitem>autofs</systemitem> offers a clever solution for that.
+    directory with individual users' home directories
+    inside&mdash;<systemitem>autofs</systemitem> offers a clever solution.
    </para>
    <para>
     In case of home directories, add the following line in

--- a/xml/autofs.xml
+++ b/xml/autofs.xml
@@ -444,7 +444,7 @@ drwxr-xr-x  4 1001 users 4096 Apr 25 08:56 manual/</screen>
   </para>
 
   <sect2 xml:id="sec-autofs-advanced-net">
-   <title><filename>/net</filename> Mount point</title>
+   <title><filename>/net</filename> mount point</title>
    <para>
     This helper mount point is useful if you use a lot of NFS shares.
     <filename>/net</filename> auto-mounts all NFS shares on your local network

--- a/xml/net_samba.xml
+++ b/xml/net_samba.xml
@@ -64,13 +64,11 @@
     <term>CIFS protocol</term>
     <listitem>
      <para>
-      The CIFS (common Internet file system) protocol, also known as SMB1 is
-      an early version of the SMB protocol.
-      CIFS defines a standard remote file system
-      access protocol for use over the network, enabling groups of users to
-      work together and share documents across the network.
-      In recent versions of Samba, it is disabled by default for security
-      reasons.
+      The CIFS (Common Internet File System) protocol, also known as SMB1, is
+      an early version of the SMB protocol. CIFS defines a standard remote file
+      system access protocol for use over the network, enabling groups of users
+      to work together and share documents across the network. In recent
+      versions of Samba, it is disabled by default for security reasons.
      </para>
     </listitem>
    </varlistentry>
@@ -106,9 +104,10 @@
     <listitem>
      <para>
       Samba server provides SMB/CIFS services and NetBIOS over IP naming
-      services to clients. For Linux, there are three daemons for Samba server:
-      smbd for SMB/CIFS services, nmbd for naming services, and winbind for
-      authentication.
+      services to clients. For Linux, there are three daemons for the Samba
+      server: <literal>smbd</literal> for SMB/CIFS services,
+      <literal>nmbd</literal> for naming services, and
+      <literal>winbind</literal> for authentication.
      </para>
     </listitem>
    </varlistentry>
@@ -118,7 +117,7 @@
      <para>
       The Samba client is a system that uses Samba services from a Samba server
       over the SMB protocol. Common operating systems, such as Windows and
-      macOS support the SMB protocol. The TCP/IP protocol must be
+      macOS, support the SMB protocol. The TCP/IP protocol must be
       installed on all computers. Samba provides a client for the different
       Unix flavors. For Linux, there is a kernel module for SMB that allows the
       integration of SMB resources on the Linux system level. You do not need
@@ -143,16 +142,16 @@
     <term>DC</term>
     <listitem>
      <para>
-      A domain controller (DC) is a server that handles accounts
-      in a domain. For data replication, additional domain controllers are
-      available in one domain.
+      A domain controller (DC) is a server that handles accounts in a domain.
+      For data replication, it is possible to have multiple domain controllers
+      in a single domain.
      </para>
     </listitem>
    </varlistentry>
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-samba-server-sled" os="sled">
-  <title>Installing a samba server</title>
+  <title>Installing a Samba server</title>
   <para>
    Installing a Samba server is not supported on &sled;.
    For information about installing and configuring a Samba server, see
@@ -160,7 +159,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-samba-install" os="sles;osuse">
-  <title>Installing a samba server</title>
+  <title>Installing a Samba server</title>
 
   <para>
    To install a Samba server, start &yast; and select
@@ -172,7 +171,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-samba-serv-start" os="sles;osuse">
-  <title>Starting and stopping samba</title>
+  <title>Starting and stopping Samba</title>
 
   <para>
    You can start or stop the Samba server automatically (during boot) or
@@ -197,7 +196,7 @@
   </tip>
  </sect1>
  <sect1 xml:id="sec-samba-serv-inst" os="sles;osuse">
-  <title>Configuring a samba server</title>
+  <title>Configuring a Samba server</title>
 
   <para>
    A Samba server in &productnamereg; can be configured in two different ways:
@@ -206,14 +205,14 @@
   </para>
 
   <sect2 xml:id="sec-samba-yast2-conf">
-   <title>Configuring a samba server with &yast;</title>
+   <title>Configuring a Samba server with &yast;</title>
    <para>
     To configure a Samba server, start &yast; and select
     <menuchoice><guimenu>Network Services</guimenu><guimenu>Samba
     Server</guimenu></menuchoice>.
    </para>
    <sect3 xml:id="sec-samba-yast2-conf-inst">
-    <title>Initial samba configuration</title>
+    <title>Initial Samba configuration</title>
     <para>
      When starting the module for the first time, the <guimenu>Samba
      Installation</guimenu> dialog starts, prompting you to make a few basic
@@ -283,7 +282,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-samba-yast2-conf-adv">
-    <title>Advanced samba configuration</title>
+    <title>Advanced Samba configuration</title>
     <para>
      During the first start of the Samba server module the <guimenu>Samba
      Configuration</guimenu> dialog appears directly after the two initial
@@ -646,7 +645,7 @@
      </varlistentry>
     </variablelist>
     <warning>
-     <title>Do not share <literal>NFS</literal> mounts with samba</title>
+     <title>Do not share <literal>NFS</literal> mounts with Samba</title>
      <para>
       Sharing <literal>NFS</literal> mounts with Samba may result in data loss
       and is not supported. Install Samba directly on the file server or
@@ -721,7 +720,7 @@
   </para>
 
   <sect2 xml:id="sec-samba-client-inst-yast">
-   <title>Configuring a samba client with &yast;</title>
+   <title>Configuring a Samba client with &yast;</title>
    <para>
     Configure a Samba client to access resources (files or printers) on the
     Samba or Windows server. Enter the NT or Active Directory domain or
@@ -880,13 +879,13 @@ smbpasswd -a -m hostname</screen>
 <screen>net groupmap add ntgroup="Domain Admins" unixgroup=ntadmin</screen>
  </sect1>
  <sect1 xml:id="sec-samba-adnet" os="sles;osuse">
-  <title>Samba server in the network with active directory</title>
+  <title>Samba server in the network with Active Directory</title>
 
   <para>
    If you run Linux servers and Windows servers together, you can build two
    independent authentication systems and networks or connect servers to one
    network with one central authentication system. Because Samba can cooperate
-   with an active directory domain, you can join your &productname; server with
+   with an Active Directory domain, you can join your &productname; server with
    an Active Directory (AD) domain.
   </para>
 
@@ -1085,7 +1084,7 @@ smbpasswd -a -m hostname</screen>
     </para>
 <screen>&prompt.sudo;systemctl restart nmb smb</screen>
     <figure xml:id="fig-yast2-samba-snapshot">
-     <title>Adding a new samba share with snapshots enabled</title>
+     <title>Adding a new Samba share with snapshots enabled</title>
      <mediaobject>
       <imageobject role="fo">
        <imagedata fileref="yast2_samba_snapshot.png" width="75%" format="PNG"/>
@@ -1230,7 +1229,7 @@ password:       (null)</screen>
      <filename>/srv/smb</filename> is the path to the SMB share.
     </para>
     <procedure>
-     <title>Detailed samba server configuration</title>
+     <title>Detailed Samba server configuration</title>
      <step>
       <para>
        Join Active Directory domain via &yast;.<phrase os="sles;osuse"> For

--- a/xml/net_samba.xml
+++ b/xml/net_samba.xml
@@ -44,12 +44,12 @@
     <term>SMB protocol</term>
     <listitem>
      <para>
-      Samba uses the SMB (server message block) protocol that is
-      based on the <phrase role="productname">NetBIOS</phrase> services.
-      Microsoft released the protocol so other software manufacturers could
-      establish connections to a Microsoft domain network. With Samba, the SMB
-      protocol works on top of the TCP/IP protocol, so the TCP/IP protocol must
-      be installed on all clients.
+      Samba uses the SMB (server message block) protocol, which is
+      based on <phrase role="productname">NetBIOS</phrase> services.
+      Microsoft released the protocol so that software from other manufacturers
+      could establish connections to a servers running Microsoft operating
+      systems. Samba implements the SMB protocol on top of the TCP/IP protocol,
+      which means that TCP/IP must be installed and enabled on all clients.
      </para>
      <tip arch="zseries" os="sles">
       <title>&zseries;: NetBIOS support</title>
@@ -64,11 +64,16 @@
     <term>CIFS protocol</term>
     <listitem>
      <para>
-      The CIFS (Common Internet File System) protocol, also known as SMB1, is
-      an early version of the SMB protocol. CIFS defines a standard remote file
-      system access protocol for use over the network, enabling groups of users
-      to work together and share documents across the network. In recent
-      versions of Samba, it is disabled by default for security reasons.
+      The CIFS (Common Internet File System) protocol is an early version of the
+      SMB protocol, also known as SMB1. CIFS defines a standard remote file
+      system access protocol for use over TCP/IP, enabling groups of users
+      to work together and share documents across the Internet.
+     </para>
+     <para>
+      SMB1 was superseded by SMB2, first released as part of Microsoft Windows
+      Vista&trade;. This was in turn superseded by SMB3 in Microsoft Windows
+      8&trade; and Microsoft Windows Server 2012. In recent versions of Samba,
+      SMB1 is disabled by default for security reasons.
      </para>
     </listitem>
    </varlistentry>
@@ -76,25 +81,25 @@
     <term>NetBIOS</term>
     <listitem>
      <para>
-      NetBIOS is a software interface (API) designed for
-      communication between machines providing a name service. It enables
-      machines connected to the network to reserve names for themselves. After
-      reservation, these machines can be addressed by name. There is no central
-      process that checks names. Any machine on the network can reserve as many
-      names as it wants as long as the names are not already in use. The
-      NetBIOS interface can be implemented for different network architectures.
-      An implementation that works relatively closely with network hardware is
-      called <phrase role="productname">NetBEUI</phrase>, but this is often
-      called <phrase role="productname">NetBIOS</phrase>. Network protocols
-      implemented with NetBIOS are IPX from Novell (NetBIOS via TCP/IP) and
-      TCP/IP.
+      <phrase role="productname">NetBIOS</phrase> is a software interface (API)
+      designed for name resolution and communication between computers on a
+      network. It enables machines connected to the network to reserve names for
+      themselves. After reservation, these machines can be addressed by name.
+      There is no central process that checks names. Any machine on the network
+      can reserve as many names as it wants, as long as the names are not
+      already in use. NetBIOS can be implemented on top of different network
+      protocols. One relatively simple, non-routable implementation is called
+      <phrase role="productname">NetBEUI</phrase>. (This is often confused with
+      the NetBIOS API.) NetBIOS is also suppported on top of the Novell
+      IPX/SPX protocol. Since version 3.2, Samba supports NetBIOS over both
+      IPv4 and IPv6.
      </para>
      <para>
       The NetBIOS names sent via TCP/IP have nothing in common with the names
       used in <filename>/etc/hosts</filename> or those defined by DNS. NetBIOS
       uses its own, completely independent naming convention. However, it is
-      recommended to use names that correspond to DNS host names to make
-      administration easier or use DNS natively. This is the default used by
+      recommended to use names that correspond to DNS host names, to make
+      administration easier, or to use DNS natively. This is the default used by
       Samba.
      </para>
     </listitem>
@@ -130,11 +135,17 @@
     <listitem>
      <para>
       SMB servers provide resources to the clients by means of
-      shares. Shares are printers and directories with their subdirectories on
-      the server. It is exported by means of a name and can be accessed by its
-      name. The share name can be set to any name&mdash;it does not need to be
-      the name of the export directory. A printer is also assigned a name.
-      Clients can access the printer by its name.
+      <emphasis>shares</emphasis>. Shares are directories (including their
+      subdirectories) and printers on the server. A share is exported by means
+      of a <emphasis>share name</emphasis>, and can be accessed by this name.
+      The share name can be set to any name&mdash;it does not need to be
+      the name of the export directory. Shared printers are also assigned names.
+      Clients can access shared directories and printers by their names.
+     </para>
+     <para>
+      By convention, share names ending with a dollar symbol
+      (<literal>$</literal>) are hidden; that is, when using a Windows computer
+      to browse available shares, they will not be displayed.
      </para>
     </listitem>
    </varlistentry>
@@ -175,8 +186,8 @@
 
   <para>
    You can start or stop the Samba server automatically (during boot) or
-   manually. Starting and stopping policy is a part of the &yast; Samba server
-   configuration described in <xref linkend="sec-samba-yast2-conf"/>.
+   manually. The starting and stopping policy is a part of the &yast; Samba
+   server configuration described in <xref linkend="sec-samba-yast2-conf"/>.
   </para>
 
   <para>
@@ -269,8 +280,8 @@
      to serve shares using at least the SMB 2.1 protocol.
     </para>
     <para>
-     There are setups in which only SMB1 can be used, for example, because they
-     rely on SMB1's/CIFS's Unix extensions. These extensions have not been
+     There are setups in which only SMB1 can be used&mdash;for example, because
+     they rely on SMB1's/CIFS's Unix extensions. These extensions have not been
      ported to newer protocol versions. If you are in this situation, consider
      changing your setup or see <xref linkend="sec-samba-client-old-server"/>.
     </para>
@@ -284,7 +295,7 @@
    <sect3 xml:id="sec-samba-yast2-conf-adv">
     <title>Advanced Samba configuration</title>
     <para>
-     During the first start of the Samba server module the <guimenu>Samba
+     During the first start of the Samba server module, the <guimenu>Samba
      Configuration</guimenu> dialog appears directly after the two initial
      steps described in <xref linkend="sec-samba-yast2-conf-inst"/>. Use it to
      adjust your Samba server configuration.
@@ -488,7 +499,7 @@
        </para>
        <para>
         If your Windows machines are connected to separate subnets and need to
-        still be aware of each other, you have to set up a WINS server. To turn
+        still be aware of each other, you need to set up a WINS server. To turn
         a Samba server into such a WINS server, set the option <literal>wins
         support = Yes</literal>. Make sure that only one Samba server of the
         network has this setting enabled. The options <literal>wins
@@ -661,7 +672,7 @@
     </para>
     <variablelist>
      <varlistentry>
-      <term>User Level security (<literal>security = user</literal>)</term>
+      <term>User level security (<literal>security = user</literal>)</term>
       <listitem>
        <para>
         This variant introduces the concept of the user to SMB. Each user must
@@ -672,7 +683,7 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term>ADS Level security (<literal>security = ADS</literal>)</term>
+      <term>ADS level security (<literal>security = ADS</literal>)</term>
       <listitem>
        <para>
         In this mode, Samba will act as a domain member in an Active Directory
@@ -684,13 +695,13 @@
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term>Domain Level security (<literal>security = domain</literal>)</term>
+      <term>Domain level security (<literal>security = domain</literal>)</term>
       <listitem>
        <para>
-        This mode will only work correctly if the machine has been joined into
-        a Windows NT Domain. Samba will try to validate user name and password
-        by passing it to a Windows NT Primary or Backup Domain Controller. The
-        same way as a Windows NT Server would do. It expects the encrypted
+        This mode will only work correctly if the machine has been joined to
+        a Windows NT domain. Samba will try to validate the user name and
+        password by passing it to a Windows Primary or Backup Domain Controller,
+        the same way as a Windows Server would do. It expects the encrypted
         passwords parameter to be set to <literal>yes</literal>.
        </para>
       </listitem>
@@ -723,11 +734,11 @@
    <title>Configuring a Samba client with &yast;</title>
    <para>
     Configure a Samba client to access resources (files or printers) on the
-    Samba or Windows server. Enter the NT or Active Directory domain or
+    Samba or Windows server. Enter the Windows or Active Directory domain or
     workgroup in the dialog <menuchoice> <guimenu>Network Services</guimenu>
     <guimenu>Windows Domain Membership</guimenu></menuchoice>. If you activate
     <guimenu>Also Use SMB Information for Linux Authentication</guimenu>, the
-    user authentication runs over the Samba, NT or Kerberos server.
+    user authentication runs over the Samba, Windows, or Kerberos server.
    </para>
    <para>
     Click <guimenu>Expert Settings</guimenu> for advanced configuration
@@ -746,7 +757,7 @@
    <title>Mounting SMB1/CIFS shares on clients</title>
    <para>
     The first version of the SMB network protocol, SMB1 or CIFS, is an old and
-    insecure protocol which has been deprecated by its originator, Microsoft.
+    insecure protocol, which has been deprecated by its originator Microsoft.
     For security reasons, the <command>mount</command> command on
     &productname; will only mount SMB shares using newer protocol versions
     by default, namely SMB 2.1, SMB 3.0, or SMB 3.02.
@@ -754,7 +765,7 @@
    <para>
     However, this change only affects <command>mount</command> and
     mounting via <filename>/etc/fstab</filename>. SMB1 is still
-    available by explicitly requiring it. Use the following command:
+    available by explicitly requiring it. Use the following:
    </para>
    <itemizedlist>
     <listitem>
@@ -827,10 +838,10 @@
   <title>Samba as login server</title>
 
   <para>
-   In enterprise settings, it is often desirable to allow access only to
+   In business settings, it is often desirable to allow access only to
    users registered on a central instance.
    In a Windows-based network, this task is handled by a primary domain
-   controller (PDC). You can use a Windows NT server configured as PDC, but
+   controller (PDC). You can use a Windows Server configured as PDC, but
    this task can also be done with a Samba server. The entries that must be
    made in the <literal>[global]</literal> section of
    <filename>smb.conf</filename> are shown in
@@ -907,8 +918,8 @@ smbpasswd -a -m hostname</screen>
    </step>
    <step>
     <para>
-     Enter the domain to join at <guimenu>Domain or Workgroup</guimenu> in the
-     <guimenu>Windows Domain Membership</guimenu> screen.
+     Enter the domain to join in the <guimenu>Domain or Workgroup</guimenu>
+     field in the <guimenu>Windows Domain Membership</guimenu> screen.
     </para>
     <figure>
      <title>Determining Windows domain membership</title>
@@ -964,7 +975,7 @@ smbpasswd -a -m hostname</screen>
 
   <para>
    This section introduces more advanced techniques to manage both the client
-   and server part of the Samba suite.
+   and server parts of the Samba suite.
   </para>
 
   <sect2 xml:id="sec-samba-advanced-compress">
@@ -1030,9 +1041,9 @@ smbpasswd -a -m hostname</screen>
    <title>Snapshots</title>
    <para>
     Snapshots, also called Shadow Copies, are copies of the state of a file
-    system subvolume at a certain point of time. Snapper is the tool to manage
+    system subvolume at a certain point in time. Snapper is the tool to manage
     these snapshots in Linux. Snapshots are supported on the Btrfs file system
-    or thinly-provisioned LVM volumes. The Samba suite supports managing
+    or thinly provisioned LVM volumes. The Samba suite supports managing
     remote snapshots through the FSRVP protocol on both the server and client
     side.
    </para>
@@ -1040,7 +1051,7 @@ smbpasswd -a -m hostname</screen>
     <title>Previous versions</title>
     <para>
      Snapshots on a Samba server can be exposed to remote Windows clients as
-     file or directory previous versions.
+     previous versions of files or directories.
     </para>
     <para>
      To enable snapshots on a Samba server, the following conditions must be
@@ -1054,12 +1065,12 @@ smbpasswd -a -m hostname</screen>
      </listitem>
      <listitem>
       <para>
-       The SMB network share path has a related snapper configuration file. You
+       The SMB network share path has a related Snapper configuration file. You
        can create the snapper file with
       </para>
 <screen>&prompt.sudo;snapper -c &lt;cfg_name&gt; create-config <option>/path/to/share</option></screen>
       <para>
-       For more information on snapper, see <xref linkend="cha-snapper"/>.
+       For more information on Snapper, see <xref linkend="cha-snapper"/>.
       </para>
      </listitem>
      <listitem>
@@ -1072,15 +1083,15 @@ smbpasswd -a -m hostname</screen>
     </itemizedlist>
     <para>
      To support remote snapshots, you need to modify the
-     <filename>/etc/samba/smb.conf</filename> file. You can do it either with
+     <filename>/etc/samba/smb.conf</filename> file. You can do this either with
      <menuchoice><guimenu>&yast;</guimenu><guimenu>Network
      Services</guimenu><guimenu>Samba Server</guimenu></menuchoice>, or
      manually by enhancing the relevant share section with
     </para>
 <screen>vfs objects = snapper</screen>
     <para>
-     Note that you need to restart the Samba service for manual
-     <filename>smb.conf</filename> changes to take effect:
+     Note that you need to restart the Samba service for manual changes to
+     <filename>smb.conf</filename> to take effect:
     </para>
 <screen>&prompt.sudo;systemctl restart nmb smb</screen>
     <figure xml:id="fig-yast2-samba-snapshot">
@@ -1095,7 +1106,7 @@ smbpasswd -a -m hostname</screen>
      </mediaobject>
     </figure>
     <para>
-     After being configured, snapshots created by snapper for the Samba share
+     After being configured, snapshots created by Snapper for the Samba share
      path can be accessed from Windows Explorer from a file or directory's
      <guimenu>Previous Versions</guimenu> tab.
     </para>
@@ -1115,8 +1126,8 @@ smbpasswd -a -m hostname</screen>
     <title>Remote share snapshots</title>
     <para>
      By default, snapshots can only be created and deleted on the Samba server
-     locally, via the snapper command line utility, or using snapper's time
-     line feature.
+     locally, via the Snapper command line utility, or using Snapper's timeline
+     feature.
     </para>
     <para>
      Samba can be configured to process share snapshot creation and deletion
@@ -1214,31 +1225,32 @@ password:       (null)</screen>
    <sect3 xml:id="sec-samba-advanced-snapshots-client-winserver">
     <title>Managing snapshots remotely from Windows with <command>DiskShadow.exe</command></title>
     <para>
-     You can manage snapshots of SMB shares on the Linux Samba server from the
-     Windows environment acting as a client as well. Windows Server 2012
-     includes the <command>DiskShadow.exe</command> utility that can manage
-     remote shares similar to the <command>rpcclient</command> described in
+     You can manage snapshots of SMB shares on the Linux Samba server from
+     Windows clients as well. Windows Server 2012 includes the
+     <command>DiskShadow.exe</command> utility which can manage remote shares
+     similarly to the <command>rpcclient</command> command described in
      <xref linkend="sec-samba-advanced-snapshots-client-linux"/>. Note that you
      need to carefully set up the Samba server first.
     </para>
     <para>
-     Following is an example procedure to set up the Samba server so that the
-     Windows Server client can manage its share's snapshots. Note that <replaceable>EXAMPLE</replaceable>
-     is the Active Directory domain used in the testing environment,
-     <uri>fsrvp-server.example.com</uri> is the host name of the Samba server, and
-     <filename>/srv/smb</filename> is the path to the SMB share.
+     The following is an example procedure to set up the Samba server so that
+     the Windows client can manage its shares' snapshots. Note that
+     <replaceable>EXAMPLE</replaceable> is the Active Directory domain used in
+     the testing environment, <uri>fsrvp-server.example.com</uri> is the host
+     name of the Samba server, and <filename>/srv/smb</filename> is the path to
+     the SMB share.
     </para>
     <procedure>
      <title>Detailed Samba server configuration</title>
      <step>
       <para>
        Join Active Directory domain via &yast;.<phrase os="sles;osuse"> For
-       more information, <xref linkend="sec-samba-adnet"/>.</phrase>
+       more information, see <xref linkend="sec-samba-adnet"/>.</phrase>
       </para>
      </step>
      <step>
       <para>
-       Ensure that the Active Domain DNS entry was correct:
+       Ensure that the Active Directory domain's DNS entry is correct:
       </para>
 <screen>fsrvp-server:~ # net -U 'Administrator' ads dns register \
 fsrvp-server.example.com &lt;IP address&gt;
@@ -1252,16 +1264,17 @@ Successfully registered hostname with DNS</screen>
      </step>
      <step>
       <para>
-       Create snapper configuration file for path <filename>/srv/smb</filename>
+       Create a Snapper configuration file for the path
+       <filename>/srv/smb</filename>:
       </para>
 <screen>fsrvp-server:~ # snapper -c &lt;snapper_config&gt; create-config /srv/smb</screen>
      </step>
      <step>
       <para>
-       Create new share with path <filename>/srv/smb</filename>, and &yast;
-       <guimenu>Expose Snapshots</guimenu> check box enabled. Make sure to add
-       the following snippets to the global section of
-       <filename>/etc/samba/smb.conf</filename> as mentioned in
+       Create a new share with path <filename>/srv/smb</filename>, and the
+       &yast; <guimenu>Expose Snapshots</guimenu> check box enabled. Make sure
+       to add the following snippets to the global section of
+       <filename>/etc/samba/smb.conf</filename>, as mentioned in
        <xref linkend="sec-samba-advanced-snapshots-server"/>:
       </para>
 <screen>[global]
@@ -1276,13 +1289,13 @@ Successfully registered hostname with DNS</screen>
      </step>
      <step>
       <para>
-       Configure snapper permissions:
+       Configure Snapper permissions:
       </para>
 <screen>fsrvp-server:~ # snapper -c &lt;snapper_config&gt; set-config \
 ALLOW_USERS="EXAMPLE\\\\Administrator EXAMPLE\\\\win-client$"</screen>
       <para>
-       Ensure that any ALLOW_USERS are also permitted traversal of the
-       <filename>.snapshots</filename> subdirectory.
+       Ensure that any instances of <literal>ALLOW_USERS</literal> are also
+       permitted access to the <filename>.snapshots</filename> subdirectory.
       </para>
 <screen>fsrvp-server:~ # snapper -c &lt;snapper_config&gt; set-config SYNC_ACL=yes</screen>
       <important>
@@ -1348,7 +1361,8 @@ DISKSHADOW&gt; begin backup</screen>
      </step>
      <step>
       <para>
-       Specify that shadow copy persists across program exit, reset or reboot:
+       Specify that shadow copies persist across program exits, resets, and
+       reboots:
       </para>
 <screen>DISKSHADOW&gt; set context PERSISTENT</screen>
      </step>
@@ -1418,8 +1432,8 @@ No shadow copies found in system.</screen>
     <formalpara>
      <title>Man pages:</title>
      <para>
-      To see a list of all man pages installed with the package
-      <package>samba</package>, run <command>apropos samba</command>.
+      To see a list of all <command>man</command> pages installed with the
+      package <package>samba</package>, run <command>apropos samba</command>.
       Open any of the man pages with
       <command>man <replaceable>NAME_OF_MAN_PAGE</replaceable></command>.
      </para>
@@ -1436,7 +1450,7 @@ No shadow copies found in system.</screen>
    </listitem>
    <listitem>
     <formalpara>
-     <title>Additional packaged documentation:</title>
+     <title>Additional package documentation:</title>
      <para>
       Install the package <systemitem>samba-doc</systemitem> with
       <command>zypper install samba-doc</command>.

--- a/xml/storage_fcoe.xml
+++ b/xml/storage_fcoe.xml
@@ -6,7 +6,7 @@
 ]>
 
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-fcoe" xml:lang="en">
- <title>Fibre channel storage over ethernet networks: FCoE</title>
+ <title>Fibre Channel storage over Ethernet networks: FCoE</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>

--- a/xml/storage_filesystems.xml
+++ b/xml/storage_filesystems.xml
@@ -26,7 +26,7 @@
  <para>
   With &sle; 12, Btrfs is the default file system for the operating system and
   XFS is the default for all other use cases. &suse; also continues to support
-  the Ext family of file systems, and OCFS2. By default, the Btrfs file system
+  the Ext family of file systems and OCFS2. By default, the Btrfs file system
   will be set up with subvolumes. Snapshots will be automatically enabled for
   the root file system using the snapper infrastructure. For more information
   about snapper, refer to <xref linkend="cha-snapper"/>.
@@ -241,7 +241,7 @@
     <para>
      Use the <option>compress</option> or <option>compress-force</option>
      mount option and select the compression algorithm, <literal>zstd</literal>,
-     <literal>lzo</literal> or <literal>zlib</literal> (the default). zlib
+     <literal>lzo</literal>, or <literal>zlib</literal> (the default). zlib
      compression has a higher compression ratio while lzo is faster and takes
      less CPU load. The zstd algorithm offers a modern compromise, with
      performance close to lzo and compression ratios similar to zlib.
@@ -475,12 +475,12 @@ Id Path      single   single    single   Unallocated
    <title>Btrfs quota support for subvolumes</title>
    <para>
     The Btrfs root file system subvolumes (for example,
-    <filename>/var/log</filename>, <filename>/var/crash</filename> or
+    <filename>/var/log</filename>, <filename>/var/crash</filename>, or
     <filename>/var/cache</filename>) can use all of the available disk space
     during normal operation, and cause a system malfunction. To help avoid this
     situation, &productname; offers quota support for Btrfs subvolumes. If you
-    set up the root file system from a &yast; proposal, you
-    are ready to enable and set subvolume quotas.
+    set up the root file system from a &yast; proposal, you are ready to enable
+    and set subvolume quotas.
    </para>
    <sect3 xml:id="setting-btrfs-quotas-using-yast">
     <title>Setting Btrfs quotas using &yast;</title>
@@ -510,7 +510,8 @@ Id Path      single   single    single   Unallocated
      <step>
       <para>
        In the <guimenu>Edit Btrfs</guimenu> window, activate the <guimenu>Enable
-       Subvolume Quotas</guimenu> check-box and confirm with <guimenu>Next</guimenu>.
+       Subvolume Quotas</guimenu> check box and confirm with
+       <guimenu>Next</guimenu>.
       </para>
       <figure>
        <title>Enabling Btrfs quotas</title>
@@ -641,36 +642,58 @@ Id Path      single   single    single   Unallocated
    </sect3>
   </sect2>
 
-<sect2 xml:id="sec-filesystems-major-btrfs-swapping">
-	<title>Swapping on Btrfs</title>
-<important>
-<title>Snapshots with swapping</title>
-<para>You will not be able to create a snapshot if there is any enabled swap file in the source subvolume.</para>
-</important>
-	<para>
-	&slsa; supports swapping to a file on the btrfs file system if the following criteria relating to the resulting swap file are fulfilled:
-</para>
-<itemizedlist>
-	<listitem>
-		<para>the swap file must have the <option>NODATACOW</option> and <option>NODATASUM</option> mount options.</para>
-	</listitem>
-	<listitem>
-		<para>the swap file can not be compressed&mdash;that you can accomplish by setting the <option>NODATACOW</option> and <option>NODATASUM</option> mount options. Both options disable the swap file compression.</para>
-	</listitem>
-<listitem>
-		<para>the swap file can not be activated while exclusive operations are running&mdash;such as device resizing, adding, removing or replacing or when a balancing operation is running.</para>
-	</listitem>
-<listitem>
-		<para>The swap file can not be sparse.</para>
-	</listitem>
-<listitem>
-		<para>The swap file can not be an inline file.</para>
-	</listitem>
-<listitem>
-		<para>The swap file must be on a <literal>single</literal> allocation profile file system.</para>
-	</listitem>
-</itemizedlist>
-</sect2>
+  <sect2 xml:id="sec-filesystems-major-btrfs-swapping">
+	  <title>Swapping on Btrfs</title>
+    <important>
+     <title>Snapshots with swapping</title>
+     <para>
+      You will not be able to create a snapshot if there is any enabled swap
+      file in the source subvolume.
+     </para>
+    </important>
+	   <para>
+	    &slsa; supports swapping to a file on the Btrfs file system if the
+	    following criteria relating to the resulting swap file are fulfilled:
+    </para>
+    <itemizedlist>
+	    <listitem>
+		    <para>
+		     The swap file must have the <option>NODATACOW</option> and
+		     <option>NODATASUM</option> mount options.
+		    </para>
+	    </listitem>
+	    <listitem>
+		    <para>
+		     The swap file can not be compressed&mdash;you can ensure this by setting
+		     the <option>NODATACOW</option> and <option>NODATASUM</option>
+		     mount options. Both options disable swap file compression.
+		    </para>
+	    </listitem>
+     <listitem>
+		    <para>
+		     The swap file cannot be activated while exclusive operations are
+		     running&mdash;such as device resizing, adding, removing, or replacing, or
+		     when a balancing operation is running.
+		    </para>
+	    </listitem>
+     <listitem>
+		    <para>
+		     The swap file cannot be sparse.
+		    </para>
+	    </listitem>
+     <listitem>
+		    <para>
+		     The swap file can not be an inline file.
+		    </para>
+	    </listitem>
+     <listitem>
+		    <para>
+		     The swap file must be on a <literal>single</literal> allocation profile
+		     file system.
+		    </para>
+	    </listitem>
+    </itemizedlist>
+   </sect2>
 
   <sect2 xml:id="sec-filesystems-major-btrfs-s-r">
    <title>Btrfs send/receive</title>
@@ -2036,7 +2059,7 @@ inode_ratio = 8192</screen>
     prevention of this issue.
    </para>
    <sect3 xml:id="sec-filesystems-trouble-btrfs-volfull-snapshots">
-    <title>Disk space consumed by snapper snapshots</title>
+    <title>Disk space consumed by Snapper snapshots</title>
     <para>
      If Snapper is running for the Btrfs file system, the <quote><literal>No
      space left on device</literal></quote> problem is typically caused by
@@ -2073,7 +2096,7 @@ Label: none uuid: 40123456-cb2c-4678-8b3d-d014d1c78c78
       <para>
        This command attempts to relocate data in empty or near-empty data
        chunks, allowing the space to be reclaimed and reassigned to metadata.
-       This can take a while (many hours for 1 TB) although the system is
+       This can take a while (many hours for 1&nbsp;TB) although the system is
        otherwise usable during this time.
       </para>
      </step>
@@ -2173,9 +2196,9 @@ Label: none uuid: 40123456-cb2c-4678-8b3d-d014d1c78c78
    <itemizedlist>
     <listitem>
      <para>
-      Assume you have 1&nbsp;TB drive with 600&nbsp;GB used by data and you add
-      another 1&nbsp;TB drive. The balancing will theoretically result in
-      having 300&nbsp;GB used space on each drive.
+      Assume you have a 1&nbsp;TB drive with 600&nbsp;GB used by data and you
+      add another 1&nbsp;TB drive. The balancing will theoretically result in
+      having 300&nbsp;GB of used space on each drive.
      </para>
     </listitem>
     <listitem>
@@ -2188,13 +2211,13 @@ Label: none uuid: 40123456-cb2c-4678-8b3d-d014d1c78c78
      <para>
       You need to compact half-empty block group based on the percentage of
       their usage. The following command will balance block groups whose usage
-      is 5&nbsp;% or less:
+      is 5% or less:
      </para>
 <screen>&prompt.sudo;btrfs balance start -dusage=5 /</screen>
      <tip>
       <para>
        The <filename>/etc/cron.weekly/btrfs-balance</filename> script takes
-       care of cleaning up unused block groups on weekly basis.
+       care of cleaning up unused block groups on a weekly basis.
       </para>
      </tip>
     </listitem>

--- a/xml/storage_iscsi.xml
+++ b/xml/storage_iscsi.xml
@@ -1482,7 +1482,7 @@ Configuration restored from /etc/target/example.json
     <para>
      To test whether the configured target is working, connect to it using the
      <package>open-iscsi</package> iSCSI initiator installed on the same
-     system (replace <replaceable>HOSTNAME</replaceable> with the hostname of
+     system (replace <replaceable>HOSTNAME</replaceable> with the host name of
      the local machine):
     </para>
 <screen>&prompt.user;iscsiadm -m discovery -t st -p <replaceable>HOSTNAME</replaceable></screen>
@@ -1491,7 +1491,7 @@ Configuration restored from /etc/target/example.json
    </para>
 <screen>192.168.20.3:3260,1 iqn.2003-01.org.linux-iscsi.e83.x8664:sn.8b35d04dd456</screen>
     <para>
-     You can then connect to the listed target using the
+     You can then connect to the listed target using the 
      <command>login</command> iSCSI command. This makes the target available as
      a local disk.
     </para>

--- a/xml/storage_lvm.xml
+++ b/xml/storage_lvm.xml
@@ -127,8 +127,8 @@
   <note>
    <title>LVM and RAID</title>
    <para>
-    Even though LVM also supports RAID of&nbsp;0/1/4/5/6&nbsp;levels, we
-    recommend to use MD RAID (see <xref linkend="cha-raid"/>). However,
+    Even though LVM also supports RAID levels 0, 1, 4, 5 and 6, we recommend
+    using <literal>mdraid</literal> (see <xref linkend="cha-raid"/>). However,
     LVM works fine with RAID&nbsp;0 and 1, as RAID&nbsp;0 is similar to common
     logical volume management (individual logical blocks are mapped onto blocks
     on the physical devices). LVM used on top of RAID&nbsp;1 can keep
@@ -136,8 +136,8 @@
     synchronization process. With higher RAID levels you need a management
     daemon that monitors the states of attached disks and can inform
     administrators if there is a problem in the disk array. LVM includes such a
-    daemon, but in exceptional situations like a device failure, the daemon
-    does not working properly.
+    daemon, but in exceptional situations such as a device failure, the daemon
+    does not work properly.
    </para>
   </note>
 
@@ -153,7 +153,7 @@
   </warning>
 
   <para>
-   With these features, using LVM already makes sense for heavily used home PCs
+   With these features, using LVM already makes sense for heavily-used home PCs
    or small servers. If you have a growing data stock, as in the case of
    databases, music archives, or user directories, LVM is especially useful. It
    allows file systems that are larger than the physical hard disk. However,
@@ -597,11 +597,11 @@
     and removing.
    </para>
    <sect3 xml:id="sec-mirroring-procedure">
-    <title>Setting up mirrored non-raid logical volumes</title>
+    <title>Setting up mirrored non-RAID logical volumes</title>
     <para>
      To create a mirrored volume use the <command>lvcreate</command> command.
-     The following example creates a 500 GB logical volume with two mirrors
-     called <emphasis>lv1</emphasis> which uses a volume group
+     The following example creates a 500&nbsp;GB logical volume with two mirrors
+     called <emphasis>lv1</emphasis>, which uses a volume group
      <emphasis>vg1</emphasis>.
     </para>
 <screen>&prompt.sudo;lvcreate -L 500G -m 2 -n lv1 vg1</screen>
@@ -1031,14 +1031,14 @@ root's password:
    </step>
    <step>
     <para>
-     Depending on your choice warning dialogues are shown. Confirm them with
+     Depending on your choice, warning dialogs are shown. Confirm them with
      <guimenu>Yes</guimenu>.
     </para>
    </step>
    <step>
     <para>
      Click <guimenu>Next</guimenu>, verify that the deleted volume group is
-     listed (deletion is indicated by a red colored font), then click
+     listed&mdash;deletion is indicated by a red-colored font&mdash;then click
      <guimenu>Finish</guimenu>.
     </para>
    </step>
@@ -1048,10 +1048,10 @@ root's password:
   <title>Using LVM commands</title>
 
   <para>
-   For information about using LVM commands, see the man pages for the commands
-   described in the following table. All commands need to be executed with
-   &rootuser; privileges. Either use <command>sudo</command>
-   <replaceable>COMMAND</replaceable> (recommended) or execute them directly as
+   For information about using LVM commands, see the <command>man</command>
+   pages for the commands described in the following table. All commands need to
+   be executed with &rootuser; privileges. Either use <command>sudo</command>
+   <replaceable>COMMAND</replaceable> (recommended), or execute them directly as
    &rootuser;.
   </para>
 

--- a/xml/storage_multipath.xml
+++ b/xml/storage_multipath.xml
@@ -1066,7 +1066,7 @@
   <para/>
 
   <sect2 xml:id="sec-multipath-configuration-start">
-   <title>Enabling, disabling, starting and stopping multipath I/O services</title>
+   <title>Enabling, disabling, starting, and stopping multipath I/O services</title>
    <para>
     To enable multipath services to start at boot time, run the following
     command:
@@ -4621,14 +4621,14 @@ Give root password for maintenance
      At this stage, you are working in a temporary <command>dracut</command>
      emergency shell from the initrd environment. To make the configuration
      changes described below persistent, you need to perform them in the
-     in the environment of the installed system.
+     environment of the installed system.
     </para>
     <procedure>
      <step>
       <para>
        Identify what the system root (<filename>/</filename>) file system is.
-       Inspect the content of the <filename>/proc/cmdline</filename> and
-       look for the <option>root=</option> parameter.
+       Inspect the content of <filename>/proc/cmdline</filename> and look for
+       the <option>root=</option> parameter.
       </para>
      </step>
      <step>

--- a/xml/storage_nfs.xml
+++ b/xml/storage_nfs.xml
@@ -30,12 +30,12 @@
   <title>Overview</title>
   <para>
    The <emphasis>Network File System</emphasis> (NFS) is a standardized,
-   well-proven and widely supported network protocol that allows files to
+   well-proven, and widely-supported network protocol that allows files to
    be shared between separate hosts.
   </para>
   <para>
    The <emphasis>Network Information Service</emphasis> (NIS) can be used
-   to have a centralized user management in the network. Combining NFS
+   to have centralized user management in the network. Combining NFS
    and NIS allows using file and directory permissions for access control
    in the network. NFS with NIS makes a network transparent to the user.
   </para>
@@ -50,8 +50,8 @@
    Often, this level of security is perfectly satisfactory, such
    as when the network that is trusted is truly private, often localized
    to a single cabinet or machine room, and no unauthorized access is
-   possible. In other cases the need to trust a whole subnet as a unit
-   is restrictive and there is a need for more fine-grained trust. To
+   possible. In other cases, the need to trust a whole subnet as a unit
+   is restrictive, and there is a need for more fine-grained trust. To
    meet the need in these cases, NFS supports various security levels
    using the <emphasis>&krb;</emphasis> infrastructure. &krb; requires
    NFSv4, which is used by default. For details, see
@@ -133,8 +133,9 @@
    <title>Need for DNS</title>
    <para>
     In principle, all exports can be made using IP addresses only. To avoid
-    time-outs, you need a working DNS system. DNS is necessary at least for
-    logging purposes, because the <systemitem class="daemon">mountd</systemitem> daemon does reverse lookups.
+    timeouts, you need a working DNS system. DNS is necessary at least for
+    logging purposes, because the <systemitem class="daemon">mountd</systemitem>
+    daemon does reverse lookups.
    </para>
   </important>
  </sect1>
@@ -253,7 +254,7 @@
         <literal>localdomain</literal> (the default) if you do not run
         <systemitem class="daemon">idmapd</systemitem> or do not have any
         special requirements. For more information on the <systemitem
-        class="daemon">idmapd</systemitem> daemon see <xref
+        class="daemon">idmapd</systemitem> daemon, see <xref
         linkend="var-nfs-export-manual-idmapd"/>.
        </para>
       </step>
@@ -332,7 +333,7 @@
    <note>
     <title>NFSv4</title>
     <para>
-     NFSv4 is the latest version of NFS protocol available on &productname;.
+     NFSv4 is the latest version of the NFS protocol available on &productname;.
      Configuring directories for export with NFSv4 is now the same as with
      NFSv3.
     </para>
@@ -365,9 +366,9 @@
        (<literal>@my-hosts</literal>).
       </para>
       <para>
-       For a detailed explanation of all options and their meaning, refer to
-       the man page of <filename>/etc/exports</filename> (<command>man
-       exports</command>).
+       For a detailed explanation of all options and their meanings, refer to
+       the <literal>man</literal> page of <filename>/etc/exports</filename>:
+       (<command>man exports</command>).
       </para>
       <para>
        In case you have modified <filename>/etc/exports</filename> while the
@@ -433,7 +434,7 @@ MOUNTD_OPTIONS="-V2"</screen>
      <listitem>
       <para>
        The <systemitem class="daemon">idmapd</systemitem> daemon is only
-       required if &krb; authentication is used, or if clients cannot work
+       required if &krb; authentication is used or if clients cannot work
        with numeric user names. Linux clients can work with numeric user names
        since Linux kernel 2.6.39. The <systemitem
        class="daemon">idmapd</systemitem> daemon does the name-to-ID mapping
@@ -447,12 +448,12 @@ MOUNTD_OPTIONS="-V2"</screen>
       </para>
       <para>
        Make sure that there is a uniform way in which user names and IDs (UIDs)
-       are assigned to users across machines that might probably be sharing
-       file systems using NFS. This can be achieved by using NIS, LDAP, or any
-       uniform domain authentication mechanism in your domain.
+       are assigned to users across machines that might be sharing file systems
+       using NFS. This can be achieved by using NIS, LDAP, or any uniform domain
+       authentication mechanism in your domain.
       </para>
       <para>
-       The parameter <literal>Domain</literal> must be set the same for both,
+       The parameter <literal>Domain</literal> must be set the same for both
        client and server in the <filename>/etc/idmapd.conf</filename> file. If
        you are not sure, leave the domain as <literal>localdomain</literal> in
        the server and client files. A sample configuration file looks like the
@@ -523,7 +524,7 @@ Nobody-Group = nobody</screen>
    <para>
     &krb; authentication also requires the <systemitem
     class="daemon">idmapd</systemitem> daemon to run on the server. For more
-    information refer to <xref linkend="var-nfs-export-manual-idmapd"/>.
+    information, refer to <xref linkend="var-nfs-export-manual-idmapd"/>.
    </para>
    <para>
     For more information about configuring kerberized NFS, refer to the links
@@ -579,7 +580,7 @@ Nobody-Group = nobody</screen>
     <step>
      <para>
       Enable <guimenu>Open Port in Firewall</guimenu> in the <guimenu>NFS
-      Settings</guimenu> tab if you use a Firewall and want to allow access to
+      Settings</guimenu> tab if you use a firewall and want to allow access to
       the service from remote computers. The firewall status is displayed next
       to the check box.
      </para>
@@ -600,16 +601,16 @@ Nobody-Group = nobody</screen>
    <tip>
     <title>NFS as a root file system</title>
     <para>
-     On (diskless) systems, where the root partition is mounted via network as
+     On (diskless) systems where the root partition is mounted via network as
      an NFS share, you need to be careful when configuring the network device
      with which the NFS share is accessible.
     </para>
     <para>
      When shutting down or rebooting the system, the default processing order
-     is to turn off network connections, then unmount the root partition. With
+     is to turn off network connections then unmount the root partition. With
      NFS root, this order causes problems as the root partition cannot be
      cleanly unmounted as the network connection to the NFS share is already
-     not activated. To prevent the system from deactivating the relevant
+     deactivated. To prevent the system from deactivating the relevant
      network device, open the network device configuration tab as described in
      <xref linkend="sec-network-yast-change-start"/> and choose <guimenu>On
      NFSroot</guimenu> in the <guimenu>Device Activation</guimenu> pane.
@@ -641,8 +642,8 @@ Nobody-Group = nobody</screen>
     a running RPC port mapper. The <option>nfs</option> service takes care to
     start it properly; thus, start it by entering <command>systemctl start
     nfs</command> as <systemitem class="username">root</systemitem>. Then
-    remote file systems can be mounted in the file system like local partitions
-    using <command>mount</command>:
+    remote file systems can be mounted in the file system just like local
+    partitions, using the <command>mount</command>:
    </para>
 <screen>&prompt.sudo;mount <replaceable>HOST</replaceable>:<replaceable>REMOTE-PATH</replaceable><replaceable>LOCAL-PATH</replaceable></screen>
    <para>
@@ -650,18 +651,38 @@ Nobody-Group = nobody</screen>
     machine, for example, use:
    </para>
 <screen>&prompt.sudo;mount &nfsname;:/home /home</screen>
-<para>To define a count of TCP connections that the clients makes to the NFS server, you can use the <literal>nconnect</literal> option of the <command>mount</command> command. You can specify any number between 1 and 16, where 1 is the default value if the mount option has not been specified.</para>
-<para>The <literal>nconnect</literal> setting is applied only during the first mount process to the particular NFS server. If the same client executes the mount command to the same NFS server, all already established connections will be shared&mdash;no new connection will be established. To change the <literal>nconnect</literal> setting, you have to unmount <emphasis role="bold">all</emphasis> clients connections to the particular NFS server. Then you can define a new value of the <literal>nconnect</literal> option.
-</para>
-<para>
-You can find the current <literal>nconnect</literal> value in effect in output of the <command>mount</command> or in the file <filename>/proc/mounts</filename>. If there is no value of the mount option, then the option has not been used during mounting and the default value <emphasis>1</emphasis> is in use.
-</para>
-<note>
-<title>Different number of connections than defined by <literal>nconnect</literal></title>
-<para>
-As you can close and open connections after the first mount, the actual count of connections necessarily does not have to be the same as the value of <literal>nconnect</literal>.
-</para>
-</note>
+   <para>
+    To define a count of TCP connections that the clients make to the NFS
+    server, you can use the <literal>nconnect</literal> option of the
+    <command>mount</command> command. You can specify any number between 1 and
+    16, where 1 is the default value if the mount option has not been specified.
+   </para>
+   <para>
+    The <literal>nconnect</literal> setting is applied only during the first
+    mount process to the particular NFS server. If the same client executes the
+    mount command to the same NFS server, all already established connections
+    will be shared&mdash;no new connection will be established. To change the
+    <literal>nconnect</literal> setting, you have to unmount
+    <emphasis role="bold">all</emphasis> client connections to the particular
+    NFS server. Then you can define a new value for the
+    <literal>nconnect</literal> option.
+   </para>
+   <para>
+    You can find the value of <literal>nconnect</literal> that is in currently
+    in effect in the output of the <command>mount</command>, or in the file
+    <filename>/proc/mounts</filename>. If there is no value for the mount
+    option, then the option has not been used during mounting and the default
+    value of <emphasis>1</emphasis> is in use.
+   </para>
+   <note>
+    <title>Different number of connections than defined by <literal>nconnect</literal></title>
+    <para>
+     As you can close and open connections after the first mount, the actual
+     count of connections does not necessarily have to be the same as the value
+     of <literal>nconnect</literal>.
+    </para>
+   </note>
+   
    <sect3 xml:id="sec-nfs-automount">
     <title>Using the automount service</title>
     <para>
@@ -726,28 +747,28 @@ nfs4mount -fstype=nfs4 server2:/</screen>
   <sect2 xml:id="sec-nfs-pnfs">
    <title>Parallel NFS (pNFS)</title>
    <para>
-    NFS is one of the oldest protocols, developed in the '80s. As such, NFS is
+    NFS is one of the oldest protocols, developed in the 1980s. As such, NFS is
     usually sufficient if you want to share small files. However, when you want
-    to transfer big files or many clients want to access data, an
-    NFS server becomes a bottleneck and has a significant impact on the system
-    performance. This is because of files quickly getting bigger, whereas the
-    relative speed of your Ethernet has not fully kept up.
+    to transfer big files or many clients want to access data, an NFS server
+    becomes a bottleneck and has a significant impact on the system performance.
+    This is because files are quickly getting bigger, whereas the relative speed
+    of Ethernet has not fully kept pace.
    </para>
    <para>
     When you request a file from a regular NFS server, the server
-    looks up the file metadata, collects all the data and transfers it over the
+    looks up the file metadata, collects all the data, and transfers it over the
     network to your client. However, the performance bottleneck becomes
     apparent no matter how small or big the files are:
    </para>
    <itemizedlist mark="bullet" spacing="normal">
     <listitem>
      <para>
-      With small files most of the time is spent collecting the metadata.
+      With small files, most of the time is spent collecting the metadata.
      </para>
     </listitem>
     <listitem>
      <para>
-      With big files most of the time is spent on transferring the data from
+      With big files, most of the time is spent on transferring the data from
       server to client.
      </para>
     </listitem>
@@ -872,7 +893,7 @@ nfs4mount -fstype=nfs4 server2:/</screen>
    <command>nfs</command>, and <command>mount</command>, information about
    configuring an NFS server and client is available in
    <filename>/usr/share/doc/packages/nfsidmap/README</filename>. For further
-   documentation online refer to the following Web sites:
+   documentation online, refer to the following Web sites:
   </para>
 
   <itemizedlist mark="bullet" spacing="normal">
@@ -922,123 +943,261 @@ nfs4mount -fstype=nfs4 server2:/</screen>
    </listitem>
   </itemizedlist>
  </sect1>
+ 
  <sect1 xml:id="sec-nfs-troubleshooting">
- <title>Gathering information for NFS troubleshooting</title>
- <sect2 xml:id="sec-nfs-common-troubleshooting">
- <title>Common troubleshooting</title>
- <para>In some cases you can understand the problem in your NFS by reading the produced error message and looking into the <filename>/var/log/messages</filename> file. However, in many cases information provided by the error message and in the <filename>/var/log/messages</filename> is not detailed enough. In those cases, most NFS problems can be best understood through capturing network packets while reproducing the problem.</para>
+  <title>Gathering information for NFS troubleshooting</title>
+   <sect2 xml:id="sec-nfs-common-troubleshooting">
+    <title>Common troubleshooting</title>
+     <para>
+      In some cases, you can understand the problem in your NFS by reading the
+      error messages produced and looking into the
+      <filename>/var/log/messages</filename> file. However, in many cases,
+      the information provided by the error messages and in
+      <filename>/var/log/messages</filename> is not detailed enough. In these
+      cases, most NFS problems can be best understood through capturing network
+      packets while reproducing the problem.
+     </para>
  
- <para>Define clearly the problem. Examine the problem by testing the system in a variety of ways and determining when the problem occurs. Isolate the simplest steps that leads to the problem. Then try to reproduce the problem as described in the procedure below.</para>
+     <para>
+      Clearly define the problem. Examine the problem by testing the system in a
+      variety of ways and determining when the problem occurs. Isolate the
+      simplest steps that lead to the problem. Then try to reproduce the
+      problem as described in the procedure below.
+     </para>
  
- <procedure>
- <title>Reproducing the problem</title>
- <step>
- <para>Capture network packets.  On Linux, you can use the <command>tcpdump</command> command, which is supplied by the <literal>tcpdump</literal> package.  And example of <command>tcpdump</command> syntax follows:</para>
- <screen>tcpdump -s0 -i <replaceable>eth0</replaceable> -w <replaceable>/tmp/nfs-demo.cap</replaceable> host <replaceable>x.x.x.x</replaceable></screen>
- <para>where</para>
- <itemizedlist>
- <listitem>
- <para><literal>s0</literal> - prevents packet truncation</para>
- </listitem>
- <listitem>
- <para><literal>eth0</literal> - should be replaced with the name of the local interface which the packets will pass through. You can use the <literal>any</literal> value to capture all interfaces at the same time, but usage of the attribute often results in inferior data as well as confusion in analysis.</para>
- </listitem>
- <listitem>
- <para><literal>w</literal> - designates the name of the capture file to write.</para>
- </listitem>
- <listitem>
- <para><literal>x.x.x.x</literal> - should be replaced with the IP address of the other end of the NFS connection. For example, when taking a tcpdump at the NFS client side, specify the IP address of the NFS Server, and vice versa.</para>
- </listitem>
- </itemizedlist>
- <note>
- <para>In some cases, capturing the data at either the NFS client or NFS Server is sufficient. However, in cases were end-to-end network integrity is in doubt, it is often necessary to capture data at both ends.</para>
- </note>
- <para>Do not shut down the <command>tcpdump</command> process and proceed to the next step.</para>
+     <procedure>
+      <title>Reproducing the problem</title>
+       <step>
+        <para>
+         Capture network packets.  On Linux, you can use the
+         <command>tcpdump</command> command, which is supplied by the
+         <package>tcpdump</package> package.
+        </para>
+        <para>
+         An example of <command>tcpdump</command> syntax follows:
+        </para>
+<screen>tcpdump -s0 -i <replaceable>eth0</replaceable> -w <replaceable>/tmp/nfs-demo.cap</replaceable> host <replaceable>x.x.x.x</replaceable></screen>
+        <para>
+         Where:
+        </para>
+        <variablelist>
+         <varlistentry>
+          <term>s0</term>
+          <listitem>
+           <para>Prevents packet truncation
+           </para> 
+          </listitem>
+         </varlistentry>
+         <varlistentry>
+          <term>eth0</term>
+          <listitem>
+           <para>
+            Should be replaced with the name of the local interface which the
+            packets will pass through. You can use the <literal>any</literal>
+            value to capture all interfaces at the same time, but usage of this
+            attribute often results in inferior data as well as confusion in
+            analysis.
+           </para>
+          </listitem>
+         </varlistentry>
+         <varlistentry>
+          <term>w</term>
+         <listitem>
+          <para>
+           Designates the name of the capture file to write.
+          </para>
+         </listitem>
+         </varlistentry>
+         <varlistentry>
+          <term>x.x.x.x</term>
+          <listitem>
+           <para>
+            Should be replaced with the IP address of the other end of the NFS
+            connection. For example, when taking a <command>tcpdump</command> at
+            the NFS client side, specify the IP address of the NFS Server, and
+            vice versa.
+           </para>
+          </listitem>
+         </varlistentry>
+        </variablelist>
+       <note>
+        <para>
+         In some cases, capturing the data at either the NFS client or NFS
+         server is sufficient. However, in cases where end-to-end network
+         integrity is in doubt, it is often necessary to capture data at both
+         ends.
+        </para>
+       </note>
+       <para>
+        Do not shut down the <command>tcpdump</command> process and proceed to
+        the next step.
+       </para>
+      </step>
+      <step>
+       <para>
+        (Optional) If the problem occurs during execution of the
+        <command>nfs mount</command> command itself, you can try to use the
+        high-verbosity option (<literal>-vvv</literal>) of the
+        <command>nfs mount</command> command to get more output.
+       </para>
   </step>
   <step>
-  <para>(Optional) If the problem occurs during execution of the <command>nfs mount</command> command itself, you can try to use the high verbosity option (<literal>-vvv</literal>) of the <command>nfs mount</command> command to get more output.</para>
+   <para>
+    (Optional) Get an <command>strace</command> of the reproduction method. An
+    <command>strace</command> of reproduction steps records exactly what system
+    calls were made at exactly what time. This information can be used to
+    further determine on which events in the <literal>tcpdump</literal> you
+    should focus.
+   </para>
+   <para>
+    For example, if you found out that executing the command
+    <emphasis>mycommand --param</emphasis> was failing on an NFS mount, then you
+    can <command>strace</command> the command with:
+   </para>
+<screen>strace -ttf -s128 -o/tmp/nfs-strace.out mycommand --param</screen>
+   <para>
+    In case you do not get any <command>strace</command> of the reproduction
+    step, note the time when the problem was reproduced. Check the
+    <filename>/var/log/messages</filename> log file to isolate the problem.
+   </para>
   </step>
   <step>
-  <para>(Optional) Get an strace of the reproduction method. An strace of a reproduction steps exactly records what system calls were made at exactly what time. This information can be used to further determine on which events in the <literal>tcpdump</literal> you should focus.</para>
-  <para>For example, if you found out that executing the command <emphasis>mycommand --param</emphasis> was failing on an NFS mount, then you can <command>strace</command> the command with:</para>
-  <screen>
-  strace -ttf -s128 -o/tmp/nfs-strace.out mycommand --param
-  </screen>
-  <para>In case you do not get any strace of the reproduction step, note the time when the problem was reproduced. Check the <filename>/var/log/messages</filename> log file to isolate the problem.</para>
+   <para>
+    Once the problem has been reproduced, stop <command>tcpdump</command>
+    running in your terminal by pressing
+    <keycombo><keycap>CTRL</keycap><keycap>c</keycap></keycombo>. If the 
+    <command>strace</command> command resulted in a hang, also terminate the
+    <command>strace</command> command.
+   </para>
   </step>
   <step>
-  <para>Once the problem has been reproduced, stop <command>tcpdump</command> running in your terminal by pressing <keycombo><keycap>CTRL</keycap><keycap>c</keycap></keycombo>. If the <command>strace</command> command  resulted in a hang, terminate also the <command>strace</command> command.</para>
-  
-  </step>
-  <step>
-  <para>An administrator with experience in analyzing packet traces and <command>strace</command> data can now inspect data in <filename>/tmp/nfs-demo.cap</filename> and <filename>/tmp/nfs-strace.out</filename>.</para>
+   <para>
+    An administrator with experience in analyzing packet traces and
+    <command>strace</command> data can now inspect data in
+    <filename>/tmp/nfs-demo.cap</filename> and
+    <filename>/tmp/nfs-strace.out</filename>.
+   </para>
   </step>  
- </procedure>
+  </procedure>
  </sect2>
  
  <sect2 xml:id="sec-advance-debugging">
- <title>Advance NFS debugging</title>
- <important>
- <title>Advance debugging is for experts</title>
- <para>Please bear in mind that the following section is intended only for skilled NFS administrators who understand the NFS code. Therefore, perform first steps described in <xref linkend="sec-nfs-common-troubleshooting"/> to help narrow down the problem and to inform an expert about which areas of debug code (if any) might be needed to learn deeper details.</para>
- </important>
- <para>
- There are various areas of debug code that can be enabled to gather additional NFS-related information.  However, the debug messages are quite cryptic and their volume can be so large that the use of debug code can effect system performance.  It may even impact the system enough to prevent the problem from occurring.  In the majority of cases, the debug code output is not needed, nor is it typically useful to anyone who is not highly familiar with the NFS code.  
- </para>
+  <title>Advanced NFS debugging</title>
+   <important>
+    <title>Advanced debugging is for experts</title>
+    <para>
+     Please bear in mind that the following section is intended only for skilled
+     NFS administrators who understand the NFS code. Therefore, perform the
+     first steps described in <xref linkend="sec-nfs-common-troubleshooting"/>
+     to help narrow down the problem and to inform an expert about which areas
+     of debug code (if any) might be needed to learn deeper details.</para>
+   </important>
+   <para>
+    There are various areas of debug code that can be enabled to gather
+    additional NFS-related information. However, the debug messages are quite
+    cryptic and the volume of them can be so large that the use of debug code
+    can affect system performance. It may even impact the system enough to
+    prevent the problem from occurring. In the majority of cases, the debug code
+    output is not needed, nor is it typically useful to anyone who is not highly
+    familiar with the NFS code.  
+   </para>
  
- <sect3 xml:id="sec-rpcdebug">
- <title>Activating debugging with <command>rpcdebug</command></title>
- <para>The <command>rpcdebug</command> allows you to set and clear NFS client and server debug flags. In case the <command>rpcdebug</command> tool is not accessible in your &slea;, you can install it from the package: <literal>nfs-client</literal> or <literal>nfs-kernel-server</literal> for the NFS server. </para>
- <para>To set debug flags, run:</para>
- <screen>rpcdebug -m <replaceable>module</replaceable> -s flags</screen>
- <para>To clear the debug flags, run:</para>
- <screen>rpcdebug -m <replaceable>module</replaceable> -c flags</screen>
- <para>where <replaceable>module</replaceable> can be</para>
- <variablelist>
- <varlistentry>
- <term>nfsd</term>
- <listitem>
- <para>debug for the NFS server code</para>
- </listitem>
- </varlistentry>
- <varlistentry>
- <term>nfs</term>
- <listitem>
- <para>debug for the NFS client code</para>
- </listitem>
- </varlistentry><varlistentry>
- <term>nlm</term>
- <listitem>
- <para>debug for the NFS Lock Manager, at either the NFS client or NFS server.  This only applies to NFS v2/v3.</para>
- </listitem>
- </varlistentry><varlistentry>
- <term>rpc</term>
- <listitem>
- <para>debug for the Remote Procedure Call module, at either the NFS client or NFS Server.</para>
- </listitem>
- </varlistentry> 
- </variablelist>
- <para>for a detailed usage of the <command>rpcdebug</command> command refer to the manual page:</para>
- <screen>man 8 rpcdebug</screen>
+   <sect3 xml:id="sec-rpcdebug">
+    <title>Activating debugging with <command>rpcdebug</command></title>
+    <para>
+     The <command>rpcdebug</command> tool allows you to set and clear NFS
+     client and server debug flags. In case the <command>rpcdebug</command> tool
+     is not accessible in your &slea;, you can install it from the package
+     <package>nfs-client</package> or <package>nfs-kernel-server</package> for
+     the NFS server.
+    </para>
+    <para>
+     To set debug flags, run:
+    </para>
+<screen>rpcdebug -m <replaceable>module</replaceable> -s flags</screen>
+    <para>
+     To clear the debug flags, run:
+    </para>
+<screen>rpcdebug -m <replaceable>module</replaceable> -c flags</screen>
+    <para>
+     where <replaceable>module</replaceable> can be:
+    </para>
+    <variablelist>
+     <varlistentry>
+      <term>nfsd</term>
+      <listitem>
+      <para>
+       Debug for the NFS server code
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>nfs</term>
+      <listitem>
+      <para>
+       Debug for the NFS client code
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>nlm</term>
+      <listitem>
+       <para>
+        Debug for the NFS Lock Manager, at either the NFS client or NFS server.
+        This only applies to NFS v2/v3.
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term>rpc</term>
+      <listitem>
+      <para>
+       Debug for the Remote Procedure Call module, at either the NFS client or
+       NFS server.
+      </para>
+     </listitem>
+    </varlistentry> 
+   </variablelist>
+   <para>
+    For detailed usage of the <command>rpcdebug</command> command, refer to the
+    manual page:
+   </para>
+<screen>man 8 rpcdebug</screen>
   </sect3>
  
  <sect3 xml:id="sec-other-nfs-debug">
- <title>Activating debug for other code upon which NFS depends</title>
- <para>NFS activities may depend on other related services, such as the nfs mount daemon&mdash;<command>rpc.mountd</command>. You can set options for related services within <filename>/etc/sysconfig/nfs</filename>.</para>
- <para>For example, <filename>/etc/sysconfig/nfs</filename> contains the parameter:</para>
- <screen>MOUNTD_OPTIONS=""</screen>
- <para>To enable the debug mode, you have to use the <literal>-d</literal> option followed by any of the values: <literal>all</literal>, <literal>auth</literal>, <literal>call</literal>, <literal>general</literal> or <literal>parse</literal>.</para>
- <para>For example, the following code enables all forms of <command>rpc.mountd</command> logging.</para>
- <screen>MOUNTD_OPTIONS="-d all"</screen>
- <para>For all available options refer to the manual pages:</para>
- <screen>man 8 rpc.mountd</screen>
- <para>After changing <filename>/etc/sysconfig/nfs</filename>, services needs to be restarted:</para>
- <screen>
-systemctl restart nfsserver  # for nfs server related changes
-systemctl restart nfs  # for nfs client related changes
- </screen>
- </sect3>
- </sect2>
- 
+  <title>Activating debug for other code upon which NFS depends</title>
+  <para>
+   NFS activities may depend on other related services, such as the NFS mount
+   daemon&mdash;<command>rpc.mountd</command>. You can set options for related
+   services within <filename>/etc/sysconfig/nfs</filename>.
+  </para>
+  <para>
+   For example, <filename>/etc/sysconfig/nfs</filename> contains the parameter:
+  </para>
+<screen>MOUNTD_OPTIONS=""</screen>
+  <para>
+   To enable the debug mode, you have to use the <literal>-d</literal> option
+   followed by any of the values: <literal>all</literal>,
+   <literal>auth</literal>, <literal>call</literal>, <literal>general</literal>,
+   or <literal>parse</literal>.
+  </para>
+  <para>
+   For example, the following code enables all forms of
+   <command>rpc.mountd</command> logging:
+  </para>
+<screen>MOUNTD_OPTIONS="-d all"</screen>
+  <para>
+   For all available options refer to the manual pages:
+  </para>
+<screen>man 8 rpc.mountd</screen>
+  <para>
+   After changing <filename>/etc/sysconfig/nfs</filename>, services need to be
+   restarted:
+  </para>
+<screen>systemctl restart nfsserver  # for nfs server related changes
+systemctl restart nfs  # for nfs client related changes</screen>
+   </sect3>
+  </sect2>
  </sect1>
 </chapter>

--- a/xml/storage_nfs.xml
+++ b/xml/storage_nfs.xml
@@ -1052,7 +1052,7 @@ nfs4mount -fstype=nfs4 server2:/</screen>
    <para>
     For example, if you found out that executing the command
     <emphasis>mycommand --param</emphasis> was failing on an NFS mount, then you
-    can <command>strace</command> the command with:
+    could <command>strace</command> the command with:
    </para>
 <screen>strace -ttf -s128 -o/tmp/nfs-strace.out mycommand --param</screen>
    <para>
@@ -1159,8 +1159,8 @@ nfs4mount -fstype=nfs4 server2:/</screen>
     </varlistentry> 
    </variablelist>
    <para>
-    For detailed usage of the <command>rpcdebug</command> command, refer to the
-    manual page:
+    For information on detailed usage of the <command>rpcdebug</command>
+    command, refer to the manual page:
    </para>
 <screen>man 8 rpcdebug</screen>
   </sect3>

--- a/xml/storage_nvmeof.xml
+++ b/xml/storage_nvmeof.xml
@@ -28,9 +28,9 @@
   </para>
   <para>
    <emphasis>&nvmeof;</emphasis> is an architecture to access &nvme;
-   storage over different networking fabrics, for example
-   <emphasis>RDMA</emphasis>, <emphasis>TCP</emphasis> or <emphasis>&nvme; over Fibre
-   Channel</emphasis> (<emphasis>&fcnvme;</emphasis>). The role of
+   storage over different networking fabrics&mdash;for example, 
+   <emphasis>RDMA</emphasis>, <emphasis>TCP</emphasis>, or <emphasis>&nvme; over
+   Fibre Channel</emphasis> (<emphasis>&fcnvme;</emphasis>). The role of
    &nvmeof; is similar to iSCSI. To increase the fault-tolerance,
    &nvmeof; has a built-in support for multipathing. The &nvmeof;
    multipathing is not based on the traditional &dmmpio;.
@@ -55,7 +55,7 @@
   <para>
    To use &nvmeof;, a target must be available with one of the
    supported networking methods. Supported are &nvme; over Fibre
-   Channel, TCP and RDMA. The following sections describe how to connect a
+   Channel, TCP, and RDMA. The following sections describe how to connect a
    host to an &nvme; target.
   </para>
   <sect2 xml:id="sec-nvmeof-host-configuration-cli">
@@ -74,6 +74,7 @@
     execute <command>man nvme-discover</command>.
    </para>
   </sect2>
+  
   <sect2 xml:id="sec-nvmeof-host-configuration-target-discovery">
    <title>Discovering &nvmeof; targets</title>
    <para>
@@ -83,10 +84,10 @@
    <screen>&prompt.sudo;<command>nvme discover -t <replaceable>TRANSPORT</replaceable> -a <replaceable>DISCOVERY_CONTROLLER_ADDRESS</replaceable> -s <replaceable>SERVICE_ID</replaceable></command></screen>
    <para>
     Replace <replaceable>TRANSPORT</replaceable> with the underlying
-    transport medium: <option>loop</option>, <option>rdma</option>, <option>tcp</option> or
-    <option>fc</option>. Replace
+    transport medium: <option>loop</option>, <option>rdma</option>,
+    <option>tcp</option>, or <option>fc</option>. Replace
     <replaceable>DISCOVERY_CONTROLLER_ADDRESS</replaceable> with the
-    address of the discovery controller. For RDMA and TCP this should be an
+    address of the discovery controller. For RDMA and TCP, this should be an
     IPv4 address. Replace <replaceable>SERVICE_ID</replaceable> with
     the transport service ID. If the service is IP based, like RDMA or TCP,
     service ID specifies the port number. For Fibre Channel, the service
@@ -111,7 +112,7 @@
     After you have identified the &nvme; subsystem, you can connect it
     with the <command>nvme connect</command> command.
    </para>
-   <screen>&prompt.sudo;<command>nvme connect -t <replaceable>transport</replaceable> -a <replaceable>DISCOVERY_CONTROLLER_ADDRESS</replaceable> -s <replaceable>SERVICE_ID</replaceable> -n <replaceable>SUBSYSTEM_NQN</replaceable></command></screen>
+<screen>&prompt.sudo;<command>nvme connect -t <replaceable>transport</replaceable> -a <replaceable>DISCOVERY_CONTROLLER_ADDRESS</replaceable> -s <replaceable>SERVICE_ID</replaceable> -n <replaceable>SUBSYSTEM_NQN</replaceable></command></screen>
    <para>
     Replace <replaceable>TRANSPORT</replaceable> with the underlying
     transport medium: <option>loop</option>, <option>rdma</option>, <option>tcp</option> or
@@ -128,7 +129,7 @@
     &nvme; Qualified Name</emphasis>. The NQN must be unique.
    </para>
    <para>Example:</para>
-   <screen>&prompt.sudo;<command>nvme connect -t tcp -a 10.0.0.3 -s 4420 -n nqn.2014-08.com.example:nvme:nvm-subsystem-sn-d78432</command></screen>
+<screen>&prompt.sudo;<command>nvme connect -t tcp -a 10.0.0.3 -s 4420 -n nqn.2014-08.com.example:nvme:nvm-subsystem-sn-d78432</command></screen>
    <para>
     Alternatively, use <command>nvme connect-all</command> to connect
     to all discovered namespaces. For advanced usage see
@@ -139,38 +140,41 @@
   <sect2 xml:id="sec-nvmeof-host-configuration-multipathing">
    <title>Multipathing</title>
    <para>
-    &nvme; native multipathing is enabled by default. If the <option>CMIC</option> option in the controller identify settings is set, the NVMe stack recognises an NVME drive as a multipathed device by default.
-</para>
-<para>To manage the multipathing, you can use the following:</para>
-<variablelist>
-<title>Managing multipathing</title>
-<varlistentry>
-<term><command>nvme list-subsys</command></term>
-<listitem>
-<para>
-prints the layout of the multipath devices.
-</para>
-</listitem>
-</varlistentry>
-<varlistentry>
-<term><command>multipath -ll</command></term>
-<listitem>
-<para>
-the command has a compatibility mode and displays &nvme; multipath devices.
-</para>
-</listitem>
-</varlistentry>
-<varlistentry>
-<term><option>nvme-core.multipath=N</option></term>
-<listitem>
-<para>
-when the option is added as a boot parameter, the NVMe native multipathing will be disabled.
-</para>
-</listitem>
-</varlistentry>
-
-</variablelist>
-      </sect2>
+    &nvme; native multipathing is enabled by default. If the
+    <option>CMIC</option> option in the controller identity settings is set, the
+    NVMe stack recognizes an NVME drive as a multipathed device by default.
+   </para>
+   <para>To manage the multipathing, you can use the following:</para>
+   <variablelist>
+     <title>Managing multipathing</title>
+     <varlistentry>
+      <term><command>nvme list-subsys</command></term>
+     <listitem>
+      <para>
+       Prints the layout of the multipath devices.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><command>multipath -ll</command></term>
+     <listitem>
+     <para>
+      The command has a compatibility mode and displays &nvme; multipath devices.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><option>nvme-core.multipath=N</option></term>
+    <listitem>
+     <para>
+      When the option is added as a boot parameter, the NVMe native multipathing
+      will be disabled.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </sect2>
+  
  </sect1>
  <sect1 xml:id="sec-nvmeof-target-configuration">
   <title>Setting up an &nvmeof; target</title>

--- a/xml/storage_raid.xml
+++ b/xml/storage_raid.xml
@@ -17,7 +17,7 @@
   The purpose of RAID (redundant array of independent disks) is to combine
   several hard disk partitions into one large virtual hard disk to optimize
   performance, data security, or both. Most RAID controllers use the SCSI
-  protocol because it can address a larger number of hard disks in a more
+  protocol, because it can address a larger number of hard disks in a more
   effective way than the IDE protocol and is more suitable for parallel
   processing of commands. There are some RAID controllers that support IDE or
   SATA hard disks. Software RAID provides the advantages of RAID systems
@@ -420,17 +420,17 @@ lrwxrwxrwx 1 8 Dec  9 15:11 myRAID -&gt; ../md127</screen>
      <listitem>
       <para>
        In case a named link to the device is not sufficient for your setup, add
-       the line CREATE names=yes to <filename>/etc/mdadm.conf</filename> by
-       running the following command:
+       the line <literal>CREATE names=yes</literal> to
+       <filename>/etc/mdadm.conf</filename> by running the following command:
       </para>
 <screen>&prompt.sudo;echo "CREATE names=yes" &gt;&gt; /etc/mdadm.conf</screen>
       <para>
-       It will cause names like <literal>myRAID</literal> to be used as a
+       This will cause names like <literal>myRAID</literal> to be used as a
        <quote>real</quote> device name. The device will not only be accessible
        at <filename>/dev/myRAID</filename>, but also be listed as
        <literal>myRAID</literal> under <filename>/proc</filename>. Note that
        this will only apply to RAIDs configured after the change to the
-       configuration file. Active RAIDS will continue to use the
+       configuration file. Active RAIDs will continue to use the
        <literal>mdN</literal> names until they get stopped and re-assembled.
       </para>
       <warning>
@@ -446,14 +446,31 @@ lrwxrwxrwx 1 8 Dec  9 15:11 myRAID -&gt; ../md127</screen>
    </variablelist>
   </sect2>
  </sect1>
+ 
  <sect1 xml:id="sec-raid-counters">
- <title>Monitoring software RAIDs</title>
- <para>You can run <command>mdadm</command> as a daemon in the <literal>monitor</literal> mode to monitor your software RAID. In the <literal>monitor</literal> mode <command>mdadm</command> performs regular checks on the array for disk failures. If there is a failure, <command>mdadm</command> sends an email to the administrator. To define the time interval of the checks, run the following command:</para>
- <screen>mdadm --monitor --mail=root@localhost --delay=1800 /dev/md2</screen>
- <para>The command above turns on monitoring of the <literal>/dev/md2</literal> array in intervals of 1800s. In case of a failure, an email to <literal>root@localhost</literal> will be send.</para>
+  <title>Monitoring software RAIDs</title>
+   <para>
+    You can run <command>mdadm</command> as a daemon in the
+    <literal>monitor</literal> mode to monitor your software RAID. In the
+    <literal>monitor</literal> mode, <command>mdadm</command> performs regular
+    checks on the array for disk failures. If there is a failure,
+    <command>mdadm</command> sends an email to the administrator. To define the
+    time interval of the checks, run the following command:
+   </para>
+<screen>mdadm --monitor --mail=root@localhost --delay=1800 /dev/md2</screen>
+ <para>
+  The command above turns on monitoring of the <literal>/dev/md2</literal> array
+  in intervals of 1800&nbsp;seconds. In the event of a failure, an email will be
+  sent to <literal>root@localhost</literal>.
+ </para>
  <note>
- <title>RAID checks are enabled by default</title>
- 	<para>The RAID checks are enabled by default. It may happen that the interval between each check is not long enough and you may encounter warnings. Thus you can increase the interval by setting higher value by the <literal>delay</literal> option.</para>
+  <title>RAID checks are enabled by default</title>
+ 	<para>
+ 	 The RAID checks are enabled by default. It may happen that the interval
+ 	 between each check is not long enough and you may encounter warnings. Thus,
+ 	 you can increase the interval by setting a higher value with the
+ 	 <literal>delay</literal> option.
+ 	</para>
  </note>
  
  </sect1>

--- a/xml/storage_raid_troubleshooting.xml
+++ b/xml/storage_raid_troubleshooting.xml
@@ -53,12 +53,12 @@
     </listitem>
    </itemizedlist>
    <para>
-    In the case of the disk media or controller failure, the device needs to be
-    replaced or repaired. If a hot-spare was not configured within the RAID,
+    In the case of disk media or controller failure, the device needs to be
+    replaced or repaired. If a hot spare was not configured within the RAID,
     then manual intervention is required.
    </para>
    <para>
-    In the last case, the failed device can be automatically re-added by the
+    In the last case, the failed device can be automatically re-added with the
     <command>mdadm</command> command after the connection is repaired (which
     might be automatic).
    </para>
@@ -69,8 +69,8 @@
     device is reliable.
    </para>
    <para>
-    Under some circumstances&mdash;such as storage devices with the internal
-    RAID array&mdash; the connection problems are very often the cause of the
+    Under some circumstances&mdash;such as storage devices with an internal
+    RAID array&mdash;connection problems are very often the cause of the
     device failure. In such case, you can tell <command>mdadm</command> that it
     is safe to automatically <option>--re-add</option> the device after it
     appears. You can do this by adding the following line to

--- a/xml/storage_raidroot.xml
+++ b/xml/storage_raidroot.xml
@@ -22,7 +22,7 @@
  </para>
  <sect1 xml:id="sec-raidroot-require">
   <title>
-   Prerequisites for Using a Software RAID Device for the Root Partition
+   Prerequisites for using a software RAID device for the root partition
   </title>
 
   <para>
@@ -79,8 +79,8 @@
  </sect1>
  <sect1 xml:id="sec-raidroot-setup">
   <title>
-   Setting Up the System with a Software RAID Device for the Root
-   (<filename>/</filename>) Partition
+   Setting up the system with a software RAID device for the root
+   (<filename>/</filename>) partition
   </title>
 
   <procedure>
@@ -109,14 +109,15 @@
    <step>
     <para>
      (Optional) If there are FCoE target devices that you want to use, you
-     need to configure interface by clicking <menuchoice><guimenu>System</guimenu> 
+     need to configure the interface by clicking <menuchoice><guimenu>System</guimenu> 
      <guimenu>Configure</guimenu> <guimenu>Configure FCoE</guimenu>
      </menuchoice> from the upper left section of the screen. 
     </para>
    </step>
    <step>
    	<para>
-   	(Optional) In case you need to discard the partitioning changes, click <menuchoice><guimenu>System</guimenu><guimenu>Rescan Devices</guimenu></menuchoice>. 
+   	(Optional) In case you need to discard the partitioning changes, click
+   	 <menuchoice><guimenu>System</guimenu><guimenu>Rescan Devices</guimenu></menuchoice>. 
    	</para>
    </step>
    <!-- There is no Configure Multipath now? 
@@ -304,7 +305,9 @@
      </step>
      <step>
      <para>
-     	In the left panel, click the <guimenu>RAID</guimenu>. In the <guimenu>Device Overview</guimenu> tab select your new RAID and click <guimenu>Edit</guimenu>.
+     	In the left panel, click the <guimenu>RAID</guimenu>. In the
+      <guimenu>Device Overview</guimenu> tab, select your new RAID and click
+      <guimenu>Edit</guimenu>.
      </para>
      <informalfigure>
        <mediaobject>
@@ -367,7 +370,12 @@
     </para>
    </step>
    <step>
-   	<para>Optionally you can create a swap partition in RAID. Use similar steps as described above, but under the <guimenu>Role</guimenu> select <guimenu>swap</guimenu>. Select the file system and mount point as shown bellow. Click <guimenu>Next</guimenu></para>
+   	<para>
+   	 Optionally, you can create a swap partition in RAID. Use similar steps
+   	 to those described above, but under the <guimenu>Role</guimenu>, select
+   	 <guimenu>swap</guimenu>. Select the file system and mount point as shown
+   	 below. Click <guimenu>Next</guimenu>.
+   	</para>
    	<informalfigure>
        <mediaobject>
         <imageobject role="fo">
@@ -381,10 +389,10 @@
    </step>
    <step>
     <para>
-     Optionally for UEFI machines, use similar steps to create the
-     <filename>/boot/efi</filename> mounted partition. Remember that only RAID
-     1 is supported for <filename>/boot/efi</filename>, and the partition needs
-     to be formatted with the FAT file system.
+     Optionally, for UEFI machines, use similar steps to create the
+     <filename>/boot/efi</filename> mounted partition. Remember that only
+     RAID&nbsp;1 is supported for <filename>/boot/efi</filename>, and the
+     partition needs to be formatted with the FAT32 file system.
     </para>
     <informalfigure>
        <mediaobject>
@@ -429,7 +437,7 @@
     <para>
      Whenever you reboot your server, Device Mapper is started at boot time so
      that the software RAID is automatically recognized, and the operating
-     system on the root (/) partition can be started.
+     system on the root (<literal>/</literal>) partition can be started.
     </para>
    </step>
   </procedure>


### PR DESCRIPTION
### Description

Integrate Dublin proofreading suggestions into the Storage Guide.

Note: I have made some additional changes, including rewords to the introductory material in the Samba chapter, as this was badly confused and included some incorrect information.


### Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [ ] 15 SP4  |*(no backport necessary)*
| [ ] 15 SP3  | [ ]
| [ ] 15 SP2  | [ ]
| [ ] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
