### PR TITLE
Migrate chapter 'Modify permissions on certain system files' to SLES Hardening Guide

### DIFF
--- a/xml/file_management.xml
+++ b/xml/file_management.xml
@@ -90,42 +90,118 @@
     <xref linkend="cha-security-cryptofs"/> for details.
    </para>
   </sect1>
-  <sect1 xml:id="sec-sec-prot-general-check-perms">
-   <title>Checking file permissions and ownership</title>
 
-   <para>
-    The following sections deal with some ways the default permissions and
-    file settings can be modified to enhance the security of a host. It is
-    important to note that the default &productname; utilities, like
-    <command>seccheck</command>, can be run to lock down and improve the
-    general file security and user environment. However, it is beneficial to
-    understand how to modify these things.
-   </para>
+ <sect1 xml:id="sec-sec-prot-general-file-permissions">
+  <title>Modifying permissions of certain system files</title>
 
-   <para>
-    &productname; hosts include three default settings for file permissions:
-    <filename>permissions.easy</filename>,
-    <filename>permissions.secure</filename>, and
-    <filename>permissions.paranoid</filename>, all located in the
-    <filename>/etc</filename> directory. The purpose of these files is to
-    define special permissions, such as world-writable directories or, for
-    files, the setuser ID bit (programs with the setuser ID bit set do not run
-    with the permissions of the user that has launched it, but with the
-    permissions of the file owner, usually &rootuser;).
-   </para>
+  <para>
+   Many files&mdash;especially in the <filename>/etc</filename>
+   directory&mdash;are world-readable, which means that unprivileged users can
+   read their contents. Normally this is not a problem, but if you want to take
+   extra care, you can remove the world-readable or group-readable bits for
+   sensitive files.
+  </para>
 
-   <para>
-    Administrators can use the file
-    <filename>/etc/permissions.local</filename> to add their own settings. The
-    easiest way to implement one of the default permission rule-sets above is
-    to use the <guimenu>Local Security</guimenu> module in &yast;.
-   </para>
+  <para>
+   &sle; provides the <package>permissions</package> package to easily apply
+   file permissions. The package comes with three pre-defined system profiles:
+  </para>
 
+  <variablelist>
+   <varlistentry>
+    <term>easy</term>
+    <listitem>
+     <para>
+      Profile for systems that require user-friendly graphical user interaction.
+      This is the default profile.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>secure</term>
+    <listitem>
+     <para>
+      Profile for server systems without fully-fledged graphical user interface.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>paranoid</term>
+    <listitem>
+     <para>
+      Profile for maximum security. In addition to the <literal>secure</literal>
+      profile, it removes <emphasis>all</emphasis> special permissions like
+      setuid/setgid and capability bits.
+     </para>
+
+     <warning>
+      <title>Unusable system for non-privileged users</title>
+      <para>
+       Except for simple tasks like changing passwords, a system without special
+       permissions might be unusable for non-privileged users.
+      </para>
+      <para>
+       Do not use the <literal>paranoid</literal> profile is as is but as a
+       template for custom permissions. For more information, refer to the
+       <filename>permissions.paranoid</filename> file.
+      </para>
+     </warning>
+
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+  <para>
+   To define custom file permissions, edit
+   <filename>/etc/permissions.local</filename> or create a drop-in file in the
+   <filename>/etc/permissions.d/</filename> direcory.
+  </para>
+
+  <screen># Additional custom hardening
+   /etc/security/access.conf       root:root       0400
+   /etc/sysctl.conf                root:root       0400
+   /root/                          root:root       0700</screen>
+
+  <para>
+   The first column specifies the file name. Directory names have to end with a
+   slash. The second column specifies the owner and group, the third the mode.
+   For more information about the configuration file format, refer to
+   <command>man permissions</command>.
+  </para>
+
+  <para>
+   Select the profile in <filename>/etc/sysconfig/security</filename>. To use
+   the <literal>easy</literal> profile and custom permissions from
+   <filename>/etc/permissions.local</filename>, set:
+  </para>
+
+  <screen>PERMISSION_SECURITY="<replaceable>easy local</replaceable>"</screen>
+
+  <para>
+   To apply the setting, run <command>chkstat --system --set</command>.
+  </para>
+
+  <para>
+   The permissions will also be applied implicitly during package updates via
+   <command>zypper</command>. You could also call <command>chkstat</command>
+   regularly via <systemitem class="daemon">cron</systemitem> or a &systemd;
+   timer.
+  </para>
+
+  <important>
+   <title>Custom file permissions</title>
    <para>
