### PR TITLE
AutoYaST: describe the <aliases> section

### DIFF
--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -293,7 +293,7 @@
     </para>
 
   <variablelist>
-  <varlistentry>
+<varlistentry>
     <term>
       <literal>bootproto</literal>
     </term>
@@ -675,6 +675,16 @@
          </para>
     </listitem>
   </varlistentry>
+  <varlistentry>
+    <term>
+      <literal>aliases</literal>
+    </term>
+    <listitem>
+      <para>
+          Additional IP addresses. See <xref linkend="CreateProfile-Network-Aliases"/>.
+         </para>
+    </listitem>
+  </varlistentry>
   <!-- TODO: all wireless attributes, but not so many users configure wireless with autoyast -->
 </variablelist>
 
@@ -754,6 +764,98 @@
 </screen>
    </example>
   </sect2>
+
+   <sect2 xml:id="CreateProfile-Network-Aliases">
+     <title>Assigning Multiple IP Addresses</title>
+
+     <para>
+      &ay; allows assigning multiple IP addresses to the same interface. They are specified using
+      an <literal>aliases</literal> element that contains an <literal>aliasX</literal> entry for
+      each address.
+     </para>
+
+     <para>
+      Each of those entries support the following elements:
+     </para>
+
+     <variablelist>
+      <varlistentry>
+       <term>IPADDR</term>
+       <listitem>
+        <para>
+         Additional IP address. It can include a network prefix, for example: <literal>192.168.1.1/24</literal>.
+        </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry>
+       <term>PREFIXLEN</term>
+       <listitem>
+        <para>
+         Network prefix, for example: <literal>24</literal>
+        </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry>
+       <term>NETMASK</term>
+       <listitem>
+        <para>
+         Address' netmask.
+        </para>
+        <para>
+         Deprecated. Use <literal>PREFIXLEN</literal> instead or include the network prefix in the
+         <literal>IPADDR</literal> element.
+        </para>
+       </listitem>
+      </varlistentry>
+
+      <varlistentry>
+       <term>LABEL</term>
+       <listitem>
+        <para>
+         Address' label.
+        </para>
+       </listitem>
+      </varlistentry>
+     </variablelist>
+
+     <note>
+      <title>Case Sensitive Elements</title>
+      <para>
+       Please, beware that for historical reasons, within the <literal>aliases</literal> section the
+       <literal>IPADDR</literal>, <literal>PREFIXLEN</literal>, <literal>LABEL</literal> and
+       <literal>NETMASK</literal> elements are case-sensitive.
+      </para>
+     </note>
+
+   <example xml:id="ex-ay-network-config-aliases">
+     <title>Multiple IP Addresses</title>
+<screen>
+&lt;interfaces config:type="list"&gt;
+  &lt;interface&gt;
+    &lt;name&gt;br0&lt;/name&gt;
+    &lt;bootproto&gt;static&lt;/bootproto&gt;
+    &lt;ipaddr&gt;&subnetI;.100&lt;/ipaddr&gt;
+    &lt;prefixlen&gt;24&lt;/prefixlen&gt;
+    &lt;startmode&gt;auto&lt;/startmode&gt;
+    &lt;aliases&gt;
+      &lt;alias0&gt;
+        &lt;IPADDR&gt;&subnetI;.101&lt;/IPADDR&gt;
+        &lt;PREFIXLEN&gt;24&lt;/PREFIXLEN&gt;
+        &lt;LABEL&gt;http&lt;/LABEL&gt;
+      &lt;/alias0&gt;
+      &lt;alias1&gt;
+        &lt;IPADDR&gt;&subnetII;.100&lt;/IPADDR&gt;
+        &lt;PREFIXLEN&gt;24&lt;/PREFIXLEN&gt;
+        &lt;LABEL&gt;extra&lt;/LABEL&gt;
+      &lt;/alias1&gt;
+    &lt;/aliases&gt;
+  &lt;/interface&gt;
+&lt;/interfaces&gt;
+</screen>
+   </example>
+   </sect2>
 
    <sect2 xml:id="CreateProfile-Network-names">
     <title>Persistent names of network interfaces</title>

--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -769,13 +769,13 @@
      <title>Assigning Multiple IP Addresses</title>
 
      <para>
-      &ay; allows assigning multiple IP addresses to the same interface. They are specified using
+      &ay; makes it possible to assign multiple IP addresses to the same interface. They are specified using
       an <literal>aliases</literal> element that contains an <literal>aliasX</literal> entry for
       each address.
      </para>
 
      <para>
-      Each of those entries support the following elements:
+      Each entry supports the following elements:
      </para>
 
      <variablelist>
@@ -801,7 +801,7 @@
        <term>NETMASK</term>
        <listitem>
         <para>
-         Address' netmask.
+         Netmask of the address.
         </para>
         <para>
          Deprecated. Use <literal>PREFIXLEN</literal> instead or include the network prefix in the
@@ -814,7 +814,7 @@
        <term>LABEL</term>
        <listitem>
         <para>
-         Address' label.
+         Label of the address.
         </para>
        </listitem>
       </varlistentry>
@@ -823,9 +823,7 @@
      <note>
       <title>Case Sensitive Elements</title>
       <para>
-       Please, beware that for historical reasons, within the <literal>aliases</literal> section the
-       <literal>IPADDR</literal>, <literal>PREFIXLEN</literal>, <literal>LABEL</literal> and
-       <literal>NETMASK</literal> elements are case-sensitive.
+       Keep in mind that for historical reasons, the <literal>IPADDR</literal>, <literal>PREFIXLEN</literal>, <literal>LABEL</literal> and <literal>NETMASK</literal> elements within the <literal>aliases</literal> section are case-sensitive.
       </para>
      </note>
 


### PR DESCRIPTION
### PR creator: Description

The `<aliases>` section is missing from the AutoYaST documentation. This PR adds the description and a simple example.

An issue is still pending. As you can see, the elements in that section are case-sensitive. We have improved the implementation and starting with `yast2-network` 4.2.104 (SP2), and 4.3.75 (SP3), and 4.4.25 (SP4) that's not the case anymore. So I am unsure about how to express this information. Maybe the user does not need to know so many details and we could simply remove the notice from the SP4 documentation (it will not be case sensitive from the beginning).

### PR creator: Are there any relevant issues/feature requests?

* [bsc#1190739](https://bugzilla.suse.com/show_bug.cgi?id=1190739)

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
