### PR TITLE
Starting corrections for SELinux section of Security and Hardening Guide

### DIFF
--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -181,11 +181,13 @@
     <para>
      No default or reference policy is provided in
      &productname;.  &selnx; will not operate without a policy,
-     so you must build and install one. The &selnx; Reference Policy Project
+     so you must build and install one.
+      <!-- section removed, it is outdated for SLE 15*. cschroder 2021-7-14 -->
+     <!--The &selnx; Reference Policy Project
      (<link xlink:href="https://github.com/SELinuxProject/refpolicy/wiki"/>)
      should be helpful in providing examples and detailed information on creating
      your own policies, and this chapter also provides guidance on managing
-     your &selnx; policy.
+     your &selnx; policy.-->
     </para>
    </warning>
    <para>
@@ -229,6 +231,9 @@
    </para>
   </sect2>
  </sect1>
+ 
+ <!-- section removed, it is outdated for SLE 15*. cschroder 2021-7-14 --> 
+  <!-- 
  <sect1 xml:id="sec-selinux-policy">
   <title>Policy</title>
 
@@ -308,7 +313,8 @@ system_u:object_r:var_t var</screen>
    recommended to use a modular policy and not a monolithic policy. Modular
    policies are much easier to manage.
   </para>
- </sect1>
+ </sect1> -->
+ 
  <sect1 xml:id="sec-selinux-install">
   <title>Installing &selnx; packages and modifying &grub;</title>
 
@@ -473,14 +479,20 @@ system_u:object_r:var_t var</screen>
   <para>
    The policy is an essential component of &selnx;. &productname; &productnumber;
    does not include a default or reference policy, and you must build a policy that is
-   customized for your installation. For testing and learning, see The &selnx; Reference
+   customized for your installation.
+ </para>
+   
+ <!-- section removed, it is outdated for SLE 15*. cschroder 2021-7-14 -->  
+ <!--
+ <para>
+   For testing and learning, see The &selnx; Reference
    Policy Project at <link xlink:href="https://github.com/SELinuxProject/refpolicy/wiki"/>.
    You must have a policy, as &selnx; will not operate without one.
-  </para>
+  </para>--> 
   <para>
    After installing the policy, you are ready to start file system labeling.
    Run
-  </para>
+  </para>  
 
 <screen>&prompt.sudo;restorecon -Rp /</screen>
 
@@ -504,7 +516,7 @@ system_u:object_r:var_t var</screen>
    related <filename>file_contexts.local</filename> file:
   </para>
 
-<screen>/etc/example_file    unconfined_u:object_r:samba_share_t:s0</screen>
+<screen>/etc/example_file unconfined_u:object_r:samba_share_t:s0</screen>
 
   <para>
    Then run
@@ -595,10 +607,7 @@ Controlling term:               root:object_r:user_devpts_t
    In that case, switch back to the mode where &selnx; is not enforcing and
    start tuning your server.
   </para>
-
-  <!-- <sect2 xml:id="sec-selinux-verify"> -->
-  <!--  <title>Verifying the installation</title> -->
-   <para>
+  <para>
     Before you start tuning your server, verify the &selnx; installation.
     You have already used the command <command>sestatus -v</command> to view
     the current mode, process, and file contexts. Next, run
@@ -653,7 +662,6 @@ virt_use_nfs                   -&gt; off   virt_use_nfs</screen>
 /var/run/xdmctl(/.*)?                              all files          system_u:object_r:xdm_var_run_t
 /var/run/yiff-[0-9]+\.pid                          regular file       system_u:object_r:soundd_var_run_t</screen>
    </example>
-  <!-- </sect2> -->
  </sect1>
  <sect1 xml:id="sec-selinux-manage">
   <title>Managing &selnx;</title>
@@ -1160,7 +1168,7 @@ gen_context(system_u:object_r:httpd_modules_t,s0)</screen>
     that you can see when using <command>ls -Z</command> on the file or
     directory.
    </para>
-   -->
+
    <para>
     To change the contents of any of the policy module files,
     compile the changes into a new policy module file. To do this,
@@ -1172,7 +1180,7 @@ gen_context(system_u:object_r:httpd_modules_t,s0)</screen>
    <para>
     When <command>make</command> has completed, you can manually load the
     modules into the system, using <command>semodule -i</command>.
-   </para>
+   </para>   -->
   </sect2>
  </sect1>
  <sect1 xml:id="sec-selinux-troubleshoot">


### PR DESCRIPTION
this needs more work; for now, incorrect sections are removed

### PR creator: Description
The SELinux section of the Security and Hardening Guide is outdated and incorrect. This PR removes the incorrect sections. Updates will come in future commits.


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
