### PR TITLE
Manual PXE boot when installing new VM (bsc#1185327)

### DIFF
--- a/xml/libvirt_guest_installation.xml
+++ b/xml/libvirt_guest_installation.xml
@@ -132,8 +132,11 @@
       <term><guimenu>Manual install</guimenu></term>
       <listitem>
        <para>
-        To install a specific product version, start typing its name&mdash;for example, <literal>sles</literal>&mdash;and select it once a match appears.
-        Verify that the product's bootable disk or image is available to the virtual machine.
+        This installation method is suitable if you want to create a virtual
+        machine, manually configure its components, and install its OS later.
+        To adjust the VM to a specific product version, start typing its
+        name&mdash;for example, <literal>sles</literal>&mdash;and select it
+        once a match appears.
        </para>
       </listitem>
      </varlistentry>
@@ -214,6 +217,62 @@
     installing a &vmguest;.
    </para>
   </tip>
+  <sect2 xml:id="tip-libvirt-inst-vmm-pxe">
+   <title>Configuring the virtual machine for PXE boot</title>
+   <para>
+    PXE boot enables your virtual machine to boot the installation media from
+    network instead of from a physical medium or an installation disk image.
+    Refer to <xref linkend="cha-deployment-prep-pxe"/> for more details about
+    setting up the PXE boot environment.
+   </para>
+   <para>
+    To let your VM boot from a PXE server, follow these steps:
+   </para>
+   <procedure>
+    <step>
+     <para>
+      Start the installation wizard as described in
+      <xref linkend="sec-libvirt-inst-vmm"/>.
+     </para>
+    </step>
+    <step>
+     <para>
+      Select the <guimenu>Manual Install</guimenu> method.
+     </para>
+    </step>
+    <step>
+     <para>
+      Proceed to the last step of the wizard and activate <guimenu>Customize
+      configuration before install</guimenu>. Confirm with
+      <guimenu>Finish</guimenu>.
+     </para>
+    </step>
+    <step>
+     <para>
+      On the <guimenu>Customize</guimenu> screen, select <guimenu>Boot
+      Options</guimenu>.
+     </para>
+    </step>
+    <step>
+     <para>
+      Inspect <guimenu>Boot device order</guimenu> and activate the box next to
+      <guimenu>Enable boot menu</guimenu>.
+     </para>
+    </step>
+    <step>
+     <para>
+      Under <guimenu>Enable boot menu</guimenu>, activate <guimenu>Network
+      PXE</guimenu> and confirm with <guimenu>Apply</guimenu>.
+     </para>
+    </step>
+    <step>
+     <para>
+      Start the installation by clicking <guimenu>Begin Installation</guimenu>.
+      If a PXE server is properly configured, the PXE menu screen will appear.
+     </para>
+    </step>
+   </procedure>
+  </sect2>
  </sect1>
  <sect1 xml:id="sec-libvirt-inst-virt-install">
   <title>Installing from the command line with <command>virt-install</command></title>

--- a/xml/libvirt_guest_installation.xml
+++ b/xml/libvirt_guest_installation.xml
@@ -135,8 +135,8 @@
         This installation method is suitable if you want to create a virtual
         machine, manually configure its components, and install its OS later.
         To adjust the VM to a specific product version, start typing its
-        name&mdash;for example, <literal>sles</literal>&mdash;and select it
-        once a match appears.
+        name&mdash;for example, <literal>sles</literal>&mdash;and select the
+        desired version once a match appears.
        </para>
       </listitem>
      </varlistentry>

--- a/xml/libvirt_guest_installation.xml
+++ b/xml/libvirt_guest_installation.xml
@@ -170,8 +170,10 @@
      On the last screen of the wizard, specify the name for the virtual
      machine. To be offered the possibility to review and make changes to the
      virtualized hardware selection, activate <guimenu>Customize configuration
-     before install</guimenu>. Find options to specify the network device under
-     <guimenu>Network Selection</guimenu>.
+     before install</guimenu>. Specify the network device under
+     <guimenu>Network Selection</guimenu>. When using <guimenu>Bridge
+     device</guimenu>, the first bridge found on the host is pre-filled. To use
+     a different bridge, manually update the text-field with its name.
     </para>
     <para>
      Click <guimenu>Finish</guimenu>.

--- a/xml/libvirt_guest_installation.xml
+++ b/xml/libvirt_guest_installation.xml
@@ -224,8 +224,8 @@
    <para>
     PXE boot enables your virtual machine to boot the installation media from
     network instead of from a physical medium or an installation disk image.
-    Refer to <xref linkend="cha-deployment-prep-pxe"/> for more details about
-    setting up the PXE boot environment.
+    <phrase os="sles">Refer to <xref linkend="cha-deployment-prep-pxe"/> for
+    more details about setting up a PXE boot environment.</phrase>
    </para>
    <para>
     To let your VM boot from a PXE server, follow these steps:


### PR DESCRIPTION
### Description

PXE boot option was removed from VMM. This update describes how to configure it manually.


### Are there any relevant issues/feature requests?

* bsc#1185327
* jsc#DOCTEAM-172


### To which product versions do the changes apply?

The first column is to be filled by the requester, the second column is to be filled by the doc team after the changes have been backported to the maintenance branches.

| Code 15     | Backport Done
| ----------  | ----------
| [x] 15 SP4  |*(no backport necessary)*
| [x] 15 SP3  | [ ]
| [ ] 15 SP2  | [ ]
| [ ] 15 SP1  | [ ]
| [ ] 15 SP0  | [ ]

| Code 12     | Backport Done
| ----------  | ----------
| [ ] 12 SP5  | [ ]
| [ ] 12 SP4  | [ ]
| [ ] 12 SP3  | [ ]
| [ ] 12 SP2  | [ ]
