### PR TITLE
AutoYaST: make proxy settings more clear

### DIFF
--- a/xml/ay_configuration_installation_options.xml
+++ b/xml/ay_configuration_installation_options.xml
@@ -79,6 +79,7 @@
   <xi:include os="sles;sled;osuse" href="ay_upgrade.xml"/>
   <xi:include os="sles;sled;slemicro;osuse" href="ay_services_targets.xml"/>
   <xi:include os="sles;sled;slemicro;osuse" href="ay_networking.xml"/>
+  <xi:include os="sles;sled;slemicro;osuse" href="ay_proxy.xml"/>
   <xi:include os="sles;sled;osuse" href="ay_nis_client.xml"/>
   <xi:include os="sles;sled;osuse" href="ay_nis_server.xml"/>
   <xi:include os="sles;sled;osuse" href="ay_hosts.xml"/>

--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -1040,32 +1040,6 @@
     </tip>
    </sect2>
 
-   <sect2 xml:id="Configuration-Network-Proxy">
-    <title>Proxy</title>
-    <para>
-     Configure your Internet proxy (caching) settings.
-    </para>
-    <para>
-     Configure proxies for HTTP, HTTPS, and FTP with
-     <literal>http_proxy</literal>, <literal>https_proxy</literal>
-     and <literal>ftp_proxy</literal>, respectively. Addresses or names that
-     should be directly accessible need to be specified with
-     <literal>no_proxy</literal> (space separated values). If you are using
-     a proxy server with authorization, fill in
-     <literal>proxy_user</literal> and <literal>proxy_password</literal>,
-    </para>
-    <example>
-     <title>Network configuration: proxy</title>
-<screen>&lt;proxy&gt;
-  &lt;enabled config:type="boolean"&gt;true&lt;/enabled&gt;
-  &lt;ftp_proxy&gt;http://192.168.1.240:3128&lt;/ftp_proxy&gt;
-  &lt;http_proxy&gt;http://192.168.1.240:3128&lt;/http_proxy&gt;
-  &lt;no_proxy&gt;www.&exampledomain; .&exampledomain2; localhost&lt;/no_proxy&gt;
-  &lt;proxy_password&gt;testpw&lt;/proxy_password&gt;
-  &lt;proxy_user&gt;testuser&lt;/proxy_user&gt;
-&lt;/proxy&gt;</screen>
-    </example>
-   </sect2>
    <!-- 2017-10-20 tbazant: xinetd is gone (https://fate.suse.com/323373)
    <sect2 xml:id="Configuration-Network-Inetd">
     <title>(X)Inetd</title>

--- a/xml/ay_proxy.xml
+++ b/xml/ay_proxy.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect1
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+    %entities;
+]>
+
+<sect1 version="5.0" xml:id="Configuration-Network-Proxy"
+  xmlns="http://docbook.org/ns/docbook"
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>Proxy</title>
+
+ <info>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker></dm:bugtracker>
+   <dm:translation>yes</dm:translation>
+  </dm:docmanager>
+ </info>
+
+  <para>
+   Configure your Internet proxy (caching) settings.
+  </para>
+  <para>
+   Configure proxies for HTTP, HTTPS, and FTP with
+   <literal>http_proxy</literal>, <literal>https_proxy</literal>
+   and <literal>ftp_proxy</literal>, respectively. Addresses or names that
+   should be directly accessible need to be specified with
+   <literal>no_proxy</literal> (space separated values). If you are using
+   a proxy server with authorization, fill in
+   <literal>proxy_user</literal> and <literal>proxy_password</literal>,
+  </para>
+  <example>
+   <title>Network configuration: proxy</title>
+<screen>&lt;proxy&gt;
+  &lt;enabled config:type="boolean"&gt;true&lt;/enabled&gt;
+  &lt;ftp_proxy&gt;http://192.168.1.240:3128&lt;/ftp_proxy&gt;
+  &lt;http_proxy&gt;http://192.168.1.240:3128&lt;/http_proxy&gt;
+  &lt;no_proxy&gt;www.&exampledomain; .&exampledomain2; localhost&lt;/no_proxy&gt;
+  &lt;proxy_password&gt;testpw&lt;/proxy_password&gt;
+  &lt;proxy_user&gt;testuser&lt;/proxy_user&gt;
+&lt;/proxy&gt;</screen>
+  </example>
+  <note>
+   <para>
+    The proxy settings will be written during the installation when the network
+    configuration is forced to be written before the proposal or when the proxy settings
+    are given through <command>linuxrc</command>.
+   </para>
+  </note>
+ </sect1>


### PR DESCRIPTION
### PR creator: Description

The proxy documentation is currently under the networking section which leads to errors expecting the resource to be also under the networking resource.

This PR tries to make it a little bit clearer.

There are some fixes about the behavior that will be available in SLE-15-SP3 through a maintenance update.

### PR creator: Are there any relevant issues/feature requests?

* https://bugzilla.suse.com/show_bug.cgi?id=1185016
* Related to (https://github.com/SUSE/doc-sle/pull/752)

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [X] SLE 15 SP4/openSUSE Leap 15.4 *(if applicable to 15 SP4 _only_ -- do not merge yet!)*
  - [X] SLE 15 SP3/openSUSE Leap 15.3 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
