### PR TITLE
virsh cpu and mem fixes

### DIFF
--- a/xml/libvirt_configuration_virsh.xml
+++ b/xml/libvirt_configuration_virsh.xml
@@ -514,7 +514,19 @@ current      live           4
 
   <para>
    The amount of memory allocated for the &vmguest; can also be configured with
-   virsh. It is stored in the <tag>memory</tag> element. Follow these steps:
+   virsh. It is stored in the <tag>memory</tag> element and defines the
+   maximum allocation of memory for the &vmguest; at boot time. The optional
+   <tag>currentMemory</tag> element defines the actual memory allocated to
+   the &vmguest;. <tag>currentMemory</tag> can be less than <tag>memory</tag>,
+   allowing for increasing, or ballooning, the memory while the &vmguest; is
+   running. If <tag>currentMemory</tag> is omitted, it defaults to the same
+   value as the <tag>memory</tag> element.
+  </para>
+  <para>
+   Memory settings can be adjusted by editing the &vmguest; configuration,
+   but be aware that changes do not take place until the next boot. The
+   following steps demonstrate changing a &vmguest; to boot with 4G of
+   memory, but allow later expansion to 8G:
   </para>
 
   <procedure>
@@ -526,18 +538,53 @@ current      live           4
    </step>
    <step>
     <para>
-     Search for the <tag>memory</tag> element and set the amount of allocated
-     RAM:
+     Search for the <tag>memory</tag> element and set to 8G:
     </para>
 <screen>...
-&lt;memory unit='KiB'&gt;524288&lt;/memory&gt;
+&lt;memory unit='KiB'&gt;8388608&lt;/memory&gt;
 ...</screen>
    </step>
    <step>
     <para>
-     Check the amount of allocated RAM in your VM by running:
+     If the <tag>currentMemory</tag> element does not exist, add it below
+     the <tag>memory</tag> element, or change its value to 4G:
     </para>
-<screen>&prompt.user;<command>cat /proc/meminfo</command></screen>
+<screen>...
+&lt;memory unit='KiB'&gt;8388608&lt;/memory&gt;
+&lt;currentMemory unit='KiB'&gt;4194304&lt;/currentMemory&gt;
+...</screen>
+   </step>
+  </procedure>
+  <para>
+   Changing the memory allocation while the &vmguest; is running can be done
+   with the setmem subcommand. The following example shows increasing the
+   memory allocation to 8G:
+  </para>
+
+   <procedure>
+   <step>
+    <para>
+     Check &vmguest; existing memory settings
+    </para>
+<screen>&prompt.sudo;<command>virsh dominfo sles15 | grep memory</command>
+Max memory:     8388608 KiB
+Used memory:    4194608 KiB
+</screen>
+   </step>
+   <step>
+    <para>
+     Change the used memory to 8G:
+    </para>
+<screen>&prompt.sudo;<command>virsh setmem sles15 8388608</command></screen>
+   </step>
+   <step>
+    <para>
+     Check the updated memory settings
+    </para>
+<screen>&prompt.sudo;<command>virsh dominfo sles15 | grep memory</command>
+Max memory:     8388608 KiB
+Used memory:    8388608 KiB
+</screen>
    </step>
   </procedure>
  </sect1>

--- a/xml/libvirt_configuration_virsh.xml
+++ b/xml/libvirt_configuration_virsh.xml
@@ -587,6 +587,13 @@ Used memory:    8388608 KiB
 </screen>
    </step>
   </procedure>
+  <important>
+   <title>Large memory &vmguest;s</title>
+   <para>
+    &vmguests; with memory requirements of 4TB or more must currently
+    use the host-passthrough CPU model.
+   </para>
+  </important>
  </sect1>
  <sect1 xml:id="sec-libvirt-config-pci-virsh">
   <title>Adding a PCI device</title>

--- a/xml/libvirt_configuration_virsh.xml
+++ b/xml/libvirt_configuration_virsh.xml
@@ -196,54 +196,63 @@ Product Name: Standard PC (Q35 + ICH9, 2009)</screen>
   </para>
  </sect1>
  <sect1 xml:id="libvirt-cpu-virsh">
