### PR TITLE
Fix the `ntp-server` section examples

### DIFF
--- a/xml/ay_ntp_client.xml
+++ b/xml/ay_ntp_client.xml
@@ -34,17 +34,17 @@
    <example>
     <title>Network configuration: NTP client</title>
 <screen>
-&lt;ntp-client>
-&lt;ntp_policy>auto&lt;/ntp_policy><co xml:id="co-ay-ntp-policy"/>
- &lt;ntp_servers config:type="list">
-  &lt;ntp_server>
-   &lt;address>cz.pool.ntp.org&lt;/address><co xml:id="co-ay-ntp-address"/>
-   &lt;iburst config:type="boolean">false&lt;/iburst><co xml:id="co-ay-ntp-iburst"/>
-   &lt;offline config:type="boolean">false&lt;/offline><co xml:id="co-ay-ntp-offline"/>
-  &lt;/ntp_server>
- &lt;/ntp_servers>
- &lt;ntp_sync>15&lt;/ntp_sync><co xml:id="co-ay-ntp-sync"/>
-&lt;/ntp-client>
+&lt;ntp-client&gt;
+  &lt;ntp_policy>auto&lt;/ntp_policy&gt;<co xml:id="co-ay-ntp-policy"/>
+  &lt;ntp_servers config:type="list"&gt;
+    &lt;ntp_server&gt;
+      &lt;address&gt;cz.pool.ntp.org&lt;/address&gt;<co xml:id="co-ay-ntp-address"/>
+      &lt;iburst config:type="boolean">false&lt;/iburst&gt;<co xml:id="co-ay-ntp-iburst"/>
+      &lt;offline config:type="boolean"&gt;false&lt;/offline&gt;<co xml:id="co-ay-ntp-offline"/>
+    &lt;/ntp_server&gt;
+  &lt;/ntp_servers&gt;
+  &lt;ntp_sync>15&lt;/ntp_sync&gt;<co xml:id="co-ay-ntp-sync"/>
+&lt;/ntp-client&gt;
 </screen>
     <calloutlist>
      <callout arearefs="co-ay-ntp-policy">
@@ -91,18 +91,13 @@
         The following example illustrates an IPv6 configuration. You may use the server's 
         IP address, host name, or both:
     </para>
-    <screen>&lt;peer>
-  &lt;address>2001:418:3ff::1:53&lt;/address>
-  &lt;comment/>
-  &lt;options/>
-  &lt;type>server&lt;/type>
-&lt;/peer>
+    <screen>&lt;ntp-server&gt;
+  &lt;address&gt;2001:418:3ff::1:53&lt;/address&gt;
+&lt;/ntp-server&gt;
 
-&lt;peer>
-  &lt;address>2.pool.ntp.org&lt;/address>
-  &lt;comment/>
-  &lt;options/>
-  &lt;type>server&lt;/type>
-&lt;/peer>  </screen>      
+&lt;ntp-server&gt;
+  &lt;address&gt;2.pool.ntp.org&lt;/address&gt;
+&lt;/ntp-server&gt;
+</screen>
    </example>
 </sect1>


### PR DESCRIPTION
### PR creator: Description

Fix the `ntp-server` section examples in the AutoYaST documentation. Additionally, I took the opportunity to improve the indentation for consistency with other examples.

Unfortunately, this change applies to all SLE 15 systems, so you might need to do some backporting work. Sorry for that.

### PR creator: Are there any relevant issues/feature requests?

* [bsc#1188349](https://bugzilla.suse.com/show_bug.cgi?id=1188349)

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [X] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [X] SLE 15 SP3/openSUSE Leap 15.3
  - [X] SLE 15 SP2/openSUSE Leap 15.2
  - [X] SLE 15 SP1
  - [X] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
