### PR TITLE
Proofing corrections to Virtualization Guide

### DIFF
--- a/xml/libvirt_configuration_gui.xml
+++ b/xml/libvirt_configuration_gui.xml
@@ -1040,7 +1040,7 @@
     &kvm; guests using the &qemu; Q35 machine type have a PCI topology that
     includes a <literal>pcie-root</literal> controller and seven
     <literal>pcie-root-port</literal> controllers. The
-    <literal>pcie-root</literal> controller does not support hotplug. Each
+    <literal>pcie-root</literal> controller does not support hotplugging. Each
     <literal>pcie-root-port</literal> controller supports hotplugging a single
     PCIe device. PCI controllers cannot be hotplugged, so plan accordingly and
     add more <literal>pcie-root-port</literal>s if more than seven PCIe

--- a/xml/libvirt_configuration_virsh.xml
+++ b/xml/libvirt_configuration_virsh.xml
@@ -499,7 +499,7 @@ CPU Affinity:   yy
   &lt;/source&gt;
 &lt;/hostdev&gt;</screen>
     <tip xml:id="tip-libvirt-config-pci-virsh-managed">
-     <title><literal>managed</literal> Compared to <literal>unmanaged</literal></title>
+     <title><literal>managed</literal> compared to <literal>unmanaged</literal></title>
      <para>
       <systemitem>libvirt</systemitem> recognizes two modes for handling PCI
       devices: they can be either <literal>managed</literal> or
@@ -562,7 +562,7 @@ CPU Affinity:   yy
     &kvm; guests using the &qemu; Q35 machine type have a PCI topology that
     includes a <literal>pcie-root</literal> controller and seven
     <literal>pcie-root-port</literal> controllers. The
-    <literal>pcie-root</literal> controller does not support hotplug. Each
+    <literal>pcie-root</literal> controller does not support hotplugging. Each
     <literal>pcie-root-port</literal> controller supports hotplugging a single
     PCIe device. PCI controllers cannot be hotplugged, so plan accordingly and
     add more <literal>pcie-root-port</literal>s if more than seven PCIe devices

--- a/xml/libvirt_connect.xml
+++ b/xml/libvirt_connect.xml
@@ -165,7 +165,7 @@
     </varlistentry>
    </variablelist>
    <sect3 xml:id="sec-libvirt-connect-auth-libvirt-traditional">
-    <title>Access control for unix sockets with permissions and group ownership</title>
+    <title>Access control for Unix sockets with permissions and group ownership</title>
     <para>
      To grant access for non-&rootuser; accounts, configure the
      sockets to be owned and accessible by a certain group
@@ -231,7 +231,7 @@ auth_unix_rw = "none"<co xml:id="co-libvirt-connect-ssh-enable"/></screen>
     </procedure>
    </sect3>
    <sect3 xml:id="sec-libvirt-connect-auth-libvirt-pk">
-    <title>Local access control for unix sockets with &pk;</title>
+    <title>Local access control for Unix sockets with &pk;</title>
     <para>
      Access control for Unix sockets with &pk; is the default
      authentication method on &productname; for non-remote connections.
@@ -406,14 +406,14 @@ auth_unix_rw = "none"<co xml:id="co-libvirt-connect-ssh-enable"/></screen>
    <note>
     <title>VNC authentication for &xen;</title>
     <para>
-     In contrast of &kvm;, &xen; does not yet offer more sophisticated VNC authentication
-     than setting a password on a per VM
-     basis. See the <literal>&lt;graphics type='vnc'...</literal>
-     &libvirt; configuration option below.
+     In contrast with &kvm;, &xen; does not yet offer VNC authentication more
+     sophisticated than setting a password on a per-VM basis. See the
+     <literal>&lt;graphics type='vnc'...</literal> &libvirt; configuration
+     option below.
     </para>
    </note>
    <para>
-    Two authentication types are available: SASL and single password
+    Two authentication types are available: SASL and single-password
     authentication. If you are using SASL for &libvirt; authentication,
     it is strongly recommended to use it for VNC authentication as
     well&mdash;it is possible to share the same database.
@@ -1288,7 +1288,7 @@ virsh -c xen+tls://<replaceable>&wsIVname;</replaceable>/system list --all</scre
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term><emphasis role="bold">System wide client certificates</emphasis>
+      <term><emphasis role="bold">System-wide client certificates</emphasis>
       </term>
       <listitem>
        <para>

--- a/xml/libvirt_guest_installation.xml
+++ b/xml/libvirt_guest_installation.xml
@@ -223,7 +223,7 @@
    <title>Configuring the virtual machine for PXE boot</title>
    <para>
     PXE boot enables your virtual machine to boot the installation media from
-    network instead of from a physical medium or an installation disk image.
+    the network, instead of from a physical medium or an installation disk image.
     <phrase os="sles">Refer to <xref linkend="cha-deployment-prep-pxe"/> for
     more details about setting up a PXE boot environment.</phrase>
    </para>

--- a/xml/libvirt_host.xml
+++ b/xml/libvirt_host.xml
@@ -273,7 +273,7 @@ virbr_test  1 PVID Egress Untagged
      a &vmguest; to hosts in a different network segment. Or to create a private
      bridge that only &vmguest; systems may connect to (even when running on
      different &vmhost; systems). An easy way to build such connections is to
-     setup VLAN networks.
+     set up VLAN networks.
     </para>
     <para>
      VLAN interfaces are commonly set up on the &vmhost;. They either
@@ -376,8 +376,8 @@ virbr_test  1 PVID Egress Untagged
    </para>
    <para>
     &libvirt;-managed virtual networks can be used to satisfy a wide range of
-    use-cases but are commonly used on &vmhost;s that have a wireless
-    connection or dynamic/sporadic network connectivity such as laptops.
+    use cases, but are commonly used on &vmhost;s that have a wireless
+    connection or dynamic/sporadic network connectivity, such as laptops.
     Virtual networks are also useful when the &vmhost;'s network has limited IP
     addresses, allowing forwarding of packets between the virtual network and
     the &vmhost;'s network. However, most server use cases are better suited
@@ -1026,8 +1026,8 @@ Network vnet_isolated has been undefined</screen>
          the volume once before to use it with &libvirt;. Use the &yast;
          <guimenu>iSCSI Initiator</guimenu> to detect and log in to a
          volume<phrase os="sles">, see <xref linkend="book-storage"/> for
-         details</phrase>. Volume creation on iSCSI pools is not supported,
-         instead each existing Logical Unit Number (LUN) represents a volume.
+         details</phrase>. Volume creation on iSCSI pools is not supported;
+         instead, each existing Logical Unit Number (LUN) represents a volume.
          Each volume/LUN also needs a valid (empty) partition table or disk
          label before you can use it. If missing, use <command>fdisk</command>
          to add it:
@@ -1052,7 +1052,7 @@ Syncing disks.</screen>
        <term>LVM volume group (logical)</term>
        <listitem>
         <para>
