### PR TITLE
vt-doc: Add Xen note to qemu guest agent chapter

### DIFF
--- a/xml/vt_qemu_ga.xml
+++ b/xml/vt_qemu_ga.xml
@@ -14,7 +14,19 @@
  </para>
  <para>
   &qemu; GA is included in the <package>qemu-guest-agent</package> package and
-  is installed, configured, and activated by default on &kvm; or &xen; virtual machines.
+  is installed, configured, and activated by default on &kvm; virtual machines.
+ </para>
+ <para>
+  &qemu; GA is installed in &xen; virtual machines, but it is not activated by
+  default. Although it is possible to use &qemu; GA with &xen; virtual machines,
+  there is no integration with libvirt as described below for &kvm; virtual
+  machines. To use &qemu; GA with &xen; a channel device must be added to the
+  &vmguest; configuration. The channel device includes a Unix domain socket path
+  on the &vmhost; for communicating with &qemu; GA.
+<screen>&lt;channel type='unix'&gt;
+  &lt;source mode='bind' path='/example/path'/&gt;
+  &lt;target type='xen' name='org.qemu.guest_agent.0'/&gt;
+  &lt;/channel&gt;</screen>
  </para>
  <sect1 xml:id="cha-qemu-ga-libvirt-general">
   <title>Running &qemu; GA commands</title>


### PR DESCRIPTION
The qemu guest agent is not enabled in Xen VMs by default. Remove
the note claiming it is. Add a new paragraph explaining its limitations
and include an example of configuring a channel device in the VM for
communicating with the guest agent.

https://bugzilla.suse.com/show_bug.cgi?id=1191709

### PR creator: Description

Describe the overall goals of this pull request.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1191709


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [x] all necessary backports are done