-  <title>Configuring CPU allocation</title>
+  <title>Configuring CPU</title>
 
   <para>
-   The number of allocated CPUs is stored in the &vmguest;'s XML configuration
-   file in <filename>/etc/libvirt/qemu/</filename> in the
-   <tag class="attribute">vcpu</tag> element:
+   Many aspects of the virtual CPUs presented to &vmguest;s are configurable
+   with virsh. The number of current and maximum CPUs allocated to a &vmguest;
+   can be changed, as well as the model of the CPU and its feature set. The
+   following subsections describe how to change the common CPU settings of a
+   &vmguest;.
   </para>
 
+  <sect2 xml:id="sec-libvirt-cpu-num-virsh">
+   <title>Configuring the number of CPUs</title>
+   <para>
+    The number of allocated CPUs is stored in the &vmguest;'s XML configuration
+    file in <filename>/etc/libvirt/qemu/</filename> in the
+    <tag class="attribute">vcpu</tag> element:
+   </para>
 <screen>&lt;vcpu placement='static'&gt;1&lt;/vcpu&gt;</screen>
 
-  <para>
-   In this example, the &vmguest; has only one allocated CPU. The following
-   procedure shows how to change the number of allocated CPUs for the
-   &vmguest;:
-  </para>
+   <para>
+    In this example, the &vmguest; has only one allocated CPU. The following
+    procedure shows how to change the number of allocated CPUs for the
+    &vmguest;:
+   </para>
 
-  <procedure>
-   <step>
-    <para>
-     Check whether your &vmguest; is inactive:
-    </para>
+   <procedure>
+    <step>
+     <para>
+      Check whether your &vmguest; is inactive:
+     </para>
 <screen>&prompt.sudo;<command>virsh list --inactive</command>
 Id    Name                           State
 ----------------------------------------------------
 -     sles15                         shut off</screen>
-   </step>
-   <step>
-    <para>
-     Edit the configuration for an existing &vmguest;:
-    </para>
+    </step>
+    <step>
+     <para>
+      Edit the configuration for an existing &vmguest;:
+     </para>
 <screen>&prompt.sudo;<command>virsh edit sles15</command></screen>
-   </step>
-   <step>
-    <para>
-     Change the number of allocated CPUs:
-    </para>
+    </step>
+    <step>
+     <para>
+      Change the number of allocated CPUs:
+     </para>
 <screen>&lt;vcpu placement='static'&gt;2&lt;/vcpu&gt;</screen>
-   </step>
-   <step>
-    <para>
-     Restart the &vmguest;:
-    </para>
+    </step>
+    <step>
+     <para>
+      Restart the &vmguest;:
+     </para>
 <screen>&prompt.sudo;<command>virsh start sles15</command></screen>
-   </step>
-   <step>
-    <para>
-     Check if the number of CPUs in the VM has changed.
-    </para>
+    </step>
+    <step>
+     <para>
+      Check if the number of CPUs in the VM has changed.
+     </para>
 <screen>
 &prompt.sudo;<command>virsh vcpuinfo sled15</command>
 VCPU:           0
@@ -257,9 +266,83 @@ CPU:            N/A
 State:          N/A
 CPU time        N/A
 CPU Affinity:   yy