-         Use an LVM volume group as a pool. You may either use a predefined
+         Use an LVM volume group as a pool. You can either use a predefined
          volume group, or create a group by specifying the devices to use.
          Storage volumes are created as partitions on the volume.
         </para>
@@ -1778,7 +1778,7 @@ done</screen>
      </note>
      <para>
       To permanently make a pool inaccessible, click <guimenu>Delete</guimenu>
-      in the bottom left corner of the Storage Manager. You may only delete
+      in the bottom left corner of the Storage Manager. You can only delete
       inactive pools. Deleting a pool does not physically erase its contents on
       &vmhost;&mdash;it only deletes the pool configuration. However, you need
       to be extra careful when deleting pools, especially when deleting LVM
@@ -1837,16 +1837,16 @@ done</screen>
         LVM group-based pools.
        </para>
        <para>
-        Next to <guimenu>Max Capacity</guimenu>, specify the amount maximum
-        size that the disk image is allowed to reach. Unless you are working
-        with a <literal>qcow2</literal> image, you can also set an amount for
+        Next to <guimenu>Max Capacity</guimenu>, specify the maximum size that
+        the disk image is allowed to reach. Unless you are working with a
+        <literal>qcow2</literal> image, you can also set an amount for 
         <guimenu>Allocation</guimenu> that should be allocated initially. If
-        both values differ, a sparse image file will be created which grows on
-        demand.
+        the two values differ, a sparse image file will be created, which grows
+        on demand.
        </para>
        <para>
         For <literal>qcow2</literal> images, you can use a <guimenu>Backing
-        Store</guimenu> (also called <quote>backing file</quote>) which
+        Store</guimenu> (also called <quote>backing file</quote>), which
         constitutes a base image. The newly created <literal>qcow2</literal>
         image will then only record the changes that are made to the base
         image.

--- a/xml/libvirt_host.xml
+++ b/xml/libvirt_host.xml
@@ -1841,7 +1841,7 @@ done</screen>
         the disk image is allowed to reach. Unless you are working with a
         <literal>qcow2</literal> image, you can also set an amount for 
         <guimenu>Allocation</guimenu> that should be allocated initially. If
-        the two values differ, a sparse image file will be created, which grows
+        the two values differ, a sparse image file will beqenuqqrum created, which grows
         on demand.
        </para>
        <para>

--- a/xml/libvirt_host.xml
+++ b/xml/libvirt_host.xml
@@ -1841,7 +1841,7 @@ done</screen>
         the disk image is allowed to reach. Unless you are working with a
         <literal>qcow2</literal> image, you can also set an amount for 
         <guimenu>Allocation</guimenu> that should be allocated initially. If
-        the two values differ, a sparse image file will beqenuqqrum created, which grows
+        the two values differ, a sparse image file will be created, which grows
         on demand.
        </para>
        <para>

--- a/xml/libvirt_management_vagrant.xml
+++ b/xml/libvirt_management_vagrant.xml
@@ -47,7 +47,7 @@
       <para>
        Services to set up and create virtual environments. &vagrant; ships with
        support for &virtualbox; and &hyperv; virtualization. Other services
-       such as &libvirt;, &vmware; or AWS are supported via plugins.
+       such as &libvirt;, &vmware; or AWS are supported via plug-ins.
       </para>
      </listitem>
     </varlistentry>

--- a/xml/pv2fv.xml
+++ b/xml/pv2fv.xml
@@ -5,7 +5,7 @@
     %entities;
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="pv-to-fv">
- <title>&xen;: converting a paravirtual (PV) guest to a fully virtual (FV/HVM) guest</title>
+ <title>&xen;: converting a paravirtual (PV) guest into a fully virtual (FV/HVM) guest</title>
  <para>
   This chapter explains how to convert a &xen; paravirtual machine into a &xen;
   fully virtualized machine.
@@ -66,15 +66,15 @@
     <title>Prefer UUIDs</title>
     <para>
      You should use UUIDs or logical volumes within your
-     <filename>/etc/fstab</filename>. Using UUID simplifies using attached
+     <filename>/etc/fstab</filename>. Using UUIDs simplifies the use of attached
      network storage, multipathing, and virtualization. To find the UUID of
-     your disk use the command <command>blkid</command>.
+     your disk, use the command <command>blkid</command>.
     </para>
    </note>
   </step>
   <step>
    <para>
-    To avoid any error regenerating the initrd with the required modules you
+    To avoid any error regenerating the initrd with the required modules, you
     can create a symbolic link from <filename>/dev/hda2</filename> to
     <filename>/dev/xvda2</filename> etc. by using the <command>ln</command>:
    </para>
@@ -179,7 +179,7 @@ ln -sf /dev/xvda1 /dev/hda1
    <itemizedlist>
     <listitem>
      <para>
-      Make sure the machine, the type and the <literal>loader</literal> entries
+      Make sure the machine, the type, and the <literal>loader</literal> entries
       in the OS section are changed from <literal>xenpv</literal> to
       <literal>xenfv</literal>. The updated OS section should look similar to:
      </para>
@@ -191,7 +191,7 @@ ln -sf /dev/xvda1 /dev/hda1
     </listitem>
     <listitem>
      <para>
-      In the OS section remove anything that is specific to PV guest:
+      In the OS section, remove anything that is specific to PV guests:
      </para>
      <itemizedlist>
       <listitem>

--- a/xml/qemu_host_installation.xml
+++ b/xml/qemu_host_installation.xml
@@ -219,7 +219,7 @@ kvm                   411041  1 kvm_intel</screen>
     </varlistentry>
    </variablelist>
    <sect3>
-    <title><systemitem>virtio-scsi</systemitem> Usage</title>
+    <title><systemitem>virtio-scsi</systemitem> usage</title>
     <para>
      &kvm; supports the SCSI pass-through feature with the
      <systemitem>virtio-scsi-pci</systemitem> device:

--- a/xml/qemu_monitor.xml
+++ b/xml/qemu_monitor.xml
@@ -1101,7 +1101,7 @@ Escape character is '^]'.
    <title>Access QMP via Unix socket</title>
    <para>
     Invoke &qemu; using the <option>-qmp</option> option, and create a
-    unix socket:
+    Unix socket:
    </para>
 <screen>&prompt.sudo;qemu-system-x86_64 [...] \
 -qmp unix:/tmp/qmp-sock,server --monitor stdio

--- a/xml/qemu_monitor.xml
+++ b/xml/qemu_monitor.xml
@@ -1098,7 +1098,7 @@ Escape character is '^]'.
   </sect2>
 
   <sect2 xml:id="sec-qemu-monitor-qmp-socket">
-   <title>Access QMP via unix socket</title>
+   <title>Access QMP via Unix socket</title>
    <para>
     Invoke &qemu; using the <option>-qmp</option> option, and create a
     unix socket:

