### PR TITLE
Add section about PPC partitioning

### DIFF
--- a/xml/inst_yast2.xml
+++ b/xml/inst_yast2.xml
@@ -2431,6 +2431,53 @@ sle_update.xml#sec.update.sle.terminology: "Modules" -->
    </para>
   </important>
 
+  <note arch="power">
+   <title>Suggested Partitioning on IBM &ppc;</title>
+   <para>
+    The default partitioning setup on IBM &ppc; suggests to create a special PReP
+    partition (type 41). When the system boots, the firmware looks for a PReP partition
+    in order to load the OS bootloader. Some IBM &ppc; machines may have booting
+    trouble if the PReP partition is not the first partition on the disk (e.g., /dev/sda1)
+    and if the partition is not placed at the beginning of the disk. An already existing
+    PReP partition is re-used by &yast; when making the partitioning proposal. If
+    a PReP partition does no exist yet, then &yast; will propose to create a new one as the
+    first partition on the disk.
+
+    In case the PReP partition reused for the suggested partitioning is not the first partition
+    placed at beginning of the disk, the partitioning setup will require to be manually
+    adapted. Follow these steps in order to ensure the PReP partition is correctly created:
+   </para>
+
+   <itemizedlist mark="bullet" spacing="normal">
+    <listitem>
+     <para>
+      Select the <guimenu>Expert Partitioner</guimenu> option.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Delete all partitions from the disk you want to use for the installation.
+     </para>
+    </listitem>
+    <listitem>
+    <para>
+     Add a new partition to the disk. When entering the partition size, make sure the
+     <emphasis>Start Cylinder</emphasis> field is prefilled with a <liter>0</literal>.
+     That indicates the partition is going to be created at the beginning of the disk.
+     In <emphasis>Custom Size</emphasis> enter <literal>8MiB</literal>. It will complain
+     because the partition is too small, but simply accept the minimum size it proposes.
+     Note that the partition will be automatically resized later. In the next dialog, select
+     PReP in the partition type selector.
+    </para>
+    </listitem>
+    <listitem>
+     <para>
+      Add the partitions for root and swap, and proceed with the installation.
+     </para>
+    </listitem>
+   </itemizedlist>
+  </note>
+
 <!--
 
   <note arch="power">

--- a/xml/inst_yast2.xml
+++ b/xml/inst_yast2.xml
@@ -2462,7 +2462,7 @@ sle_update.xml#sec.update.sle.terminology: "Modules" -->
     <listitem>
     <para>
      Add a new partition to the disk. When entering the partition size, make sure the
-     <emphasis>Start Cylinder</emphasis> field is prefilled with a <liter>0</literal>.
+     <emphasis>Start Cylinder</emphasis> field is prefilled with a <literal>0</literal>.
      That indicates the partition is going to be created at the beginning of the disk.
      In <emphasis>Custom Size</emphasis> enter <literal>8MiB</literal>. It will complain
      because the partition is too small, but simply accept the minimum size it proposes.
@@ -2472,7 +2472,7 @@ sle_update.xml#sec.update.sle.terminology: "Modules" -->
     </listitem>
     <listitem>
      <para>
-      Add the partitions for root and swap, and proceed with the installation.
+      Add other partitions (e.g., for root and swap), and proceed with the installation.
      </para>
     </listitem>
    </itemizedlist>


### PR DESCRIPTION
### PR creator: Description

When installing in a PowerPC machine, YaST re-uses an existing PReP partition. Generally, that PReP partition is the first partition on the disk, otherwise there could be booting trouble.

This PR is for adding a note in order to explain what to do when the partition proposal wants to re-use a PReP partition which is not placed at the beginning of the disk. 

NOTE: this explanation is only needed for SLE-12 family. In SLE-15, this is properly managed by the new storage stack (yast2-storage-ng). 


### PR creator: Are there any relevant issues/feature requests?

* https://bugzilla.suse.com/show_bug.cgi?id=1188214


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4
  - [x] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
