### PR TITLE
Improve style of LDAP section

### DIFF
--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -322,6 +322,7 @@ they also have a trademark policy, let's be careful here. -->
 <!ENTITY gpg           "GPG"> <!-- or GnuGP -->
 <!ENTITY clamav        "ClamAV">
 <!ENTITY ds389         "389 Directory Server">
+<!ENTITY ds389a        "389 DS">
 <!-- oddities -->
 <!ENTITY thrdmrk       "*">
 <!ENTITY kexec          "Kexec">

--- a/xml/security_ldap.xml
+++ b/xml/security_ldap.xml
@@ -11,9 +11,9 @@
         <para>
     The Lightweight Directory Access Protocol (LDAP) is a protocol
     designed to access and maintain information directories. LDAP can be
-    used for tasks such as user and group management, system configuration 
+    used for tasks such as user and group management, system configuration
     management, and address management. In &productname; &productnumbershort; the
-    LDAP service is provided by the &ds389;, replacing OpenLDAP.    
+    LDAP service is provided by the &ds389;, replacing OpenLDAP.
    </para>
       </abstract>
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -42,14 +42,14 @@
   <xi:include href="security_ldap_directory_tree.xml"/>
   <xi:include href="security_ldap_install.xml"/>
   <xi:include href="security_ldap_firewall.xml"/>
-  <xi:include href="security_ldap_backups.xml"/> 
+  <xi:include href="security_ldap_backups.xml"/>
   <xi:include href="security_ldap_users.xml"/>
   <xi:include href="security_ldap_sssd.xml"/>
   <xi:include href="security_ldap_modules.xml"/>
   <!-- default installation uses self-signed cert -->
   <xi:include href="security_ldap_migrate_test.xml"/>
   <xi:include href="security_ldap_ca.xml"/>
-  
+
 <sect1 xml:id="sec-security-ldap-info">
   <title>More information</title>
   <para>

--- a/xml/security_ldap.xml
+++ b/xml/security_ldap.xml
@@ -7,20 +7,16 @@
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-security-ldap">
  <title>389 LDAP Directory Server</title>
  <info>
-      <abstract>
-        <para>
+  <abstract>
+   <para>
     The Lightweight Directory Access Protocol (LDAP) is a protocol
     designed to access and maintain information directories. LDAP can be
     used for tasks such as user and group management, system configuration
     management, and address management. In &productname; &productnumbershort; the
     LDAP service is provided by the &ds389;, replacing OpenLDAP.
    </para>
-      </abstract>
-      <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-        <dm:bugtracker>
-          </dm:bugtracker>
-      </dm:docmanager>
-    </info>
+  </abstract>
+ </info>
 
   <para>
    Ideally, a central server stores the data in a directory and distributes

--- a/xml/security_ldap.xml
+++ b/xml/security_ldap.xml
@@ -5,7 +5,7 @@
     %entities;
 ]>
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-security-ldap">
- <title>389 LDAP Directory Server</title>
+ <title>LDAP with &ds389;</title>
  <info>
   <abstract>
    <para>

--- a/xml/security_ldap_backups.xml
+++ b/xml/security_ldap_backups.xml
@@ -4,94 +4,93 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-
 <sect1 xmlns="http://docbook.org/ns/docbook" 
   xmlns:xi="http://www.w3.org/2001/XInclude" 
   xmlns:xlink="http://www.w3.org/1999/xlink" 
   version="5.0" 
   xml:id="sec-security-ldap-backup">
-  <title>Making Backups and Restores</title>
+ <title>Making Backups and Restores</title>
+
+ <para>
+  &ds389; supports making offline and online backups. The
+  <command>dsctl</command> command makes offline database backups, and the
+  <command>dsconf</command> command makes online database backups. Back up the
+  LDAP server configuration directory, to enable complete restoration in case
+  of a major failure.
+ </para>
+
+ <sect2 xml:id="sec-security-ldap-backup-config">
+  <title>Backing Up the Server Configuration</title>
   <para>
-    &ds389; supports making offline and online backups. The 
-    <command>dsctl</command> command makes offline database backups, and the
-    <command>dsconf</command> command makes online database backups. Back up 
-    the LDAP server configuration directory, to enable complete restoration 
-    in case of a major failure.
+   Your LDAP server configuration is in
+   <filename>/etc/dirsrv/slapd-<replaceable>instance-name</replaceable></filename>.
+   This contains certificates, keys, and the <filename>dse.ldif</filename>
+   file. Make a compressed backup of this directory with the
+   <command>tar</command> command:
   </para>