-    Each of the following topics will be modified by a selected rule-set, but
-    the information is important to understand on its own.
+    While the system profiles are well tested, custom permissions can break
+    standard applications. &suse; cannot provide support for such scenarios.
    </para>
-  </sect1>
+   <para>
+    Always test custom file permissions before applying them with
+    <command>chkstat</command> to make sure everything works as desired.
+   </para>
+  </important>
+
+ </sect1>
+
   <sect1 xml:id="sec-sec-prot-general-umask">
    <title>Default umask</title>
 
@@ -193,117 +269,6 @@ drwxr-----. 2 17086 4096 Nov 29 15:06 f
 </screen>
 
   </sect1>
-
- <sect1 xml:id="sec-sec-prot-general-file-permissions">
-  <title>Modifying permissions of certain system files</title>
-
-  <para>
-   Many files&mdash;especially in the <filename>/etc</filename>
-   directory&mdash;are world-readable, which means that unprivileged users can
-   read their contents. Normally this is not a problem, but if you want to take
-   extra care, you can remove the world-readable or group-readable bits for
-   sensitive files.
-  </para>
-
-  <para>
-   &sle; provides the <package>permissions</package> package to easily apply
-   file permissions. The package comes with three pre-defined system profiles:
-  </para>
-
-  <variablelist>
-   <varlistentry>
-    <term>easy</term>
-    <listitem>
-     <para>
-      Profile for systems that require user-friendly graphical user interaction.
-      This is the default profile.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>secure</term>
-    <listitem>
-     <para>
-      Profile for server systems without fully-fledged graphical user interface.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>paranoid</term>
-    <listitem>
-     <para>
-      Profile for maximum security. In addition to the <literal>secure</literal>
-      profile, it removes <emphasis>all</emphasis> special permissions like
-      setuid/setgid and capability bits.
-     </para>
-
-     <warning>
-      <title>Unusable system for non-privileged users</title>
-      <para>
-       Except for simple tasks like changing passwords, a system without special
-       permissions might be unusable for non-privileged users. 
-      </para>
-      <para>
-       Do not use the <literal>paranoid</literal> profile is as is but as a
-       template for custom permissions. For more information, refer to the
-       <filename>permissions.paranoid</filename> file.
-      </para>
-     </warning>
-
-    </listitem>
-   </varlistentry>
-  </variablelist>
-
-  <para>
-   To define custom file permissions, edit
-   <filename>/etc/permissions.local</filename> or create a drop-in file in the
-   <filename>/etc/permissions.d/</filename> direcory.
-  </para>
-
-<screen># Additional custom hardening
-/etc/security/access.conf       root:root       0400
-/etc/sysctl.conf                root:root       0400
-/root/                          root:root       0700</screen>
-
-  <para>
-   The first column specifies the file name. Directory names have to end with a
-   slash. The second column specifies the owner and group, the third the mode.
-   For more information about the configuration file format, refer to
-   <command>man permissions</command>.
-  </para>
-
-  <para>
-   Select the profile in <filename>/etc/sysconfig/security</filename>. To use
-   the <literal>easy</literal> profile and custom permissions from
-   <filename>/etc/permissions.local</filename>, set:
-  </para>
-
-  <screen>PERMISSION_SECURITY="<replaceable>easy local</replaceable>"</screen>
-
-  <para>
-   To apply the setting, run <command>chkstat --system --set</command>.
-  </para>
-
-  <para>
-   The permissions will also be applied implicitly during package updates via
-   <command>zypper</command>. You could also call <command>chkstat</command>
-   regularly via <systemitem class="daemon">cron</systemitem> or a &systemd;
-   timer.
-  </para>
-
-  <important>
-   <title>Custom file permissions</title>
-   <para>
-    While the system profiles are well tested, custom permissions can break
-    standard applications. &suse; cannot provide support for such scenarios.
-   </para>
-   <para>
-    Always test custom file permissions before applying them with
-    <command>chkstat</command> to make sure everything works as desired.
-   </para>
-  </important>
-
- </sect1>
 
  <sect1 xml:id="sec-sec-prot-general-s-bit">
    <title>SUID/SGID files</title>

