### PR TITLE
Update dsc/RN links across docs

### DIFF
--- a/xml/art_installation-sleds.xml
+++ b/xml/art_installation-sleds.xml
@@ -523,10 +523,7 @@ disk:
     you have chosen in the first step of this installation. For a description
     of the modules and their life cycles, select a module to see the
     accompanying text. More detailed information is available in the <link
-    xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/art-modules.html">&modulesquick;</link>
-    and the <link
-     xlink:href="https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15/#Intro.Module">Release
-    Notes</link>.
+    xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/article-modules.html">&modulesquick;</link>.
    </para>
    <para>
     The selection of modules indirectly affects the scope of the

--- a/xml/art_modules.xml
+++ b/xml/art_modules.xml
@@ -68,7 +68,7 @@
       life cycle. Except for the &suse; Package Hub module, &suse;
       provides L3 support for almost all packages provided by modules. For more
       information about the &productname; support statement refer to the <link
-      xlink:href="https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15/#Intro.Support">Release
+      xlink:href="https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15-SP3/#intro-support">Release
       Notes</link>.
      </para>
     </listitem>

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -1076,10 +1076,8 @@ sle-live-patching 8c541494</screen>
    The availability of certain modules or extensions depends on the product you
    chose in the first step of this installation. For a description of the
    modules and their life cycles, select a module to see the accompanying
-   text. More detailed information is available in the <link
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xlink:href="https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15/#Intro.Module">Release
-   Notes</link>.
+   text. More detailed information is available in the
+   <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/article-modules.html">&modulesquick;</link>.
   </para>
   <para>
    The selection of modules indirectly affects the scope of the installation,

--- a/xml/storage_filesystems.xml
+++ b/xml/storage_filesystems.xml
@@ -17,8 +17,9 @@
     including Btrfs, Ext4, Ext3, Ext2 and XFS. Each file system has its own
     advantages and disadvantages. For a side-by-side feature comparison of the
     major file systems in &productname;, see
-    <link xlink:href="https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15-SP2/#allArch-filesystems"/>
-    (File System Support and Sizes). This chapter contains an overview of how
+    <link xlink:href="https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15-SP3/#file-system-comparison"/>
+    (<citetitle>Comparison of supported file systems</citetitle>).
+    This chapter contains an overview of how
     these file systems work and what advantages they offer.
    </para>
   </abstract>
@@ -37,7 +38,7 @@
   &productname; includes OCFS2 (Oracle Cluster File System 2) and the
   Distributed Replicated Block Device (DRBD) in the &hasi; add-on. These
   advanced storage systems are not covered in this guide. For information, see
-  the <link xlink:href="https://documentation.suse.com/sle-ha-15/html/SLE-HA-all/book-sleha-guide.html">
+  the <link xlink:href="https://documentation.suse.com/sle-ha-15/html/SLE-HA-all/book-administration.html">
   <citetitle>&haguide; for the &sle; &hasi;</citetitle></link>.
  </para>
  <para>

--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -117,7 +117,7 @@
   <para>
    For the maximum total virtual CPUs per host, see
    <link
-     xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/article-vt-best-practices.html#sec-vt-best-perf-cpu-assign">recommendations
+     xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/article-virtualization-best-practices.html#sec-vt-best-perf-cpu-assign">recommendations
    in the Virtualization Best Practices Guide regarding over-commitment of
    physical CPUs</link>. The total number of virtual CPUs should be
    proportional to the number of available physical CPUs.
@@ -183,7 +183,7 @@
        <emphasis>Maximum virtual CPUs per VM</emphasis>: See recommendations in
        the <citetitle>Virtualization Best Practices Guide</citetitle> regarding over-commitment of
        physical CPUs at
-       <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/article-vt-best-practices.html#sec-vt-best-perf-cpu-assign"/>.
+       <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/article-virtualization-best-practices.html#sec-vt-best-perf-cpu-assign"/>.
        The total virtual CPUs should be proportional to the available physical
        CPUs.
       </para>
@@ -255,7 +255,7 @@
         <para>
          See recommendations in the Virtualization Best Practices Guide
          regarding over-commitment of physical CPUs in
-         <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/article-vt-best-practices.html#sec-vt-best-perf-cpu-assign"/>.
+         <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/article-virtualization-best-practices.html#sec-vt-best-perf-cpu-assign"/>.
          The total virtual CPUs should be proportional to the available
          physical CPUs
         </para>

--- a/xml/xen_administrating.xml
+++ b/xml/xen_administrating.xml
@@ -297,7 +297,7 @@ cpuid = [
    <tip>
     <para>
      &libvirt; also supports calculating a baseline CPU for migration. For more details, refer to <link
-xlink:href="https://documentation.suse.com/sles-15/single-html/SLES-vt-best-practices/" />.
+xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/article-virtualization-best-practices.html" />.
     </para>
    </tip>
    <sect3 xml:id="sec-xen-manage-migrate-cpu-info">

--- a/xml/yast2_sw_addon.xml
+++ b/xml/yast2_sw_addon.xml
@@ -26,7 +26,7 @@
   cycle and update timeline. They are a set of packages, have a clearly
   defined scope and are delivered via online channel only.
   For a list of modules, their dependencies and lifecycles see
-  <link xlink:href="https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15/#Intro.ModuleExtensionRelated"/>.
+  <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/article-modules.html">&modulesquick;</link>.
  </para>
  <para>
   Extensions, such as the &slewe; or the &hasi;, add functionality to the


### PR DESCRIPTION
### PR creator: Description

Update outdated links.

@taroth21 Some items were using the `/sles-15/` URLs. Rather conveniently, we broke many of these URLs with the ID updates :/


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(if applicable to 15 SP4 _only_ -- do not merge yet!)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