--- a/xml/qemu_running_vms_qemukvm.xml
+++ b/xml/qemu_running_vms_qemukvm.xml
@@ -1411,7 +1411,7 @@ bootfile=/images/boot/pxelinux.0<co xml:id="co-usermode-bootfile"/></screen>
         Broadcasts the specified file as a BOOTP (a network protocol that
         offers an IP address and a network location of a boot image, often used
         in diskless workstations) file. When used together with
-        <litlibreral>tftp</litlibreral>, the &vmguest; can boot over the network from
+        <literal>tftp</literal>, the &vmguest; can boot over the network from
         the local directory on the host.
        </para>
       </callout>

--- a/xml/qemu_running_vms_qemukvm.xml
+++ b/xml/qemu_running_vms_qemukvm.xml
@@ -93,8 +93,8 @@
      </para>
      <para>
       For example, <literal>qemu-system-ARCH [...] -boot order=ndc</literal>
-      first tries to boot from network, then from the first CD-ROM drive, and
-      finally from the first hard disk.
+      first tries to boot from the network, then from the first CD-ROM drive,
+      and finally from the first hard disk.
      </para>
     </listitem>
    </varlistentry>
@@ -1411,8 +1411,8 @@ bootfile=/images/boot/pxelinux.0<co xml:id="co-usermode-bootfile"/></screen>
         Broadcasts the specified file as a BOOTP (a network protocol that
         offers an IP address and a network location of a boot image, often used
         in diskless workstations) file. When used together with
-        <literal>tftp</literal>, the &vmguest; can boot from network from the
-        local directory on the host.
+        <litlibreral>tftp</litlibreral>, the &vmguest; can boot over the network from
+        the local directory on the host.
        </para>
       </callout>
      </calloutlist>

--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -74,7 +74,7 @@
    <note os="sles">
     <title>&arm64;</title>
     <para>
-     &arm64; is a continuously-evolving platform. It does not have a
+     &arm64; is a continuously evolving platform. It does not have a
      traditional standards and compliance certification program to enable
      interoperability with operating systems and hypervisors. Ask your
      vendor for the support statement on &sls;.
@@ -83,7 +83,8 @@
    <note os="sles">
     <title>&power;</title>
     <para>
-     Running &kvm; or &xen; hypervisors on &power; platform is not supported.
+     Running &kvm; or &xen; hypervisors on the &power; platform is not
+     supported.
     </para>
    </note>
   </sect2>
@@ -96,7 +97,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="virt-hypervisors-limits">
-  <title>Hypervisors limits</title>
+  <title>Hypervisor limits</title>
 
   <para os="sles;sled">
    New features and virtualization limits for &xen; and &kvm; are outlined in
@@ -105,8 +106,8 @@
   </para>
 
   <para>
