### PR TITLE
Migrate chapter 'Change home directory permissions from 755 to 700' from SAP HANA Hardening Guide to SLE Security & Hardening Guide (BSC#1176621)

### DIFF
--- a/xml/file_management.xml
+++ b/xml/file_management.xml
@@ -205,13 +205,11 @@
  </sect1>
 
  <sect1 xml:id="sec-sec-prot-general-home-permissions">
-  <title>Changing home directory permissions from 775 to 700</title>
+  <title>Changing home directory permissions from 755 to 700</title>
   <para>
-   By default, home directories of users are accessible (read, execute) by
-   other members of the group <literal>users</literal>, means all other user
-   accounts on the system.
-   As this is a potential security leak, home directories should only be
-   accessible by their owners.
+   By default, home directories of users are accessible (read, execute) by all
+   by users on the system. As this is a potential information leak, home
+   directories should only be accessible by their owners.
   </para>
   <para>
    The following commands will set the permissions to <literal>700</literal>

--- a/xml/file_management.xml
+++ b/xml/file_management.xml
@@ -204,6 +204,65 @@
 
  </sect1>
 
+ <sect1 xml:id="sec-sec-prot-general-home-permissions">
+  <title>Changing home directory permissions from 775 to 700</title>
+  <para>
+   By default, home directories of users are accessible (read, execute) by
+   other members of the group <literal>users</literal>, means all other user
+   accounts on the system.
+   As this is a potential security leak, home directories should only be
+   accessible by their owners.
+  </para>
+  <para>
+   The following commands will set the permissions to <literal>700</literal>
+   (directory only accessible for the owner) for all existing home directories
+   in <filename>/home</filename>:
+  </para>
+  <screen>&prompt.sudo;chmod 755 /home
+   &prompt.sudo;for a in /home/*; do \
+   echo "Changing rights for directory $a"; chmod 700 ”$a”; done</screen>
+
+  <!-- cwickert 2021-11-11: the following only works with shadow >= 4.8.1,
+   means SLES 15 >= SP3. Beware when backporting! -->
+  <para>
+   To ensure newly created home directories will be created with secure
+   permissions, edit <filename>/etc/login.defs</filename> and set
+   <varname>HOME_MODE</varname> to <literal>700</literal>.
+  </para>
+
+  <screen># HOME_MODE is used by useradd(8) and newusers(8) to set the mode for new
+   # home directories.
+   # If HOME_MODE is not set, the value of UMASK is used to create the mode.
+   HOME_MODE      0700</screen>
+
+  <para>
+   If you don't set <varname>HOME_MODE</varname>, permissions will be calculated
+   from the default umask. Please note that <varname>HOME_MODE</varname>
+   specifies the permissions used, not a mask used to remove access like umask.
+   For more information about umask, refer to <xref
+    linkend="sec-sec-prot-general-umask"/>.
+  </para>
+
+  <para>
+   You can verify the configuration change by creating a new user with
+   <command>useradd -m testuser</command>. Check the permissions of the
+   directories with <command>ls -l /home</command>. Afterwards, remove the user
+   created for this test.
+  </para>
+  <!-- cwickert 2021-11-11: end of SLE 15 >= SP3-only content -->
+  <important>
+   <title>Test permission changes</title>
+   <para>
+    Users are no longer allowed to access other users' home directories. This
+    may be unexpected for users and software.
+   </para>
+   <para>
+    Test this change before using it in production and notify users affected by
+    the change.
+   </para>
+  </important>
+ </sect1>
+
   <sect1 xml:id="sec-sec-prot-general-umask">
    <title>Default umask</title>
 


### PR DESCRIPTION
### PR creator: Description

This PR migrates the chapter 'Change home directory permissions from 775 to 700' from the SAP HANA Hardening Guide to the SLE Security & Hardening Guide (BSC#1176621)

### PR creator: Are there any relevant issues/feature requests?

https://bugzilla.suse.com/show_bug.cgi?id=1176621

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
