### PR TITLE
Remove uneeded cio_ignore examples

### DIFF
--- a/xml/ay_general_options.xml
+++ b/xml/ay_general_options.xml
@@ -770,8 +770,6 @@
 <profile xmlns="http://www.suse.com/1.0/yast2ns"
  xmlns:config="http://www.suse.com/1.0/configns">
  <general>
-  <! -- Use cio_ignore on &zseries; only -->
-  <cio_ignore config:type="boolean">false</cio_ignore>
   <mode>
    <halt config:type="boolean">false</halt>
    <forceboot config:type="boolean">false</forceboot>
@@ -846,8 +844,6 @@ echo "Sleeping 10 seconds"
 <profile xmlns="http://www.suse.com/1.0/yast2ns"
  xmlns:config="http://www.suse.com/1.0/configns">
  <general>
-  <! -- Use cio_ignore on &zseries; only -->
-  <cio_ignore config:type="boolean">false</cio_ignore>
   <mode>
    <halt config:type="boolean">false</halt>
    <forceboot config:type="boolean">false</forceboot>


### PR DESCRIPTION
### PR creator: Description

Remove unneeded references to the `cio_ignore` element. These examples do not bring any value.

### PR creator: Are there any relevant issues/feature requests?

* [bsc#1188168](https://bugzilla.suse.com/show_bug.cgi?id=1188168)

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