-   Only packages which are part of the official SLES repositories are
-   supported. Conversely, all optional subpackages and plugins (for &qemu;,
+   Only packages that are part of the official SLES repositories are
+   supported. Conversely, all optional subpackages and plug-ins (for &qemu;,
    &libvirt;) provided at 
    <link xmlns:xlink="http://www.w3.org/1999/xlink"
      xlink:href="https://packagehub.suse.com/">packagehub</link>
@@ -179,8 +180,8 @@
     <itemizedlist>
      <listitem>
       <para>
-       <emphasis>Maximum virtual CPUs per VM</emphasis>: see recommendations in
-       the Virtualization Best Practices Guide regarding over-commit of
+       <emphasis>Maximum virtual CPUs per VM</emphasis>: See recommendations in
+       the Virtualization Best Practices Guide regarding over-commitment of
        physical CPUs at
        <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/article-vt-best-practices.html#sec-vt-best-perf-cpu-assign"/>.
        The total virtual CPUs should be proportional to the available physical
@@ -235,7 +236,7 @@
       <row>
        <entry>
         <para>
-         Max total physical CPUs
+         Maximum total physical CPUs
         </para>
        </entry>
        <entry>
@@ -247,13 +248,13 @@
       <row>
        <entry>
         <para>
-         Max total virtual CPUs per host
+         Maximum total virtual CPUs per host
         </para>
        </entry>
        <entry>
         <para>
          See recommendations in the Virtualization Best Practices Guide
-         regarding over-commit of physical CPUs in
+         regarding over-commitment of physical CPUs in
          <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/article-vt-best-practices.html#sec-vt-best-perf-cpu-assign"/>.
          The total virtual CPUs should be proportional to the available
          physical CPUs
@@ -263,7 +264,7 @@
       <row>
        <entry>
         <para>
-         Max physical memory
+         Maximum physical memory
         </para>
        </entry>
        <entry>
@@ -281,8 +282,9 @@
   <title>Supported host environments (hypervisors)</title>
 
   <para>
-   Support status of &productname; &productnumber; running as a guest operating
-   system on top of various virtualization hosts (hypervisors).
+   This section describes the support status of &productname; &productnumber;
+   running as a guest operating system on top of various virtualization hosts
+   (hypervisors).
   </para>
 
   <table>
@@ -388,7 +390,7 @@
   <para>
    You can also search in the
    <link xlink:href="https://www.suse.com/yessearch/Search.jsp">SUSE YES
-   certification Database.</link>
+   certification database</link>
   </para>
 
   <itemizedlist>
@@ -425,7 +427,7 @@
   </para>
 
   <itemizedlist>
-   <title>Since &sls; 12 SP3, all the following guest operating systems are fully supported (L3):</title>
+   <title>Starting from &sls; 12 SP3, all the following guest operating systems are fully supported (L3):</title>
    <listitem>
     <para>
      &sls; 11 SP4
@@ -475,7 +477,7 @@
   <note>
    <title>RHEL PV drivers</title>
    <para>
-    Since RHEL 7.2 &redhat;, removed &xen; PV drivers.
+    Starting from RHEL 7.2, &redhat; removed &xen; PV drivers.
    </para>
   </note>
 
@@ -492,21 +494,20 @@
    <title>All other guest operating systems</title>
    <listitem>
     <para>
-     In other combinations L2 support is provided but fixes are available only
+     In other combinations, L2 support is provided but fixes are available only
      if feasible. &suse; fully supports the host OS (hypervisor). The guest OS
-     issues need to be supported be the respective OS vendor. If an issue fix
+     issues need to be supported by the respective OS vendor. If an issue fix
      involves both the host and guest environments, the customer needs to
      approach both &suse; and the guest VM OS vendor.
     </para>
    </listitem>
    <listitem>
     <para>
-     All guest operating systems are supported both fully-virtualized and
-     paravirtualized. The exception is Windows, which are only supported
-     fully-virtualized (but it can use PV drivers
-     <link
+     All guest operating systems are supported both fully virtualized and
+     paravirtualized. The exception is Windows systems, which are only supported
+     fully virtualized (but they can use PV drivers: <link
      xlink:href="https://www.suse.com/products/vmdriverpack/"/>),
-     and OES operating systems which are supported only paravirtualized.
+     and OES operating systems, which are supported only paravirtualized.
     </para>
    </listitem>
    <listitem>
@@ -562,8 +563,8 @@
      <term>&redhat;</term>
      <listitem>
       <para>
-       Available since &rhel; 5.4. Starting from 7.2 &rhel; removed the PV
-       drivers.
+       Available since &rhel; 5.4. Starting from &rhel; 7.2, &redhat; removed
+       the PV drivers.
       </para>
      </listitem>
     </varlistentry>
@@ -582,11 +583,14 @@
    <note>
     <title>PVops kernel</title>
     <para>
-     Since &sls; 12 SP2 we switched to a PVops kernel. We are no longer using
-     a dedicated kernel-xen. Dom0 kernel-default+kernel-xen was replaced with
-     kernel-default, domU PV kernel-xen was replaced by kernel-default, domU
-     HVM kernel-default+xen-kmp was replaced by kernel-default, dom0 toolstack
-     still load all back-end drivers.
+     Starting from &sls; 12 SP2, we switched to a PVops kernel. We are no longer
+     using a dedicated <package>kernel-xen</package> package. Dom0
+     <package>kernel-default+kernel-xen</package> was replaced with
+     <package>kernel-default</package>, domU PV <package>kernel-xen</package>
+     was replaced by <package>kernel-default</package>, domU
+     HVM <package>kernel-default+xen-kmp</package> was replaced by
+     <package>kernel-default</package>; dom0 toolstack still loads all back-end
+     drivers.
     </para>
    </note>
   </sect2>
@@ -1233,7 +1237,7 @@
       <para>
        &suse; strives to support live migration of virtual machines from a host
        running a service pack under LTSS to a host running a newer service
-       pack, within the same SLES major version. For example, virtual machine
+       pack within the same SLES major version. For example, virtual machine
        migration from a SLES 12 SP2 host to a SLES 12 SP5 host. &suse; only
        performs minimal testing of LTSS-to-newer migration scenarios and
        recommends thorough on-site testing before attempting to migrate
@@ -1780,12 +1784,12 @@
   <para>
    Nested virtualization allows you to run a virtual machine inside another VM
    while still using hardware acceleration from the host. It has very bad
-   performance, and add more complexity while debugging. Nested is mostly used
-   for testing purposes. In &sls; Nested virtualization is a Technology
-   Preview. It is only provided for testing purposes and is not supported. Bugs
-   can be reported but they will be treated with low priority. Any attempt to
-   live migrate or save/restore VMs in the presence of nested virtualization is
-   also explicitly unsupported.
+   performance and adds more complexity while debugging. Nested virtualization
+   is mostly used for testing purposes. In &sls;, nested virtualization is a
+   Technology Preview. It is only provided for testing purposes and is not
+   supported. Bugs can be reported but they will be treated with low priority.
+   Any attempt to live-migrate or save/restore VMs in the presence of nested
+   virtualization is also explicitly unsupported.
   </para>
  </sect1>
  <!-- End X86_64 only -->

--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -181,7 +181,7 @@
      <listitem>
       <para>
        <emphasis>Maximum virtual CPUs per VM</emphasis>: See recommendations in
-       the Virtualization Best Practices Guide regarding over-commitment of
+       the <citetitle>Virtualization Best Practices Guide</citetitle> regarding over-commitment of
        physical CPUs at
        <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/article-vt-best-practices.html#sec-vt-best-perf-cpu-assign"/>.
        The total virtual CPUs should be proportional to the available physical
@@ -589,7 +589,7 @@
      <package>kernel-default</package>, domU PV <package>kernel-xen</package>
      was replaced by <package>kernel-default</package>, domU
      HVM <package>kernel-default+xen-kmp</package> was replaced by
-     <package>kernel-default</package>; dom0 toolstack still loads all back-end
+     <package>kernel-default</package>. The dom0 toolstack still loads all back-end
      drivers.
     </para>
    </note>
@@ -1788,7 +1788,7 @@
    is mostly used for testing purposes. In &sls;, nested virtualization is a
    Technology Preview. It is only provided for testing purposes and is not
    supported. Bugs can be reported but they will be treated with low priority.
-   Any attempt to live-migrate or save/restore VMs in the presence of nested
+   Any attempt to live-migrate or to save or restore VMs in the presence of nested
    virtualization is also explicitly unsupported.
   </para>
  </sect1>

--- a/xml/vt_guestfs.xml
+++ b/xml/vt_guestfs.xml
@@ -212,7 +212,7 @@
     </listitem>
    </itemizedlist>
    <warning>
-    <title>Unsupported file system</title>
+    <title>Unsupported file systems</title>
     <para>
      Guestfs may also support Windows* file systems (VFAT, NTFS), BSD* and
      Apple* file systems, and other disk image formats (VMDK, VHDX...).

--- a/xml/vt_io.xml
+++ b/xml/vt_io.xml
@@ -6,7 +6,7 @@
 ]>
 
 <sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="sec-vt-io">
- <title>I/O Virtualization</title>
+ <title>I/O virtualization</title>
 
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">

--- a/xml/vt_io.xml
+++ b/xml/vt_io.xml
@@ -108,7 +108,7 @@
      </listitem>
     </itemizedlist>
     <para>
-     In &productname; the USB and PCI Pass-through methods of device assignment
+     In &productname; the USB and PCI pass-through methods of device assignment
      are considered deprecated and are superseded by the VFIO model.
    </para>
    </listitem>

--- a/xml/vt_qemu_ga.xml
+++ b/xml/vt_qemu_ga.xml
@@ -121,7 +121,7 @@
     <term><command>virsh domfsfreeze</command> and <command>virsh domfsthaw</command></term>
     <listitem>
      <para>
-      Instructs the guest to make its file system quiescent: to flush all I/O
+      Instructs the guest to make its file system quiescent&mdash;to flush all I/O
       operations in the cache and leave volumes in a consistent state, so that
       no checks will be needed when they are remounted.
      </para>
@@ -167,7 +167,7 @@
    <listitem>
     <para>
      The &virsh; manual page (<command>man 1 virsh</command>) includes
-     descriptions of the commands that support &qemu; GA interface.
+     descriptions of the commands that support the &qemu; GA interface.
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/vt_qemu_tpm.xml
+++ b/xml/vt_qemu_tpm.xml
@@ -58,16 +58,15 @@
    <step>
     <para>
      Create a directory <filename>mytpm0</filename> inside the VM
-     directory&mdash;for example,
-     <filename>/var/lib/libvirt/qemu/sle15sp3</filename>&mdash;to store the TPM
-     states:
+     directory to store the TPM states&mdash;for example,
+     <filename>/var/lib/libvirt/qemu/sle15sp3</filename>:
     </para>
 <screen>&prompt.sudo;mkdir /var/lib/libvirt/qemu/sle15sp3/mytpm0</screen>
    </step>
    <step>
     <para>
-     Start <command>swtmp</command>. It will create a socket file&mdash;for
-     example, <filename>swtpm-sock</filename>&mdash;that &qemu; can use:
+     Start <command>swtmp</command>. It will create a socket file that &qemu; can use&mdash;for example,
+     <filename>/var/lib/libvirt/qemu/sle15sp3</filename>:
     </para>
 <screen>
  &prompt.sudo;swtpm socket

--- a/xml/vt_qemu_tpm.xml
+++ b/xml/vt_qemu_tpm.xml
@@ -13,73 +13,92 @@
  </info>
  <sect1 xml:id="tpm-introduction">
   <title>Introduction</title>
+
   <para>
-   The Trusted Platform Module (TPM) is a cryptoprocessor that secures hardware using cryptographic keys.
-   For developers who use the TPM to develop security features, a software TPM emulator is a convenient solution.
-   Compared to a hardware TPM device, the emulator has no limit on the number of guests that can access it.
-   Also, it is simple to switch between TPM versions 1.2 and 2.0.
-   &qemu; supports the software TPM emulator that is included in the <package>swtpm</package> package.
+   The Trusted Platform Module (TPM) is a cryptoprocessor that secures hardware
+   using cryptographic keys. For developers who use the TPM to develop security
+   features, a software TPM emulator is a convenient solution. Compared to a
+   hardware TPM device, the emulator has no limit on the number of guests that
+   can access it. Also, it is simple to switch between TPM versions 1.2 and
+   2.0. &qemu; supports the software TPM emulator that is included in the
+   <package>swtpm</package> package.
   </para>
  </sect1>
  <sect1 xml:id="tpm-prerequisite">
   <title>Prerequisites</title>
+
   <para>
-   Before you can install and use the software TPM emulator, you need to install the &libvirt; virtualization environment.
-   Refer to <xref linkend="vt-installation-yast"/> and install one of the provided virtualization solutions.
+   Before you can install and use the software TPM emulator, you need to
+   install the &libvirt; virtualization environment. Refer to
+   <xref linkend="vt-installation-yast"/> and install one of the provided
+   virtualization solutions.
   </para>
  </sect1>
  <sect1 xml:id="tpm-installation">
   <title>Installation</title>
+
   <para>
-   To use the software TPM emulator, install the <package>swtpm</package> package:
+   To use the software TPM emulator, install the <package>swtpm</package>
+   package:
   </para>
+
 <screen>&prompt.sudo;zypper install swtpm</screen>
  </sect1>
  <sect1 xml:id="tpm-qemu">
   <title>Using <command>swtpm</command> with &qemu;</title>
-   <para>
-    <command>swtpm</command> provides three types of interface: <literal>socket</literal>, <literal>chardev</literal>, and <literal>cuse</literal>.
-    This procedure focuses on the <emphasis>socket</emphasis> interface.
-   </para>
-   <procedure>
-    <step>
-     <para>
-      Create a directory <filename>mytpm0</filename> inside the VM directory&mdash;for example, <filename>/var/lib/libvirt/qemu/sle15sp3</filename>&mdash;to store the TPM states:
-     </para>
- <screen>&prompt.sudo;mkdir /var/lib/libvirt/qemu/sle15sp3/mytpm0</screen>
-    </step>
-    <step>
-     <para>
-      Start <command>swtmp</command>. It will create a socket file&mdash;for example, <filename>swtpm-sock</filename>&mdash;that &qemu; can use:
-     </para>
- <screen>
+
+  <para>
+   <command>swtpm</command> provides three types of interface:
+   <literal>socket</literal>, <literal>chardev</literal>, and
+   <literal>cuse</literal>. This procedure focuses on the
+   <emphasis>socket</emphasis> interface.
+  </para>
+
+  <procedure>
+   <step>
+    <para>
+     Create a directory <filename>mytpm0</filename> inside the VM
+     directory&mdash;for example,
+     <filename>/var/lib/libvirt/qemu/sle15sp3</filename>&mdash;to store the TPM
+     states:
+    </para>
+<screen>&prompt.sudo;mkdir /var/lib/libvirt/qemu/sle15sp3/mytpm0</screen>
+   </step>
+   <step>
+    <para>
+     Start <command>swtmp</command>. It will create a socket file&mdash;for
+     example, <filename>swtpm-sock</filename>&mdash;that &qemu; can use:
+    </para>
+<screen>
  &prompt.sudo;swtpm socket
   --tpmstate dir=/var/lib/libvirt/qemu/sle15sp3/mytpm0 \
   --ctrl type=unixio,path=/var/lib/libvirt/qemu/sle15sp3/mytpm0/swtpm-sock \
   --log level=20
  </screen>
-     <tip>
-      <title>TPM version 2.0</title>
-      <para>
-       By default, <command>swtpm</command> starts a TPM version 1.2 emulator and stores its states in the <filename>tpm-00.permall</filename> directory.
-       To create a TPM 2.0 instance, run:
-      </para>
- <screen>
+    <tip>
+     <title>TPM version 2.0</title>
+     <para>
+      By default, <command>swtpm</command> starts a TPM version 1.2 emulator
+      and stores its states in the <filename>tpm-00.permall</filename>
+      directory. To create a TPM 2.0 instance, run:
+     </para>
+<screen>
  &prompt.sudo;swtpm socket
   --tpm2
   --tpmstate dir=/var/lib/libvirt/qemu/sle15sp3/mytpm0 \
   --ctrl type=unixio,path=/var/lib/libvirt/qemu/sle15sp3/mytpm0/swtpm-sock \
   --log level=20
  </screen>
-      <para>
-       TPM 2.0 states will be stored in the <filename>tpm2-00.permall</filename> directory.
-      </para>
-     </tip>
-    </step>
-    <step>
      <para>
-      Add the following command line parameters to the &qemusystemarch; command:
+      TPM 2.0 states will be stored in the <filename>tpm2-00.permall</filename>
+      directory.
      </para>
+    </tip>
+   </step>
+   <step>
+    <para>
+     Add the following command line parameters to the &qemusystemarch; command:
+    </para>
 <screen>
 &prompt.user;qemu-system-x86_64 \
 [...]
@@ -87,11 +106,12 @@
 -tpmdev emulator,id=tpm0,chardev=chrtpm \
 -device tpm-tis,tpmdev=tpm0
 </screen>
-    </step>
-    <step>
-     <para>
-      Verify that the TPM device is available in the guest by running the following command:
-     </para>
+   </step>
+   <step>
+    <para>
+     Verify that the TPM device is available in the guest by running the
+     following command:
+    </para>
 <screen>&prompt.user;tpm_version
 TPM 1.2 Version Info:
 Chip Version:        1.2.18.158
@@ -101,14 +121,17 @@ TPM Vendor ID:       IBM
 TPM Version:         01010000
 Manufacturer Info:   49424d00
 </screen>
-    </step>
-   </procedure>
+   </step>
+  </procedure>
  </sect1>
  <sect1 xml:id="tpm-libvirt">
   <title>Using swtpm with &libvirt;</title>
+
   <para>
-   To use swtpm with &libvirt;, add the following TPM device to the guest XML specification:
+   To use swtpm with &libvirt;, add the following TPM device to the guest XML
+   specification:
   </para>
+
 <screen>
 &lt;devices>
  &lt;tpm model='tpm-tis'>
@@ -116,44 +139,55 @@ Manufacturer Info:   49424d00
  &lt;/tpm>
 &lt;/devices>
 </screen>
+
   <para>
-   &libvirt; will start swtpm for the guest automatically; you do not need to start it manually in advance.
-   The corresponding <filename>permall</filename> file will be created in <filename>/var/lib/libvirt/swtpm/<replaceable>VM_UUID</replaceable></filename>.
+   &libvirt; will start swtpm for the guest automatically; you do not need to
+   start it manually in advance. The corresponding <filename>permall</filename>
+   file will be created in
+   <filename>/var/lib/libvirt/swtpm/<replaceable>VM_UUID</replaceable></filename>.
   </para>
  </sect1>
  <sect1 xml:id="tpm-ovmf">
   <title>TPM measurement with OVMF firmware</title>
+
   <para>
-   If the guest uses the Open Virtual Machine Firmware (OVMF), it will measure components with TPM.
-   You can find the event log in <filename>/sys/kernel/security/tpm0/binary_bios_measurements</filename>.
+   If the guest uses the Open Virtual Machine Firmware (OVMF), it will measure
+   components with TPM. You can find the event log in
+   <filename>/sys/kernel/security/tpm0/binary_bios_measurements</filename>.
   </para>
  </sect1>
  <sect1 xml:id="qemu-tpm-resources">
   <title>Resources</title>
+
   <itemizedlist>
    <listitem>
     <para>
-     Wikipedia offers a thorough description of the TPM at the page <link xlink:href="https://en.wikipedia.org/wiki/Trusted_Platform_Module"/>.
+     Wikipedia offers a thorough description of the TPM at the page
+     <link xlink:href="https://en.wikipedia.org/wiki/Trusted_Platform_Module"/>.
     </para>
    </listitem>
    <listitem>
     <para>
-     Configuring a specific virtualization environment on &productname; is described in <xref linkend="cha-vt-installation"/>.
+     Configuring a specific virtualization environment on &productname; is
+     described in <xref linkend="cha-vt-installation"/>.
     </para>
    </listitem>
    <listitem>
     <para>
-     Details on the use of <package>swtpm</package> are on its manual page (<command>man 8 swtpm</command>).
+     Details on the use of <package>swtpm</package> are on its manual page
+     (<command>man 8 swtpm</command>).
     </para>
    </listitem>
    <listitem>
     <para>
-     A detailed &libvirt; specification of TPM is at <link xlink:href="https://libvirt.org/formatdomain.html#elementsTpm"/>
+     A detailed &libvirt; specification of TPM is at
+     <link xlink:href="https://libvirt.org/formatdomain.html#elementsTpm"/>
     </para>
    </listitem>
    <listitem>
     <para>
-     A description of enabling UEFI firmware by using OVMF is at <xref linkend="sec-vt-installation-ovmf"/>.
+     A description of enabling UEFI firmware by using OVMF is at
+     <xref linkend="sec-vt-installation-ovmf"/>.
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/vt_qemu_tpm.xml
+++ b/xml/vt_qemu_tpm.xml
@@ -16,7 +16,7 @@
   <para>
    The Trusted Platform Module (TPM) is a cryptoprocessor that secures hardware using cryptographic keys.
    For developers who use the TPM to develop security features, a software TPM emulator is a convenient solution.
-   Compared to a hardware TPM device, the emulator has no limit for the number of guests that can access it.
+   Compared to a hardware TPM device, the emulator has no limit on the number of guests that can access it.
    Also, it is simple to switch between TPM versions 1.2 and 2.0.
    &qemu; supports the software TPM emulator that is included in the <package>swtpm</package> package.
   </para>
@@ -143,17 +143,17 @@ Manufacturer Info:   49424d00
    </listitem>
    <listitem>
     <para>
-     Details about <package>swtpm</package> usage are in its manual page (<command>man 8 swtpm</command>).
+     Details on the use of <package>swtpm</package> are on its manual page (<command>man 8 swtpm</command>).
     </para>
    </listitem>
    <listitem>
     <para>
-     Detailed &libvirt; specification for TPM is at <link xlink:href="https://libvirt.org/formatdomain.html#elementsTpm"/>
+     A detailed &libvirt; specification of TPM is at <link xlink:href="https://libvirt.org/formatdomain.html#elementsTpm"/>
     </para>
    </listitem>
    <listitem>
     <para>
-     Description of enabling UEFI firmware by using OVMF is at <xref linkend="sec-vt-installation-ovmf"/>.
+     A description of enabling UEFI firmware by using OVMF is at <xref linkend="sec-vt-installation-ovmf"/>.
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/vt_scenarios.xml
+++ b/xml/vt_scenarios.xml
@@ -134,7 +134,7 @@
    </listitem>
    <listitem>
     <para>
-     Usage of paravirtualization and <literal>virtio</literal> drivers will
+     Use of paravirtualization and <literal>virtio</literal> drivers will
      generally improve VM performance and efficiency.
     </para>
    </listitem>

--- a/xml/vt_scenarios.xml
+++ b/xml/vt_scenarios.xml
@@ -21,23 +21,22 @@
     Virtualization provides several useful capabilities to your
     organization: more efficient hardware use, support for legacy software,
     operating system isolation, live migration, disaster recovery, and 
-    load-balancing. 
+    load balancing. 
    </para>
   </abstract>
  </info>
  <sect1 xml:id="sec-virtualization-scenarios-capabilities">
   <title>Server consolidation</title>
   <para>
-   Many servers can be replaced by one big physical
-   server, so that hardware is consolidated, and guest operating systems are
-   converted to virtual machines. This also supports running legacy
-   software on new hardware.
+   Many servers can be replaced by one big physical server, so that hardware is
+   consolidated, and guest operating systems are converted to virtual machines.
+   This also supports running legacy software on new hardware.
    <!-- reduce cost -->
   </para>
   <itemizedlist>
    <listitem>
     <para>
-     Better usage of resources which were not running at 100%
+     Better usage of resources that were not running at 100%
     </para>
    </listitem>
    <listitem>
@@ -62,7 +61,7 @@
    </listitem>
    <listitem>
     <para>
-     Faster and agile Virtual Machine provisioning.
+     Faster and agile virtual machine provisioning.
     </para>
    </listitem>
    <listitem>
@@ -129,12 +128,14 @@
    </listitem>
    <listitem>
     <para>
-     Use of advanced hypervisor features such as PCI pass-through or NUMA will adversely affect VM migration capabilities
+     Use of advanced hypervisor features such as PCI pass-through or NUMA will
+     adversely affect VM migration capabilities.
     </para>
    </listitem>
    <listitem>
     <para>
-     Usage of paravirtualization and <literal>virtio</literal> drivers will generally improve VM performance and efficiency
+     Usage of paravirtualization and <literal>virtio</literal> drivers will
+     generally improve VM performance and efficiency.
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/xen2kvm.xml
+++ b/xml/xen2kvm.xml
@@ -1058,8 +1058,8 @@ getty@xvc1.service -&gt; /usr/lib/systemd/system/getty@xvc1.service
 
 </screen>
     <para>
-     Save the configuration to a file in your home directory, for example, as
-     <filename>SLES11SP3.xml</filename>. Later, after you import it, it will be
+     Save the configuration to a file in your home directory, as
+     <filename>SLES11SP3.xml</filename>, for example. After you import it, it will be
      copied to the default <filename>/etc/libvirt/qemu</filename> folder.
     </para>
    </sect3>

--- a/xml/xen2kvm.xml
+++ b/xml/xen2kvm.xml
@@ -34,9 +34,9 @@
    <para>
     This section is focused on converting Linux guests. Converting Microsoft
     Windows guests using <command>virt-v2v</command> is the same as converting
-    Linux guests, except in regards to handling the Virtual Machine Driver Pack
+    Linux guests, except with regard to handling the Virtual Machine Driver Pack
     (VMDP). Additional details on converting Windows guests with the VMDP can
-    be found in the separate at
+    be found separately at
     <link
      xlink:href="https://documentation.suse.com/sle-vmdp/">Virtual
     Machine Driver Pack documentation</link>.
@@ -116,13 +116,13 @@
    <note>
     <title>Conditions for skipping this step</title>
     <para>
-     If running <command>virt-v2v</command> on &slsa; 12 SP1 or before, this
+     If running <command>virt-v2v</command> on &slsa; 12 SP1 or earlier, this
      step can be safely skipped. This step can also be ignored if the virtual
      machine is fully virtualized or if it runs on &slsa; 12 SP2 or later.
     </para>
    </note>
    <para>
-    The &xen; virtual machine must have default kernel installed. To ensure
+    The &xen; virtual machine must have the default kernel installed. To ensure
     this, run <command>zypper in kernel-default</command> on the virtual
     machine.
    </para>
@@ -153,7 +153,7 @@
      <para>
       <command>virt-v2v</command> copies the storage of the source virtual
       machine to a local storage pool managed by &libvirt; (the original disk
-      image remains unchanged). You can create the pool either with &vmm;, or
+      image remains unchanged). You can create the pool either with &vmm; or
       <command>virsh</command>. For more information, see
       <xref linkend="sec-libvirt-storage-vmm"/> and
       <xref linkend="sec-libvirt-storage-virsh"/>.
