### PR TITLE
FTP server uses RSA certificates

### DIFF
--- a/xml/yast2_ftp.xml
+++ b/xml/yast2_ftp.xml
@@ -219,7 +219,7 @@
   <para>
    If you want encrypted communication between clients and the server, you can
    <guimenu>Enable SSL</guimenu>. Check the versions of the protocol to be
-   supported and specify the DSA certificate to be used for SSL encrypted
+   supported and specify the RSA certificate to be used for SSL encrypted
    connections.
 <!--use the FTPS protocol (FTP/SSH). However note that FTPS is different
    from the much more common SFTP (SSH File Transport Protocol) protocol.


### PR DESCRIPTION
## PR creator: Description

Five years ago, yast2-ftp-server was [adapted to use RSA certificates](https://github.com/yast/yast-ftp-server/pull/18). Unfortunately, we did not update the interface. This problem was revealed by [bsc#1183786](https://bugzilla.suse.com/show_bug.cgi?id=1183786) and @dgdavid noticed that we needed to update the docs too.

We fixed the label in all versions (starting in SLE 12 SP5).

Thanks!

### PR creator: Are there any relevant issues/feature requests?

* [bsc#1183786](https://bugzilla.suse.com/show_bug.cgi?id=1183786)

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(if applicable to 15 SP4 _only_ -- do not merge yet!)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [x] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
