### PR TITLE
SEO: edit urls removed l10n SLE 15 SP3

### DIFF
--- a/l10n/sled/ar-ar/xml/MAIN.SLEDS.xml
+++ b/l10n/sled/ar-ar/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>حزمة الخدمة SP3 العامة لـ SUSE Linux Enterprise Desktop 15</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>
    <dm:translation>نعم</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sled/cs-cz/xml/MAIN.SLEDS.xml
+++ b/l10n/sled/cs-cz/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>PUBLIC SUSE Linux Enterprise Desktop 15 SP3</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>
    <dm:translation>ano</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sled/de-de/xml/MAIN.SLEDS.xml
+++ b/l10n/sled/de-de/xml/MAIN.SLEDS.xml
@@ -39,7 +39,6 @@
     <dm:product>SUSE Linux Enterprise Desktop 15 SP3</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP3/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sled/es-es/xml/MAIN.SLEDS.xml
+++ b/l10n/sled/es-es/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Desktop 15 SP3 (PÚBLICA)</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>
    <dm:translation>sí</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sled/fr-fr/xml/MAIN.SLEDS.xml
+++ b/l10n/sled/fr-fr/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>PUBLIC SUSE Linux Enterprise Desktop 15 SP3</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>
    <dm:translation>oui</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sled/hu-hu/xml/MAIN.SLEDS.xml
+++ b/l10n/sled/hu-hu/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>NYILVÁNOS SUSE Linux Enterprise Desktop 15 SP3</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>
    <dm:translation>Igen</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sled/it-it/xml/MAIN.SLEDS.xml
+++ b/l10n/sled/it-it/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>PUBLIC SUSE Linux Enterprise Desktop 15 SP3</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>
    <dm:translation>sì</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sled/ja-jp/xml/MAIN.SLEDS.xml
+++ b/l10n/sled/ja-jp/xml/MAIN.SLEDS.xml
@@ -39,7 +39,6 @@
     <dm:product>PUBLIC SUSE Linux Enterprise Desktop 15 SP3</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP3/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sled/ko-kr/xml/MAIN.SLEDS.xml
+++ b/l10n/sled/ko-kr/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>공용 SUSE Linux Enterprise Desktop 15 SP3</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>
    <dm:translation>예</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sled/pl-pl/xml/MAIN.SLEDS.xml
+++ b/l10n/sled/pl-pl/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Desktop 15 SP3, wersja publiczna</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>
    <dm:translation>tak</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sled/pt-br/xml/MAIN.SLEDS.xml
+++ b/l10n/sled/pt-br/xml/MAIN.SLEDS.xml
@@ -39,7 +39,6 @@
     <dm:product>SUSE Linux Enterprise Desktop 15 SP3 PÚBLICO</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP3/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sled/ru-ru/xml/MAIN.SLEDS.xml
+++ b/l10n/sled/ru-ru/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Desktop 15 SP3 (ОТКРЫТАЯ ВЕРСИЯ)</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>
    <dm:translation>да</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sled/zh-cn/xml/MAIN.SLEDS.xml
+++ b/l10n/sled/zh-cn/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>PUBLIC SUSE Linux Enterprise Desktop 15 SP3</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP3/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sled/zh-tw/xml/MAIN.SLEDS.xml
+++ b/l10n/sled/zh-tw/xml/MAIN.SLEDS.xml
@@ -39,7 +39,6 @@
     <dm:product>PUBLIC SUSE Linux Enterprise Desktop 15 SP3</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP3/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sles/ar-ar/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/ar-ar/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>حزمة الخدمة SP3 العامة لخادم SUSE Linux Enterprise Server 15</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>
    <dm:translation>نعم</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sles/cs-cz/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/cs-cz/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>PUBLIC SUSE Linux Enterprise Server 15 SP3</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>
    <dm:translation>ano</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sles/de-de/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/de-de/xml/MAIN.SLEDS.xml
