### PR TITLE
Expand list of partition_ids for AutoYaST partitioning

### DIFF
--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -811,18 +811,29 @@
                  <para>
                      The <literal>partition_id</literal> sets the id of the 
                      partition. If you want different identifiers than 131 for 
-                     Linux partition or  130 for swap, configure them with
+                     Linux partition or 130 for swap, configure them with
                      <literal>partition_id.</literal> The default is 
                      <literal>131</literal> for a Linux partition and
                      <literal>130</literal> for swap.
                  </para>
 <screen>&lt;partition_id config:type="integer"&gt;131&lt;/partition_id&gt;</screen>                 
 <simplelist>
- <member>Swap: <literal>130</literal></member>
- <member>Linux: <literal>131</literal></member>
- <member>LVM: <literal>142</literal></member>
- <member>MD RAID: <literal>253</literal></member>
- <member>EFI partition: <literal>259</literal></member>
+ <member>FAT16 (MS-DOS): <literal>6</literal></member>
+ <member>NTFS (MS-DOS): <literal>7</literal></member> 
+ <member>FAT32 (MS-DOS): <literal>12</literal></member>
+ <member>Extended FAT16 (MS-DOS): <literal>15</literal></member> 
+ <member>DIAG, Diagnostics and firmware (MS-DOS, GPT): <literal>18</literal></member> 
+ <member>PPC PReP Boot partition (MS-DOS, GPT): <literal>65</literal></member> 
+ <member>Swap (MS-DOS, GPT, DASD, implicit): <literal>130</literal></member> 
+ <member>Linux (MS-DOS, GPT, DASD): <literal>131</literal></member>
+ <member>Intel Rapid Start Technology (MS-DOS, GPT): <literal>132</literal></member>
+ <member>LVM (MS-DOS, GPT, DASD): <literal>142</literal></member>
+ <member>EFI System Partition (MS-DOS, GPT): <literal>239</literal></member>
+ <member>MD RAID (MS-DOS, GPT, DASD): <literal>253</literal></member>
+ <member>BIOS boot (GPT): <literal>257</literal></member>
+ <member>Windows basic data (GPT): <literal>258</literal></member> 
+ <member>EFI (GPT): <literal>259</literal></member>
+ <member>Microsoft reserved (GPT): <literal>261</literal></member>  
 </simplelist>
              </listitem>
          </varlistentry>


### PR DESCRIPTION
resolves BSC #1186218, Jira #DOCTEAM-189


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
