### PR TITLE
Clarify that DNS section of YaST takes host name, not FQDN

### DIFF
--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -831,11 +831,18 @@
       <listitem>
        <para>
         Host name, excluding the domain name part. For example:
-        <literal>foo</literal> (instead of <literal>foo.bar</literal>).
+        <replaceable>foo</replaceable> instead of <replaceable>foo.bar</replaceable>. 
+        The Linux kernel allows using the fully-qualified
+        domain name (FQDN) in place of the host name, and 
+        so does &yast;. However, this is not the correct usage in the dns 
+        section of &yast;. The resolver should determine the FQDN. (See "THE 
+        FQDN" section of <command>man 1 hostname</command> for information on 
+        how FQDNs are resolved.) 
        </para>
         <para>
          If a host name is not specified and is not taken from a DHCP server
-         (see <literal>dhcp_hostname</literal>), &ay; will generate a random one.
+         (see <literal>dhcp_hostname</literal>), &ay; will generate a random 
+         hostname.
         </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
Resolves BSC #1188874, Jira DOCTEAM-319

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
