### PR TITLE
updated path to smt export (bsc#1188092)

### DIFF
--- a/xml/rmt_migrate_from_smt.xml
+++ b/xml/rmt_migrate_from_smt.xml
@@ -735,7 +735,7 @@
    <step>
     <para>
      The exported configuration is now saved to
-     <filename>smt-export.<replaceable>TIMESTAMP</replaceable>.tar.gz</filename>.
+     <filename>smt-data-export.<replaceable>TIMESTAMP</replaceable>.tar.gz</filename>.
      Copy the file to a location that can be accessed by the new &rmt; server.
     </para>
    </step>
@@ -757,8 +757,8 @@
     </para>
 <screen>&prompt.user;<command>mkdir <replaceable>EMPTY_DIR</replaceable></command>
 &prompt.user;<command>cd <replaceable>EMPTY_DIR</replaceable></command>
-&prompt.user;<command>tar xf <replaceable>/PATH/TO/</replaceable>smt-export.<replaceable>TIMESTAMP</replaceable>.tar.gz</command>
-&prompt.user;<command>cd smt-export</command>
+&prompt.user;<command>tar xf <replaceable>/PATH/TO/</replaceable>smt-data-export.<replaceable>TIMESTAMP</replaceable>.tar.gz</command>
+&prompt.user;<command>cd smt-data-export</command>
 </screen>
    </step>
    <step>


### PR DESCRIPTION
### PR creator: Description

Path to the data export of SMT was wrong, this update fixes this.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1188092



### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [x] all necessary backports are done