-      </screen>
-   </step>
-  </procedure>
+</screen>
+    </step>
+   </procedure>
+  </sect2>
+  <sect2 xml:id="sec-libvirt-cpu-model-virsh">
+   <title>Configuring the CPU model</title>
+   <para>
+    The CPU model exposed to a &vmguest; can often influence the workload
+    running within it. The default CPU model is derived from a cpu mode
+    known as host-model.
+   </para>
+<screen>&lt;cpu mode='host-model'/&gt;</screen>
+   <para>
+    When starting a &vmguest; with cpu mode host-model, &libvirt; will
+    copy its model of the host CPU into the &vmguest; definition. The host
+    CPU model and features copied to the &vmguest; definition can be
+    observed in the output of 'virsh capabilities'.
+   </para>
+   <para>
+    Another interesting CPU mode is host-passthrough.
+   </para>
+<screen>&lt;cpu mode='host-passthrough'/&gt;</screen>
+   <para>
+    When starting a &vmguest; with CPU mode host-passthrough, it is presented
+    with a CPU that is exactly the same as the &vmhost; CPU. This can be
+    useful when the &vmguest; workload requires CPU features not available in
+    &libvirt;'s simplified host-model CPU. The host-passthrough CPU mode is
+    also required in some cases, e.g. when running &vmguest;s with more than
+    4TB of memory. The host-passthrough CPU mode comes with the disadvantage of
+    reduced migration flexibility. A &vmguest; with host-passthrough CPU mode
+    can only be migrated to a &vmhost; with identical hardware.
+   </para>
+   <para>
+    When using the host-passthrough CPU mode, it is still possible to
+    disable undesirable features. The following configuration will present
+    the &vmguest; with a CPU that is exactly the same as the host CPU but
+    with the vmx feature disabled.
+   </para>
+<screen>&lt;cpu mode='host-passthrough'&gt;
+   &lt;feature policy='disable' name='vmx'/&gt;
+   &lt;/cpu&gt;
+</screen>
+   <para>
+    The custom CPU mode is another common mode used to define a normalized
+    CPU that can be migrated throughout dissimilar hosts in a cluster. For
+    example in a cluster with hosts containing Nehalem, IvyBridge, and
+    SandyBridge CPUs, the &vmguest; can be configured with a custom CPU
+    mode that contains a Nehalem CPU model.
+   </para>
+<screen>&lt;cpu mode='custom' match='exact'&gt;
+  &lt;model fallback='allow'&gt;Nehalem&lt;/model&gt;
+  &lt;feature policy='require' name='vme'/&gt;
+  &lt;feature policy='require' name='ds'/&gt;
+  &lt;feature policy='require' name='acpi'/&gt;
+  &lt;feature policy='require' name='ss'/&gt;
+  &lt;feature policy='require' name='ht'/&gt;
+  &lt;feature policy='require' name='tm'/&gt;
+  &lt;feature policy='require' name='pbe'/&gt;
+  &lt;feature policy='require' name='dtes64'/&gt;
+  &lt;feature policy='require' name='monitor'/&gt;
+  &lt;feature policy='require' name='ds_cpl'/&gt;
+  &lt;feature policy='require' name='vmx'/&gt;
+  &lt;feature policy='require' name='est'/&gt;
+  &lt;feature policy='require' name='tm2'/&gt;
+  &lt;feature policy='require' name='xtpr'/&gt;
+  &lt;feature policy='require' name='pdcm'/&gt;
+  &lt;feature policy='require' name='dca'/&gt;
+  &lt;feature policy='require' name='rdtscp'/&gt;
+  &lt;feature policy='require' name='invtsc'/&gt;
+  &lt;/cpu&gt;
+</screen>
+   <para>
+    For more information on &libvirt;'s CPU model and topology options, see
+    the <citetitle>CPU model and topology</citetitle> documentation
+    at <link xlink:href="https://libvirt.org/formatdomain.html#cpu-model-and-topology"/>.
+   </para>
+  </sect2>
  </sect1>
  <sect1 xml:id="sec-libvirt-config-boot-menu-virsh">
   <title>Changing boot options</title>

--- a/xml/libvirt_configuration_virsh.xml
+++ b/xml/libvirt_configuration_virsh.xml
@@ -302,6 +302,28 @@ current      live           4
 </screen>
     </step>
    </procedure>
+   <important>
+     <title>Exceeding 255 CPUs</title>
+     <para>
+      With KVM it is possible to define a &vmguest; with more than 255
+      CPUs, however additional configuration is necessary to start and
+      run the &vmguest;. The ioapic feature must be tuned and an IOMMU
+      device must be added to the &vmguest;. Below is an example
+      configuration for 288 CPUs.
+     </para>
+<screen>&lt;domain&gt;
+     &lt;vcpu placement='static'&gt;288&lt;/vcpu&gt;
+     &lt;features&gt;
+     &lt;ioapic driver='qemu'/&gt;
+     &lt;/features&gt;
+     &lt;devices&gt;
+     &lt;iommu model='intel'&gt;
+     &lt;driver intremap='on' eim='on'/&gt;
+     &lt;/iommu&gt;
+     &lt;/devices&gt;
+     &lt;/domain&gt;
+</screen>
+   </important>
   </sect2>
   <sect2 xml:id="sec-libvirt-cpu-model-virsh">
    <title>Configuring the CPU model</title>