-  
-  <sect2 xml:id="sec-security-ldap-backup-config">
-    <title>Backing Up the Server Configuration</title>
-      <para>
-        Your LDAP server configuration is in 
-        <filename>/etc/dirsrv/slapd-<replaceable>instance-name</replaceable></filename>. This contains certificates, keys, and the
-        <filename>dse.ldif</filename> file. Make a compressed backup of this 
-        directory with the <command>tar</command> command:
-      </para>
-      <screen>&prompt.sudo;tar caf config_slapd-<replaceable>ldap1</replaceable>_$(date +%Y-%m-%d_%H-%M-%S).tar.gz /etc/dirsrv/slapd-<replaceable>ldap1</replaceable>/
+<screen>&prompt.sudo;tar caf config_slapd-<replaceable>ldap1</replaceable>_$(date +%Y-%m-%d_%H-%M-%S).tar.gz /etc/dirsrv/slapd-<replaceable>ldap1</replaceable>/
 tar: Removing leading `/' from member names</screen>
-      <para>
-        To restore this configuration, move the existing configuration (if
-        it exists), unpack the backup archive, and copy it to 
-        <filename>/etc/dirsrv/slapd-<replaceable>instance-name</replaceable></filename>:
-      </para>
-      <screen>&prompt.sudo;mv /etc/dirsrv/slapd-<replaceable>ldap1/</replaceable> <replaceable>/etc/dirsrv/old/slapd-ldap1-old/</replaceable>
+  <para>
+   To restore this configuration, move the existing configuration (if it
+   exists), unpack the backup archive, and copy it to
+   <filename>/etc/dirsrv/slapd-<replaceable>instance-name</replaceable></filename>:
+  </para>
+<screen>&prompt.sudo;mv /etc/dirsrv/slapd-<replaceable>ldap1/</replaceable> <replaceable>/etc/dirsrv/old/slapd-ldap1-old/</replaceable>
 &prompt.sudo;tar -xvzf <replaceable>config_slapd-ldap1_2021-07-28_09-27.tar.gz</replaceable>
 &prompt.sudo;cp -r <replaceable>etc/dirsrv/slapd-ldap1</replaceable> <replaceable>/etc/dirsrv/slapd-ldap1</replaceable></screen>
-  </sect2>
-  
-  <sect2 xml:id="sec-security-ldap-offline-backup">
+ </sect2>
+
+ <sect2 xml:id="sec-security-ldap-offline-backup">
   <title>Offline Database Backup and Restore</title>
-    <para>
-    The <command>dsctl</command> command makes offline backups. Stop the 
-    server, then make the backup using your instance name:
-    </para>
-    <screen>&prompt.sudo;dsctl <replaceable>ldap1</replaceable> stop
+  <para>
+   The <command>dsctl</command> command makes offline backups. Stop the server,
+   then make the backup using your instance name:
+  </para>
+<screen>&prompt.sudo;dsctl <replaceable>ldap1</replaceable> stop
 Instance <replaceable>"ldap1"</replaceable> has been stopped     
 &prompt.sudo;dsctl <replaceable>ldap1</replaceable> db2bak
 db2bak successful</screen>
-    <para>
-      This example creates a backup archive at 
-      <filename>/var/lib/dirsrv/slapd-ldap1/bak/ldap1-2021_07_26_13_03_17</filename>.
-    </para>
-    <para>
-      Restore from this backup, naming the directory containing the backup
-      archive:
-    </para>
-    <screen>&prompt.sudo;dsctl <replaceable>ldap1</replaceable> bak2db <replaceable>/var/lib/dirsrv/slapd-ldap1/bak/ldap1-2021_07_26_13_03_17/</replaceable>
+  <para>
+   This example creates a backup archive at
+   <filename>/var/lib/dirsrv/slapd-ldap1/bak/ldap1-2021_07_26_13_03_17</filename>.
+  </para>
+  <para>
+   Restore from this backup, naming the directory containing the backup
+   archive:
+  </para>
+<screen>&prompt.sudo;dsctl <replaceable>ldap1</replaceable> bak2db <replaceable>/var/lib/dirsrv/slapd-ldap1/bak/ldap1-2021_07_26_13_03_17/</replaceable>
 bak2db successful</screen>
-    <para>
-      Then start the server:
-    </para>
-    <screen>&prompt.sudo;dsctl <replaceable>ldap1</replaceable> start
+  <para>
+   Then start the server:
+  </para>
+<screen>&prompt.sudo;dsctl <replaceable>ldap1</replaceable> start
 Instance "<replaceable>ldap1</replaceable>" has been started</screen>
-    <para>
-      You may also create LDIF backups:
-    </para>
-      <screen>&prompt.sudo;dsctl ldap1 db2ldif  --replication userRoot
+  <para>
+   You may also create LDIF backups:
+  </para>
+<screen>&prompt.sudo;dsctl ldap1 db2ldif  --replication userRoot
 ldiffile: <replaceable>/var/lib/dirsrv/slapd-ldap1/ldif/ldap1-userRoot-2021_07_28_08_47_30.ldif</replaceable>
 db2ldif successful</screen>
-      <para>
-        Restore this backup with the name of the archive, then start
-        the server:
-      </para>
-      <screen>&prompt.sudo;dsctl ldif2db userRoot <replaceable>/var/lib/dirsrv/slapd-ldap1/ldif/ldap1-userRoot-2021_07_28_08_47_30.ldif</replaceable>
+  <para>
+   Restore this backup with the name of the archive, then start the server:
+  </para>
+<screen>&prompt.sudo;dsctl ldif2db userRoot <replaceable>/var/lib/dirsrv/slapd-ldap1/ldif/ldap1-userRoot-2021_07_28_08_47_30.ldif</replaceable>
 &prompt.sudo;dsctl ldap1 start</screen>
-  </sect2>
-  
-  <sect2 xml:id="sec-security-ldap-online-backup">
+ </sect2>
+
+ <sect2 xml:id="sec-security-ldap-online-backup">
   <title>Online Database Backup and Restore</title>
-    <para>
-      Use the <command>dsconf</command> to make an online backup of your LDAP
-      database:
-    </para>
-    <screen>&prompt.sudo;dsconf <replaceable>ldap1</replaceable> backup create
+  <para>
+   Use the <command>dsconf</command> to make an online backup of your LDAP
+   database:
+  </para>
+<screen>&prompt.sudo;dsconf <replaceable>ldap1</replaceable> backup create
 The backup create task has finished successfully</screen>
-    <para>
-      This creates 
-      <replaceable>/var/lib/dirsrv/slapd-ldap1/bak/ldap1-2021_07_28_09_46_08</replaceable>. Restore it:
-    </para>
-    <screen>&prompt.sudo;dsconf <replaceable>ldap1</replaceable> backup restore <replaceable>/var/lib/dirsrv/slapd-ldap1/bak/ldap1-2021_07_28_09_46_08</replaceable></screen>
-  
-  </sect2>
-  
+  <para>
+   This creates
+   <replaceable>/var/lib/dirsrv/slapd-ldap1/bak/ldap1-2021_07_28_09_46_08</replaceable>.
+   Restore it:
+  </para>
+<screen>&prompt.sudo;dsconf <replaceable>ldap1</replaceable> backup restore <replaceable>/var/lib/dirsrv/slapd-ldap1/bak/ldap1-2021_07_28_09_46_08</replaceable></screen>
+ </sect2>
 </sect1>

--- a/xml/security_ldap_backups.xml
+++ b/xml/security_ldap_backups.xml
@@ -22,13 +22,13 @@
  <sect2 xml:id="sec-security-ldap-backup-config">
   <title>Backing up the LDAP server configuration</title>
   <para>
-   Your LDAP server configuration is in
-   <filename>/etc/dirsrv/slapd-<replaceable>instance-name</replaceable></filename>.
-   This contains certificates, keys, and the <filename>dse.ldif</filename>
+   Your LDAP server configuration is in the directory
+   <filename>/etc/dirsrv/slapd-<replaceable>INSTANCE_NAME</replaceable></filename>.
+   This directory contains certificates, keys, and the <filename>dse.ldif</filename>
    file. Make a compressed backup of this directory with the
    <command>tar</command> command:
   </para>
-<screen>&prompt.sudo;<command>tar caf config_slapd-<replaceable>ldap1</replaceable>_$(date +%Y-%m-%d_%H-%M-%S).tar.gz /etc/dirsrv/slapd-<replaceable>ldap1</replaceable>/</command></screen>
+<screen>&prompt.sudo;<command>tar caf config_slapd-<replaceable>INSTANCE_NAME</replaceable>_$(date +%Y-%m-%d_%H-%M-%S).tar.gz /etc/dirsrv/slapd-<replaceable>INSTANCE_NAME</replaceable>/</command></screen>
   <note role="compact">
    <para>
     When running <command>tar</command>, you may see the harmless informational
@@ -43,20 +43,20 @@
     <para>
      To avoid overwriting it, move any existing configuration:
     </para>
-<screen>&prompt.sudo;<command>old /etc/dirsrv/slapd-<replaceable>ldap1</replaceable>/</command></screen>
+<screen>&prompt.sudo;<command>old /etc/dirsrv/slapd-<replaceable>INSTANCE_NAME</replaceable>/</command></screen>
    </step>
    <step>
     <para>
      Unpack the backup archive:
     </para>
-<screen>&prompt.sudo;<command>tar -xvzf config_slapd-<replaceable>ldap1</replaceable>_<replaceable>DATE</replaceable>.tar.gz</command></screen>
+<screen>&prompt.sudo;<command>tar -xvzf config_slapd-<replaceable>INSTANCE_NAME</replaceable>_<replaceable>DATE</replaceable>.tar.gz</command></screen>
    </step>
    <step>
     <para>
      Copy it to
      <filename>/etc/dirsrv/slapd-<replaceable>INSTANCE_NAME</replaceable></filename>:
     </para>
-<screen>&prompt.sudo;<command>cp -r <replaceable>etc/dirsrv/slapd-ldap1</replaceable> <replaceable>/etc/dirsrv/slapd-ldap1</replaceable></command></screen>
+<screen>&prompt.sudo;<command>cp -r <replaceable>etc/dirsrv/slapd-INSTANCE_NAME</replaceable> /etc/dirsrv/slapd-<replaceable>INSTANCE_NAME</replaceable></command></screen>
    </step>
   </procedure>
  </sect2>
@@ -66,39 +66,39 @@
   <para>
    The <command>dsctl</command> command makes offline backups. Stop the server:
   </para>
-<screen>&prompt.sudo;<command>dsctl <replaceable>ldap1</replaceable> stop</command>
-Instance "<replaceable>ldap1</replaceable>" has been stopped</screen>
+<screen>&prompt.sudo;<command>dsctl <replaceable>INSTANCE_NAME</replaceable> stop</command>
+Instance "<replaceable>INSTANCE_NAME</replaceable>" has been stopped</screen>
   <para>
    Then make the backup using your instance name:
   </para>
-<screen>&prompt.sudo;<command>dsctl <replaceable>ldap1</replaceable> db2bak</command>
+<screen>&prompt.sudo;<command>dsctl <replaceable>INSTANCE_NAME</replaceable> db2bak</command>
 db2bak successful</screen>
   <para>
    This example creates a backup archive at
-   <filename>/var/lib/dirsrv/slapd-ldap1/bak/ldap1-2021_07_26_13_03_17</filename>.
+   <filename>/var/lib/dirsrv/slapd-INSTANCE_NAME/bak/INSTANCE_NAME-2021_07_26_13_03_17</filename>.
   </para>
   <para>
    Restore from this backup, naming the directory containing the backup
    archive:
   </para>
-<screen>&prompt.sudo;<command>dsctl <replaceable>ldap1</replaceable> bak2db <replaceable>/var/lib/dirsrv/slapd-ldap1/bak/ldap1-2021_07_26_13_03_17/</replaceable></command>
+<screen>&prompt.sudo;<command>dsctl <replaceable>INSTANCE_NAME</replaceable> bak2db <replaceable>/var/lib/dirsrv/slapd-INSTANCE_NAME/bak/INSTANCE_NAME-2021_07_26_13_03_17/</replaceable></command>
 bak2db successful</screen>
   <para>
    Then start the server:
   </para>
-<screen>&prompt.sudo;<command>dsctl <replaceable>ldap1</replaceable> start</command>
-Instance "<replaceable>ldap1</replaceable>" has been started</screen>
+<screen>&prompt.sudo;<command>dsctl <replaceable>INSTANCE_NAME</replaceable> start</command>
+Instance "<replaceable>INSTANCE_NAME</replaceable>" has been started</screen>
   <para>
    You can also create LDIF backups:
   </para>
-<screen>&prompt.sudo;<command>dsctl <replaceable>ldap1</replaceable> db2ldif --replication userRoot</command>
-ldiffile: <replaceable>/var/lib/dirsrv/slapd-ldap1/ldif/ldap1-userRoot-2021_07_28_08_47_30.ldif</replaceable>
+<screen>&prompt.sudo;<command>dsctl <replaceable>INSTANCE_NAME</replaceable> db2ldif --replication userRoot</command>
+ldiffile: <replaceable>/var/lib/dirsrv/slapd-INSTANCE_NAME/ldif/INSTANCE_NAME-userRoot-2021_07_28_08_47_30.ldif</replaceable>
 db2ldif successful</screen>
   <para>
    To restore an LDIF backup with the name of the archive, then start the server:
   </para>
-<screen>&prompt.sudo;<command>dsctl ldif2db userRoot <replaceable>/var/lib/dirsrv/slapd-ldap1/ldif/ldap1-userRoot-2021_07_28_08_47_30.ldif</replaceable></command>
-&prompt.sudo;<command>dsctl ldap1 start</command></screen>
+<screen>&prompt.sudo;<command>dsctl ldif2db userRoot <replaceable>/var/lib/dirsrv/slapd-INSTANCE_NAME/ldif/INSTANCE_NAME-userRoot-2021_07_28_08_47_30.ldif</replaceable></command>
+&prompt.sudo;<command>dsctl INSTANCE_NAME start</command></screen>
  </sect2>
 
  <sect2 xml:id="sec-security-ldap-online-backup">
@@ -107,15 +107,15 @@ db2ldif successful</screen>
    Use the <command>dsconf</command> to make an online backup of your LDAP
    database:
   </para>
-<screen>&prompt.sudo;<command>dsconf <replaceable>ldap1</replaceable> backup create</command>
+<screen>&prompt.sudo;<command>dsconf <replaceable>INSTANCE_NAME</replaceable> backup create</command>
 The backup create task has finished successfully</screen>
   <para>
    This creates
-   <replaceable>/var/lib/dirsrv/slapd-ldap1/bak/ldap1-2021_07_28_09_46_08</replaceable>.
+   <replaceable>/var/lib/dirsrv/slapd-INSTANCE_NAME/bak/INSTANCE_NAME-2021_07_28_09_46_08</replaceable>.
   </para>
   <para>
    Restore it:
   </para>
-<screen>&prompt.sudo;<command>dsconf <replaceable>ldap1</replaceable> backup restore <replaceable>/var/lib/dirsrv/slapd-ldap1/bak/ldap1-2021_07_28_09_46_08</replaceable></command></screen>
+<screen>&prompt.sudo;<command>dsconf <replaceable>INSTANCE_NAME</replaceable> backup restore <replaceable>/var/lib/dirsrv/slapd-INSTANCE_NAME/bak/INSTANCE_NAME-2021_07_28_09_46_08</replaceable></command></screen>
  </sect2>
 </sect1>

--- a/xml/security_ldap_backups.xml
+++ b/xml/security_ldap_backups.xml
@@ -28,27 +28,50 @@
    file. Make a compressed backup of this directory with the
    <command>tar</command> command:
   </para>
-<screen>&prompt.sudo;tar caf config_slapd-<replaceable>ldap1</replaceable>_$(date +%Y-%m-%d_%H-%M-%S).tar.gz /etc/dirsrv/slapd-<replaceable>ldap1</replaceable>/
-tar: Removing leading `/' from member names</screen>
+<screen>&prompt.sudo;<command>tar caf config_slapd-<replaceable>ldap1</replaceable>_$(date +%Y-%m-%d_%H-%M-%S).tar.gz /etc/dirsrv/slapd-<replaceable>ldap1</replaceable>/</command></screen>
+  <note role="compact">
+   <para>
+    When running <command>tar</command>, you may see the harmless informational
+    message <literal>tar: Removing leading `/' from member names</literal>.
+   </para>
+  </note>
   <para>
-   To restore this configuration, move the existing configuration (if it
-   exists), unpack the backup archive, and copy it to
-   <filename>/etc/dirsrv/slapd-<replaceable>instance-name</replaceable></filename>:
+   To restore a previous configuration, unpack it to the same directory:
   </para>
-<screen>&prompt.sudo;mv /etc/dirsrv/slapd-<replaceable>ldap1/</replaceable> <replaceable>/etc/dirsrv/old/slapd-ldap1-old/</replaceable>
-&prompt.sudo;tar -xvzf <replaceable>config_slapd-ldap1_2021-07-28_09-27.tar.gz</replaceable>
-&prompt.sudo;cp -r <replaceable>etc/dirsrv/slapd-ldap1</replaceable> <replaceable>/etc/dirsrv/slapd-ldap1</replaceable></screen>
+  <procedure>
+   <step performance="optional">
+    <para>
+     To avoid overwriting it, move any existing configuration:
+    </para>
+<screen>&prompt.sudo;<command>old /etc/dirsrv/slapd-<replaceable>ldap1</replaceable>/</command></screen>
+   </step>
+   <step>
+    <para>
+     Unpack the backup archive:
+    </para>
+<screen>&prompt.sudo;<command>tar -xvzf config_slapd-<replaceable>ldap1</replaceable>_<replaceable>DATE</replaceable>.tar.gz</command></screen>
+   </step>
+   <step>
+    <para>
+     Copy it to
+     <filename>/etc/dirsrv/slapd-<replaceable>INSTANCE_NAME</replaceable></filename>:
+    </para>
+<screen>&prompt.sudo;<command>cp -r <replaceable>etc/dirsrv/slapd-ldap1</replaceable> <replaceable>/etc/dirsrv/slapd-ldap1</replaceable></command></screen>
+   </step>
+  </procedure>
  </sect2>
 
  <sect2 xml:id="sec-security-ldap-offline-backup">
   <title>Offline Database Backup and Restore</title>
   <para>
-   The <command>dsctl</command> command makes offline backups. Stop the server,
-   then make the backup using your instance name:
+   The <command>dsctl</command> command makes offline backups. Stop the server:
   </para>
-<screen>&prompt.sudo;dsctl <replaceable>ldap1</replaceable> stop
-Instance <replaceable>"ldap1"</replaceable> has been stopped     
-&prompt.sudo;dsctl <replaceable>ldap1</replaceable> db2bak
+<screen>&prompt.sudo;<command>dsctl <replaceable>ldap1</replaceable> stop</command>
+Instance "<replaceable>ldap1</replaceable>" has been stopped</screen>
+  <para>
+   Then make the backup using your instance name:
+  </para>
+<screen>&prompt.sudo;<command>dsctl <replaceable>ldap1</replaceable> db2bak</command>
 db2bak successful</screen>
   <para>
    This example creates a backup archive at
@@ -58,39 +81,41 @@ db2bak successful</screen>
    Restore from this backup, naming the directory containing the backup
    archive:
   </para>
-<screen>&prompt.sudo;dsctl <replaceable>ldap1</replaceable> bak2db <replaceable>/var/lib/dirsrv/slapd-ldap1/bak/ldap1-2021_07_26_13_03_17/</replaceable>
+<screen>&prompt.sudo;<command>dsctl <replaceable>ldap1</replaceable> bak2db <replaceable>/var/lib/dirsrv/slapd-ldap1/bak/ldap1-2021_07_26_13_03_17/</replaceable></command>
 bak2db successful</screen>
   <para>
    Then start the server:
   </para>
-<screen>&prompt.sudo;dsctl <replaceable>ldap1</replaceable> start
+<screen>&prompt.sudo;<command>dsctl <replaceable>ldap1</replaceable> start</command>
 Instance "<replaceable>ldap1</replaceable>" has been started</screen>
   <para>
-   You may also create LDIF backups:
+   You can also create LDIF backups:
   </para>
-<screen>&prompt.sudo;dsctl ldap1 db2ldif  --replication userRoot
+<screen>&prompt.sudo;<command>dsctl <replaceable>ldap1</replaceable> db2ldif --replication userRoot</command>
 ldiffile: <replaceable>/var/lib/dirsrv/slapd-ldap1/ldif/ldap1-userRoot-2021_07_28_08_47_30.ldif</replaceable>
 db2ldif successful</screen>
   <para>
-   Restore this backup with the name of the archive, then start the server:
+   To restore an LDIF backup with the name of the archive, then start the server:
   </para>
-<screen>&prompt.sudo;dsctl ldif2db userRoot <replaceable>/var/lib/dirsrv/slapd-ldap1/ldif/ldap1-userRoot-2021_07_28_08_47_30.ldif</replaceable>
-&prompt.sudo;dsctl ldap1 start</screen>
+<screen>&prompt.sudo;<command>dsctl ldif2db userRoot <replaceable>/var/lib/dirsrv/slapd-ldap1/ldif/ldap1-userRoot-2021_07_28_08_47_30.ldif</replaceable></command>
+&prompt.sudo;<command>dsctl ldap1 start</command></screen>
  </sect2>
 
  <sect2 xml:id="sec-security-ldap-online-backup">
-  <title>Online Database Backup and Restore</title>
+  <title>Creating an online backup of the LDAP database and restoring from it</title>
   <para>
    Use the <command>dsconf</command> to make an online backup of your LDAP
    database:
   </para>
-<screen>&prompt.sudo;dsconf <replaceable>ldap1</replaceable> backup create
+<screen>&prompt.sudo;<command>dsconf <replaceable>ldap1</replaceable> backup create</command>
 The backup create task has finished successfully</screen>
   <para>
    This creates
    <replaceable>/var/lib/dirsrv/slapd-ldap1/bak/ldap1-2021_07_28_09_46_08</replaceable>.
+  </para>
+  <para>
    Restore it:
   </para>
-<screen>&prompt.sudo;dsconf <replaceable>ldap1</replaceable> backup restore <replaceable>/var/lib/dirsrv/slapd-ldap1/bak/ldap1-2021_07_28_09_46_08</replaceable></screen>
+<screen>&prompt.sudo;<command>dsconf <replaceable>ldap1</replaceable> backup restore <replaceable>/var/lib/dirsrv/slapd-ldap1/bak/ldap1-2021_07_28_09_46_08</replaceable></command></screen>
  </sect2>
 </sect1>

--- a/xml/security_ldap_backups.xml
+++ b/xml/security_ldap_backups.xml
@@ -9,7 +9,7 @@
   xmlns:xlink="http://www.w3.org/1999/xlink" 
   version="5.0" 
   xml:id="sec-security-ldap-backup">
- <title>Making Backups and Restores</title>
+ <title>Backing up and restoring LDAP servers</title>
 
  <para>
   &ds389; supports making offline and online backups. The
@@ -20,7 +20,7 @@
  </para>
 
  <sect2 xml:id="sec-security-ldap-backup-config">
-  <title>Backing Up the Server Configuration</title>
+  <title>Backing up the LDAP server configuration</title>
   <para>
    Your LDAP server configuration is in
    <filename>/etc/dirsrv/slapd-<replaceable>instance-name</replaceable></filename>.
@@ -62,7 +62,7 @@
  </sect2>
 
  <sect2 xml:id="sec-security-ldap-offline-backup">
-  <title>Offline Database Backup and Restore</title>
+  <title>Creating an offline backup of the LDAP database and restoring from it</title>
   <para>
    The <command>dsctl</command> command makes offline backups. Stop the server:
   </para>

--- a/xml/security_ldap_directory_tree.xml
+++ b/xml/security_ldap_directory_tree.xml
@@ -150,12 +150,12 @@
       </entry>
       <entry>
        <para>
-        doc
+        <literal>documentationdept</literal>
        </para>
       </entry>
       <entry>
        <para>
-        ou
+        <literal>ou</literal>
        </para>
       </entry>
      </row>
@@ -173,12 +173,12 @@
       </entry>
       <entry>
        <para>
-        Geeko Linux
+        <literal>&exampleuserfull;</literal>
        </para>
       </entry>
       <entry>
        <para>
-        cn
+        <literal>cn</literal>
        </para>
       </entry>
      </row>
@@ -253,14 +253,14 @@ objectclass (2.16.840.1.113730.3.2.333 NAME 'nsPerson' <co xml:id="co-ldap-schem
    </callout>
    <callout arearefs="co-ldap-schema-core-must-oc">
     <para>
-     With <literal>MUST</literal> list all attribute types that must be used
+     With <literal>MUST</literal>, list all attribute types that must be used
      with an object of the type
      <literal>nsPerson</literal>.
     </para>
    </callout>
    <callout arearefs="co-ldap-schema-core-may-oc">
     <para>
-     With <literal>MAY</literal> list all attribute types that are optionally
+     With <literal>MAY</literal>, list all attribute types that are optionally
      permitted with this object class.
     </para>
    </callout>

--- a/xml/security_ldap_firewall.xml
+++ b/xml/security_ldap_firewall.xml
@@ -5,10 +5,10 @@
     %entities;
 ]>
 
-<sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="sec-security-ldap-firewall"> 
+<sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="sec-security-ldap-firewall">
   <title>Firewall configuration</title>
   <para>
-      The default TCP ports for &ds389; are 389 and 636. TCP 389 is for unencrypted 
+      The default TCP ports for &ds389; are 389 and 636. TCP 389 is for unencrypted
       connections, and STARTTLS. 636 is for encrypted connections over TLS.
   </para>
   <para>
@@ -23,7 +23,7 @@
   <para>
       Replace the zone with the appropriate zone for your server. See
       <xref linkend="sec-security-ldap-server-ca"/> for information on securing
-          your connections with TLS, and 
+          your connections with TLS, and
           <xref linkend="sec-security-firewall-fw"/> to learn about &firewalld;.
   </para>
 </sect1>

--- a/xml/security_ldap_install.xml
+++ b/xml/security_ldap_install.xml
@@ -16,8 +16,7 @@
       <package>lib389</package> packages. After installation, set up the
       server
      <phrase os="sles;osuse">as described in
-       <xref linkend="sec-security-ldap-server"
-      xrefstyle="select:label"/>.</phrase>
+       <xref linkend="sec-security-ldap-server"/>.</phrase>
     </para>
 
  <sect2 xml:id="sec-security-ldap-server">

--- a/xml/security_ldap_install.xml
+++ b/xml/security_ldap_install.xml
@@ -12,12 +12,12 @@
     </para>
     <screen>&prompt.sudo;zypper install 389-ds</screen>
     <para>
-      This installs the <package>389-ds</package> and 
-      <package>lib389</package> packages. After installation, set up the        
-      server 
-     <phrase os="sles;osuse">as described in 
+      This installs the <package>389-ds</package> and
+      <package>lib389</package> packages. After installation, set up the
+      server
+     <phrase os="sles;osuse">as described in
        <xref linkend="sec-security-ldap-server"
-      xrefstyle="select:label"/>.</phrase>      
+      xrefstyle="select:label"/>.</phrase>
     </para>
 
  <sect2 xml:id="sec-security-ldap-server">
@@ -39,7 +39,7 @@
       and configure identity services.
   </para>
   <para>
-      Follow these steps to set up a simple instance for testing and development, 
+      Follow these steps to set up a simple instance for testing and development,
       populated with a small set of sample entries.
   </para>
   <procedure>
@@ -130,7 +130,7 @@
     </varlistentry>
   </variablelist>
 </sect2>
- 
+
     <sect2 xml:id="sec-security-ldap-server-instance">
   <title>Creating a &ds389; instance with a custom configuration file</title>
     <para>
@@ -139,9 +139,9 @@
      like.
     </para>
     <para>
-       The default instance name is <literal>localhost</literal>. The instance 
+       The default instance name is <literal>localhost</literal>. The instance
        name cannot be changed after it has been created. It is better
-       to create your own instance name, rather than using the default, to avoid 
+       to create your own instance name, rather than using the default, to avoid
        confusion and to enable a better understanding of how it all works.
     </para>
     <para>
@@ -152,13 +152,13 @@
    <procedure>
     <step>
      <para>
-      Copy the following example file, <filename>ldap1.inf</filename>, to 
+      Copy the following example file, <filename>ldap1.inf</filename>, to
       your home directory:
      </para>
      <example xml:id="ex-ldap-389-ds-inf">
       <title>Minimal &ds389; instance configuration file</title>
       <screen># <replaceable>ldap1.inf</replaceable>
-        
+
 [general]
 config_version = 2 <co xml:id="co-ldap-389-ds-config-version"/>
 
@@ -187,7 +187,7 @@ suffix = <replaceable>dc=ldap1,dc=com</replaceable></screen>
        </callout>
        <callout arearefs="co-ldap-389-ds-cert">
         <para>
-         Create self-signed server certificates in 
+         Create self-signed server certificates in
          <filename>/etc/dirsrv/slapd-<replaceable>instance-name</replaceable></filename>.
         </para>
        </callout>
@@ -195,7 +195,7 @@ suffix = <replaceable>dc=ldap1,dc=com</replaceable></screen>
         <para>
          Populate the new instance with sample user and group entries.
         </para>
-       </callout>       
+       </callout>
       </calloutlist>
      </example>
    </step>
@@ -206,24 +206,24 @@ suffix = <replaceable>dc=ldap1,dc=com</replaceable></screen>
     <screen>&prompt.sudo;dscreate -v from-file <replaceable>ldap1.inf</replaceable> | tee <replaceable>ldap1-output.txt</replaceable></screen>
     <para>
      This shows all activity during the instance creation, stores all the messages in
-     <filename>ldap1-output.txt</filename>, and creates a working 
+     <filename>ldap1-output.txt</filename>, and creates a working
      LDAP server in about a minute. The verbose output contains a lot of useful
-     information. If you do not want to save it, then delete the 
+     information. If you do not want to save it, then delete the
      <literal>| tee <replaceable>ldap1-output.txt</replaceable></literal>
      portion of the command.
     </para>
    </step>
    <step>
     <para>
-     If the <command>dscreate</command> command should fail, the messages will 
-     tell you why. After correcting any issues, remove the instance 
+     If the <command>dscreate</command> command should fail, the messages will
+     tell you why. After correcting any issues, remove the instance
      (see <xref linkend="sec-security-ldap-server-remove"/>) and create a
-     new instance.    
+     new instance.
     </para>
    </step>
    <step>
     <para>
-     A successful installation reports "<literal>Completed installation for 
+     A successful installation reports "<literal>Completed installation for
        <replaceable>ldap1</replaceable></literal>". Check the status of your
      new server:
     </para>
@@ -232,8 +232,8 @@ Instance "ldap1" is running</screen>
    </step>
    <step xml:id="sec-security-ldap-server-remove">
     <para>
-     The following commands are for cleanly removing the instance. The first 
-     command performs a dry run and does not remove the instance. When you are 
+     The following commands are for cleanly removing the instance. The first
+     command performs a dry run and does not remove the instance. When you are
      sure you want to remove it, use the second command with the
      <command>--do-it</command> option:
     </para>
@@ -242,19 +242,19 @@ Not removing: if you are sure, add --do-it
 
 &prompt.sudo;dsctl <replaceable>ldap1</replaceable> remove --do-it</screen>
     <para>
-     This command also removes partially installed or corrupted instances. You 
+     This command also removes partially installed or corrupted instances. You
      can reliably create and remove instances as often as you want.
     </para>
    </step>
   </procedure>
   <para>
-    If you forget the name of your instance, use <command>dsctl</command> to 
+    If you forget the name of your instance, use <command>dsctl</command> to
     list all instances:
   </para>
   <screen>&prompt.user;/usr/sbin/dsctl -l
-slapd-ldap1</screen>    
+slapd-ldap1</screen>
  </sect2>
- 
+
  <sect2 xml:id="sec-security-ldap-server-template">
    <title>Creating a &ds389; instance from a template</title>
    <para>
@@ -279,18 +279,18 @@ slapd-ldap1</screen>
        This is a snippet from the new file:
    </para>
    <screen># full_machine_name (str)
-# Description: Sets the fully qualified hostname (FQDN) of this system. When 
-# installing this instance with GSSAPI authentication behind a load balancer, set 
-# this parameter to the FQDN of the load balancer and, additionally, set 
+# Description: Sets the fully qualified hostname (FQDN) of this system. When
+# installing this instance with GSSAPI authentication behind a load balancer, set
+# this parameter to the FQDN of the load balancer and, additionally, set
 # "strict_host_checking" to "false".
 # Default value: ldapserver1.test.net
 ;full_machine_name = ldapserver1.test.net
 
 # selinux (bool)
-# Description: Enables SELinux detection and integration during the installation 
-# of this instance. If set to "True", dscreate auto-detects whether SELinux is 
+# Description: Enables SELinux detection and integration during the installation
+# of this instance. If set to "True", dscreate auto-detects whether SELinux is
 # enabled. Set this parameter only to "False" in a development environment.
-# Default value: True 
+# Default value: True
 ;selinux = True</screen>
 
    <para>
@@ -299,7 +299,7 @@ slapd-ldap1</screen>
    </para>
    <screen>&prompt.sudo;dscreate from-file <replaceable>ldap1-template.txt</replaceable></screen>
    <para>
-       This creates a new instance named <literal>localhost</literal>, and 
+       This creates a new instance named <literal>localhost</literal>, and
        automatically starts it after creation:
    </para>
    <screen>&prompt.sudo;dsctl <replaceable>localhost</replaceable> status
@@ -309,10 +309,10 @@ Instance "localhost" is running</screen>
         some values you might want to change.
     </para>
     <para>
-        The instance name cannot be changed after it has been created. It is 
-        better to create your own instance name, rather than using the default, 
-        to avoid confusion and to enable a better understanding of how it all 
-        works. To do this, uncomment the 
+        The instance name cannot be changed after it has been created. It is
+        better to create your own instance name, rather than using the default,
+        to avoid confusion and to enable a better understanding of how it all
+        works. To do this, uncomment the
         <literal>;instance_name = localhost</literal> line and change
         <literal>localhost</literal> to your chosen name. In the following
         examples, the instance name is <replaceable>ldap1</replaceable>.
@@ -328,24 +328,24 @@ Instance "localhost" is running</screen>
     </para>
     <para>
         The template does not create a default suffix, so you should
-        configure your own on the <literal>suffix</literal> line, like 
+        configure your own on the <literal>suffix</literal> line, like
         the following example:
-    </para>    
+    </para>
     <screen>suffix = <replaceable>dc=ldap1,dc=com</replaceable></screen>
     <para>
-       You can cleanly remove any instance and start over with 
+       You can cleanly remove any instance and start over with
        <command>dsctl</command>:
     </para>
     <screen>&prompt.sudo;dsctl <replaceable>ldap1</replaceable> remove --do-it</screen>
  </sect2>
- 
+
  <sect2 xml:id="sec-security-ldap-server-stop-start">
      <title>Stopping and starting &ds389;</title>
      <para>
          Use &systemd; to manage your &ds389; instance. Get the
          status of your server:
      </para>
-     <screen>&prompt.user;systemctl status --no-pager --full <replaceable>dirsrv@ldap1.service</replaceable>       
+     <screen>&prompt.user;systemctl status --no-pager --full <replaceable>dirsrv@ldap1.service</replaceable>
    ● dirsrv@ldap1.service - 389 Directory Server ldap1.
      Loaded: loaded (/usr/lib/systemd/system/dirsrv@.service; enabled; vendor preset: disabled)
      Active: active (running) since Thu 2021-03-11 08:55:28 PST; 2h 7min ago
@@ -363,7 +363,7 @@ Instance "localhost" is running</screen>
 &prompt.sudo;systemctl stop <replaceable>dirsrv@ldap1.service</replaceable>
 &prompt.sudo;systemctl restart <replaceable>dirsrv@ldap1.service</replaceable></screen>
    <para>
-       See <xref linkend="cha-systemd"/> for more information on using 
+       See <xref linkend="cha-systemd"/> for more information on using
        <command>systemctl</command>.
    </para>
    <para>
@@ -382,21 +382,21 @@ Instance "localhost" is running</screen>
     For local administration of the &ds389;, you can create a
     <filename>.dsrc</filename> configuration file in the <filename>/root</filename>
     directory, allowing root and sudo users to administer the server without
-    typing connection details with every command. 
-    <xref linkend="ex-security-ldap-server-credentials-local" xrefstyle="select:label"/> 
-    shows an example for local administration on the server, using 
-    <replaceable>ldap1</replaceable> and <replaceable>com</replaceable> for 
+    typing connection details with every command.
+    <xref linkend="ex-security-ldap-server-credentials-local" xrefstyle="select:label"/>
+    shows an example for local administration on the server, using
+    <replaceable>ldap1</replaceable> and <replaceable>com</replaceable> for
     the base DN.
    </para>
    <para>
      After creating your <filename>/root/.dsrc</filename> file, try a few
-     administration commands, such as creating new users (see 
+     administration commands, such as creating new users (see
      <xref linkend="sec-security-ldap-server-users"/>).
    </para>
    <example xml:id="ex-security-ldap-server-credentials-local">
     <title>A <filename>.dsrc</filename> file for local administration</title>
-     <screen># /root/.dsrc file for administering the ldap1 instance
-         
+<screen># /root/.dsrc file for administering the ldap1 instance
+
 [<replaceable>ldap1</replaceable>] <co xml:id="co-ldap-server-dsrc-instance-name"/>
 
 uri = ldapi://<replaceable>%%2fvar%%2frun%%2fslapd-ldap1.socket</replaceable> <co xml:id="co-ldap-server-dsrc-remote-ldapi"/>
@@ -408,20 +408,20 @@ binddn = cn=Directory Manager
       <para>
         This must specify your exact instance name.
       </para>
-    </callout>       
+    </callout>
     <callout arearefs="co-ldap-server-dsrc-remote-ldapi">
       <para>
-        <literal>ldapi</literal> detects the UID and GID of the user attempting 
+        <literal>ldapi</literal> detects the UID and GID of the user attempting
         to log in to the server. If the UID/GID are <literal>0/0</literal> or
-        <literal>dirsrv:dirsrv</literal>, <literal>ldapi</literal> binds the user 
-        as the directory server root dn, which is 
+        <literal>dirsrv:dirsrv</literal>, <literal>ldapi</literal> binds the user
+        as the directory server root dn, which is
         <literal>cn=Directory Manager</literal>.
       </para>
       <para>
         In the URI, the slashes are replaced with <literal>%%2f</literal>, so
-        in this example the path is 
+        in this example the path is
         <filename>/var/run/slapd-ldap1.socket</filename>.
-      </para> 
+      </para>
     </callout>
    </calloutlist>
   </example>

--- a/xml/security_ldap_kerberos_ad_yast.xml
+++ b/xml/security_ldap_kerberos_ad_yast.xml
@@ -34,7 +34,7 @@
   </para>
  </listitem>
  <!-- commenting out, may be removed because of changes to 389ds and
-Kerberos. cschroder, 16-12-2020 
+Kerberos. cschroder, 16-12-2020
  <listitem>
   <formalpara>
    <title><guimenu>LDAP and Kerberos authentication</guimenu></title>

--- a/xml/security_ldap_migrate_test.xml
+++ b/xml/security_ldap_migrate_test.xml
@@ -63,7 +63,7 @@
      <para>
        This results in something similar to the following example:
      </para>
-     <screen>&prompt.sudo;ls slapd.d/*
+     <screen>&prompt.sudo;<command>ls slapd.d/*</command>
 
 slapd.d/cn=config.ldif
 

--- a/xml/security_ldap_migrate_test.xml
+++ b/xml/security_ldap_migrate_test.xml
@@ -8,10 +8,12 @@
 <sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="sec-security-ldap-migrate">
 
   <title>Migrating to &ds389; from OpenLDAP</title>
-   <para>OpenLDAP is deprecated and no longer supported as of &sle;&nbsp;
-     15.3, replaced by &ds389;. &suse; provides the
+   <para>
+     OpenLDAP is deprecated<phrase os="sles;sled"> and no longer supported as of
+     &sle; 15&nbsp;SP3</phrase>.
+     It has been replaced by &ds389;. &suse; provides the
      <command>openldap_to_ds</command> utility to assist with migration, included
-     in the <package>&ds389;</package> package.
+     in the <package>389-ds</package> package.
    </para>
    <para>
      The <command>openldap_to_ds</command> utility is designed to automate as

--- a/xml/security_ldap_migrate_test.xml
+++ b/xml/security_ldap_migrate_test.xml
@@ -6,29 +6,29 @@
 ]>
 
 <sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="sec-security-ldap-migrate">
-  
+
   <title>Migrating to &ds389; from OpenLDAP</title>
    <para>OpenLDAP is deprecated and no longer supported as of &sle;&nbsp;
-     15.3, replaced by &ds389;. &suse; provides the 
-     <command>openldap_to_ds</command> utility to assist with migration, included 
+     15.3, replaced by &ds389;. &suse; provides the
+     <command>openldap_to_ds</command> utility to assist with migration, included
      in the <package>&ds389;</package> package.
    </para>
    <para>
-     The <command>openldap_to_ds</command> utility is designed to automate as 
-     much of the migration as possible. However, every LDAP deployment is 
-     different, and it is not possible to write a tool that satisfies all 
+     The <command>openldap_to_ds</command> utility is designed to automate as
+     much of the migration as possible. However, every LDAP deployment is
+     different, and it is not possible to write a tool that satisfies all
      situations. It is likely there will be some manual steps to perform, and
-     you should test your migration procedure thoroughly before attempting a 
+     you should test your migration procedure thoroughly before attempting a
      production migration.
    </para>
-   
+
   <sect2 xml:id="sec-security-ldap-migrate-test">
   <title>Testing migration from OpenLDAP</title>
    <para>
-     There are enough differences between OpenLDAP and &ds389; that 
+     There are enough differences between OpenLDAP and &ds389; that
      migration will probably involve repeated testing and adjustments.
-     It can be helpful to do a quick migration test to get an idea of what 
-     steps will be necessary for a successful migration.     
+     It can be helpful to do a quick migration test to get an idea of what
+     steps will be necessary for a successful migration.
    </para>
    <para>
      Prerequisites:
@@ -41,7 +41,7 @@
     </listitem>
     <listitem>
      <para>
-       An OpenLDAP <filename>slapd</filename> configuration file or directory 
+       An OpenLDAP <filename>slapd</filename> configuration file or directory
        in dynamic ldif format.
      </para>
     </listitem>
@@ -52,8 +52,8 @@
     </listitem>
    </itemizedlist>
    <para>
-     If your slapd configuration is not in dynamic ldif format, create a 
-     dynamic copy with <command>slaptest</command>. Create the 
+     If your slapd configuration is not in dynamic ldif format, create a
+     dynamic copy with <command>slaptest</command>. Create the
      <filename>slapd.d</filename> directory, then run the following command:
    </para>
    <screen>&prompt.sudo;slaptest -f /etc/openldap/slapd.conf -F /root/slapd.d
@@ -70,7 +70,7 @@ cn=schema          olcDatabase={-1}frontend.ldif  olcDatabase={1}mdb.ldif
 </screen>
    <para>
      Create one ldif file per suffix. In the following examples, the suffix
-     is <replaceable>dc=ldap1,dc=com</replaceable>. If you are using the 
+     is <replaceable>dc=ldap1,dc=com</replaceable>. If you are using the
      <filename>/etc/openldap/slapd.conf</filename>
      format, use the following command to create the ldif backup file:
    </para>
@@ -79,9 +79,9 @@ cn=schema          olcDatabase={-1}frontend.ldif  olcDatabase={1}mdb.ldif
    <para>
      For the <filename>/etc/openldap/slapd.d</filename> format, use the following command:
    </para>
-   <screen>&prompt.sudo;slapcat -f /etc/openldap/slapd.conf -b <replaceable>dc=ldap1,dc=com</replaceable> -l /root/<replaceable>ldap1-com</replaceable>.ldif</screen>   
+   <screen>&prompt.sudo;slapcat -f /etc/openldap/slapd.conf -b <replaceable>dc=ldap1,dc=com</replaceable> -l /root/<replaceable>ldap1-com</replaceable>.ldif</screen>
    <para>
-     Use <command>openldap_to_ds</command> to analyze the configuration and 
+     Use <command>openldap_to_ds</command> to analyze the configuration and
      files, and show a migration plan without changing anything:
    </para>
    <screen>&prompt.sudo;openldap_to_ds <replaceable>ldap1</replaceable> /root/slapd.d <replaceable>ldap1-com</replaceable>.ldif</screen>
@@ -109,7 +109,7 @@ The following migration steps will be performed:
 No actions taken. To apply migration plan, use '--confirm'
 </screen>
    <para>
-     The following example performs the migration, and the output looks 
+     The following example performs the migration, and the output looks
      different from the dry run:
    </para>
    <screen>&prompt.sudo;openldap_to_ds <replaceable>ldap1</replaceable> /root/slapd.d <replaceable>ldap1-com</replaceable>.ldif --confirm
@@ -131,7 +131,7 @@ You should now review your instance configuration and data:
  * [ ] - Review Schema Inconistent ObjectClass -> pilotOrganization (0.9.2342.19200300.100.4.20)
  * [ ] - Review Database Imported Content is Correct -> dc=ldap1,dc=com
 </screen>
-  
+
    <para>
      When the migration is complete, <command>openldap_to_ds</command>
      creates a checklist of post-migration tasks that must be completed.
@@ -143,10 +143,10 @@ You should now review your instance configuration and data:
    <important>
      <title>Develop a rollback plan</title>
      <para>
-       It is essential to develop a rollback plan in case of any failures. 
-       This plan should define a successful migration, the tests to determine 
-       what worked and what needs to be fixed, which steps are critical, what 
-       can be deferred until later, how to decide when to undo any changes, 
+       It is essential to develop a rollback plan in case of any failures.
+       This plan should define a successful migration, the tests to determine
+       what worked and what needs to be fixed, which steps are critical, what
+       can be deferred until later, how to decide when to undo any changes,
        how to undo them with minimal disruption, and which other teams need to be involved.
      </para>
    </important>
@@ -176,9 +176,9 @@ You should now review your instance configuration and data:
       <para>
         Have your test migration documentation readily available.
       </para>
-    </listitem> 
-   </itemizedlist>    
-  </sect2>     
+    </listitem>
+   </itemizedlist>
+  </sect2>
  <sect2 xml:id="sec-security-ldap-migrate-plan">
   <title>Planning your migration</title>
   <para>

--- a/xml/security_ldap_migrate_test.xml
+++ b/xml/security_ldap_migrate_test.xml
@@ -185,8 +185,9 @@ You should now review your instance configuration and data:
  <sect2 xml:id="sec-security-ldap-migrate-plan">
   <title>Planning your migration</title>
   <para>
-   As OpenLDAP is a "box of parts" and highly customizable, it is not possible
-   to prescribe a "one size fits all" migration. It is necessary to assess your
+   As OpenLDAP is a <quote>box of parts</quote> and highly customizable, it is
+   not possible to prescribe a <quote>one size fits all</quote> migration.
+   It is necessary to assess your
    current environment and configuration with OpenLDAP and other integrations.
    This includes, and is not limited to:
   </para>

--- a/xml/security_ldap_migrate_test.xml
+++ b/xml/security_ldap_migrate_test.xml
@@ -61,7 +61,8 @@
      <para>
        This results in something similar to the following example:
      </para>
-     <screen>&prompt.sudo;ls  slapd.d/*
+     <screen>&prompt.sudo;ls slapd.d/*
+
 slapd.d/cn=config.ldif
 
 slapd.d/cn=config:
@@ -190,37 +191,37 @@ You should now review your instance configuration and data:
   <itemizedlist>
    <listitem>
     <para>
-     Replication topology.
+     Replication topology
     </para>
    </listitem>
    <listitem>
     <para>
-     High availability and load balancer configurations.
+     High availability and load balancer configurations
     </para>
    </listitem>
    <listitem>
     <para>
-     External data flows (IGA, HR, AD, etc.).
+     External data flows (IGA, HR, AD, etc.)
     </para>
    </listitem>
    <listitem>
     <para>
-     Configured overlays (plug-ins in &ds389;).
+     Configured overlays (plug-ins in &ds389;)
     </para>
    </listitem>
    <listitem>
     <para>
-     Client configuration and expected server features.
+     Client configuration and expected server features
     </para>
    </listitem>
    <listitem>
     <para>
-     Customized schema.
+     Customized schema
     </para>
    </listitem>
    <listitem>
     <para>
-     TLS configuration.
+     TLS configuration
     </para>
    </listitem>
   </itemizedlist>
@@ -228,9 +229,9 @@ You should now review your instance configuration and data:
    Plan what your &ds389; deployment will look like in the end. This includes
    the same list, except replace overlays with plugins. Once you have assessed
    your current environment, and planned what your &ds389; environment will
-   look like, you can then form a migration plan. It is recommended you build
+   look like, you can then form a migration plan. We recommended to build
    the &ds389; environment in parallel to your OpenLDAP environment to allow
-   you to switch between them.
+   switching between them.
   </para>
   <para>
    Migrating from OpenLDAP to &ds389; is a one-way migration. There are enough
@@ -252,7 +253,7 @@ You should now review your instance configuration and data:
      <row>
       <entry>Two-way replication</entry>
       <entry>SyncREPL</entry>
-      <entry>389-specific system</entry>
+      <entry>&ds389a;-specific system</entry>
       <entry>No</entry>
      </row>
      <row>
@@ -298,16 +299,16 @@ You should now review your instance configuration and data:
       <entry>Yes, all formats supported excluding Argon2</entry>
      </row>
      <row>
-      <entry>OpenLDAP to &ds389; replication</entry>
+      <entry>OpenLDAP to &ds389a; replication</entry>
       <entry>-</entry>
       <entry>-</entry>
-      <entry>No mechanism to replicate to 389 is possible</entry>
+      <entry>No mechanism to replicate to &ds389a; is possible</entry>
      </row>
      <row>
       <entry>Time-based one-time password (TOTP)</entry>
       <entry>TOTP overlay</entry>
       <entry>-</entry>
-      <entry>No, may be supported in the future</entry>
+      <entry>No, currently not supported</entry>
      </row>
      <row>
       <entry>entryUUID</entry>

--- a/xml/security_ldap_modules.xml
+++ b/xml/security_ldap_modules.xml
@@ -8,14 +8,14 @@
 <sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="sec-security-ldap-modules">
   <title>Managing modules</title>
   <para>
-    Use the following command to list all available modules, enabled and 
+    Use the following command to list all available modules, enabled and
     disabled. Use your server's hostname rather than the instance name
     of your &ds389; server, like the following example hostname of
     <replaceable>ldapserver1</replaceable>:
   </para>
   <screen>&prompt.sudo;dsconf -D "cn=Directory Manager" ldap://<replaceable>ldapserver1</replaceable> plugin list
     [sudo] password for root: <replaceable>password</replaceable>
-    Enter password for cn=Directory Manager on 
+    Enter password for cn=Directory Manager on
     ldap://<replaceable>ldapserver1</replaceable>: <replaceable>password</replaceable>
 7-bit check
 Account Policy Plugin
@@ -24,28 +24,28 @@ ACL Plugin
 ACL preoperation
 [...]</screen>
   <para>
-    This is how to enable the MemberOf plugin referenced in 
+    This is how to enable the MemberOf plugin referenced in
     <xref linkend="sec-security-ldap-server-sssd"/>:
   </para>
   <screen>&prompt.sudo;dsconf -D "cn=Directory Manager" ldap://<replaceable>ldapserver1</replaceable> plugin memberof enable</screen>
   <para>
-    Note that the plugin names used in commands are lowercase, so they  
-    are different from how 
+    Note that the plugin names used in commands are lowercase, so they
+    are different from how
     they appear when you list them. If you make a mistake with a plugin
     name, you will see a helpful error message:
   </para>
-    <screen>dsconf instance plugin: error: invalid choice: 'MemberOf' (choose 
-      from 'memberof', 'automember', 'referential-integrity', 'root-dn', 
+    <screen>dsconf instance plugin: error: invalid choice: 'MemberOf' (choose
+      from 'memberof', 'automember', 'referential-integrity', 'root-dn',
       'usn', 'account-policy', 'attr-uniq', 'dna', 'linked-attr', 'managed-
-      entries', 'pass-through-auth', 'retro-changelog', 'posix-winsync', 
+      entries', 'pass-through-auth', 'retro-changelog', 'posix-winsync',
       'contentsync', 'list', 'show', 'set')</screen>
     <para>
     After enabling a plugin, it is necessary to restart the server:
     </para>
     <screen>&prompt.sudo;systemctl restart <replaceable>dirsrv@ldap1.service</replaceable></screen>
-    <para>    
-      To avoid having to restart the server, set the  
-    <literal>nsslapd-dynamic-plugins</literal> parameter to 
+    <para>
+      To avoid having to restart the server, set the
+    <literal>nsslapd-dynamic-plugins</literal> parameter to
     <literal>on</literal>:
    </para>
     <screen>&prompt.sudo;dsconf -D "cn=Directory Manager" ldap://<replaceable>ldapserver1</replaceable> config replace nsslapd-dynamic-plugins=on

--- a/xml/security_ldap_modules.xml
+++ b/xml/security_ldap_modules.xml
@@ -13,10 +13,10 @@
     of your &ds389; server, like the following example hostname of
     <replaceable>ldapserver1</replaceable>:
   </para>
-  <screen>&prompt.sudo;dsconf -D "cn=Directory Manager" ldap://<replaceable>ldapserver1</replaceable> plugin list
-    [sudo] password for root: <replaceable>password</replaceable>
-    Enter password for cn=Directory Manager on
-    ldap://<replaceable>ldapserver1</replaceable>: <replaceable>password</replaceable>
+<screen>&prompt.sudo;<command>dsconf -D "cn=Directory Manager" ldap://<replaceable>ldapserver1</replaceable> plugin list</command>
+[sudo] password for root: <replaceable>PASSWORD</replaceable>
+Enter password for cn=Directory Manager on ldap://<replaceable>ldapserver1</replaceable>: <replaceable>PASSWORD</replaceable>
+
 7-bit check
 Account Policy Plugin
 Account Usability Plugin
@@ -27,28 +27,30 @@ ACL preoperation
     This is how to enable the MemberOf plugin referenced in
     <xref linkend="sec-security-ldap-server-sssd"/>:
   </para>
-  <screen>&prompt.sudo;dsconf -D "cn=Directory Manager" ldap://<replaceable>ldapserver1</replaceable> plugin memberof enable</screen>
+  <screen>&prompt.sudo;<command>dsconf -D "cn=Directory Manager" ldap://<replaceable>ldapserver1</replaceable> plugin memberof enable</command></screen>
   <para>
     Note that the plugin names used in commands are lowercase, so they
     are different from how
     they appear when you list them. If you make a mistake with a plugin
     name, you will see a helpful error message:
   </para>
-    <screen>dsconf instance plugin: error: invalid choice: 'MemberOf' (choose
-      from 'memberof', 'automember', 'referential-integrity', 'root-dn',
-      'usn', 'account-policy', 'attr-uniq', 'dna', 'linked-attr', 'managed-
-      entries', 'pass-through-auth', 'retro-changelog', 'posix-winsync',
-      'contentsync', 'list', 'show', 'set')</screen>
+<screen>dsconf instance plugin: error: invalid choice: 'MemberOf' (choose from
+'memberof', 'automember', 'referential-integrity', 'root-dn', 'usn',
+'account-policy', 'attr-uniq', 'dna', 'linked-attr', 'managed-entries',
+'pass-through-auth', 'retro-changelog', 'posix-winsync', 'contentsync', 'list',
+'show', 'set')</screen>
     <para>
     After enabling a plugin, it is necessary to restart the server:
     </para>
-    <screen>&prompt.sudo;systemctl restart <replaceable>dirsrv@ldap1.service</replaceable></screen>
+    <screen>&prompt.sudo;<command>systemctl restart <replaceable>dirsrv@ldap1.service</replaceable></command></screen>
     <para>
       To avoid having to restart the server, set the
     <literal>nsslapd-dynamic-plugins</literal> parameter to
     <literal>on</literal>:
    </para>
-    <screen>&prompt.sudo;dsconf -D "cn=Directory Manager" ldap://<replaceable>ldapserver1</replaceable> config replace nsslapd-dynamic-plugins=on
-  Enter password for cn=Directory Manager on ldap://<replaceable>ldapserver1</replaceable>: <replaceable>password</replaceable>
+<screen>&prompt.sudo;<command>dsconf -D "cn=Directory Manager" ldap://<replaceable>ldapserver1</replaceable> config replace \
+  nsslapd-dynamic-plugins=on</command>
+Enter password for cn=Directory Manager on ldap://<replaceable>ldapserver1</replaceable>: <replaceable>PASSWORD</replaceable>
+
 Successfully replaced "nsslapd-dynamic-plugins"</screen>
 </sect1>

--- a/xml/security_ldap_sssd.xml
+++ b/xml/security_ldap_sssd.xml
@@ -64,20 +64,20 @@ systemctl start sssd</screen>
    </step>
    <step>
     <para>
-     To make sure SSSD is part of PAM and NSS, follow the instructions in 
-     the sections 
-      <citetitle>Configure PAM (&suse;)</citetitle> and 
-      <citetitle>Configure NSS (&suse;)</citetitle> at 
+     To make sure SSSD is part of PAM and NSS, follow the instructions in
+     the sections
+      <citetitle>Configure PAM (&suse;)</citetitle> and
+      <citetitle>Configure NSS (&suse;)</citetitle> at
       <link xlink:href="https://www.port389.org/docs/389ds/howto/howto-sssd.html"/>.
     </para>
    </step>
    <step>
     <para>
-     Your user must have their own SSH key pair, and SSH access to your SSSD server. 
+     Your user must have their own SSH key pair, and SSH access to your SSSD server.
      If everything is set up correctly, &exampleuserII; can access the &ds389;
      instance via SSH to the machine where you have installed and configured
      SSSD. However, &exampleuserIII; will fail to do so, because &exampleuserIII;
-     does not belong to the group <literal>server_admins</literal> that we 
+     does not belong to the group <literal>server_admins</literal> that we
      configured in <xref linkend="pro-security-ldap-server-groups"
       xrefstyle="select:label"/>.
     </para>

--- a/xml/security_ldap_sssd.xml
+++ b/xml/security_ldap_sssd.xml
@@ -18,14 +18,14 @@
    <step>
      <para>On a separate server, install the <systemitem>sssd</systemitem> and <systemitem>sssd-ldap</systemitem> packages:
      </para>
-    <screen>&prompt.sudo;zypper in sssd sssd-ldap</screen>
+    <screen>&prompt.sudo;<command>zypper in sssd sssd-ldap</command></screen>
    </step>
    <step>
     <para>
      Disable and stop the <systemitem class="daemon">nscd</systemitem> daemon
      because it conflicts with <systemitem class="daemon">sssd</systemitem>:
     </para>
-    <screen>&prompt.sudo;systemctl disable nscd &amp;&amp; systemctl stop nscd</screen>
+    <screen>&prompt.sudo;<command>systemctl disable nscd &amp;&amp; systemctl stop nscd</command></screen>
    </step>
    <step>
     <para>
@@ -39,7 +39,7 @@
       clients can log in and authorize (see <xref linkend="sec-security-ldap-modules"/>).
      </para>
     </tip>
-    <screen>&prompt.sudo;dsidm localhost client_config sssd.conf server_admins</screen>
+    <screen>&prompt.sudo;<command>dsidm localhost client_config sssd.conf server_admins</command></screen>
    </step>
    <step>
     <para>

--- a/xml/security_ldap_sssd.xml
+++ b/xml/security_ldap_sssd.xml
@@ -30,8 +30,8 @@
    <step>
     <para>
      Create the SSSD configuration and restrict the login to the members of the group <systemitem
-     class="groupname">server_admins</systemitem> that we created in <xref
-      linkend="pro-security-ldap-server-groups" xrefstyle="select:label"/>:
+     class="groupname">server_admins</systemitem> that was set up in <xref
+      linkend="pro-security-ldap-server-groups"/>:
     </para>
     <tip>
      <para>
@@ -50,25 +50,27 @@
    <step>
     <para>
      To configure the certificates on your client, copy <filename>ca.crt</filename>
-     from the LDAP server to your client:</para>
-    <screen>&prompt.sudo;mkdir -p /etc/openldap/certs
-cp [...]>/ca.crt /etc/openldap/certs/
-/usr/bin/c_rehash /etc/openldap/certs</screen>
+     from the LDAP server to your client:
+    </para>
+<screen>&prompt.sudo;<command>mkdir -p /etc/openldap/certs</command>
+
+&prompt.sudo;<command>cp <replaceable>/PATH/TO/</replaceable>ca.crt /etc/openldap/certs/</command>
+
+&prompt.sudo;<command>c_rehash /etc/openldap/certs</command></screen>
    </step>
    <step>
     <para>
      Enable and start SSSD:
     </para>
-    <screen>&prompt.sudo;systemctl enable sssd
-systemctl start sssd</screen>
+    <screen>&prompt.sudo;<command>systemctl enable --now sssd</command></screen>
    </step>
    <step>
     <para>
      To make sure SSSD is part of PAM and NSS, follow the instructions in
      the sections
-      <citetitle>Configure PAM (&suse;)</citetitle> and
-      <citetitle>Configure NSS (&suse;)</citetitle> at
-      <link xlink:href="https://www.port389.org/docs/389ds/howto/howto-sssd.html"/>.
+     <citetitle>Configure PAM (&suse;)</citetitle> and
+     <citetitle>Configure NSS (&suse;)</citetitle> at
+     <link xlink:href="https://www.port389.org/docs/389ds/howto/howto-sssd.html"/>.
     </para>
    </step>
    <step>
@@ -77,9 +79,8 @@ systemctl start sssd</screen>
      If everything is set up correctly, &exampleuserII; can access the &ds389;
      instance via SSH to the machine where you have installed and configured
      SSSD. However, &exampleuserIII; will fail to do so, because &exampleuserIII;
-     does not belong to the group <literal>server_admins</literal> that we
-     configured in <xref linkend="pro-security-ldap-server-groups"
-      xrefstyle="select:label"/>.
+     does not belong to the group <literal>server_admins</literal>, as
+     configured in <xref linkend="pro-security-ldap-server-groups"/>.
     </para>
    </step>
   </procedure>

--- a/xml/security_ldap_users.xml
+++ b/xml/security_ldap_users.xml
@@ -10,7 +10,7 @@
    <para>
     Users and groups are created and managed with the <command>dsidm</command>
     command. It runs interactively, or you can run it on the command line, and
-    enter all options in a single command. 
+    enter all options in a single command.
    </para>
    <para>
      List your existing users and groups:
@@ -31,22 +31,22 @@
    <screen>&prompt.sudo;dsidm <replaceable>ldap1</replaceable> group members <replaceable>demo_group</replaceable></screen>
    <para>
    In the following example we add two users, &exampleuserII; and &exampleuserIII;,
-   by specifying their data via command-line arguments. The example server 
-   instance is named <replaceable>ldap1</replaceable>, and the instance's suffix is 
+   by specifying their data via command-line arguments. The example server
+   instance is named <replaceable>ldap1</replaceable>, and the instance's suffix is
    <replaceable>dc=ldap1,dc=com</replaceable>.
    </para>
   <procedure xml:id="pro-security-ldap-server-users">
    <title>Creating LDAP users</title>
    <para>
-     LDAP users are your users that already exist. They should have Linux 
+     LDAP users are your users that already exist. They should have Linux
      system accounts, with Linux logins and home directories. Adding them to
-     your LDAP server provides central user management for your network. You 
-     need to enter accurate user data, which you can obtain by accessing 
-     the computers that hold their accounts, and running the 
+     your LDAP server provides central user management for your network. You
+     need to enter accurate user data, which you can obtain by accessing
+     the computers that hold their accounts, and running the
      <command>id</command> command, like this example for &exampleuserIIfull;:
    </para>
    <screen>&prompt.user;id &exampleuserIII_plain;
-uid=1001(wilber) gid=101(users) groups=101(users)</screen>   
+uid=1001(wilber) gid=101(users) groups=101(users)</screen>
    <step>
     <para>
     Create the LDAP user &exampleuserII;:
@@ -57,7 +57,7 @@ uid=1001(wilber) gid=101(users) groups=101(users)</screen>
    </step>
    <step>
     <para>
-     Verify by looking up your new user's 
+     Verify by looking up your new user's
      <literal>distinguished name</literal> (fully qualified
      name to the directory object, which is guaranteed unique):
     </para>
@@ -65,7 +65,7 @@ uid=1001(wilber) gid=101(users) groups=101(users)</screen>
 dn: uid=&exampleuserII_plain;,ou=people,dc=ldap1,dc=com
 [...]</screen>
     <para>
-     You need the distinguished name for actions such as changing the 
+     You need the distinguished name for actions such as changing the
      password for a user.
     </para>
    </step>
@@ -97,7 +97,7 @@ dn: uid=&exampleuserII_plain;,ou=people,dc=ldap1,dc=com
     <screen>&prompt.sudo;<command>dsidm</command> <replaceable>ldap1</replaceable> user create --uid &exampleuserIII_plain;\
   --cn &exampleuserIII_plain; --displayName '&exampleuserIIIfull;' \
   --uidNumber 1002 --gidNumber 102 --homeDirectory /home/&exampleuserIII;
-  
+
 &prompt.sudo;dsidm <replaceable>ldap1</replaceable> account reset_password \
   uid=&exampleuserIII;,ou=people,dc=ldap1,dc=com</screen>
    </step>
@@ -107,7 +107,7 @@ dn: uid=&exampleuserII_plain;,ou=people,dc=ldap1,dc=com
     </para>
    <screen>&prompt.user;ldapwhoami -D uid=geeko,ou=people,dc=ldap1,dc=com -W
 Enter LDAP Password: <replaceable>password</replaceable>
-dn: uid=geeko,ou=people,dc=ldap1,dc=com    
+dn: uid=geeko,ou=people,dc=ldap1,dc=com
      </screen>
    </step>
   </procedure>
@@ -115,19 +115,19 @@ dn: uid=geeko,ou=people,dc=ldap1,dc=com
    <para>
      The following example deletes the user &exampleuserII;:
    </para>
-   <screen>&prompt.sudo;<command>dsidm</command> <replaceable>ldap1</replaceable> user delete 
+   <screen>&prompt.sudo;<command>dsidm</command> <replaceable>ldap1</replaceable> user delete
    Enter dn to delete : <replaceable>uid=wilber,ou=people,dc=ldap1,dc=com</replaceable>
    Deleting nsUserAccount uid=wilber,ou=people,dc=ldap1,dc=com :
    Type 'Yes I am sure' to continue: Yes I am sure
    Successfully deleted uid=wilber,ou=people,dc=ldap1,dc=com</screen>
-  
+
   <procedure xml:id="pro-security-ldap-server-groups">
    <title>Creating LDAP groups and assigning users to them</title>
    <para>
-    In the following examples, we create a group, 
-    <replaceable>server_admins</replaceable>, and assign the user 
-    &exampleuserII; to this group. The example server instance is named 
-    <literal>ldap1</literal>, and the instance's suffix is 
+    In the following examples, we create a group,
+    <replaceable>server_admins</replaceable>, and assign the user
+    &exampleuserII; to this group. The example server instance is named
+    <literal>ldap1</literal>, and the instance's suffix is
     <literal>dc=ldap1,dc=com</literal>.
     </para>
    <step>


### PR DESCRIPTION
### PR creator: Description

Hi @cjschroder -- this PR tries to correct a few things within the LDAP chapter. I've ultimately refrained from making this exhaustive though (because time). I would like to make sure this PR doesn't break any eggs to make the omelette though.

A few things in the chapter are imo inconsistent with SUSE style:

* Collecting multiple commands within a screen is something that I don't think is normally done in SUSE docs. I've tried to reduce those occurrences but I didn't want to rewrite the entire chapter. (Afaik this is not an explicit style rule [sadly].)
* Using things that look like actual values rather than a generic placeholder within replaceables (such as `ldap1` rather than `INSTANCE_NAME` in this chapter). (While the capitalization is a style rule, the rule to use a generic placeholder is [sadly] implicit only.)
* Using "we" to mean roughly "the writer + the reader". Either don't address the reader or use "you".
  "We" means "SUSE", as in "we recommend" = "official SUSE recommendation". (This one is an explicit style rule.)
* The source tends to be formatted badly and include many trailing spaces. `daps-xmlformat` / `daps xmlformat` can resolve both issues.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] ? SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
