### PR TITLE
Document ssl_verify option for AutoYaST

### DIFF
--- a/xml/ay_auto_installation.xml
+++ b/xml/ay_auto_installation.xml
@@ -284,10 +284,15 @@ xml:id="Invoking">
        <title>Disabling SSL checks</title>
        <para>
          When you are using HTTPS, SSL checking is enabled by default. If 
-         necessary, you can disable SSL checking by appending <literal>?ssl_verify=no</literal>
-          to your HTTPS URL, like the following example:
+         necessary, you can disable SSL checking by appending <literal>ssl_verify=no</literal>
+          to your HTTPS URL, like the following examples:
         </para>
         <screen>install=<replaceable>https://192.168.2.1/CDs/</replaceable>?ssl_verify=no</screen>
+        <para>
+          If you are passing multiple query options, separate them with 
+          ampersands:
+        </para>
+         <screen>install=<replaceable>https://192.168.2.1/CDs/</replaceable>?foo=bar&amp;ssl_verify=no</screen>       
         <para>
           See the "FTP/HTTP/HTTPS directory tree" section of 
           <command>man 8 zypper</command> for more information.

--- a/xml/ay_auto_installation.xml
+++ b/xml/ay_auto_installation.xml
@@ -280,6 +280,19 @@ xml:id="Invoking">
        Location of the installation directory, for example
        <literal>install=nfs://192.168.2.1/CDs/</literal>.
       </para>
+      <note>
+       <title>Disabling SSL checks</title>
+       <para>
+         When you are using HTTPS, SSL checking is enabled by default. If 
+         necessary, you can disable SSL checking by appending <literal>?ssl_verify=no</literal>
+          to your HTTPS URL, like the following example:
+        </para>
+        <screen>install=<replaceable>https://192.168.2.1/CDs/</replaceable>?ssl_verify=no</screen>
+        <para>
+          See the "FTP/HTTP/HTTPS directory tree" section of 
+          <command>man 8 zypper</command> for more information.
+        </para>
+        </note>
      </listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
re jira#SLE-21833

### PR creator: Description

How to disable SSL verification for HTTPS installation paths
Reviewers, see attached PDF

[invoking-autoinst_color_en.pdf](https://github.com/SUSE/doc-sle/files/7514678/invoking-autoinst_color_en.pdf)

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
