### PR TITLE
#bsc1190757 add sharing samba GNOME

### DIFF
--- a/xml/gnome_networking.xml
+++ b/xml/gnome_networking.xml
@@ -215,12 +215,7 @@
     <procedure>
      <step>
       <para>
-       Start &yast; from the main menu.
-      </para>
-     </step>
-     <step>
-      <para>
-       Enter the &rootuser; password.
+       Start &yast; from the main menu and enter the &rootuser; password.
       </para>
      </step>
      <step>
@@ -234,16 +229,16 @@
        Click <guimenu>Allow Users to Share Their Directories</guimenu>, then
        click <guimenu>OK</guimenu>.
       </para>
-      <para>
-       Sharing directories is now enabled on your computer.
-      </para>
      </step>
     </procedure>
+    <para>
+     Sharing directories is now enabled on your computer.
+    </para>
    </sect3>
 
    <sect3>
-    <title>Enabling sharing with <productname>Samba</productname> config
-     file</title>
+    <title>Enabling sharing by editing the <productname>Samba</productname>
+     config file</title>
     <procedure>
      <step>
       <para>
@@ -252,21 +247,22 @@
      </step>
      <step>
       <para>
-       Open the configuration file <filename>smb.conf</filename> as &rootuser;.
+       Open the configuration file <filename>/etc/samba/smb.conf</filename> as
+       &rootuser;.
       </para>
       <para>
-       For the example with the command:
-       <command>sudo vi /etc/samba/smb.conf</command>.
+       Use the following command:
       </para>
+      <screen>sudo vi /etc/samba/smb.conf</screen>
      </step>
      <step>
       <para>
-       To enable editing, press the key <keycap>i</keycap>.
+       To enable editing, press the <keycap>I</keycap> key.
        </para>
      </step>
      <step>
       <para>
-       In the category <parameter>[global]</parameter>, add the following
+       In the section <parameter>[global]</parameter>, add the following
        entry:
       </para>
       <screen>usershare max shares = 100</screen>
@@ -275,11 +271,11 @@
       <para>
        Save and exit the editor.
       </para>
-      <para>
-       Sharing directories is now enabled on your computer.
-      </para>
      </step>
     </procedure>
+    <para>
+     Sharing directories is now enabled on your computer.
+    </para>
    </sect3>
   </sect2>
   


### PR DESCRIPTION
### PR creator: Description

Instruction added of how to enable sharing with samba config file


### PR creator: Are there any relevant issues/feature requests?

* bsc#1190757
* jsc#DOCTEAM-378


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
