### PR TITLE
Leap 15.3 does not have /lib/udev anymore

### DIFF
--- a/xml/tuning_storagescheduler.xml
+++ b/xml/tuning_storagescheduler.xml
@@ -65,8 +65,8 @@
    persist during reboot. For permanent I/O scheduler change for a particular
    device either place the command switching the I/O scheduler into init
    scripts or add appropriate udev rule into
-   <filename>/lib/udev/rules.d/</filename>. See
-   <filename>/lib/udev/rules.d/60-io-scheduler.rules</filename> for an example
+   <filename>/usr/lib/udev/rules.d/</filename>. See
+   <filename>/usr/lib/udev/rules.d/60-io-scheduler.rules</filename> for an example
    of such tuning.
   </para>
 


### PR DESCRIPTION
Leap 15.3 does not have /lib/udev directory anymore. It is /usr/lib/udev now

### PR creator: Description

Fix wrong path in documentation


### PR creator: Are there any relevant issues/feature requests?

No. Should I create some?

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
