### PR TITLE
Add references to 'Understanding Linux audit' that explain

### DIFF
--- a/xml/audit_components.xml
+++ b/xml/audit_components.xml
@@ -5,19 +5,6 @@
     %entities;
 ]>
 
-<!-- fs 2008-12-30:
-     Changelog:
-     ==========
-     http://people.redhat.com/sgrubb/audit/ChangeLog
-     A bit of documentation:
-     =======================
-     http://people.redhat.com/sgrubb/audit/
-     Usecases:
-     =========
-     http://www.cyberciti.biz/tips/linux-audit-files-to-see-who-made-changes-to-a-file.html (may only work on RHEL4)
-     http://www.linux.com/feature/114422
-     http://expo.pistonbroke.com/content/sessions/S11/S11Baudit_lwe_final_v4.pdf
--->
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-audit-comp">
  <title>Understanding Linux audit</title>
  <info>
@@ -1319,17 +1306,50 @@ exit,always success!=0 syscall=open</screen>
     The following examples highlight two typical events that are logged by
     audit and how their trails in the audit log are read. The audit log or
     logs (if log rotation is enabled) are stored in the
-    <filename>/var/log/audit</filename> directory. The first example is a
-    simple <command>less</command> command. The second example covers a
-    great deal of PAM activity in the logs when a user tries to remotely log
-    in to a machine running audit.
+    <filename>/var/log/audit</filename> directory.
+   </para>
+   <para>
+     The logs record two types of information: record types and event 
+     fields. The record types are identified by <literal>type=</literal> in
+     each log entry. Event fields are all other items on the left side of
+     the equals signs. In the following examples, 
+     <literal>type=SYSCALL</literal> and <literal>type=CWD</literal>are 
+     record types, and <literal>arch=c000003e</literal> and
+     <literal>syscall=2</literal> are event fields, followed by their values.
+   </para>
+   <para>
+     Refer to the <filename>/usr/include/libaudit.h</filename> file (from the
+     <package>audit-devel</package> package) to see
+     a complete list of record types and their definitions.
+   </para>
+   <para>
+     Run the <command>ausyscall --dump</command> command to see a table of 
+     syscall numbers, and what they represent:
+   </para>
+   <screen>&prompt.user;ausyscall --dump
+Using x86_64 syscall table:
+0       read
+1       write
+2       open
+3       close
+4       stat
+5       fstat
+[...]</screen>
+   <para>    
+    The first example is a simple <command>less</command> command. The second 
+    example covers a great deal of PAM activity in the logs when a user tries 
+    to remotely log in to a machine running audit.
    </para>
    <example xml:id="ex-audit-aureport-logtrail">
     <title>A simple audit event&mdash;viewing the audit log</title>
-<screen>type=SYSCALL msg=audit(1234874638.599:5207): arch=c000003e syscall=2 success=yes exit=4 a0=62fb60 a1=0 a2=31 a3=0 items=1 ppid=25400 pid
-=25616 auid=0 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=pts1 ses=1164 comm="less" exe="/usr/bin/less" key="doc_log"
+<screen>type=SYSCALL msg=audit(1234874638.599:5207): arch=c000003e syscall=2 
+success=yes exit=4 a0=62fb60 a1=0 a2=31 a3=0 items=1 ppid=25400 pid
+=25616 auid=0 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 
+tty=pts1 ses=1164 comm="less" exe="/usr/bin/less" key="doc_log"
 type=CWD msg=audit(1234874638.599:5207):  cwd="/root"
-type=PATH msg=audit(1234874638.599:5207): item=0 name="/var/log/audit/audit.log" inode=1219041 dev=08:06 mode=0100644 ouid=0 ogid=0 rdev=00:00</screen>
+type=PATH msg=audit(1234874638.599:5207): item=0 name="/var/log/audit/
+audit.log" inode=1219041 dev=08:06 mode=0100644 ouid=0 ogid=0 rdev=00:00
+</screen>
    </example>
    <para>
     The above event, a simple <command>less


### PR DESCRIPTION
record types and event fields in /var/log/audit
resolves BSC #1187485 and Jira DOCTEAM-310.

Applies to SLE 15*

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
