### PR TITLE
UEFI Secure Boot improvements for ARM (jsc#SLE-15822)

### DIFF
--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -354,6 +354,7 @@ they also have a trademark policy, let's be careful here. -->
 <!ENTITY virsh           "<command xmlns='http://docbook.org/ns/docbook'>virsh</command>">
 <!ENTITY ptp             "Precision Time Protocol">
 <!ENTITY ntp             "Network Time Protocol">
+<!ENTITY uefisecboot     "UEFI Secure Boot">
 <!ENTITY chrony          "<systemitem xmlns='http://docbook.org/ns/docbook' class='resource'>chrony</systemitem>">
 <!ENTITY chronyd         "<systemitem xmlns='http://docbook.org/ns/docbook' class='daemon'>chronyd</systemitem>">
 <!ENTITY chronyc         "<command xmlns='http://docbook.org/ns/docbook'>chronyc</command>">

--- a/xml/libvirt_guest_installation.xml
+++ b/xml/libvirt_guest_installation.xml
@@ -462,7 +462,7 @@ network=vnet_nated</screen>
      </para>
      <para>
       &uefisecboot; will be used automatically when setting up a new VM
-      with OVMF. To use a specific firmware, use <option>--boot
+      with OVMF. To use specific firmware, use <option>--boot
       loader=<replaceable>PATH_TO_FIRMWARE</replaceable></option>.
       </para>
       <para>

--- a/xml/libvirt_guest_installation.xml
+++ b/xml/libvirt_guest_installation.xml
@@ -463,10 +463,16 @@ network=vnet_nated</screen>
      <para>
       &uefisecboot; will be used automatically when setting up a new VM
       with OVMF. To use a specific firmware, use <option>--boot
-      loader=/usr/share/qemu/ovmf-<replaceable>VERSION</replaceable>.bin</option>.
-      Replace <replaceable>VERSION</replaceable> with the file you
-      need.
-     </para>
+      loader=<replaceable>PATH_TO_FIRMWARE</replaceable></option>.
+      </para>
+      <para>
+       For example, for the &aarch64; architecture:
+      </para>
+<screen>--boot loader=/usr/share/qemu/qemu-uefi-aarch32.bin</screen>
+      <para>
+       And for the &x86-64;; architecture:
+      </para>
+<screen>--boot loader=/usr/share/qemu/ovmf-x86_64-opensuse.bin</screen>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/xml/libvirt_guest_installation.xml
+++ b/xml/libvirt_guest_installation.xml
@@ -452,7 +452,7 @@ network=vnet_nated</screen>
     </listitem>
    </varlistentry>
    <varlistentry xml:id="vle-libvirt-inst-virt-install-ovmf">
-    <term>Using UEFI and secure boot</term>
+    <term>Using &uefisecboot;</term>
     <listitem>
      <para>
       Install OVMF as described in <xref
@@ -461,7 +461,7 @@ network=vnet_nated</screen>
       <command>virt-install</command> command.
      </para>
      <para>
-      Secure boot will be used automatically when setting up a new VM
+      &uefisecboot; will be used automatically when setting up a new VM
       with OVMF. To use a specific firmware, use <option>--boot
       loader=/usr/share/qemu/ovmf-<replaceable>VERSION</replaceable>.bin</option>.
       Replace <replaceable>VERSION</replaceable> with the file you

--- a/xml/vt_installation.xml
+++ b/xml/vt_installation.xml
@@ -275,7 +275,7 @@
   </para>
   <para>
    The firmware used by virtual machines is auto-selected. The auto-selection
-   is based on the *.json files in the firmware package described above. The
+   is based on the JSON files in the firmware package described above. The
    &libvirt; &qemu; driver parses those files when loading so it knows the
    capabilities of the various types of firmware. Then when the user selects
    the type of firmware and any desired features (for example, support for

--- a/xml/vt_installation.xml
+++ b/xml/vt_installation.xml
@@ -275,13 +275,12 @@
   </para>
   <para>
    The firmware used by virtual machines is auto-selected. The auto-selection
-   is based on the *.json files in the
-   <package>qemu-ovmf-<replaceable>ARCH</replaceable></package> package. The
+   is based on the *.json files in the firmware package described above. The
    &libvirt; &qemu; driver parses those files when loading so it knows the
-   capabilities of the various types of firmware. Then when the user selects the type
-   of firmware and any desired features (for example, support for &uefisecboot;),
-   &libvirt; will be able to find a firmware that satisfies the user's
-   requirements.
+   capabilities of the various types of firmware. Then when the user selects
+   the type of firmware and any desired features (for example, support for
+   &uefisecboot;), &libvirt; will be able to find a firmware that satisfies the
+   user's requirements.
   </para>
   <para>
    For example, to specify EFI with &uefisecboot;, use the following
@@ -293,8 +292,7 @@
 &lt;/os>
 </screen>
   <para>
-   The <package>qemu-ovmf-<replaceable>ARCH</replaceable></package> packages
-   contain the following files:
+   The UEFI firmware packages contains the following files:
   </para>
 <screen>
 &prompt.root;<command>rpm -ql qemu-ovmf-x86_64</command>
@@ -306,6 +304,15 @@
 /usr/share/qemu/ovmf-x86_64-suse-vars.bin
 /usr/share/qemu/ovmf-x86_64-suse.bin
 [...]
+</screen>
+<screen>
+&prompt.root;<command>rpm -ql qemu-uefi-aarch32</command>
+[...]
+/usr/share/qemu/aavmf-aarch32-code.bin
+/usr/share/qemu/aavmf-aarch32-vars.bin
+/usr/share/qemu/firmware
+/usr/share/qemu/firmware/60-aavmf-aarch32.json
+/usr/share/qemu/qemu-uefi-aarch32.bin
 </screen>
   <para>
    The <filename>*-code.bin</filename> files are the UEFI firmware files.
@@ -320,7 +327,7 @@
    across power cycles of the VM.
   </para>
   <para>
-   The <filename>*-ms*.bin</filename> files contain Microsoft keys as
+   The <filename>*-ms*.bin</filename> files contain UEFI CA keys as
    found on real hardware. Therefore, they are configured as the default in
    &libvirt;. Likewise, the <filename>*-suse*.bin</filename> files
    contain preinstalled &suse; keys. There is also a set

--- a/xml/vt_installation.xml
+++ b/xml/vt_installation.xml
@@ -263,8 +263,8 @@
   <title>Installing UEFI support</title>
   <note>
    <para>
-    &kvm; guests support secure boot by using the OVMF firmware.
-    &xen; HVM guests support booting from the OVMF firmware as well, but they do not support secure boot.
+    &kvm; guests support &uefisecboot; by using the OVMF firmware.
+    &xen; HVM guests support booting from the OVMF firmware as well, but they do not support &uefisecboot;.
    </para>
   </note>
   <para>
@@ -279,12 +279,12 @@
    <package>qemu-ovmf-<replaceable>ARCH</replaceable></package> package. The
    &libvirt; &qemu; driver parses those files when loading so it knows the
    capabilities of the various types of firmware. Then when the user selects the type
-   of firmware and any desired features (for example, support for secure boot),
+   of firmware and any desired features (for example, support for &uefisecboot;),
    &libvirt; will be able to find a firmware that satisfies the user's
    requirements.
   </para>
   <para>
-   For example, to specify EFI with secure boot, use the following
+   For example, to specify EFI with &uefisecboot;, use the following
    configuration:
   </para>
 <screen>

--- a/xml/vt_installation.xml
+++ b/xml/vt_installation.xml
@@ -279,7 +279,7 @@
    &libvirt; &qemu; driver parses those files when loading so it knows the
    capabilities of the various types of firmware. Then when the user selects
    the type of firmware and any desired features (for example, support for
-   &uefisecboot;), &libvirt; will be able to find a firmware that satisfies the
+   &uefisecboot;), &libvirt; will be able to find a firmware file that satisfies the
    user's requirements.
   </para>
   <para>

--- a/xml/vt_io.xml
+++ b/xml/vt_io.xml
@@ -86,7 +86,7 @@
     <itemizedlist mark="bullet" spacing="normal">
      <listitem>
       <para>
-       Resource access is compatible with secure boot.
+       Resource access is compatible with &uefisecboot;.
       </para>
      </listitem>
      <listitem>

--- a/xml/vt_scenarios.xml
+++ b/xml/vt_scenarios.xml
@@ -103,7 +103,7 @@
   <itemizedlist>
    <listitem>
     <para>
-     Secure Boot can be used for VMs.
+     &uefisecboot; can be used for VMs.
     </para>
    </listitem>
    <listitem>


### PR DESCRIPTION
### PR creator: Description

This update improves UEFI mentionings in respect to the ARM architecture


### PR creator: Are there any relevant issues/feature requests?

* jsc#SLE-15822


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(if applicable to 15 SP4 _only_ -- do not merge yet!)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