--- a/xml/file_management.xml
+++ b/xml/file_management.xml
@@ -234,14 +234,22 @@ drwxr-----. 2 17086 4096 Nov 29 15:06 f
      <para>
       Profile for maximum security. In addition to the <literal>secure</literal>
       profile, it removes <emphasis>all</emphasis> special permissions like
-      setuid/setgid and capability bits. Therefore, the system might be useable
-      for non-privileged users except for simple tasks like changing passwords.
+      setuid/setgid and capability bits.
      </para>
-     <para>
-      This profile is not intended to be used as is but acts as a template for
-      additional custom permissions. For more information, refer to
-      <filename>permissions.paranoid</filename> file.
-     </para>
+
+     <warning>
+      <title>Unusable system for non-privileged users</title>
+      <para>
+       Except for simple tasks like changing passwords, a system without special
+       permissions might be unusable for non-privileged users. 
+      </para>
+      <para>
+       Do not use the <literal>paranoid</literal> profile is as is but as a
+       template for custom permissions. For more information, refer to
+       <filename>permissions.paranoid</filename> file.
+      </para>
+     </warning>
+
     </listitem>
    </varlistentry>
   </variablelist>
@@ -265,8 +273,9 @@ drwxr-----. 2 17086 4096 Nov 29 15:06 f
   </para>
 
   <para>
-   Select the system profile in <filename>/etc/sysconfig/security</filename>. To
-   use the <literal>easy</literal> profile and custom permissions, set:
+   Select the profile in <filename>/etc/sysconfig/security</filename>. To use
+   the <literal>easy</literal> profile and custom permissions from
+   <filename>/etc/permissions.local</filename>, set:
   </para>
 
   <screen>PERMISSION_SECURITY="<replaceable>easy local</replaceable>"</screen>

--- a/xml/file_management.xml
+++ b/xml/file_management.xml
@@ -121,7 +121,8 @@
     <term>secure</term>
     <listitem>
      <para>
-      Profile for server systems without fully-fledged graphical user interface.
+      Profile for server systems without fully-fledged graphical user
+      interfaces.
      </para>
     </listitem>
    </varlistentry>
@@ -142,7 +143,7 @@
       </para>
       <para>
        Do not use the <literal>paranoid</literal> profile is as-is, but as a
-       template for custom permissions. For more information, refer to the
+       template for custom permissions. More information can be found in the
        <filename>permissions.paranoid</filename> file.
       </para>
      </warning>
@@ -154,7 +155,7 @@
   <para>
    To define custom file permissions, edit
    <filename>/etc/permissions.local</filename> or create a drop-in file in the
-   <filename>/etc/permissions.d/</filename> direcory.
+   <filename>/etc/permissions.d/</filename> directory.
   </para>
 
   <screen># Additional custom hardening
@@ -183,7 +184,7 @@
   </para>
 
   <para>
-   The permissions will also be applied implicitly during package updates via
+   The permissions will also be applied during package updates via
    <command>zypper</command>. You could also call <command>chkstat</command>
    regularly via <systemitem class="daemon">cron</systemitem> or a &systemd;
    timer.