--- a/xml/libvirt_configuration_virsh.xml
+++ b/xml/libvirt_configuration_virsh.xml
@@ -200,7 +200,7 @@ Product Name: Standard PC (Q35 + ICH9, 2009)</screen>
 
   <para>
    Many aspects of the virtual CPUs presented to &vmguest;s are configurable
-   with virsh. The number of current and maximum CPUs allocated to a &vmguest;
+   with &virsh;. The number of current and maximum CPUs allocated to a &vmguest;
    can be changed, as well as the model of the CPU and its feature set. The
    following subsections describe how to change the common CPU settings of a
    &vmguest;.
@@ -270,7 +270,7 @@ CPU Affinity:   yy
     </step>
    </procedure>
    <para>
-    The number of CPUs can also be changed while the &vmguest; is running.
+    You can also change the number of CPUs while the &vmguest; is running.
     CPUs can be hotplugged until the maximum number configured at &vmguest;
     start is reached. Likewise they can be hot-unplugged until the lower
     limit of 1 is reached. The following example demonstrates changing the
@@ -294,7 +294,7 @@ current      live           2
     </step>
     <step>
      <para>
-      Check the current live vcpu count is now 4:
+      Check that the current live vcpu count is now 4:
      </para>
 <screen>&prompt.sudo;<command>virsh vcpucount sles15 | grep live</command>
 maximum      live           4
@@ -305,23 +305,24 @@ current      live           4
    <important>
      <title>Exceeding 255 CPUs</title>
      <para>
-      With KVM it is possible to define a &vmguest; with more than 255
+      With &kvm; it is possible to define a &vmguest; with more than 255
       CPUs, however additional configuration is necessary to start and
-      run the &vmguest;. The ioapic feature must be tuned and an IOMMU
-      device must be added to the &vmguest;. Below is an example
+      run the &vmguest;. The <literal>ioapic</literal> feature needs to be tuned and an IOMMU
+      device needs to be added to the &vmguest;. Below is an example
       configuration for 288 CPUs.
      </para>
-<screen>&lt;domain&gt;
-     &lt;vcpu placement='static'&gt;288&lt;/vcpu&gt;
-     &lt;features&gt;
-     &lt;ioapic driver='qemu'/&gt;
-     &lt;/features&gt;
-     &lt;devices&gt;
-     &lt;iommu model='intel'&gt;
-     &lt;driver intremap='on' eim='on'/&gt;
-     &lt;/iommu&gt;
-     &lt;/devices&gt;
-     &lt;/domain&gt;
+<screen>
+&lt;domain&gt;
+ &lt;vcpu placement='static'&gt;288&lt;/vcpu&gt;
+ &lt;features&gt;
+  &lt;ioapic driver='qemu'/&gt;
+ &lt;/features&gt;
+ &lt;devices&gt;
+  &lt;iommu model='intel'&gt;
+   &lt;driver intremap='on' eim='on'/&gt;
+  &lt;/iommu&gt;
+ &lt;/devices&gt;
+&lt;/domain&gt;
 </screen>
    </important>
   </sect2>
@@ -329,48 +330,50 @@ current      live           4
    <title>Configuring the CPU model</title>
    <para>
     The CPU model exposed to a &vmguest; can often influence the workload
-    running within it. The default CPU model is derived from a cpu mode
-    known as host-model.
+    running within it. The default CPU model is derived from a CPU mode
+    known as <literal>host-model</literal>.
    </para>
 <screen>&lt;cpu mode='host-model'/&gt;</screen>
    <para>
-    When starting a &vmguest; with cpu mode host-model, &libvirt; will
+    When starting a &vmguest; with CPU mode <literal>host-model</literal>, &libvirt; will
     copy its model of the host CPU into the &vmguest; definition. The host
     CPU model and features copied to the &vmguest; definition can be
