### PR TITLE
Update AY Guide for SLE Micro with additional profiling

### DIFF
--- a/xml/ay_auto_installation.xml
+++ b/xml/ay_auto_installation.xml
@@ -166,7 +166,7 @@ xml:id="Invoking">
      If you install via PXE, the installation will run in an endless
      loop. This happens because after the first reboot, the machine performs
      the PXE boot again and restarts the installation instead of booting from
-     the hard disk for the second stage of the installation.
+     the hard disk<phrase os="sles;sled;osuse"> for the second stage of the installation</phrase>.
     </para>
     <para>
      There are several ways to solve this problem. You can use an HTTP
@@ -811,7 +811,7 @@ textmode: 1
     </para>
    </sect2>
   </sect1>
-  <sect1 xml:id="System-Configuration">
+  <sect1 os="sles;sled;osuse" xml:id="System-Configuration">
    <title>System configuration</title>
 
    <para>

--- a/xml/ay_configuration_installation_options.xml
+++ b/xml/ay_configuration_installation_options.xml
@@ -81,10 +81,10 @@
   <xi:include os="sles;sled;slemicro;osuse" href="ay_networking.xml"/>
   <xi:include os="sles;sled;osuse" href="ay_nis_client.xml"/>
   <xi:include os="sles;sled;osuse" href="ay_nis_server.xml"/>
-  <xi:include os="sles;sled;slemicro;osuse" href="ay_hosts.xml"/>
+  <xi:include os="sles;sled;osuse" href="ay_hosts.xml"/>
   <xi:include os="sles;sled;osuse" href="ay_windows_domain_client.xml"/>
   <xi:include os="sles;sled;osuse" href="ay_samba_server.xml"/>
-  <xi:include os="sles;sled;slemicro;osuse" href="ay_auth_client.xml"/>
+  <xi:include os="sles;sled;osuse" href="ay_auth_client.xml"/>
   <xi:include os="sles;sled;osuse" href="ay_nfs.xml"/>
   <xi:include os="sles;sled;osuse" href="ay_ntp_client.xml"/>
   <xi:include os="sles;sled;osuse" href="ay_mail_server.xml"/>
@@ -92,7 +92,7 @@
   <xi:include os="sles;sled;osuse" href="ay_squid_server.xml"/>
   <xi:include os="sles;sled;osuse" href="ay_ftp_server.xml"/>
   <xi:include os="sles;sled;osuse" href="ay_tftp_server.xml"/>
-  <xi:include os="sles;sled;slemicro;osuse" href="ay_firstboot.xml"/>
+  <xi:include os="sles;sled;osuse" href="ay_firstboot.xml"/>
   <xi:include os="sles;sled;slemicro;osuse" href="ay_security_settings.xml"/>
   <xi:include os="sles;sled;osuse" href="ay_audit_framework.xml"/>
   <xi:include os="sles;sled;slemicro;osuse" href="ay_users_groups.xml"/>
@@ -103,7 +103,7 @@
   <xi:include os="sles;sled;slemicro;osuse" href="ay_kernel_dumps.xml"/>
   <xi:include os="sles;sled;osuse" href="ay_dns_server.xml"/>
   <xi:include os="sles;sled;osuse" href="ay_dhcp_server.xml"/>
-  <xi:include os="sles;sled;slemicro;osuse" href="ay_firewall.xml"/>
+  <xi:include os="sles;sled;osuse" href="ay_firewall.xml"/>
   <xi:include os="sles;sled;osuse" href="ay_hardware.xml"/>
   <xi:include os="sles;sled;slemicro;osuse" href="ay_import_ssh.xml"/>
   <xi:include os="sles;sled;slemicro;osuse" href="ay_configuration_management.xml"/>

--- a/xml/ay_custom_user_scripts.xml
+++ b/xml/ay_custom_user_scripts.xml
@@ -24,8 +24,13 @@
     stages of the installation.
    </para>
 
-   <para>
+   <para os="sles;sled;osuse">
     In the auto-installation process, five types of scripts can be executed
+    at different points in time during the installation:
+   </para>
+   
+    <para os="slemicro">
+    In the auto-installation process, three types of scripts can be executed
     at different points in time during the installation:
    </para>
 

--- a/xml/ay_general_options.xml
+++ b/xml/ay_general_options.xml
@@ -54,11 +54,13 @@
   &lt;storage&gt;<co xml:id="co-ay-general-storage"/>
    ...
   &lt;/storage&gt;
-  &lt;wait&gt;<co xml:id="co-ay-general-wait"/>
+  <phrase os="sles;sled;osuse">&lt;wait&gt;</phrase><co os="sles;sled;osuse" xml:id="co-ay-general-wait"/>
    ...
-  &lt;/wait&gt;
+  <phrase os="sles;sled;osuse">&lt;/wait&gt;</phrase>
  &lt;/general&gt;
 &lt;profile&gt;</screen>
+
+
   <calloutlist>
    <callout arearefs="co-ay-general-ask">
     <para>
@@ -111,7 +113,7 @@
      <xref linkend="CreateProfile-Partitioning" xrefstyle="HeadingOnPage"/>
     </para>
    </callout>
