### PR TITLE
SEO: remove editurls_trans_SLE15SP1

### DIFF
--- a/sled/ar/xml/MAIN.SLEDS.xml
+++ b/sled/ar/xml/MAIN.SLEDS.xml
@@ -41,8 +41,7 @@
     <dm:product>SUSE Linux Enterprise Desktop 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
-   <dm:translation>نعم</dm:translation>
+   <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>
  </info>

--- a/sled/cs/xml/MAIN.SLEDS.xml
+++ b/sled/cs/xml/MAIN.SLEDS.xml
@@ -41,8 +41,7 @@
     <dm:product>SUSE Linux Enterprise Desktop 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
-   <dm:translation>ano</dm:translation>
+   <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>
  </info>

--- a/sled/de/xml/MAIN.SLEDS.xml
+++ b/sled/de/xml/MAIN.SLEDS.xml
@@ -41,8 +41,7 @@
     <dm:product>SUSE Linux Enterprise Desktop 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
-   <dm:translation>Ja</dm:translation>
+   <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>
  </info>

--- a/sled/es/xml/MAIN.SLEDS.xml
+++ b/sled/es/xml/MAIN.SLEDS.xml
@@ -40,8 +40,7 @@
     <dm:product>SUSE Linux Enterprise Desktop 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
-   <dm:translation>sí</dm:translation>
+   <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>
  </info>

--- a/sled/fr/xml/MAIN.SLEDS.xml
+++ b/sled/fr/xml/MAIN.SLEDS.xml
@@ -40,8 +40,7 @@
     <dm:product>SUSE Linux Enterprise Desktop 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
-   <dm:translation>oui</dm:translation>
+   <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>
  </info>

--- a/sled/hu/xml/MAIN.SLEDS.xml
+++ b/sled/hu/xml/MAIN.SLEDS.xml
@@ -41,8 +41,7 @@
     <dm:product>SUSE Linux Enterprise Desktop 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
-   <dm:translation>Igen</dm:translation>
+   <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>
  </info>

--- a/sled/it/xml/MAIN.SLEDS.xml
+++ b/sled/it/xml/MAIN.SLEDS.xml
@@ -41,8 +41,7 @@
     <dm:product>SUSE Linux Enterprise Desktop 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
-   <dm:translation>sì</dm:translation>
+   <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>
  </info>

--- a/sled/ja/xml/MAIN.SLEDS.xml
+++ b/sled/ja/xml/MAIN.SLEDS.xml
@@ -41,7 +41,6 @@
     <dm:product>SUSE Linux Enterprise Desktop 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/sled/ko/xml/MAIN.SLEDS.xml
+++ b/sled/ko/xml/MAIN.SLEDS.xml
@@ -41,8 +41,7 @@
     <dm:product>SUSE Linux Enterprise Desktop 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
-   <dm:translation>예</dm:translation>
+   <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>
  </info>

--- a/sled/pl/xml/MAIN.SLEDS.xml
+++ b/sled/pl/xml/MAIN.SLEDS.xml
@@ -41,8 +41,7 @@
     <dm:product>SUSE Linux Enterprise Desktop 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
-   <dm:translation>Tak</dm:translation>
+   <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>
  </info>

--- a/sled/pt_br/xml/MAIN.SLEDS.xml
+++ b/sled/pt_br/xml/MAIN.SLEDS.xml
@@ -40,8 +40,7 @@
     <dm:product>SUSE Linux Enterprise Desktop 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
-   <dm:translation>sim</dm:translation>
+   <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>
  </info>

--- a/sled/ru/xml/MAIN.SLEDS.xml
+++ b/sled/ru/xml/MAIN.SLEDS.xml
@@ -41,8 +41,7 @@
     <dm:product>SUSE Linux Enterprise Desktop 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
-   <dm:translation>да</dm:translation>
+   <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>
  </info>

--- a/sled/zh_cn/xml/MAIN.SLEDS.xml
+++ b/sled/zh_cn/xml/MAIN.SLEDS.xml
@@ -41,8 +41,7 @@
     <dm:product>SUSE Linux Enterprise Desktop 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
-   <dm:translation>是</dm:translation>
+   <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>
  </info>

--- a/sled/zh_tw/xml/MAIN.SLEDS.xml
+++ b/sled/zh_tw/xml/MAIN.SLEDS.xml
@@ -41,8 +41,7 @@
     <dm:product>SUSE Linux Enterprise Desktop 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
-   <dm:translation>是</dm:translation>
+   <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>
  </info>

--- a/sles/ar/xml/MAIN.SLEDS.xml
+++ b/sles/ar/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/sles/cs/xml/MAIN.SLEDS.xml
+++ b/sles/cs/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/sles/de/xml/MAIN.SLEDS.xml
+++ b/sles/de/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/sles/es/xml/MAIN.SLEDS.xml
+++ b/sles/es/xml/MAIN.SLEDS.xml
@@ -39,7 +39,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/sles/fr/xml/MAIN.SLEDS.xml
+++ b/sles/fr/xml/MAIN.SLEDS.xml
@@ -39,7 +39,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/sles/hu/xml/MAIN.SLEDS.xml
+++ b/sles/hu/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/sles/it/xml/MAIN.SLEDS.xml
+++ b/sles/it/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/sles/ja/xml/MAIN.SLEDS.xml
+++ b/sles/ja/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/sles/ko/xml/MAIN.SLEDS.xml
+++ b/sles/ko/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/sles/pl/xml/MAIN.SLEDS.xml
+++ b/sles/pl/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/sles/pt_br/xml/MAIN.SLEDS.xml
+++ b/sles/pt_br/xml/MAIN.SLEDS.xml
@@ -39,7 +39,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/sles/ru/xml/MAIN.SLEDS.xml
+++ b/sles/ru/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Server15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/sles/zh_cn/xml/MAIN.SLEDS.xml
+++ b/sles/zh_cn/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/sles/zh_tw/xml/MAIN.SLEDS.xml
+++ b/sles/zh_tw/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP1</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/develop/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>


### PR DESCRIPTION
### PR creator: Description

dm:editurls tag removed for all languages of SLE15 SP1.

Will be done for each branch version separately therefore no backports needed

