### PR TITLE
Migrate chapter 'Adjust default umask' to SLES Hardening Guide

### DIFF
--- a/xml/file_management.xml
+++ b/xml/file_management.xml
@@ -132,11 +132,14 @@
    <para>
     The <command>umask</command> (user file-creation mode mask) command is a
     shell built-in command that determines the default file permissions for
-    newly created files and directories. This can be overwritten by system calls but many
-    programs and utilities use <command>umask</command>. By default,
-    <command>umask</command> is set to <literal>022</literal>. You can modify
-    this globally by changing the value in <filename>/etc/profile</filename>
-    or for each user in the start-up files of the shell.
+    newly created files and directories. This can be overwritten by system calls
+    but many programs and utilities use <command>umask</command>.
+   </para>
+
+   <para>
+    By default, <command>umask</command> is set to <literal>022</literal>.
+    This umask is subtracted from the access mode <literal>777</literal> if at
+    least one bit is set.
    </para>
 
    <para>
@@ -148,49 +151,95 @@
 022</screen>
 
    <para>
-   The umask is subtracted from the access mode <literal>777</literal> if at
-   least one bit is set.
+    With the default umask, you see the behavior most users expect to see on a
+    Linux system.
    </para>
 
-   <para>
-    With the default umask, you see the behavior most users expect to see on a Linux system.
-   </para>
-
-<screen>
-&prompt.user;touch a
+<screen>&prompt.user;touch a
 &prompt.user;mkdir b
 &prompt.user;ls -on
 total 16
 -rw-r--r--. 1 17086    0 Nov 29 15:05 a
-drwxr-xr-x. 2 17086 4096 Nov 29 15:05 b
-</screen>
+drwxr-xr-x. 2 17086 4096 Nov 29 15:05 b</screen>
 
    <para>
     You can specify arbitrary umask values, depending on your needs.
    </para>
-<screen>
-&prompt.user;umask 111
+
+<screen>&prompt.user;umask 111
 &prompt.user;touch c
 &prompt.user;mkdir d
 &prompt.user;ls -on
 total 16
 -rw-rw-rw-. 1 17086    0 Nov 29 15:05 c
-drw-rw-rw-. 2 17086 4096 Nov 29 15:05 d
-</screen>
+drw-rw-rw-. 2 17086 4096 Nov 29 15:05 d</screen>
 
    <para>
-    Based on your thread model, you can use a stricter umask like <literal>037</literal>
-    to prevent accidental data leakage.
+    Based on your thread model, you can use a stricter umask like
+    <literal>037</literal> to prevent accidental data leakage.
    </para>
-<screen>
-&prompt.user;umask 037
+
+<screen>&prompt.user;umask 037
 &prompt.user;touch e
 &prompt.user;mkdir f
 &prompt.user;ls -on
 total 16
 -rw-r-----. 1 17086    0 Nov 29 15:06 e
-drwxr-----. 2 17086 4096 Nov 29 15:06 f
-</screen>
+drwxr-----. 2 17086 4096 Nov 29 15:06 f</screen>
+
+   <tip>
+    <title>Maximum security</title>
+    <para>
+     For maximum security, use an umask of <literal>077</literal>. This will
+     force newly created files and directories to be created with no
+     permissions for the group and other users.
+    </para>
+    <para>
+     Please note that this can be unexpected for users and software and might
+     cause additional load for your support team.
+    </para>
+   </tip>
+
+   <sect2 xml:id="sec-sec-prot-general-umask-adjust">
+    <title>Adjusting the default umask</title>
+    <para>
+     You can modify the umask globally for all users by changing the
+     <varname>UMASK</varname> value in <filename>/etc/login.defs</filename>.
+    </para>
+
+<screen># Default initial "umask" value used by login(1) on non-PAM enabled systems.
+# Default "umask" value for pam_umask(8) on PAM enabled systems.
+# UMASK is also used by useradd(8) and newusers(8) to set the mode for new
+# home directories.
+# 022 is the default value, but 027, or even 077, could be considered
+# for increased privacy. There is no One True Answer here: each sysadmin
+# must make up their mind.
+UMASK           022</screen>
+
+    <para>
+     For indivudual users, add the umask to the 'gecos' field to
+     <filename>/etc/password</filename> like this:
+    </para>
+<screen>&exampleuser_plain;:x:1000:100:&exampleuserfull;,UMASK=<replaceable>022</replaceable>:/home/tux:/bin/bash</screen>
+    <para>
+     You can do the same with <command>yast users</command> by adding
+     <literal>UMASK=<replaceable>022</replaceable></literal> to a user's
+     <menuchoice><guimenu>Details</guimenu> <guimenu>Additional User
+     Information</guimenu></menuchoice>.
+    </para>
+    <para>
+     The settings made in <filename>/etc/login.defs</filename> and
+     <filename>/etc/password</filename> are applied by the PAM module
+     <filename>pam_umask.so</filename>. For additional configuration options,
+     refer to <command>man pam_umask</command>.
+    </para>
+    <para>
+     In order to take changes into effect, users need to log out and back in
+     again. Afterwards, use the <command>umask</command> command to verify the
+     umask is set correctly.
+    </para>
+
+   </sect2>
 
   </sect1>
   <sect1 xml:id="sec-sec-prot-general-s-bit">

--- a/xml/security_acls.xml
+++ b/xml/security_acls.xml
@@ -511,7 +511,8 @@
     write access (<literal>2</literal>), and giving other users no
     permissions (<literal>7</literal>). <command>umask</command>
     actually masks the corresponding permission bits or turns them off. For
-    details, consult the <command>umask</command> man page.
+    details, refer to <xref linkend="sec-sec-prot-general-umask"/> or the
+    <command>umask</command> man page.
    </para>
    <para>
     <command>mkdir mydir</command> creates the <filename>mydir</filename>


### PR DESCRIPTION
### PR creator: Description

This PR migrates the chapter  'Adjust default umask' from the OS Hardening Guide for SAP HANA to SLES Security & Hardening Guide.

### PR creator: Are there any relevant issues/feature requests?

https://bugzilla.suse.com/show_bug.cgi?id=1176616

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
