### PR TITLE
vt-limits: Increase max vCPUs to 288

### DIFF
--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -153,7 +153,7 @@
        </entry>
        <entry>
         <para>
-         256
+         288
         </para>
        </entry>
       </row>


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1188751

### PR creator: Description

Increase max supported vCPUs for KVM guests to 288.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1188751

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
