### PR TITLE
AutoYaST: Extend config:type explanation

### DIFF
--- a/xml/ay_control_file.xml
+++ b/xml/ay_control_file.xml
@@ -201,9 +201,22 @@ exit 0
      <literal>mount</literal> property.
     </para>
     <para>
-     The default type of a nested resource is map. Lists must be marked as
-     such using the <literal>config:type="list"</literal> attribute.
+     The default type of a nested resource is map, although you can specify it
+     is you want. Lists must be marked as such using the
+     <literal>config:type="list"</literal> attribute.
     </para>
+
+    <tip>
+     <title>Using sorter type annotations</title>
+     <para>
+      Starting with &productname; <phrase os="sles;sled">15 SP3</phrase>
+      <phrase os="osuse">15.3</phrase><phrase os="slemicro">5.0</phrase>, it is possible to use the attribute
+      <literal>t</literal> instead of <literal>config:type</literal> to specify
+      the element type.
+     </para>
+
+     <screen>&lt;mode t="boolean"&gt;true&lt;/mode&gt;</screen>
+    </tip>
    </sect2>
 
    <sect2 xml:id="Profile-Format-attributes">
@@ -219,30 +232,27 @@ exit 0
      The <literal>config:type</literal> attribute determines the type of the
      resource or property in the parsed data model. For resources, lists need
      a <literal>list</literal> type whereas a map is the default type that
-     does not need an attribute. For properties, <literal>boolean</literal>,
-     <literal>symbol</literal>, and <literal>integer</literal> can be used,
-     the default being a string.
+     does not need an attribute. There is one exception, when the map is empty
+     it needs to be marked as a map so it does not get confused with a simple
+     string value.
     </para>
 
-   <tip>
-     <title>Using sorter type annotations</title>
-    <para>
-     Starting with &productname; <phrase os="sles;sled">15 SP3</phrase>
-     <phrase os="osuse">15.3</phrase><phrase os="slemicro">5.0</phrase>, it is possible to use the attribute
-     <literal>t</literal> instead of <literal>config:type</literal> to specify
-     the element type.
-    </para>
+    <example>
+     <title>An empty map</title>
+     <screen>&lt;general t="map" /&gt;</screen>
+    </example>
 
-<screen>&lt;mode t="boolean"&gt;true&lt;/mode&gt;</screen>
-   </tip>
-    
     <para>
-     Attributes are not optional. It may appear that attributes are optional,
-     because various parts of the schema are not very consistent in their usage
-     of data types. In some places an enumeration is represented by a symbol,
-     elsewhere a string is required. One resource needs
-     <literal>config:type="integer"</literal>, another will parse the number
-     from a string property. Some resources use
+     For properties, <literal>boolean</literal>, <literal>symbol</literal>,
+     and <literal>integer</literal> can be used, the default being a string.
+    </para>
+    <para>
+     Except for map and string values, as explained before, attributes are not
+     optional. It may appear that attributes are optional, because various parts
+     of the schema are not very consistent in their usage of data types. In some
+     places an enumeration is represented by a symbol, elsewhere a string is
+     required. One resource needs <literal>config:type="integer"</literal>,
+     another will parse the number from a string property. Some resources use
      <literal>config:type="boolean"</literal>, others want
      <literal>yes</literal> or even <literal>1</literal>. If in doubt, consult
      the schema file.


### PR DESCRIPTION
### PR creator: Description

Add some clarification about how to set `config:type` attributes in an AutoYaST profile.

### PR creator: Are there any relevant issues/feature requests?

* [bsc#1187719](https://bugzilla.suse.com/show_bug.cgi?id=1187719)

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
