### PR TITLE
AutoYaST: how to disable the runtime validation

### DIFF
--- a/xml/ay_create_control_file.xml
+++ b/xml/ay_create_control_file.xml
@@ -355,11 +355,21 @@ You need to create the control file manually and ensure that it has a valid synt
     pre-scripts.
     For more information, see <xref linkend="part-dynamic-profiles"/>.
    </para>
+
    <para>
-    To simplify the testing and debugging process, &ay;
-    offers the <literal>check-profile</literal> command, which takes care of
-    fetching, building and, optionally, importing the profile to detect any
-    potential problem.
+    Starting with &productname; <phrase os="osuse">15.3</phrase><phrase
+    os="sles;sled">15 SP3</phrase>, &ay; validates the profile during the
+    installation, reporting any problem found to the user. Although it is
+    recommended to check whether the profile is correct or not, you can disable
+    this behavior by setting the <literal>YAST_SKIP_XML_VALIDATION</literal>
+    boot parameter to <literal>1</literal>.
+   </para>
+
+   <para>
+    Moreover, to simplify the testing and debugging process, &ay; offers the
+    <literal>check-profile</literal> command, which takes care of fetching,
+    building and, optionally, importing the profile to detect any potential
+    problem.
    </para>
 
    <note>


### PR DESCRIPTION
### PR creator: Description

Since we released SUSE 15 SP3 (and openSUSE Leap 15.3) we are receiving quite some bug reports about profile validation that AutoYaST performs at runtime. It is usually caused by wrong profiles, but we have also detected some bugs in the schema.

Although we mentioned in the release notes [that the check can be disabled](https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15-SP3/#bsc-1173091), that information is not present in the manual. So this PR addresses this problem.

Thanks!

### PR creator: Are there any relevant issues/feature requests?

* [bsc#1188153](https://bugzilla.suse.com/show_bug.cgi?id=1188153) among others.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
