### PR TITLE
Migrate chapter 'Restrict sudo for normal users' to SLES Hardening Guide

### DIFF
--- a/xml/user_management.xml
+++ b/xml/user_management.xml
@@ -464,6 +464,85 @@ tty1</screen>
    </sect2>
 
   </sect1>
+
+ <sect1 xml:id="sec-sec-prot-restrict-sudo">
+   <title>Restricting <command>sudo</command> users</title>
+   <para>
+    The <command>sudo</command> command allows users to execute commands in the
+    context of another user, typically the &rootuser; user. The
+    <command>sudo</command>configuration consists of a rule-set, that defines
+    the mappings between commands to execute, their allowed source and target
+    users and groups. The configuration is stored in the file
+    <filename>/etc/sudoers</filename>. For more information about
+    <command>sudo</command>, refer to <xref linkend="cha-adm-sudo"/>
+   </para>
+   <para>
+    By default <command>sudo</command> asks for the &rootuser; password on
+    &suse; systems. Unlike <command>su</command> however,
+    <command>sudo</command> remembers the password and allows further commands
+    to be executed as &rootuser; without asking for the password again for 5
+    minutes. Therefore <command>sudo</command> should be enabled for selected
+    administrator users only.
+   </para>
+   <procedure>
+    <title>Restricting <command>sudo</command> for normal users</title>
+    <step>
+     <para>
+      Edit file <filename>/etc/sudoers</filename>, e.g. by executing
+      <command>visudo</command>.
+     </para>
+    </step>
+    <step>
+     <para>
+      Comment out the line that allows every user to run every command as
+      long as they know the password of the user they want to use. It should
+      then look like this:
+     </para>
+<screen>#ALL ALL=(ALL) ALL # WARNING! Only use this together with 'Defaults targetpw'!</screen>
+    </step>
+    <step>
+     <para>
+      Uncomment the following line:
+     </para>
+<screen>%wheel ALL=(ALL) ALL</screen>
+     <para>
+      This limits the functionality described above to members of the group
+      <systemitem class="groupname">wheel</systemitem>. You can use a different
+      group as <systemitem class="groupname">wheel</systemitem> might have other
+      implications that may not be suitable depending on your setup.
+     </para>
+    </step>
+    <step>
+     <para>
+      Add users that should be allowed to use <command>sudo</command> to the
+      chosen group. To add the user &exampleuser; to the group
+      <systemitem class="groupname">wheel</systemitem>, use:
+     </para>
+<screen><command>usermod -aG <replaceable>wheel</replaceable> <replaceable>tux</replaceable></command></screen>
+     <para>
+      To get the new group membership, users have to logout and back in again.
+     </para>
+    </step>
+    <step>
+     <para>
+      Verify the change by running a command with a user not in the group you
+      have chosen for access control. You should see error message:
+     </para>
+<screen>&exampleuserII_plain; is not in the sudoers file.  This incident will be reported.</screen>
+     <para>
+      Next, try the same with a member of the group. They should still be able
+      to exectute commands via <command>sudo</command>.
+     </para>
+    </step>
+   </procedure>
+   <para>
+    Please note that this configuration only limits the <command>sudo</command>
+    functionality. The <command>su</command> command is still available to all
+    users. If there are other ways to access the system, users with knowledge of
+    the &rootuser; password can easily execute commands via this vector.
+   </para>
+  </sect1>
+
   <sect1 xml:id="sec-sec-prot-inactivity-logout">
    <title>Setting an inactivity timeout for interactive shell sessions</title>
    <para>


### PR DESCRIPTION
### PR creator: Description
This PR migrates the chapter 'Restrict sudo for normal users' from the OS Hardening Guide for SAP HANA to SLES Security & Hardening Guide.

### PR creator: Are there any relevant issues/feature requests?
https://bugzilla.suse.com/show_bug.cgi?id=1176615

### PR creator: Which product versions do the changes apply to?
- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
