### PR TITLE
update product release number entities for SLE 15 SP4

### DIFF
--- a/xml/containers-docker-installation.xml
+++ b/xml/containers-docker-installation.xml
@@ -71,7 +71,7 @@
     <para>
      The Containers Module can also be added with the following command:
     </para>
-<screen>&prompt.sudo;SUSEConnect -p sle-module-containers/&productnumbershort;/x86_64</screen>
+<screen>&prompt.sudo;SUSEConnect -p sle-module-containers/&productnumber-regurl;/x86_64</screen>
    </step>
   </procedure>
 

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -198,7 +198,8 @@
 <!ENTITY productnameshort "<phrase xmlns='http://docbook.org/ns/docbook' role='productname'><phrase os='osuse'>&opensuse; Leap</phrase><phrase os='sles'>&slsa;</phrase><phrase os='sled'>&sleda;</phrase><phrase os='slemicro'>&slema;</phrase></phrase>">
 <!ENTITY product-ga    "15">
 <!ENTITY product-sp    "4">
-<!ENTITY productnumbershort "&product-ga;.&product-sp;">
+<!ENTITY productnumber-regurl "&product-ga;.&product-sp;">
+<!ENTITY productnumber-leaprepo "&product-ga;.&product-sp;">
 <!ENTITY productnumber "<phrase xmlns='http://docbook.org/ns/docbook' role='productnumber'><phrase os='osuse'>15.4</phrase><phrase os='sles;sled'>&product-ga; SP&product-sp;</phrase><phrase os='slemicro'>5.2</phrase></phrase>">
 <!ENTITY sdk           "SUSE Software Development Kit">
 <!ENTITY hasi          "High Availability Extension">

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -197,9 +197,9 @@
 <!ENTITY productnamereg "<phrase xmlns='http://docbook.org/ns/docbook' role='productname'><phrase os='osuse'>&opensusereg; Leap</phrase><phrase os='sles'>&slsreg;</phrase><phrase os='sled'>&sledreg;</phrase><phrase os='slemicro'>&slemreg;</phrase></phrase>">
 <!ENTITY productnameshort "<phrase xmlns='http://docbook.org/ns/docbook' role='productname'><phrase os='osuse'>&opensuse; Leap</phrase><phrase os='sles'>&slsa;</phrase><phrase os='sled'>&sleda;</phrase><phrase os='slemicro'>&slema;</phrase></phrase>">
 <!ENTITY product-ga    "15">
-<!ENTITY product-sp    "3">
+<!ENTITY product-sp    "4">
 <!ENTITY productnumbershort "&product-ga;.&product-sp;">
-<!ENTITY productnumber "<phrase xmlns='http://docbook.org/ns/docbook' role='productnumber'><phrase os='osuse'>15.3</phrase><phrase os='sles;sled'>&product-ga; SP&product-sp;</phrase><phrase os='slemicro'>5.1</phrase></phrase>">
+<!ENTITY productnumber "<phrase xmlns='http://docbook.org/ns/docbook' role='productnumber'><phrase os='osuse'>15.4</phrase><phrase os='sles;sled'>&product-ga; SP&product-sp;</phrase><phrase os='slemicro'>5.2</phrase></phrase>">
 <!ENTITY sdk           "SUSE Software Development Kit">
 <!ENTITY hasi          "High Availability Extension">
 <!ENTITY sleha         "&sle; &hasi;">

--- a/xml/klp.xml
+++ b/xml/klp.xml
@@ -229,7 +229,7 @@
 <screen>$ SUSEConnect --list-extensions
 ...
 SUSE Linux Enterprise Live Patching &productnumber; x86_64
-Activate with: SUSEConnect -p sle-module-live-patching/&productnumbershort;/x86_64 \
+Activate with: SUSEConnect -p sle-module-live-patching/&productnumber-regurl;/x86_64 \
   -r ADDITIONAL REGCODE</screen>
    </step>
    <step>
@@ -239,7 +239,7 @@ Activate with: SUSEConnect -p sle-module-live-patching/&productnumbershort;/x86_
      <replaceable>LIVE_PATCHING_REGISTRATION_CODE</replaceable></option>, for
      example:
     </para>
-<screen>SUSEConnect -p sle-module-live-patching/&productnumbershort;/x86_64 \
+<screen>SUSEConnect -p sle-module-live-patching/&productnumber-regurl;/x86_64 \
   -r <replaceable>LIVE_PATCHING_REGISTRATION_CODE</replaceable></screen>
    </step>
    <step>

--- a/xml/rmt_migrate_from_smt.xml
+++ b/xml/rmt_migrate_from_smt.xml
@@ -813,11 +813,11 @@
      structure of the source server's URL into a top level directory. For
      example, if the URL of the custom repository is
     </para>
-<screen>http://download.opensuse.org/debug/distribution/leap/&productnumbershort;/repo/oss </screen>
+<screen>http://download.opensuse.org/debug/distribution/leap/&productnumber-leaprepo;/repo/oss </screen>
     <para>
      its path on the &rmt; server will be
     </para>
-<screen>/usr/share/rmt/public/repo/debug/distribution/leap/&productnumbershort;/repo/oss</screen>
+<screen>/usr/share/rmt/public/repo/debug/distribution/leap/&productnumber-leaprepo;/repo/oss</screen>
    </tip>
    </step>
    <step>

--- a/xml/security_ldap.xml
+++ b/xml/security_ldap.xml
@@ -12,7 +12,7 @@
     The Lightweight Directory Access Protocol (LDAP) is a protocol
     designed to access and maintain information directories. LDAP can be
     used for tasks such as user and group management, system configuration
-    management, and address management. In &productname; &productnumbershort; the
+    management, and address management. In &productname; &productnumber; the
     LDAP service is provided by the &ds389;, replacing OpenLDAP.
    </para>
   </abstract>

--- a/xml/security_xca.xml
+++ b/xml/security_xca.xml
@@ -16,7 +16,7 @@ xml:id="cha-security-xca">
       <para>
         Managing your own public key infrastructure (PKI) is traditionally
         done with the <command>openssl</command> utility. For admins who
-        prefer a graphical tool, &sle; &productnumbershort; includes XCA,
+        prefer a graphical tool, &productname; &productnumber; includes XCA,
         the X Certificate and Key management tool 
         (<link xlink:href="http://hohnstaedt.de/xca"/>).
       </para>

--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -130,8 +130,8 @@
   <sect2 xml:id="sec-selinux-support">
    <title>Support status</title>
    <para>
-    The &selnx; framework is supported on &productnumbershort;. This means 
-    that &productnameshort; offers all binaries and libraries you need to use 
+    The &selnx; framework is supported on &productname; &productnumber;.
+    &productnameshort; offers all binaries and libraries you need to use 
     &selnx; on your server.
    </para>
    <para>


### PR DESCRIPTION
update release number entities for SLE 15 SP4

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