@@ -176,7 +176,7 @@
        Network devices on the source &xen; host can be mapped during the
        conversion process to corresponding network devices on the &kvm; target
        host. For example, the &xen; bridge <literal>br0</literal> can be mapped
-       to the KVM network default. Sample mappings can be found in
+       to the default KVM network device. Sample mappings can be found in
        <filename>/etc/virt-v2v.conf</filename>. To enable these mappings,
        modify the XML rule as necessary and ensure the section is not commented
        out with <literal>&lt;!--</literal> and <literal>--&gt;</literal>
@@ -282,9 +282,9 @@
      </step>
      <step>
       <para>
-       Verify all disk image paths are correct from the &kvm; host's
+       Verify that all disk image paths are correct from the &kvm; host's
        perspective. This is not a problem when converting on one machine, but
-       may require manual changes when converting using an XML dump from
+       might require manual changes when converting using an XML dump from
        another host.
       </para>
 <screen>&lt;source file='/var/lib/libvirt/images/XenPool/SLES.qcow2'/&gt;</screen>
@@ -316,7 +316,7 @@
        <callout arearefs="v2v-method">
         <para>
          <command>virt-v2v</command> will read the information about the source
-         virtual machine form a &libvirt; XML file.
+         virtual machine from a &libvirt; XML file.
         </para>
        </callout>
        <callout arearefs="v2v-pool">
