### PR TITLE
Network bridge using nmcli (bsc#1174936)

### DIFF
--- a/xml/libvirt_host.xml
+++ b/xml/libvirt_host.xml
@@ -81,8 +81,9 @@
     </listitem>
     <listitem>
      <para>
-      If a network connection is managed by &nm;, use &nm; directly to create
-      the network bridge. &nm; is the default on laptops.
+      If a network connection is managed by &nm;, use the &nm; command line tool
+      <command>nmcli</command> to create the network bridge.
+      &nm; is the default on laptops.
      </para>
     </listitem>
    </itemizedlist>
@@ -285,20 +286,77 @@ virbr_test  1 PVID Egress Untagged
     </sect4>
    </sect3>
    <sect3 xml:id="libvirt-networks-bridged-add-nm">
-    <title>Managing network bridges with &nm;</title>
+    <title>Adding a network bridge with <command>nmcli</command></title>
     <para>
-     This section includes procedures to add or remove network bridges with
-     &nm;. Open the <guimenu>Network Connections</guimenu> application by
-     running the <command>nm-connection-editor</command> command.
+     This section includes procedures to add a network bridge with &nm;'s
+     command line tool <command>nmcli</command>.
     </para>
-    <sect4 xml:id="libvirt-networks-bridged-nm-add">
-     <title>Adding a network bridge</title>
-     <procedure>
-      <step>
-       <para>
-       </para>
-      </step>
-     </procedure>
+    <procedure>
+     <step>
+      <para>
+       List active network connections:
+      </para>
+<screen>
+&prompt.sudo;nmcli connection show --active
+NAME                   UUID                                  TYPE      DEVICE
+Ethernet connection 1  84ba4c22-0cfe-46b6-87bb-909be6cb1214  ethernet  eth0
+</screen>
+     </step>
+     <step>
+      <para>
+       Add a new bridge device named <literal>br0</literal> and verify its
+       creation:
+      </para>
+<screen>
+&prompt.sudo;nmcli connection add type bridge ifname br0
+Connection 'bridge-br0' (36e11b95-8d5d-4a8f-9ca3-ff4180eb89f7) \
+successfully added.
+&prompt.sudo;nmcli connection show --active
+NAME                   UUID                                  TYPE      DEVICE
+bridge-br0             36e11b95-8d5d-4a8f-9ca3-ff4180eb89f7  bridge    br0
+Ethernet connection 1  84ba4c22-0cfe-46b6-87bb-909be6cb1214  ethernet  eth0
+</screen>
+     </step>
+     <step>
+      <para>
+       Optionally, you can view the bridge settings:
+      </para>
+<screen>
+&prompt.sudo;nmcli -f bridge connection show bridge-br0
+bridge.mac-address:                     --
+bridge.stp:                             yes
+bridge.priority:                        32768
+bridge.forward-delay:                   15
+bridge.hello-time:                      2
+bridge.max-age:                         20
+bridge.ageing-time:                     300
+bridge.group-forward-mask:              0
+bridge.multicast-snooping:              yes
+bridge.vlan-filtering:                  no
+bridge.vlan-default-pvid:               1
+bridge.vlans:                           --
+</screen>
+     </step>
+     <step>
+      <para>
+       Link the bridge device to the physical ethernet device
+       <literal>eth0</literal>:
+      </para>
+<screen>&prompt.sudo;nmcli connection add type bridge-slave ifname eth0 master br0</screen>
+     </step>
+     <step>
+      <para>
+       Turn off the <literal>eth0</literal> interface and turn on the new
+       bridge:
+      </para>
+<screen>
+&prompt.sudo;nmcli connection down "Ethernet connection 1"
+&prompt.sudo;nmcli connection up bridge-br0
+Connection successfully activated (master waiting for slaves) \
+(D-Bus active path: /org/freedesktop/NetworkManager/ActiveConnection/9)
+</screen>
+     </step>
+    </procedure>
    </sect3>
    <sect3 xml:id="sec-xen-net-vlan">
     <title>Using VLAN interfaces</title>

--- a/xml/libvirt_host.xml
+++ b/xml/libvirt_host.xml
@@ -67,6 +67,25 @@
     preferred configuration when you simply want to connect &vmguest;s to the
     &vmhost;'s LAN.
    </para>
+   <para>
+    Which tool to use to create the network bridge depends on the service you
+    use to manage the network connection on the &vmhost;:
+   </para>
+   <itemizedlist>
+    <listitem>
+     <para>
+      If a network connection is managed by <systemitem>wicked</systemitem>,
+      use either &yast; or the command line to create the network bridge.
+      <systemitem>wicked</systemitem> is the default on server hosts.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      If a network connection is managed by &nm;, use &nm; directly to create
+      the network bridge. &nm; is the default on laptops.
+     </para>
+    </listitem>
+   </itemizedlist>
    <sect3 xml:id="libvirt-networks-bridged-yast">
     <title>Managing network bridges with &yast;</title>
     <para>
@@ -264,6 +283,22 @@ virbr_test  1 PVID Egress Untagged
       </step>
      </procedure>
     </sect4>
+   </sect3>
+   <sect3 xml:id="libvirt-networks-bridged-add-nm">
+    <title>Managing network bridges with &nm;</title>
+    <para>
+     This section includes procedures to add or remove network bridges with
+     &nm;. Open the <guimenu>Network Connections</guimenu> application by
+     running the <command>nm-connection-editor</command> command.
+    </para>
+    <sect4 xml:id="libvirt-networks-bridged-nm-add">
+     <title>Adding a network bridge</title>
+     <procedure>
+      <step>
+       <para>
+       </para>
+      </step>
+     </procedure>
    </sect3>
    <sect3 xml:id="sec-xen-net-vlan">
     <title>Using VLAN interfaces</title>


### PR DESCRIPTION
### PR creator: Description

VMs can make use of a network bridge even if network connections are controlled by NetworkManager.
This update includes a procedure to create such bridge using `nmcli`


### PR creator: Are there any relevant issues/feature requests?

* bsc#1174936


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
