### PR TITLE
info for upgrading with zypper dup added bsc#1183681

### DIFF
--- a/xml/zypper_upgrade.xml
+++ b/xml/zypper_upgrade.xml
@@ -190,35 +190,6 @@ https://download.opensuse.org/repositories/M17N:/fonts/openSUSE_Leap_15.3/ \
      licenses. Check the output of the command. If everything is OK, approve
      with <guimenu>y</guimenu>.
     </para>
-    <note>
-     <title>Upgrading with <command>zypper dup</command></title>
-     <para>You can upgrade your system by using <command>zypper dup</command>.
-     When using this command, take the following into account:</para>
-     <para>
-      The cache size for upgrading a &suse; distribution has increased. If you
-      are using <command>zypper dup</command> and there is not enough disk
-      space available, the upgrade fails. In this case, use
-      <option>--pkg-cache-dir <replaceable>DIR</replaceable></option> to set an
-      alternative package cache directory.
-     </para>
-     <para>
-        All packages having unresolved dependencies will be removed. Packages 
-        of disabled repositories are kept as long as their dependencies are 
-        satisfied. Packages that are no longer available in the repositories are
-        considered orphaned. Such packages get uninstalled if their dependencies
-        cannot be satisfied. If they can be satisfied, such packages stay
-        installed.
-     </para>
-     <para>
-      <command>zypper dup</command> ensures that all installed packages come
-      from one of the available repositories. It does not consider the version
-      or architecture, but prevents changing the vendor of the installed
-      packages by default, using the <option>--no-allow-vendor-change</option>
-      option. If you have third-party repositories enabled, some repositories
-      may break during the upgrade. In this case, use
-      <command>--allow-vendor-change</command> instead.
-       </para>
-    </note>
    </step>
    <step>
     <para>
@@ -227,5 +198,39 @@ https://download.opensuse.org/repositories/M17N:/fonts/openSUSE_Leap_15.3/ \
 <screen>&prompt.sudo;shutdown -r now</screen>
    </step>
   </procedure>
+  <para>
+   You can upgrade your system by using <command>zypper dup</command>.
+   When using this command, take the following into account:</para>
+  <itemizedlist>
+   <listitem>
+     <para>
+     If you are using <command>zypper dup</command> and there is not enough disk
+      space available, the upgrade fails. In this case, use
+      <option>--pkg-cache-dir <replaceable>DIR</replaceable></option> to set an
+      alternative package cache directory.
+      </para>
+    </listitem>
+    <listitem>
+    <para>
+      All packages with unresolved dependencies will be removed. Packages
+      installed from disabled repositories are kept as long as their
+      dependencies are satisfied. Packages that are no longer available in the
+      repositories are considered orphaned. Such packages are uninstalled if
+      their dependencies cannot be satisfied. If they can be satisfied, such
+      packages stay installed.
+    </para>
+    </listitem>
+   <listitem>
+     <para>
+      <command>zypper dup</command> ensures that all installed packages come
+      from one of the available repositories. It does not consider the version
+      or architecture, but prevents changing the vendor of the installed
+      packages by default, using the <option>--no-allow-vendor-change</option>
+      option. If you have third-party repositories enabled, some repositories
+      may break during the upgrade. In this case, use
+      <option>--allow-vendor-change</option> instead.
+     </para>
+   </listitem>
+  </itemizedlist>
  </sect3>
 </sect2>

--- a/xml/zypper_upgrade.xml
+++ b/xml/zypper_upgrade.xml
@@ -191,22 +191,33 @@ https://download.opensuse.org/repositories/M17N:/fonts/openSUSE_Leap_15.3/ \
      with <guimenu>y</guimenu>.
     </para>
     <note>
-     <title>Handling of unresolved dependencies</title>
+     <title>Upgrading with <command>zypper dup</command></title>
+     <para>You can upgrade your system by using <command>zypper dup</command>.
+     When using this command, take the following into account:</para>
      <para>
-      <command>zypper dup</command> will remove all packages having unresolved
-      dependencies, but it keeps packages of disabled repositories as long as
-      their dependencies are satisfied.
+      The cache size for upgrading a &suse; distribution has increased. If you
+      are using <command>zypper dup</command> and there is not enough disk
+      space available, the upgrade fails. In this case, use
+      <option>--pkg-cache-dir <replaceable>DIR</replaceable></option> to set an
+      alternative package cache directory.
+     </para>
+     <para>
+        All packages having unresolved dependencies will be removed. Packages 
+        of disabled repositories are kept as long as their dependencies are 
+        satisfied. Packages that are no longer available in the repositories are
+        considered orphaned. Such packages get uninstalled if their dependencies
+        cannot be satisfied. If they can be satisfied, such packages stay
+        installed.
      </para>
      <para>
       <command>zypper dup</command> ensures that all installed packages come
       from one of the available repositories. It does not consider the version
       or architecture, but prevents changing the vendor of the installed
       packages by default, using the <option>--no-allow-vendor-change</option>
-      option. Packages that are no longer available in the repositories are
-      considered orphaned. Such packages get uninstalled if their dependencies
-      cannot be satisfied. If they can be satisfied, such packages stay
-      installed.
-     </para>
+      option. If you have third-party repositories enabled, some repositories
+      may break during the upgrade. In this case, use
+      <command>--allow-vendor-change</command> instead.
+       </para>
     </note>
    </step>
    <step>


### PR DESCRIPTION
### PR creator: Description

Info about upgrading with `zypper dup` added.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1183681
* jsc#DOCTEAM-180


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(if applicable to 15 SP4 _only_ -- do not merge yet!)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
