### PR TITLE
AutoYast: Extend routing documentation and examples

### DIFF
--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -131,15 +131,15 @@
     &lt;ipv6_forward config:type="boolean"&gt;false&lt;/ipv6_forward&gt;
     &lt;routes config:type="list"&gt;
       &lt;route&gt;
-        &lt;destination&gt;&routerintipII;/24&lt;/destination&gt;
-        &lt;name&gt;eth0&lt;/name&gt;
-        &lt;extrapara&gt;foo&lt;/extrapara&gt;
+        &lt;destination&gt;&subnetnatmask;&lt;/destination&gt;
+        &lt;name&gt;eth1&lt;/name&gt;
+        &lt;extrapara&gt;scope link src &subnetnat;.100 table one&lt;/extrapara&gt;
         &lt;gateway&gt;-&lt;/gateway&gt;
       &lt;/route&gt;
       &lt;route&gt;
         &lt;destination&gt;default&lt;/destination&gt;
-        &lt;name&gt;eth0&lt;/name&gt;
-        &lt;gateway&gt;&routerintipI;&lt;/gateway&gt;
+        &lt;name&gt;eth1&lt;/name&gt;
+        &lt;gateway&gt;&subnetnat;.1&lt;/gateway&gt;
       &lt;/route&gt;
       &lt;route&gt;
         &lt;destination&gt;default&lt;/destination&gt;
@@ -931,6 +931,11 @@
         Required: Route destination. An address prefix can be specified, for
         example: <literal>192.168.122.0/24</literal>.
        </para>
+       <para>
+         The heading <literal>default</literal> can be used to indicate that
+         the route is the default gateway in the same address family 
+         (ipv4 or ipv6) as the gateway
+       </para>
       </listitem>
      </varlistentry>
 
@@ -965,7 +970,42 @@
       </listitem>
      </varlistentry>
 
+     <varlistentry>
+      <term>extrapara</term>
+      <listitem>
+       <para>
+         Optional: Further route options like the <literal>metric</literal>, 
+         <literal>mtu</literal> or <literal>table</literal>.
+       </para>
+      </listitem>
+     </varlistentry>
     </variablelist>
+
+    <example xml:id="ex-ay-network-routing">
+      <title>Network routing configuration</title>
+<screen>&lt;routing&gt;
+  &lt;ipv4_forward config:type="boolean"&gt;true&lt;/ipv4_forward&gt;
+  &lt;ipv6_forward config:type="boolean"&gt;true&lt;/ipv6_forward&gt;
+  &lt;routes config:type="list"&gt;
+    &lt;route&gt;
+      &lt;destination&gt;&subnetnatmask;&lt;/destination&gt;
+      &lt;name&gt;eth1&lt;/name&gt;
+      &lt;extrapara&gt;scope link src &subnetnat;.100 table one&lt;/extrapara&gt;
+    &lt;/route&gt;
+    &lt;route&gt;
+      &lt;destination&gt;default&lt;/destination&gt;
+      &lt;name&gt;eth1&lt;/name&gt;
+      &lt;gateway&gt;&subnetnat;.1&lt;/gateway&gt;
+    &lt;/route&gt;
+    &lt;route&gt;
+      &lt;destination&gt;default&lt;/destination&gt;
+      &lt;name&gt;lo&lt;/name&gt;
+      &lt;gateway&gt;&gateip;&lt;/gateway&gt;
+    &lt;/route&gt;
+  &lt;/routes&gt;
+&lt;/routing&gt;</screen>
+    </example>
+
    </sect2>
 
    <sect2 xml:id="CreateProfile-Network-s390">


### PR DESCRIPTION
### PR creator: Description

With **network-ng** we modified not only the **UI** but also some of the **AutoYaST** options which are now deprecated like the use of the netmask.

This **PR** tries to extend the current documentation about the different attributes as well as providing a routing example in its corresponding section.

### PR creator: Are there any relevant issues/feature requests?

* https://bugzilla.suse.com/show_bug.cgi?id=1184460
* https://jira.suse.com/browse/PM-219 (somehow related)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [X] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [X] SLE 15 SP3/openSUSE Leap 15.3
  - [X] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
