### PR TITLE
Document where yast stores keyboard settings

### DIFF
--- a/xml/yast2_keymouse.xml
+++ b/xml/yast2_keymouse.xml
@@ -51,7 +51,9 @@
   </step>
   <step>
    <para>
-    The result is stored in the files `/etc/vconsole.conf` (for text consoles) and `/etc/X11/xorg.conf.d/00-keyboard.conf` (for X11).
+    The result is stored in the files <filename>/etc/vconsole.conf</filename> 
+    (for text consoles) and 
+    <filename>/etc/X11/xorg.conf.d/00-keyboard.conf</filename> (for X11).
    </para>
   </step>
   <step>
@@ -60,8 +62,8 @@
    <guimenu>System</guimenu><guimenu>Sysconfig Editor</guimenu>
    <guimenu>Hardware</guimenu><guimenu>Keyboard</guimenu></menuchoice>.
   Here you can specify the keyboard rate and delay settings, and enable or
-  disable NumLock, CapsLock, and ScrollLock.
-  </para>
+  disable NumLock, CapsLock, and ScrollLock. These settings are stored in
+  <filename>/etc/sysconfig/keyboard</filename>.
   </step>
  </procedure>
 </sect1>

--- a/xml/yast2_keymouse.xml
+++ b/xml/yast2_keymouse.xml
@@ -50,6 +50,11 @@
    </para>
   </step>
   <step>
+   <para>
+    The result is stored in the files `/etc/vconsole.conf` (for text consoles) and `/etc/X11/xorg.conf.d/00-keyboard.conf` (for X11).
+   </para>
+  </step>
+  <step>
   <para>
   Advanced keyboard settings can be configured in <menuchoice>
    <guimenu>System</guimenu><guimenu>Sysconfig Editor</guimenu>

--- a/xml/yast2_keymouse.xml
+++ b/xml/yast2_keymouse.xml
@@ -64,6 +64,7 @@
   Here you can specify the keyboard rate and delay settings, and enable or
   disable NumLock, CapsLock, and ScrollLock. These settings are stored in
   <filename>/etc/sysconfig/keyboard</filename>.
+   </para>
   </step>
  </procedure>
 </sect1>


### PR DESCRIPTION

### PR creator: Description

This used to be `/etc/sysconfig/keyboard`, but not any more. Save people looking by documenting it.

### PR creator: Are there any relevant issues/feature requests?

No

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2  *(not sure)*

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