--- a/xml/file_management.xml
+++ b/xml/file_management.xml
@@ -245,7 +245,7 @@ drwxr-----. 2 17086 4096 Nov 29 15:06 f
       </para>
       <para>
        Do not use the <literal>paranoid</literal> profile is as is but as a
-       template for custom permissions. For more information, refer to
+       template for custom permissions. For more information, refer to the
        <filename>permissions.paranoid</filename> file.
       </para>
      </warning>

--- a/xml/file_management.xml
+++ b/xml/file_management.xml
@@ -194,16 +194,15 @@ drwxr-----. 2 17086 4096 Nov 29 15:06 f
 
   </sect1>
 
- <sect1 xml:id="sec-sec-prot-general-filepermissions">
+ <sect1 xml:id="sec-sec-prot-general-file-permissions">
   <title>Modifying permissions of certain system files</title>
 
   <para>
    Many files&mdash;especially in the <filename>/etc</filename>
-   directory&mdash;are world-readable, means unprivileged users can read their
-   contents. Normally this is not a problem, but if you want to take extra care
-   or run specialized applications that introduce sensitive files, it is
-   possible to remove the world-readable or group-readable bits from files that
-   you are worried about.
+   directory&mdash;are world-readable, which means that unprivileged users can
+   read their contents. Normally this is not a problem, but if you want to take
+   extra care, you can remove the world-readable or group-readable bits for
+   sensitive files.
   </para>
 
   <para>
@@ -233,7 +232,15 @@ drwxr-----. 2 17086 4096 Nov 29 15:06 f
     <term>paranoid</term>
     <listitem>
      <para>
-      Profile for maximum security.
+      Profile for maximum security. In addition to the <literal>secure</literal>
+      profile, it removes <emphasis>all</emphasis> special permissions like
+      setuid/setgid and capability bits. Therefore, the system might be useable
+      for non-privileged users except for simple tasks like changing passwords.
+     </para>
+     <para>
+      This profile is not intended to be used as is but acts as a template for
+      additional custom permissions. For more information, refer to
+      <filename>permissions.paranoid</filename> file.
      </para>
     </listitem>
    </varlistentry>
@@ -259,7 +266,7 @@ drwxr-----. 2 17086 4096 Nov 29 15:06 f
 
   <para>
    Select the system profile in <filename>/etc/sysconfig/security</filename>. To
-   use the <literal>easy</literal> profile with custom permissions, set:
+   use the <literal>easy</literal> profile and custom permissions, set:
   </para>
 
   <screen>PERMISSION_SECURITY="<replaceable>easy local</replaceable>"</screen>
@@ -278,7 +285,7 @@ drwxr-----. 2 17086 4096 Nov 29 15:06 f
   <important>
    <title>Custom file permissions</title>
    <para>
-    While the system profiles are well tested, custom adjustments can break
+    While the system profiles are well tested, custom permissions can break
     standard applications. &suse; cannot provide support for such scenarios.
    </para>
    <para>

--- a/xml/file_management.xml
+++ b/xml/file_management.xml
@@ -141,7 +141,7 @@
        permissions might be unusable for non-privileged users.
       </para>
       <para>
-       Do not use the <literal>paranoid</literal> profile is as is but as a
+       Do not use the <literal>paranoid</literal> profile is as-is, but as a
        template for custom permissions. For more information, refer to the
        <filename>permissions.paranoid</filename> file.
       </para>
@@ -163,8 +163,9 @@
    /root/                          root:root       0700</screen>
 
   <para>
-   The first column specifies the file name. Directory names have to end with a
-   slash. The second column specifies the owner and group, the third the mode.
+   The first column specifies the file name; note that directory names must end with a
+   slash. The second column specifies the owner and group, and the third column
+   specifies the mode.
    For more information about the configuration file format, refer to
    <command>man permissions</command>.
   </para>

