### PR TITLE
AutoYaST: drop no longer supported group attributes

### DIFF
--- a/xml/ay_users_groups.xml
+++ b/xml/ay_users_groups.xml
@@ -448,33 +448,6 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><literal>group_password</literal></term>
-    <listitem>
-     <para>
-      Text
-     </para>
-<screen>&lt;group_password&gt;password&lt;/group_password&gt;</screen>
-     <para>
-      Optional. The group's password can be written in plain text (not
-      recommended) or in encrypted form. Check the <literal>encrypted</literal>
-      to select the desired behavior.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><literal>encrypted</literal></term>
-    <listitem>
-     <para>
-      Boolean
-     </para>
-<screen>&lt;encrypted config:type="boolean"&gt;true&lt;/encrypted&gt;</screen>
-     <para>
-      Optional. Indicates if the group's password in the profile is encrypted
-      or not.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
     <term><literal>userlist</literal></term>
     <listitem>
      <para>


### PR DESCRIPTION
### PR creator: Description

In the [new yast2-users code relying on "shadow" commands](https://github.com/yast/yast-users/pull/349) support for group passwords [has been dropped](https://github.com/yast/yast-users/pull/353) due to its _"inherent security problem" nature_.

Thus, `group_password` and `encrypted` group attributes will be neither exported nor imported.

### PR creator: Are there any relevant issues/feature requests?

* [jsc#SLE-21447](https://jira.suse.com/browse/SLE-21447)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