-    observed in the output of 'virsh capabilities'.
+    observed in the output of the <command>virsh capabilities</command>.
    </para>
    <para>
-    Another interesting CPU mode is host-passthrough.
+    Another interesting CPU mode is <literal>host-passthrough</literal>.
    </para>
 <screen>&lt;cpu mode='host-passthrough'/&gt;</screen>
    <para>
-    When starting a &vmguest; with CPU mode host-passthrough, it is presented
+    When starting a &vmguest; with CPU mode <literal>host-passthrough</literal>, it is presented
     with a CPU that is exactly the same as the &vmhost; CPU. This can be
     useful when the &vmguest; workload requires CPU features not available in
-    &libvirt;'s simplified host-model CPU. The host-passthrough CPU mode is
-    also required in some cases, e.g. when running &vmguest;s with more than
-    4TB of memory. The host-passthrough CPU mode comes with the disadvantage of
-    reduced migration flexibility. A &vmguest; with host-passthrough CPU mode
+    &libvirt;'s simplified <literal>host-model</literal> CPU. The <literal>host-passthrough</literal> CPU mode is
+    also required in some cases, for example, when running &vmguest;s with more than
+    4TB of memory. The <literal>host-passthrough</literal> CPU mode comes with the disadvantage of
+    reduced migration flexibility. A &vmguest; with <literal>host-passthrough</literal> CPU mode
     can only be migrated to a &vmhost; with identical hardware.
    </para>
    <para>
-    When using the host-passthrough CPU mode, it is still possible to
+    When using the <literal>host-passthrough</literal> CPU mode, it is still possible to
     disable undesirable features. The following configuration will present
     the &vmguest; with a CPU that is exactly the same as the host CPU but
-    with the vmx feature disabled.
+    with the <literal>vmx</literal> feature disabled.
    </para>
-<screen>&lt;cpu mode='host-passthrough'&gt;
-   &lt;feature policy='disable' name='vmx'/&gt;
-   &lt;/cpu&gt;
+<screen>
+&lt;cpu mode='host-passthrough'&gt;
+  &lt;feature policy='disable' name='vmx'/&gt;
+  &lt;/cpu&gt;
 </screen>
    <para>
-    The custom CPU mode is another common mode used to define a normalized
+    The <literal>custom</literal> CPU mode is another common mode used to define a normalized
     CPU that can be migrated throughout dissimilar hosts in a cluster. For
     example in a cluster with hosts containing Nehalem, IvyBridge, and
-    SandyBridge CPUs, the &vmguest; can be configured with a custom CPU
+    SandyBridge CPUs, the &vmguest; can be configured with a <literal>custom</literal> CPU
     mode that contains a Nehalem CPU model.
    </para>
-<screen>&lt;cpu mode='custom' match='exact'&gt;
+<screen>
+&lt;cpu mode='custom' match='exact'&gt;
   &lt;model fallback='allow'&gt;Nehalem&lt;/model&gt;
   &lt;feature policy='require' name='vme'/&gt;
   &lt;feature policy='require' name='ds'/&gt;
@@ -514,7 +517,7 @@ current      live           4
 
   <para>
    The amount of memory allocated for the &vmguest; can also be configured with
-   virsh. It is stored in the <tag>memory</tag> element and defines the
+   &virsh;. It is stored in the <tag>memory</tag> element and defines the
    maximum allocation of memory for the &vmguest; at boot time. The optional
    <tag>currentMemory</tag> element defines the actual memory allocated to
    the &vmguest;. <tag>currentMemory</tag> can be less than <tag>memory</tag>,
@@ -523,7 +526,7 @@ current      live           4
    value as the <tag>memory</tag> element.
   </para>
   <para>
-   Memory settings can be adjusted by editing the &vmguest; configuration,
+   You can adjust memory settings by editing the &vmguest; configuration,
    but be aware that changes do not take place until the next boot. The
    following steps demonstrate changing a &vmguest; to boot with 4G of
    memory, but allow later expansion to 8G:
