### PR TITLE
Several small fixes in 389 Directory Server

### DIFF
--- a/xml/book_security.xml
+++ b/xml/book_security.xml
@@ -60,10 +60,6 @@
   <xi:include href="security_yast2_security.xml"/>
   <xi:include href="security_policy_kit.xml"/>
   <xi:include href="security_acls.xml"/>
-
-<!-- fs 2009-02-23:
-     Not sure whether this ships with openSUSE
--->
   <xi:include href="security_certificatestore.xml"/>
   <xi:include href="security_aide.xml"/>
  </part>

--- a/xml/security_ldap_install.xml
+++ b/xml/security_ldap_install.xml
@@ -357,10 +357,11 @@ Instance "localhost" is running</screen>
              └─4456 /usr/sbin/ns-slapd -D /etc/dirsrv/slapd-ldap1 -i /run/dirsrv/slapd-ldap1.pid
 </screen>
    <para>
-       Start and stop your server:
+       Start, stop, and restart your LDAP server:
    </para>
    <screen>&prompt.sudo;systemctl start <replaceable>dirsrv@ldap1.service</replaceable>
-&prompt.sudo;systemctl stop <replaceable>dirsrv@ldap1.service</replaceable></screen>
+&prompt.sudo;systemctl stop <replaceable>dirsrv@ldap1.service</replaceable>
+&prompt.sudo;systemctl restart <replaceable>dirsrv@ldap1.service</replaceable></screen>
    <para>
        See <xref linkend="cha-systemd"/> for more information on using 
        <command>systemctl</command>.

--- a/xml/security_ldap_modules.xml
+++ b/xml/security_ldap_modules.xml
@@ -9,10 +9,14 @@
   <title>Managing modules</title>
   <para>
     Use the following command to list all available modules, enabled and 
-    disabled:
+    disabled. Use your server's hostname rather than the instance name
+    of your &ds389; server, like the following example hostname of
+    <replaceable>ldapserver1</replaceable>:
   </para>
-  <screen>&prompt.sudo;dsconf -D "cn=Directory Manager" ldap//:<replaceable>ldapserver1</replaceable> plug-in list
-    Enter password for cn=Directory Manager on ldap://<replaceable>ldapserver1</replaceable>: 
+  <screen>&prompt.sudo;dsconf -D "cn=Directory Manager" ldap://<replaceable>ldapserver1</replaceable> plugin list
+    [sudo] password for root: <replaceable>password</replaceable>
+    Enter password for cn=Directory Manager on 
+    ldap://<replaceable>ldapserver1</replaceable>: <replaceable>password</replaceable>
 7-bit check
 Account Policy Plugin
 Account Usability Plugin
@@ -20,18 +24,31 @@ ACL Plugin
 ACL preoperation
 [...]</screen>
   <para>
-    For example, this is how to enable the MemberOf plugin referenced in 
+    This is how to enable the MemberOf plugin referenced in 
     <xref linkend="sec-security-ldap-server-sssd"/>:
   </para>
   <screen>&prompt.sudo;dsconf -D "cn=Directory Manager" ldap://<replaceable>ldapserver1</replaceable> plugin memberof enable</screen>
   <para>
-    Note that the plug-in names are case-sensitive, and are different from how 
-    they appear when you list them. After enabling a plug-in, it is necessary 
-    to restart the server. To avoid having to restart the server, set the  
+    Note that the plugin names used in commands are lowercase, so they  
+    are different from how 
+    they appear when you list them. If you make a mistake with a plugin
+    name, you will see a helpful error message:
+  </para>
+    <screen>dsconf instance plugin: error: invalid choice: 'MemberOf' (choose 
+      from 'memberof', 'automember', 'referential-integrity', 'root-dn', 
+      'usn', 'account-policy', 'attr-uniq', 'dna', 'linked-attr', 'managed-
+      entries', 'pass-through-auth', 'retro-changelog', 'posix-winsync', 
+      'contentsync', 'list', 'show', 'set')</screen>
+    <para>
+    After enabling a plugin, it is necessary to restart the server:
+    </para>
+    <screen>&prompt.sudo;systemctl restart <replaceable>dirsrv@ldap1.service</replaceable></screen>
+    <para>    
+      To avoid having to restart the server, set the  
     <literal>nsslapd-dynamic-plugins</literal> parameter to 
     <literal>on</literal>:
    </para>
     <screen>&prompt.sudo;dsconf -D "cn=Directory Manager" ldap://<replaceable>ldapserver1</replaceable> config replace nsslapd-dynamic-plugins=on
-  Enter password for cn=Directory Manager on ldap://<replaceable>ldapserver1</replaceable>: 
+  Enter password for cn=Directory Manager on ldap://<replaceable>ldapserver1</replaceable>: <replaceable>password</replaceable>
 Successfully replaced "nsslapd-dynamic-plugins"</screen>
 </sect1>

--- a/xml/security_ldap_users.xml
+++ b/xml/security_ldap_users.xml
@@ -106,7 +106,7 @@ dn: uid=&exampleuserII_plain;,ou=people,dc=ldap1,dc=com
      Verify that the user's password works:
     </para>
    <screen>&prompt.user;ldapwhoami -D uid=geeko,ou=people,dc=ldap1,dc=com -W
-Enter LDAP Password: 
+Enter LDAP Password: <replaceable>password</replaceable>
 dn: uid=geeko,ou=people,dc=ldap1,dc=com    
      </screen>
    </step>


### PR DESCRIPTION
* add <replaceable>password</replaceable> placeholders
* add systemctl restart
* clarify language in module management, improve examples
* other small corrections

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
