### PR TITLE
Obsolete user defaults

### DIFF
--- a/xml/ay_users_groups.xml
+++ b/xml/ay_users_groups.xml
@@ -357,8 +357,8 @@
      The profile can specify a set of default values for new users like
      password expiration, initial group, home directory prefix, etc. Besides using them
      as default values for the users that are defined in the profile, &ay; will
-     write those settings to <filename>/etc/default/useradd</filename> to be read for
-     <literal>useradd</literal>.
+     write those settings to <filename>/etc/default/useradd</filename> or any other
+     appropiate file to be read for <literal>useradd</literal>.
     </para>
 
 <variablelist>

--- a/xml/ay_users_groups.xml
+++ b/xml/ay_users_groups.xml
@@ -437,22 +437,6 @@
   </varlistentry>
   <varlistentry>
     <term>
-      <literal>skel</literal>
-    </term>
-    <listitem>
-      <para>
-          Path
-         </para>
-      <screen>&lt;skel&gt;/etc/skel&lt;/skel&gt;</screen>
-      <para>
-          Optional. Location of the files to be used as skeleton when adding a new
-          user. You can find more information in <literal>man 8
-          useradd</literal>.
-         </para>
-    </listitem>
-  </varlistentry>
-  <varlistentry>
-    <term>
       <literal>umask</literal>
     </term>
     <listitem>

--- a/xml/ay_users_groups.xml
+++ b/xml/ay_users_groups.xml
@@ -379,20 +379,6 @@
   </varlistentry>
   <varlistentry>
     <term>
-      <literal>groups</literal>
-    </term>
-    <listitem>
-      <para>
-          Text
-         </para>
-      <screen>&lt;groups&gt;users&lt;/groups&gt;</screen>
-      <para>
-          Optional. List of additional groups.
-         </para>
-    </listitem>
-  </varlistentry>
-  <varlistentry>
-    <term>
       <literal>home</literal>
     </term>
     <listitem>
@@ -430,20 +416,6 @@
       <screen>&lt;inactive&gt;3&lt;/inactive&gt;</screen>
       <para>
           Optional. Number of days after which an expired account is disabled.
-         </para>
-    </listitem>
-  </varlistentry>
-  <varlistentry>
-    <term>
-      <literal>no_groups</literal>
-    </term>
-    <listitem>
-      <para>
-          Boolean
-         </para>
-      <screen>&lt;no_groups config:type="boolean"&gt;true&lt;/no_groups&gt;</screen>
-      <para>
-          Optional. Do not use secondary groups.
          </para>
     </listitem>
   </varlistentry>


### PR DESCRIPTION
### Description

The YaST Team is rewriting AutoYaST user management to rely more on useradd, since the diversion between how YaST and useradd do things has brought many problems (see bug reports and Jira entries below).

During that effort we found three problems with the `<user_defaults>` section of the profile:

- The documentation states the section is used to set the configuration values at `/etc/defaults/useradd`. But that's not fully accurate since, in fact, the UMASK parameter should not be written there but somewhere in the `login.defs` directory.
- The "groups" and "no_groups" attributes has been useless since SLE-12.
- Modifying the SKEL parameter of useradd may not be a good idea, so we have decided we should stop doing it.

#### More details about "groups" and "no_groups" (copied from the extended commit description)

1) These two attributes define the value to write in `/etc/default/useradd` for the GROUPS key. The value indeed has been historically written by AutoYaST. But turns out that key has been completely ignored by useradd since SLE-12, in which he package "pwdutils" was dropped in favor of "shadow" (see more at [bsc#1099153](https://bugzilla.suse.com/show_bug.cgi?id=1099153)). The useradd implementation included in the latter package does not honor the configuration for GROUPS and does not offer any alternative to it.
    
2) In theory, those attributes were also honored by AutoYaST while creating users during the installation process. But manual tests have proven that was not the case in SLE-11, SLE-12 or SLE-15 (or any of its corresponding service packs).

#### More details about "skel" (copied from the extended commit description)

Basically, the management of skeleton directories is currently more complex than it used to be. It does not depend only on the historical SKEL setting at /etc/default/useradd. Although useradd still reads that configuration, it does not offer any way to modify it since SLE-12 (when useradd was moved from the dropped package "pwdutils" in favor of an alternative implementation in the package "shadow"). So it was decided that is not a good idea for AutoYaST to fiddle with that configuration parameter.

### Relevant issues/feature requests

* [PM-2620](https://jira.suse.com/browse/PM-2620) and [bsc#1166743](https://bugzilla.suse.com/show_bug.cgi?id=1166743) - Different management of subuids between YaST and useradd
* [bsc#1099153](https://bugzilla.suse.com/show_bug.cgi?id=1099153) - UMASK moved to another file
* [bsc#1183136](https://bugzilla.suse.com/show_bug.cgi?id=1183136) and [bsc#1179261](https://bugzilla.suse.com/show_bug.cgi?id=1179261) - Different management of skel between YaST and useradd

### Which product versions do the changes apply to?

Although some things apply to older versions as well, it will be enough to merge this for SLE-15-SP4. 

Removing the support for `<skel>` (the only part that actually does not apply to old versions) is part of the version of yast2-users that will be committed to Tumbleweed by the end of June 2021 and that will be part of SLE-15-SP4.

- SLE 15/openSUSE Leap 15.x
  - [X] SLE 15 SP4/openSUSE Leap 15.4 *(if applicable to 15 SP4 _only_ -- do not merge yet!)*