--- a/xml/file_management.xml
+++ b/xml/file_management.xml
@@ -193,7 +193,103 @@ drwxr-----. 2 17086 4096 Nov 29 15:06 f
 </screen>
 
   </sect1>
-  <sect1 xml:id="sec-sec-prot-general-s-bit">
+
+ <sect1 xml:id="sec-sec-prot-general-filepermissions">
+  <title>Modifying permissions of certain system files</title>
+
+  <para>
+   Many files&mdash;especially in the <filename>/etc</filename>
+   directory&mdash;are world-readable, means unprivileged users can read their
+   contents. Normally this is not a problem, but if you want to take extra care
+   or run specialized applications that introduce sensitive files, it is
+   possible to remove the world-readable or group-readable bits from files that
+   you are worried about.
+  </para>
+
+  <para>
+   &sle; provides the <package>permissions</package> package to easily apply
+   file permissions. The package comes with three pre-defined system profiles:
+  </para>
+
+  <variablelist>
+   <varlistentry>
+    <term>easy</term>
+    <listitem>
+     <para>
+      Profile for systems that require user-friendly graphical user interaction.
+      This is the default profile.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>secure</term>
+    <listitem>
+     <para>
+      Profile for server systems without fully-fledged graphical user interface.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>paranoid</term>
+    <listitem>
+     <para>
+      Profile for maximum security.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+
+  <para>
+   To define custom file permissions, edit
+   <filename>/etc/permissions.local</filename> or create a drop-in file in the
+   <filename>/etc/permissions.d/</filename> direcory.
+  </para>
+
+<screen># Additional custom hardening
+/etc/security/access.conf       root:root       0400
+/etc/sysctl.conf                root:root       0400
+/root/                          root:root       0700</screen>
+
+  <para>
+   The first column specifies the file name. Directory names have to end with a
+   slash. The second column specifies the owner and group, the third the mode.
+   For more information about the configuration file format, refer to
+   <command>man permissions</command>.
+  </para>
+
+  <para>
+   Select the system profile in <filename>/etc/sysconfig/security</filename>. To
+   use the <literal>easy</literal> profile with custom permissions, set:
+  </para>
+
+  <screen>PERMISSION_SECURITY="<replaceable>easy local</replaceable>"</screen>
+
+  <para>
+   To apply the setting, run <command>chkstat --system --set</command>.
+  </para>
+
+  <para>
+   The permissions will also be applied implicitly during package updates via
+   <command>zypper</command>. You could also call <command>chkstat</command>
+   regularly via <systemitem class="daemon">cron</systemitem> or a &systemd;
+   timer.
+  </para>
+
+  <important>
+   <title>Custom file permissions</title>
+   <para>
+    While the system profiles are well tested, custom adjustments can break
+    standard applications. &suse; cannot provide support for such scenarios.
+   </para>
+   <para>
+    Always test custom file permissions before applying them with
+    <command>chkstat</command> to make sure everything works as desired.
+   </para>
+  </important>
+
+ </sect1>
+
+ <sect1 xml:id="sec-sec-prot-general-s-bit">
    <title>SUID/SGID files</title>
 
    <para>
@@ -249,7 +345,8 @@ drwxr-----. 2 17086 4096 Nov 29 15:06 f
    </para>
 
   </sect1>
-  <sect1 xml:id="sec-sec-prot-general-filepermissions">
+
+  <sect1 xml:id="sec-sec-prot-general-world-writable-files">
    <title>World-writable files</title>
 
    <para>


### PR DESCRIPTION
### PR creator: Description

This PR migrates the chapter 'Modify permissions on certain system files' from the OS Hardening Guide for SAP HANA to the SLES Security & Hardening Guide.

### PR creator: Are there any relevant issues/feature requests?

* https://bugzilla.suse.com/show_bug.cgi?id=1176622

### PR creator: Which product versions do the changes apply to?

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
