### PR TITLE
"<peer/>" is deprecated in AutoYaST profile and should be removed

### DIFF
--- a/xml/ay_ntp_client.xml
+++ b/xml/ay_ntp_client.xml
@@ -87,22 +87,5 @@
       </para>
      </callout>
     </calloutlist>
-    <para>
-        The following example illustrates an IPv6 configuration. You may use the server's 
-        IP address, host name, or both:
-    </para>
-    <screen>&lt;peer>
-  &lt;address>2001:418:3ff::1:53&lt;/address>
-  &lt;comment/>
-  &lt;options/>
-  &lt;type>server&lt;/type>
-&lt;/peer>
-
-&lt;peer>
-  &lt;address>2.pool.ntp.org&lt;/address>
-  &lt;comment/>
-  &lt;options/>
-  &lt;type>server&lt;/type>
-&lt;/peer>  </screen>      
    </example>
 </sect1>


### PR DESCRIPTION
re bsc#1188349

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
