### PR TITLE
The section sec-util-processes is in a SLED book

### DIFF
--- a/xml/newbie_bash.xml
+++ b/xml/newbie_bash.xml
@@ -1780,7 +1780,7 @@ PID TTY          TIME CMD
   <para>
    This section is intended to introduce the most basic set of commands for
    handling jobs and processes. Find an overview for system administrators
-   in <xref linkend="sec-util-processes"/>.
+   in &sled; <xref linkend="sec-util-processes"/>.
   </para>
  </sect1>
 


### PR DESCRIPTION
This book is in the openSUSE documentation but it refers to a book that is not and its title does not tell what product it belongs to.  

### PR creator: Description

Add the correct product name to the reference (it is not a hyperlink) to give the reader a clue where to find the referenced book.



### PR creator: Are there any relevant issues/feature requests?

None, not worth it.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [X] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [X] SLE 15 SP3/openSUSE Leap 15.3
  - [X] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
