### PR TITLE
Update tuning_storagescheduler.xml

### DIFF
--- a/xml/tuning_storagescheduler.xml
+++ b/xml/tuning_storagescheduler.xml
@@ -63,11 +63,9 @@
    <replaceable>DEVICE</replaceable> is the block device
    (<systemitem>sda</systemitem> for example). Note that this change will not
    persist during reboot. For permanent I/O scheduler change for a particular
-   device either place the command switching the I/O scheduler into init
-   scripts or add appropriate udev rule into
-   <filename>/usr/lib/udev/rules.d/</filename>. See
-   <filename>/usr/lib/udev/rules.d/60-io-scheduler.rules</filename> for an example
-   of such tuning.
+   device, copy <filename>/usr/lib/udev/rules.d/60-io-scheduler.rules</filename> to
+   <filename>/etc/udev/rules.d/60-io-scheduler.rules</filename>, and edit
+   the latter file to suit your needs.
   </para>
 
   <note os="sles" arch="zseries">


### PR DESCRIPTION
### Description

Rather than creating a new file from scratch, users who want to change the defaults should copy the existing rules file to `/etc` and edit it there.

Note also that the IO scheduler defaults are under discussion for SLE15-SP4, and that the default has recently been changed in a MU for SLE15-SP3 (see bsc#1134353).

### Are there any relevant issues/feature requests?

* bsc#1134353

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x ] SLE 15 SP3/openSUSE Leap 15.3

(actually, others too, except that on older distros the path of the installed rules is `/lib/udev/rules.d` and not `/usr/lib/udev/rules.d`).

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
