### PR TITLE
Fix the <enable_firewall/> example

### DIFF
--- a/xml/ay_firewall.xml
+++ b/xml/ay_firewall.xml
@@ -402,7 +402,7 @@
   <example>
    <title>Example firewall section</title>
 <screen>&lt;firewall&gt;
-  &lt;enable_firewall config:type="true"&gt;true&lt;/enable_firewall&gt;
+  &lt;enable_firewall config:type="boolean"&gt;true&lt;/enable_firewall&gt;
   &lt;log_denied_packets&gt;all&lt;/log_denied_packets&gt;
   &lt;default_zone&gt;external&lt;/default_zone&gt;
   &lt;zones config:type="list"&gt;


### PR DESCRIPTION
### PR creator: Description

This PR fixes an example regarding the `<enable_firewall/>` element. The correct way to specify the type is `config:type="boolean"`, as mentioned in the original bug report.

### PR creator: Are there any relevant issues/feature requests?

* [bsc#1189137](https://bugzilla.suse.com/show_bug.cgi?id=1189137)

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