-   <callout arearefs="co-ay-general-wait">
+   <callout os="sles;sled;osuse" arearefs="co-ay-general-wait">
     <para>
 <!-- The Wait Section -->
      <xref linkend="CreateProfile-General-wait" xrefstyle="HeadingOnPage"/>
@@ -129,7 +131,7 @@
    </para>
 
    <variablelist>
-    <varlistentry>
+    <varlistentry os="sles;sled;osuse">
      <term><tag class="element">activate_systemd_default_target</tag>
      </term>
      <listitem>
@@ -196,7 +198,7 @@
 </general>]]></screen>
      </listitem>
     </varlistentry>
-    <varlistentry>
+    <varlistentry os="sles;sled;osuse">
      <term><tag class="element">final_halt</tag>
      </term>
      <listitem>
@@ -215,7 +217,7 @@
 </general>]]></screen>
      </listitem>
     </varlistentry>
-    <varlistentry>
+    <varlistentry os="sles;sled;osuse">
      <term><tag class="element">final_reboot</tag>
      </term>
      <listitem>
@@ -234,7 +236,7 @@
 </general>]]></screen>
      </listitem>
     </varlistentry>
-    <varlistentry>
+    <varlistentry os="sles;sled;osuse">
      <term><tag class="element">final_restart_services</tag>
      </term>
      <listitem>
@@ -289,9 +291,9 @@
       <para>
        Shuts down the machine after the first stage. All packages and the
        boot loader have been installed and all your chroot scripts have run.
-       Instead of rebooting into stage two, the machine is turned off. If you
+       <phrase os="sles;sled;osuse">Instead of rebooting into stage two, the machine is turned off. If you
        turn it on again, the machine boots and the second stage of the
-       autoinstallation starts. Setting this value is optional. The default is
+       autoinstallation starts.</phrase><phrase os="slemicro">After the installation is complete, the machine is turned off instead of rebooting.</phrase> Setting this value is optional. The default is
        <literal>false</literal>.
       </para>
 <screen><![CDATA[<general>
@@ -302,7 +304,7 @@
 </general>]]></screen>
      </listitem>
     </varlistentry>
-    <varlistentry>
+    <varlistentry os="sles;sled;osuse">
      <term><tag class="element">max_systemd_wait</tag>
      </term>
      <listitem>
@@ -650,7 +652,7 @@
    </variablelist>
   </sect2>
 
-  <sect2 xml:id="CreateProfile-General-wait">
+  <sect2 os="sles;sled;osuse" xml:id="CreateProfile-General-wait">
    <title>The wait section</title>
 
    <para>
@@ -757,7 +759,7 @@
      The scripts in the pre- and post-modules sections are only dummy scripts
      illustrating the concept.
     </para>
-<screen><![CDATA[<?xml version="1.0"?>
+<screen os="sles;sled;osuse"><![CDATA[<?xml version="1.0"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns"
  xmlns:config="http://www.suse.com/1.0/configns">
@@ -832,6 +834,51 @@ echo "Sleeping 10 seconds"
   </wait>
  </general>
 </profile>]]></screen>
+<screen os="slemicro">
+<![CDATA[<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns"
+ xmlns:config="http://www.suse.com/1.0/configns">
+ <general>
+  <! -- Use cio_ignore on &zseries; only -->
+  <cio_ignore config:type="boolean">false</cio_ignore>
+  <mode>
+   <halt config:type="boolean">false</halt>
+   <forceboot config:type="boolean">false</forceboot>
+   <final_reboot config:type="boolean">false</final_reboot>
+   <final_halt config:type="boolean">false</final_halt>
+   <confirm_base_product_license config:type="boolean">
+    false
+   </confirm_base_product_license>
+   <confirm config:type="boolean">true</confirm>
+   <second_stage config:type="boolean">true</second_stage>
+  </mode>
+  <proposals config:type="list">
+   <proposal>partitions_proposal</proposal>
+  </proposals>
+  <self_update config:type="boolean">true</self_update>
+  <self_update_url>http://example.com/updates/$arch</self_update_url>
+  <signature-handling>
+   <accept_unsigned_file config:type="boolean">
+    true
+   </accept_unsigned_file>
+   <accept_file_without_checksum config:type="boolean">
+    true
+   </accept_file_without_checksum>
+   <accept_verification_failed config:type="boolean">
+    true
+   </accept_verification_failed>
+   <accept_unknown_gpg_key config:type="boolean">
+    true
+   </accept_unknown_gpg_key>
+   <import_gpg_key config:type="boolean">true</import_gpg_key>
+   <accept_non_trusted_gpg_key config:type="boolean">
+   true
+   </accept_non_trusted_gpg_key>
+  </signature-handling>
+  </general>
+</profile>]]>
+</screen>
    </example>
   </sect2>
  </sect1>


### PR DESCRIPTION
re BSC# 1185835, profiled second stage options not supported
in SLE Micro. No AY second-stage options are supported.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(if applicable to 15 SP4 _only_ -- do not merge yet!)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
