### PR TITLE
Updated table of SMT vs RMT features

### DIFF
--- a/xml/rmt_migrate_from_smt.xml
+++ b/xml/rmt_migrate_from_smt.xml
@@ -270,12 +270,29 @@
      <row>
       <entry>
        <para>
-        Migration from &slea; 12 to 15
+        Support for migrating &slea; 12 to 15
+       </para>
+      </entry>
+      <entry>
+       <para>
+        yes <superscript>1</superscript>
        </para>
       </entry>
       <entry>
        <para>
         yes
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
+        Support for migrating &slea; 15 SPx to 15 SPx+1
+       </para>
+      </entry>
+      <entry>
+       <para>
+        yes <superscript>1</superscript>
        </para>
       </entry>
       <entry>
@@ -297,7 +314,7 @@
       </entry>
       <entry>
        <para>
-        no<superscript>1</superscript>
+        no<superscript>2</superscript>
        </para>
       </entry>
      </row>
@@ -405,7 +422,24 @@
      <row>
       <entry>
        <para>
-        RedHat support (Extended Support)
+        Red Hat 7 and earlier support (<link xlink:href="https://www.suse.com/products/expandedsupport/">Expanded Support</link>)
+       </para>
+      </entry>
+      <entry>
+       <para>
+        yes
+       </para>
+      </entry>
+      <entry>
+       <para>
+        no
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
+        Red Hat 8 support (<link xlink:href="https://www.suse.com/products/expandedsupport/">Expanded Support</link>)
        </para>
       </entry>
       <entry>
@@ -507,6 +541,125 @@
      <row>
       <entry>
        <para>
+        Clean up data from repositories that are not used any longer
+       </para>
+      </entry>
+      <entry>
+       <para>
+        yes
+       </para>
+      </entry>
+      <entry>
+       <para>
+        yes
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
+        Bash completion
+       </para>
+      </entry>
+      <entry>
+       <para>
+        no
+       </para>
+      </entry>
+      <entry>
+       <para>
+        yes
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
+        Available on <link xlink:href="https://github.com/SUSE/rmt/blob/master/docs/installation.md#installation-on-opensuse-leap-15">openSUSE Leap 15</link>
+       </para>
+      </entry>
+      <entry>
+       <para>
+        no
+       </para>
+      </entry>
+      <entry>
+       <para>
+        yes <superscript>3</superscript>
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
+        Option to <link xlink:href="https://github.com/SUSE/rmt/blob/master/README.md#development-setup---docker-compose">run as container</link>
+       </para>
+      </entry>
+      <entry>
+       <para>
+        no
+       </para>
+      </entry>
+      <entry>
+       <para>
+        yes <superscript>3</superscript>
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
+        Easy development setup + <link xlink:href="https://github.com/SUSE/rmt/blob/master/docs/CONTRIBUTING.md">contribution guide</link>
+       </para>
+      </entry>
+      <entry>
+       <para>
+        no
+       </para>
+      </entry>
+      <entry>
+       <para>
+        yes
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
+        100% test <link xlink:href="https://coveralls.io/github/SUSE/rmt?branch=master">coverage</link>
+       </para>
+      </entry>
+      <entry>
+       <para>
+        no
+       </para>
+      </entry>
+      <entry>
+       <para>
+        yes
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
+        <link xlink:href="https://github.com/SUSE/rmt/blob/master/docs/PLUGINS.md">Plugin functionality</link>
+       </para>
+      </entry>
+      <entry>
+       <para>
+        no
+       </para>
+      </entry>
+      <entry>
+       <para>
+        yes
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
         Web server
        </para>
       </entry>
@@ -542,7 +695,20 @@
    </tgroup>
   </table>
   <para>
-   1) Functionality is offered by &susemgr;.
+   1) &smt; only partially supports migrating systems to &slea; 15. &slea; 15
+   is composed of multiple modules and extensions. Some modules are not
+   required, as they provide additional functionality. &rmt; fully supports
+   migrations into and within &slea; 15, therefore it will only add the minimum
+   of required modules. &smt; does not fully support these migrations, and it
+   will enable all available modules on the system.
+  </para>
+  <para>
+   2) Functionality is offered by <link
+   xlink:href="https://documentation.suse.com/suma/">&susemgr;</link>.
+  </para>
+  <para>
+   3) Only available with <link
+   xlink:href="https://www.suse.com/support/self-support/">self-support</link>.
   </para>
  </sect1>
  <sect1 xml:id="sec-rmt-migrate-smt-export">


### PR DESCRIPTION
### PR creator: Description

SMT/RMT feature comparison table was outdated, this update fixes that.
Rendered PDF is here: 
[sec-rmt-migrate-notes_color_en.pdf](https://github.com/SUSE/doc-sle/files/6662139/sec-rmt-migrate-notes_color_en.pdf)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(if applicable to 15 SP4 _only_ -- do not merge yet!)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