@@ -409,8 +409,8 @@
        </callout>
        <callout arearefs="v2v-sparse">
         <para>
-         If the converted guest disk space will be <option>sparse</option> or
-         <option>preallocated</option>.
+         Whether the converted guest disk space will be <option>sparse</option>
+         or <option>preallocated</option>.
         </para>
        </callout>
       </calloutlist>
@@ -422,7 +422,7 @@
     <para>
      This method is useful if you need to convert a &xen; virtual machine
      running on a remote host. As <command>virt-v2v</command> connects to the
-     remote host via <command>ssh</command>, ensure that SSH service is running
+     remote host via <command>ssh</command>, ensure the SSH service is running
      on the host.
     </para>
     <note>
@@ -516,7 +516,8 @@
     main focus of this article is on the &libvirt; solution.
    </para>
    <para>
-    Generally, the &xen; to &kvm; migration runs in the following basic steps:
+    Generally, the &xen; to &kvm; migration consists of the following basic
+    steps:
    </para>
    <procedure>
     <step>
@@ -579,13 +580,13 @@ Id Name                 State
     </step>
     <step>
      <para>
-      Backup its configuration to an XML file.
+      Back up its configuration to an XML file.
      </para>
 <screen>&prompt.sudo;virsh dumpxml SLES11SP3 &gt; sles11sp3.xml</screen>
     </step>
     <step>
      <para>