@@ -39,7 +39,6 @@
           <dm:product>SUSE Linux Enterprise Server15 SP3</dm:product>
           <dm:assignee>fs@suse.com</dm:assignee>
         </dm:bugtracker>
-        <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP3/xml/</dm:editurl>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>
       <xi:include href="common_authors.xml"/>

--- a/l10n/sles/es-es/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/es-es/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP3 PÚBLICA</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>
    <dm:translation>sí</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sles/fr-fr/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/fr-fr/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>PUBLIC SUSE Linux Enterprise Server 15 SP3</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>
    <dm:translation>oui</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sles/hu-hu/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/hu-hu/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>NYILVÁNOS SUSE Linux Enterprise Server 15 SP3</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>
    <dm:translation>Igen</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sles/it-it/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/it-it/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>PUBLIC SUSE Linux Enterprise Server 15 SP3</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>
    <dm:translation>sì</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sles/ja-jp/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/ja-jp/xml/MAIN.SLEDS.xml
@@ -39,7 +39,6 @@
           <dm:product>PUBLIC SUSE Linux Enterprise Server 15 SP3</dm:product>
           <dm:assignee>fs@suse.com</dm:assignee>
         </dm:bugtracker>
-        <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP3/xml/</dm:editurl>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>
       <xi:include href="common_authors.xml"/>

--- a/l10n/sles/ko-kr/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/ko-kr/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>공용 SUSE Linux Enterprise Server 15 SP3</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>
    <dm:translation>예</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sles/pl-pl/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/pl-pl/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP3, wersja publiczna</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>
    <dm:translation>tak</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sles/pt-br/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/pt-br/xml/MAIN.SLEDS.xml
@@ -39,7 +39,6 @@
           <dm:product>SUSE Linux Enterprise Server 15 SP3 PÚBLICO</dm:product>
           <dm:assignee>fs@suse.com</dm:assignee>
         </dm:bugtracker>
-        <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP3/xml/</dm:editurl>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>
       <xi:include href="common_authors.xml"/>

--- a/l10n/sles/ru-ru/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/ru-ru/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP3 (ОТКРЫТАЯ ВЕРСИЯ)</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>
    <dm:translation>да</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sles/zh-cn/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/zh-cn/xml/MAIN.SLEDS.xml
@@ -39,7 +39,6 @@
           <dm:product>PUBLIC SUSE Linux Enterprise Server 15 SP3</dm:product>
           <dm:assignee>fs@suse.com</dm:assignee>
         </dm:bugtracker>
-        <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP3/xml/</dm:editurl>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>
       <xi:include href="common_authors.xml"/>

--- a/l10n/sles/zh-cn/xml/art_pci-dss.xml
+++ b/l10n/sles/zh-cn/xml/art_pci-dss.xml
@@ -19,7 +19,6 @@
     <dm:product>SUSE Linux Enterprise Server 15SP2</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   

--- a/l10n/sles/zh-cn/xml/art_raspberry-pi.xml
+++ b/l10n/sles/zh-cn/xml/art_raspberry-pi.xml
@@ -24,7 +24,6 @@
     <dm:product>SUSE Linux Enterprise Server 15SP3</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <abstract>

--- a/l10n/sles/zh-tw/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/zh-tw/xml/MAIN.SLEDS.xml
@@ -39,7 +39,6 @@
           <dm:product>PUBLIC SUSE Linux Enterprise Server 15 SP3</dm:product>
           <dm:assignee>fs@suse.com</dm:assignee>
         </dm:bugtracker>
-        <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP3/xml/</dm:editurl>
         <dm:translation>yes</dm:translation>
       </dm:docmanager>
       <xi:include href="common_authors.xml"/>


### PR DESCRIPTION
### PR creator: Description

<dm:editurls> tag removed for all languages of SLE 15 SP3.

Will be done for each branch version separately therefore no backports needed.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
