### PR TITLE
vt-doc: Fix virt-install example for Xen

### DIFF
--- a/xml/libvirt_guest_installation.xml
+++ b/xml/libvirt_guest_installation.xml
@@ -474,7 +474,7 @@ network=vnet_nated</screen>
   <example xml:id="ex-libvirt-inst-virt-install-example">
    <title>Example of a <command>virt-install</command> command line</title>
    <para>
-    The following command line example creates a new &sled; 12 virtual machine
+    The following command line example creates a new &sle; 15 SP2 virtual machine
     with a virtio accelerated disk and network card. It creates a new 10 GB
     qcow2 disk image as a storage, the source installation media being the host
     CD-ROM drive. It will use VNC graphics, and it will auto-launch the
@@ -484,17 +484,17 @@ network=vnet_nated</screen>
     <varlistentry>
      <term>KVM</term>
      <listitem>
-<screen>&prompt.user;virt-install --connect qemu:///system --virt-type kvm  --name sled12 \
---memory 1024 --disk size=10 --cdrom /dev/cdrom --graphics vnc \
---os-variant sled12</screen>
+<screen>&prompt.user;virt-install --connect qemu:///system --virt-type kvm \
+--name sle15sp2 --memory 1024 --disk size=10 --cdrom /dev/cdrom --graphics vnc \
+--os-variant sle15sp2</screen>
      </listitem>
     </varlistentry>
     <varlistentry>
      <term>&xen;</term>
      <listitem>
-<screen>&prompt.user;virt-install --connect xen:// --virt-type xen  --name sled12 \
---memory 1024 --disk size=10 --cdrom /dev/cdrom --graphics vnc \
---os-variant sled12</screen>
+<screen>&prompt.user;virt-install --connect xen:// --virt-type xen --hvm \
+--name sle15sp2 --memory 1024 --disk size=10 --cdrom /dev/cdrom --graphics vnc \
+--os-variant sle15sp2</screen>
      </listitem>
     </varlistentry>
    </variablelist>


### PR DESCRIPTION
The virt-install example for Xen (Example 8.2 in the Virtualization Guide)
does not work as is. PV is the default machine type for Xen, but PV guests
cannot boot from cdrom. HVM guests can boot from cdrom, so change the
example to create an HVM guest.

While at it, update the examples to install SLE15 SP2 instead of an old
distro like SLED12.

### PR creator: Description

Fix virt-install example in the virtualization guide

### PR creator: Are there any relevant issues/feature requests?

* bsc#1189234



### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