-      Backup its disk image file. Use the <command>cp</command> or
+      Back up its disk image file. Use the <command>cp</command> or
       <command>rsync</command> commands to create the backup copy. Remember
       that it is always a good idea to check the copy with the
       <command>md5sum</command> command.
@@ -619,8 +620,8 @@ Id Name                 State
     <warning>
      <title>No booting</title>
      <para>
-      After you installed the default kernel, do not try to boot the &xen;
-      guest with it, the system will not boot.
+      After you install the default kernel, do not try to boot the &xen;
+      guest with it, as the system will not boot.
      </para>
     </warning>
     <para>
@@ -633,9 +634,9 @@ Id Name                 State
     <orderedlist spacing="normal">
      <listitem>
       <para>
-       For &slsa; 11 update the <filename>/etc/sysconfig/kernel</filename>
+       For &slsa; 11, update the <filename>/etc/sysconfig/kernel</filename>
        file. Change the <literal>INITRD_MODULES</literal> parameter by removing
-       all &xen; drivers and replacing the with virtio drivers. Replace
+       all &xen; drivers and replacing them with virtio drivers. Replace
       </para>
 <screen>INITRD_MODULES="xenblk xennet"</screen>
       <para>
@@ -643,26 +644,26 @@ Id Name                 State
       </para>
 <screen>INITRD_MODULES="virtio_blk virtio_pci virtio_net virtio_balloon"</screen>
       <para>
