### PR TITLE
AutoYaST: minor fixes regarding ERB mark-up

### DIFF
--- a/xml/ay_erb_templates.xml
+++ b/xml/ay_erb_templates.xml
@@ -43,7 +43,7 @@ xml:id="erb-templates">
 
    <para>
     When using ERB, the Ruby code is enclosed between <literal>&lt;%</literal>
-    and <literal>&gt;</literal> signs. If you want the output of the command to
+    and <literal>%&gt;</literal> signs. If you want the output of the command to
     be included in the resulting profile, you simply need to add an equal
     sign (<literal>=</literal>).
    </para>
@@ -472,7 +472,7 @@ xml:id="erb-templates">
      <screen>&lt;products t="list"&gt;
   &lt;% if os_release[:id] == 'sle' %&gt;
   &lt;product&gt;SLES&lt;/product&gt;
-  &lt;% else %&lt;
+  &lt;% else %&gt;
   &lt;product&gt;openSUSE&lt;/product&gt;
   &lt;% end %&lt;
 &lt;/products&gt;</screen>


### PR DESCRIPTION
### PR creator: Description

ERB lines should end wiht `%>`.
### PR creator: Are there any relevant issues/feature requests?

* Related to [bsc#1187684](https://bugzilla.suse.com/show_bug.cgi?id=1187684)

### PR creator: Which product versions do the changes apply to?
When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [X] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [X] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