@@ -549,22 +552,23 @@ current      live           4
      If the <tag>currentMemory</tag> element does not exist, add it below
      the <tag>memory</tag> element, or change its value to 4G:
     </para>
-<screen>...
+<screen>
+[...]
 &lt;memory unit='KiB'&gt;8388608&lt;/memory&gt;
 &lt;currentMemory unit='KiB'&gt;4194304&lt;/currentMemory&gt;
-...</screen>
+[...]</screen>
    </step>
   </procedure>
   <para>
    Changing the memory allocation while the &vmguest; is running can be done
-   with the setmem subcommand. The following example shows increasing the
+   with the <command>setmem</command> subcommand. The following example shows increasing the
    memory allocation to 8G:
   </para>
 
    <procedure>
    <step>
     <para>
-     Check &vmguest; existing memory settings
+     Check &vmguest; existing memory settings:
     </para>
 <screen>&prompt.sudo;<command>virsh dominfo sles15 | grep memory</command>
 Max memory:     8388608 KiB
@@ -579,7 +583,7 @@ Used memory:    4194608 KiB
    </step>
    <step>
     <para>
-     Check the updated memory settings
+     Check the updated memory settings:
     </para>
 <screen>&prompt.sudo;<command>virsh dominfo sles15 | grep memory</command>
 Max memory:     8388608 KiB
@@ -591,7 +595,7 @@ Used memory:    8388608 KiB
    <title>Large memory &vmguest;s</title>
    <para>
     &vmguests; with memory requirements of 4TB or more must currently
-    use the host-passthrough CPU model.
+    use the <literal>host-passthrough</literal> CPU model.
    </para>
   </important>
  </sect1>

--- a/xml/libvirt_configuration_virsh.xml
+++ b/xml/libvirt_configuration_virsh.xml
@@ -521,7 +521,7 @@ current      live           4
    maximum allocation of memory for the &vmguest; at boot time. The optional
    <tag>currentMemory</tag> element defines the actual memory allocated to
    the &vmguest;. <tag>currentMemory</tag> can be less than <tag>memory</tag>,
-   allowing for increasing, or ballooning, the memory while the &vmguest; is
+   allowing for increasing (or <emphasis>ballooning</emphasiss>) the memory while the &vmguest; is
    running. If <tag>currentMemory</tag> is omitted, it defaults to the same
    value as the <tag>memory</tag> element.
   </para>

--- a/xml/libvirt_configuration_virsh.xml
+++ b/xml/libvirt_configuration_virsh.xml
@@ -269,6 +269,39 @@ CPU Affinity:   yy
 </screen>
     </step>
    </procedure>
+   <para>
+    The number of CPUs can also be changed while the &vmguest; is running.
+    CPUs can be hotplugged until the maximum number configured at &vmguest;
+    start is reached. Likewise they can be hot-unplugged until the lower
+    limit of 1 is reached. The following example demonstrates changing the
+    active CPU count from 2 to pre-defined maximum of 4.
+   </para>
+   <procedure>
+    <step>
+     <para>
+      Check the current live vcpu count:
+     </para>
+<screen>&prompt.sudo;<command>virsh vcpucount sles15 | grep live</command>
+maximum      live           4
+current      live           2
+</screen>
+    </step>
+    <step>
+     <para>
+      Change the current, or active, number of CPUs to 4:
+     </para>
+<screen>&prompt.sudo;<command>virsh setvcpus sles15 --count 4 --live</command></screen>
+    </step>
+    <step>
+     <para>
+      Check the current live vcpu count is now 4:
+     </para>
+<screen>&prompt.sudo;<command>virsh vcpucount sles15 | grep live</command>
+maximum      live           4
+current      live           4
+</screen>
+    </step>
+   </procedure>
   </sect2>
   <sect2 xml:id="sec-libvirt-cpu-model-virsh">
    <title>Configuring the CPU model</title>


### PR DESCRIPTION
### PR creator: Description

Similar to PR#935, improve the virsh CPU and memory sections of the VT guide. Add notes about special configuration needed for large CPU and memory VMs.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1188751


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