-       For &slsa; 12 search for <literal>xenblk xennet</literal> in
+       For &slsa; 12, search for <literal>xenblk xennet</literal> in
        <filename>/etc/dracut.conf.d/*.conf</filename> and replace them with
        <literal>virtio_blk virtio_pci virtio_net virtio_balloon</literal>
       </para>
      </listitem>
      <listitem>
       <para>
-       Paravirtualized &xen; guests are running a specific &xen; kernel. To run
-       the guest under &kvm;, you need to install the default kernel.
+       Paravirtualized &xen; guests run a specific &xen; kernel. To run the
+       guest under &kvm;, you need to install the default kernel.
       </para>
       <note>
        <title>Default kernel is already installed</title>
        <para>
         You do not need to install the default kernel for a fully virtualized
-        guests as it is already installed.
+        guest, as it is already installed.
        </para>
       </note>
       <para>
        Enter <command>rpm -q kernel-default</command> on the &xen; guest to
-       find out if the default kernel is installed. If not, install it with
+       find out whether the default kernel is installed. If not, install it with
        <command>zypper in kernel-default</command>.
       </para>
       <para>
@@ -687,7 +688,7 @@ Id Name                 State
      <listitem>
       <para>
        Update the boot loader configuration. Enter <command>rpm -q
-       grub2</command> on the &xen; guest to find out if &grub; is already
+       grub2</command> on the &xen; guest to find out whether &grub; is already
        installed. If not, install it with <command>zypper in grub2</command>.
       </para>
       <para>
@@ -710,7 +711,7 @@ Id Name                 State
        </listitem>
        <listitem>
         <para>
-         Set it the default boot menu entry:
+         Set it as the default boot menu entry:
         </para>
 <screen>&prompt.sudo;grub2-set-default <replaceable>N</replaceable></screen>
         <para>
@@ -721,8 +722,8 @@ Id Name                 State
        <listitem>
         <para>
          Open <filename>/etc/default/grub</filename>for editing, and look for
-         <option>GRUB_CMDLINE_LINUX_DEFAULT</option> and
-         <option>GRUB_CMDLINE_LINUX_RECOVERY</option> options. Remove/update
+         the <option>GRUB_CMDLINE_LINUX_DEFAULT</option> and
+         <option>GRUB_CMDLINE_LINUX_RECOVERY</option> options. Remove or update
          any reference to &xen;-specific devices. In the following example, you
          can replace
         </para>
@@ -741,10 +742,10 @@ Id Name                 State
      </listitem>
      <listitem>
       <para>
-       Update <filename>device.map</filename> in one of
+       Update <filename>device.map</filename> in either the
        <filename>/boot/grub2</filename> or <filename>/boot/grub2-efi</filename>
-       directories. Change any storage device from <literal>xvda</literal> to
-       <literal>vda</literal>.
+       directory, whichever that VM uses. Change any storage devices from
+       <literal>xvda</literal> to <literal>vda</literal>.
       </para>
      </listitem>
      <listitem>
@@ -760,7 +761,7 @@ Id Name                 State
     <orderedlist spacing="normal">
      <listitem>
       <para>
-       Update the system to use default serial console. List the configured
+       Update the system to use the default serial console. List the configured
        consoles, and remove symbolic links to <literal>xvc?</literal> ones.
       </para>
 <screen>&prompt.sudo;ls -l /etc/systemd/system/getty.target.wants/
@@ -791,7 +792,7 @@ getty@xvc1.service -&gt; /usr/lib/systemd/system/getty@xvc1.service
     <title>Export the &xen; &vmguest; configuration</title>
     <para>
      First export the configuration of the guest and save it to a file. A
-     typical one may look like this:
+     typical one might look like this:
     </para>
 <screen>&prompt.sudo;virsh dumpxml SLES11SP3
 &lt;domain type='xen'&gt;
@@ -913,7 +914,7 @@ getty@xvc1.service -&gt; /usr/lib/systemd/system/getty@xvc1.service
          <literal>/domain/devices/disk/driver</literal> element from
          <literal>file</literal> to <literal>qemu</literal>, and add a
          <literal>type</literal> attribute for the disk type. For example,
-         valid options include <literal>raw</literal> or
+         valid options include <literal>raw</literal> and
          <literal>qcow2</literal>.
         </para>
        </listitem>
@@ -935,12 +936,12 @@ getty@xvc1.service -&gt; /usr/lib/systemd/system/getty@xvc1.service
      </listitem>
      <listitem>
       <para>
-       For each network interface card, do the following changes:
+       For each network interface card, make the following changes:
       </para>
       <itemizedlist mark="bullet" spacing="normal">
        <listitem>
         <para>
-         If there is <literal>model</literal> defined in
+         If there is a <literal>model</literal> defined in
          <literal>/domain/devices/interface</literal>, change its
          <literal>type</literal> attribute value to <literal>virtio</literal>
         </para>
@@ -1057,10 +1058,9 @@ getty@xvc1.service -&gt; /usr/lib/systemd/system/getty@xvc1.service
 
 </screen>
     <para>
-     Save the configuration to a file in your home directory. After you later
-     import it, it will be copied to the default
-     <filename>/etc/libvirt/qemu</filename>. Suppose you save the file as
-     <filename>SLES11SP3.xml</filename>.
+     Save the configuration to a file in your home directory, for example, as
+     <filename>SLES11SP3.xml</filename>. Later, after you import it, it will be
+     copied to the default <filename>/etc/libvirt/qemu</filename> folder.
     </para>
    </sect3>
   </sect2>
@@ -1121,7 +1121,7 @@ getty@xvc1.service -&gt; /usr/lib/systemd/system/getty@xvc1.service
   </para>
 
   <para>
-   You can find more details on &libvirt; XML format at
+   You can find more details on the &libvirt; XML format at
    <link xlink:href="https://libvirt.org/formatdomain.html"/>.
   </para>
 

--- a/xml/xen_config_options.xml
+++ b/xml/xen_config_options.xml
@@ -1091,7 +1091,7 @@ alice                             4     1     3   -b-       2.8 2-3</screen>
       CPUs wanting to run. The impact on performance will depend on the actual
       workload being run inside of the guest systems. In most of the analyzed
       cases, the observed performance degradation, especially if under
-      considerable load, was smaller than disabling HyperThreading which leaves
+      considerable load, was smaller than disabling HyperThreading, which leaves
       all the cores with just one thread (see the <option>smt</option> boot
       option at <link
        xlink:href="https://xenbits.xen.org/docs/unstable/misc/xen-command-line.html#smt-x86"/>).

--- a/xml/xen_virtualization_manage.xml
+++ b/xml/xen_virtualization_manage.xml
@@ -324,7 +324,7 @@ boot = "n"</screen>
  </sect1>
 
  <sect1 xml:id="sec-xen-manage-tsc">
-  <title>Time stamp counter</title>
+  <title>Time Stamp Counter</title>
   <para>
    The Time Stamp Counter (TSC) may be specified for each domain in the guest
    domain configuration file (for more information, see <xref


### PR DESCRIPTION
### PR creator: Description

Integrate Dublin proofreading connections into the Virtualization Guide. 

One file had no soft line-wrapping, so I have reformatted it with `daps-xmlformat -i`. I did this in a separate commit; I hope this helps.


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(if applicable to 15 SP4 _only_ -- do not merge yet!)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
