### PR TITLE
AutoYaST: remove the nis_by_dhp element

### DIFF
--- a/xml/ay_nis_client.xml
+++ b/xml/ay_nis_client.xml
@@ -29,7 +29,6 @@
 <screen> &lt;nis&gt;
   &lt;nis_broadcast config:type="boolean"&gt;true&lt;/nis_broadcast&gt;
   &lt;nis_broken_server config:type="boolean"&gt;true&lt;/nis_broken_server&gt;
-  &lt;nis_by_dhcp config:type="boolean"&gt;false&lt;/nis_by_dhcp&gt;
   &lt;nis_domain&gt;test.com&lt;/nis_domain&gt;
   &lt;nis_local_only config:type="boolean"&gt;true&lt;/nis_local_only&gt;
   &lt;nis_options&gt;&lt;/nis_options&gt;


### PR DESCRIPTION
### PR creator: Description

According to [bsc#1176391](https://bugzilla.suse.com/show_bug.cgi?id=1176391) the `nis_by_dhcp` option is not supported anymore. Actually, the AutoYaST validation will complain about it. So just drop this element. The bad news is that a few backports are needed.

### PR creator: Are there any relevant issues/feature requests?

* [bsc#1176391](https://bugzilla.suse.com/show_bug.cgi?id=1176391)

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4
  - [x] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
