### PR TITLE
VMWare ESX as a guest hypervisor (bsc#1179596)

### DIFF
--- a/xml/vt_installation.xml
+++ b/xml/vt_installation.xml
@@ -475,5 +475,27 @@
     </para>
    </listitem>
   </itemizedlist>
+  <sect2 xml:id="sec-vt-installation-nested-vms-esxi">
+   <title>&esx; as a guest hypervisor</title>
+   <para>
+    If you use &esx; as a guest hypervisor on top of &kvm; bare metal
+    hypervisor, you may experience unstable network communication.
+    This problem happens especially between nested &kvm; guests and
+    the &kvm; bare metal hypervisor or external network.
+    The following default CPU configuration of the nested &kvm; guest is
+    causing the problem:
+   </para>
+   <screen>&lt;cpu mode='host-model' check='partial'/></screen>
+   <para>
+    To fix it, modify the CPU configuration as follow:
+   </para>
+<screen>
+[...]
+&lt;cpu mode='host-passthrough' check='none'>
+ &lt;cache mode='passthrough'/>
+&lt;/cpu>
+[...]
+</screen>
+  </sect2>
  </sect1>
 </chapter>


### PR DESCRIPTION
### PR creator: Description

This update fixes network issues when using ESX as a guest hypervisor

### PR creator: Are there any relevant issues/feature requests?

* bsc#1179596


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
