### PR TITLE
Add FIPS 140-2 chapter to Security and Hardening Guide

### DIFF
--- a/xml/book_security.xml
+++ b/xml/book_security.xml
@@ -72,6 +72,7 @@
   <xi:include href="security_firewall.xml"/>
   <xi:include href="security_vpnserver.xml"/>
   <xi:include href="security_xca.xml"/>
+  <xi:include href="security_fips.xml"/>
   </part>
 
  <part xml:id="part-apparmor">

--- a/xml/security_fips.xml
+++ b/xml/security_fips.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect1
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+    %entities;
+]>
+
+<chapter xmlns="http://docbook.org/ns/docbook" 
+       xmlns:xi="http://www.w3.org/2001/XInclude" 
+       xmlns:xlink="http://www.w3.org/1999/xlink" 
+       version="5.0" 
+       xml:id="cha-security-fips">
+ <title>Enabling FIPS 140-2</title>
+ <info>
+  <abstract>
+   <para>
+     The Federal Information Processing Standard 140-2 (FIPS 140-2) is 
+     a security standard for cryptographic modules. Modules are certified
+     by the National Institute of Standards and Technology (NIST, see
+     <link xlink:href="https://csrc.nist.gov/projects/cryptographic-module-validation-program"/>). See  
+     <link xlink:href="https://www.suse.com/support/security/certifications/"/> for a list of certified modules.
+     </para>
+     <para>
+       Note that enabling FIPS places limitations on the key sizes
+       and cryptographic algorithms you can use, for example the
+       minimum DSA key size is 2048 bits, and trying to create a smaller
+       key will fail.
+     </para>
+  </abstract>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker></dm:bugtracker>
+   <dm:translation>yes</dm:translation>
+  </dm:docmanager>
+ </info>
+ 
+<sect1 xml:id="sec-fips-enable">
+  <title>Enabling FIPS</title>
+<para>
+  Enabling FIPS takes a few steps. First, read the
+    <filename>/usr/share/doc/packages/openssh-common/README.SUSE</filename>
+    file, from the <package>openssh-common</package> package. This contains 
+    important information about FIPS on &sle;.
+  </para>
+  <para>
+    Check if it is already enabled:
+  </para>
+<screen>&prompt.sudo;sysctl -a | grep fips
+crypto.fips_enabled = 0</screen>
+  <para>
+  <literal>crypto.fips_enabled = 0</literal> indicates that it is not enabled. A return value of 1 means that it is enabled.
+  </para>  
+  <para>
+    To enable FIPS, install the <package>fips</package> pattern:
+  </para>
+  <screen>&prompt.sudo;zypper in -t pattern fips</screen>
+  <para>
+    Then edit <filename>/etc/default/grub</filename>. If 
+    <filename>/boot</filename> is not on a separate partition, add
+    <literal>fips=1</literal> to 
+    <literal>GRUB_CMDLINE_LINUX_DEFAULT</literal>, like the following
+    example:
+  </para>
+  <screen>GRUB_CMDLINE_LINUX_DEFAULT="splash=silent mitigations=auto quiet fips=1"</screen>
+  <para>
+    If <filename>/boot</filename> is on a separate partition, specify which 
+    partition, like the following example, substituting the name of your boot
+    partition:
+  </para>
+  <screen>GRUB_CMDLINE_LINUX_DEFAULT="splash=silent mitigations=auto quiet fips=1 boot=/dev/<replaceable>sda1"</replaceable></screen>
+  <para>
+    Save your changes, and rebuild your GRUB configuration and initramfs 
+    image:
+  </para>
+  <screen>&prompt.sudo;grub2-mkconfig -o /boot/grub2/grub.cfg
+&prompt.sudo;mkinitrd</screen>
+  <para>
+  Reboot, then verify your changes. The following example shows that
+  FIPS is enabled:
+  </para>
+<screen>&prompt.sudo;sysctl -a | grep fips
+crypto.fips_enabled = 1</screen>
+  <para>
+  After enabling FIPS it is possible that your system will not boot. If this  
+  happens, reboot to bring up the GRUB menu. Press <keycap>E</keycap> to edit 
+  your boot entry, and delete <literal>fips=1</literal> from the
+  <literal>linux</literal> line. Save your changes and boot. This is 
+  a temporary change, so you can find the error and correct it.  
+  </para>
+ </sect1>
+</chapter>  

--- a/xml/security_fips.xml
+++ b/xml/security_fips.xml
@@ -20,12 +20,6 @@
      <link xlink:href="https://csrc.nist.gov/projects/cryptographic-module-validation-program"/>). See  
      <link xlink:href="https://www.suse.com/support/security/certifications/"/> for a list of certified modules.
      </para>
-     <para>
-       Note that enabling FIPS places limitations on the key sizes
-       and cryptographic algorithms you can use, for example the
-       minimum DSA key size is 2048 bits, and trying to create a smaller
-       key will fail.
-     </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>
@@ -37,12 +31,13 @@
   <title>Enabling FIPS</title>
 <para>
   Enabling FIPS takes a few steps. First, read the
-    <filename>/usr/share/doc/packages/openssh-common/README.SUSE</filename>
-    file, from the <package>openssh-common</package> package. This contains 
-    important information about FIPS on &sle;.
+  <filename>/usr/share/doc/packages/openssh-common/FIPS.SUSE</filename> and
+  <filename>/usr/share/doc/packages/openssh-common/README.SUSE</filename>   
+  files, from the <package>openssh-common</package> package. These contain 
+  important information about FIPS on &sle;.
   </para>
   <para>
-    Check if it is already enabled:
+    Check if FIPS is already enabled:
   </para>
 <screen>&prompt.sudo;sysctl -a | grep fips
 crypto.fips_enabled = 0</screen>

--- a/xml/security_ssh.xml
+++ b/xml/security_ssh.xml
@@ -860,10 +860,10 @@ eval $(ssh-agent)
    </varlistentry>
    <varlistentry>
     <term>
-     <filename>/usr/share/doc/packages/openssh/README.SUSE</filename>
+     <filename>/usr/share/doc/packages/openssh-common/README.SUSE</filename>
     </term>
     <term>
-     <filename>/usr/share/doc/packages/openssh/README.FIPS</filename>
+     <filename>/usr/share/doc/packages/openssh-common/README.FIPS</filename>
     </term>
     <listitem>
      <para>


### PR DESCRIPTION
re Jira DOCTEAM-149, bsc #1164019

### PR creator: Description

Document enabling FIPS 140-2, and limitations 

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
