### PR TITLE
Security & Hardening Guide: New chapter about restricting cron and at

### DIFF
--- a/xml/book_security.xml
+++ b/xml/book_security.xml
@@ -55,7 +55,8 @@
   <xi:include href="file_management.xml"/>
   <xi:include href="security_cryptofs.xml"/>
   <xi:include href="security_cryptctl.xml"/>  
-  <xi:include href="user_management.xml"/>  
+  <xi:include href="user_management.xml"/>
+  <xi:include href="security_cron_at.xml"/>
   <xi:include href="security_spectre_meltdown_checker.xml"/>
   <xi:include href="security_yast2_security.xml"/>
   <xi:include href="security_policy_kit.xml"/>

--- a/xml/security_cron_at.xml
+++ b/xml/security_cron_at.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE chapter
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+    %entities;
+]>
+<chapter version="5.0" role="General"
+ xml:id="cha-sec-cron-at"
+ xmlns="http://docbook.org/ns/docbook"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>Restricting <command>cron</command> and <command>at</command></title>
+ <info>
+  <abstract>
+   <para>
+    This chapter explains how to restrict access to the <systemitem
+     class="daemon">cron</systemitem> and <systemitem
+     class="daemon">at</systemitem> daemons to improve the security of a system.
+   </para>
+  </abstract>
+ </info>
+ <sect1>
+  <title>Restricting the <systemitem class="daemon">cron</systemitem> daemon</title>
+  <para>
+   The Linux <systemitem class="daemon">cron</systemitem> system is used to
+   automatically run commands in the background at predefined times. For more
+   information about <systemitem class="daemon">cron</systemitem>,
+   refer to the <xref linkend="sec-suse-packages-cron"/>.
+  </para>
+  <para>
+   The <filename>cron.allow</filename> file specifies a list of users that are
+   allowed to execute jobs via <systemitem class="daemon">cron</systemitem>.
+   The file does not exist by default, so all users can create
+   <systemitem class="daemon">cron</systemitem> jobs&mdash;except for those
+   listed in <filename>cron.deny</filename>.
+  </para>
+  <procedure>
+   <para>
+    To prevent users except for root from creating <systemitem
+     class="daemon">cron</systemitem> jobs, perform the following steps.
+   </para>
+   <step>
+    <para>
+     Create an empty file <filename>/etc/cron.allow</filename>:
+    </para>
+<screen>&prompt.sudo;<command>touch</command> /etc/cron.allow</screen>
+   </step>
+   <step>
+    <para>
+     Allow users to create <systemitem class="daemon">cron</systemitem> jobs by
+     adding their usernames to the file:
+    </para>
+<screen>&prompt.sudo;<command>echo</command> "&exampleuser_plain;" >> /etc/cron.allow</screen>
+   </step>
+   <step>
+    <para>
+     To verify, try creating a cron job as non-root user listed in
+     <filename>cron.allow</filename>. You should see the message:
+    </para>
+<screen>&prompt.user;<command>crontab -e</command>
+no crontab for &exampleuser_plain; - using an empty one</screen>
+    <para>
+     Quit the crontab editor and try the same with a user
+     <emphasis>not</emphasis> listed in the file (or before adding them in step
+     2 of this procedure):
+    </para>
+<screen>&prompt.user2;<command>crontab -e</command>
+You (&exampleuserII_plain;) are not allowed to use this program (crontab)
+See crontab(1) for more information</screen>
+   </step>
+  </procedure>
+  <important>
+   <title>Existing <systemitem class="daemon">cron</systemitem> jobs</title>
+   <para>
+    implementing <function>cron.allow</function> only prevents users from
+    creating new <systemitem class="daemon">cron</systemitem> jobs. Existing
+    jobs will still be run, even for users listed in
+    <filename>cron.deny</filename>. To prevent this, create the file as
+    described and remove existing user crontabs from the directory
+    <filename>/var/spool/cron/tabs</filename> to ensure they are not run
+    anymore.
+   </para>
+  </important>
+  <note>
+   <title>Switching to &systemd; timers</title>
+   <para>
+    You should also consider switching to &systemd; timers, as they allow for
+    more powerful and reliable task execution. By default, users cannot use them
+    to run code when they are not logged in. This limits the way users can
+    interact with the system while not being connected to it.
+   </para>
+  </note>
+ </sect1>
+
+ <sect1>
+  <title>Restricting the <systemitem class="daemon">at</systemitem> scheduler</title>
+  <para>
+   The <systemitem class="daemon">at</systemitem> job execution system allows
+   users to scheduled one-time running jobs. The <filename>at.allow</filename>
+   file specifies a list of users that are allowed to schedule jobs via
+   <systemitem class="daemon">at</systemitem>. The file does not exist by
+   default, so all users can schedule <systemitem class="daemon">at</systemitem>
+   jobs&mdash;except for those listed in <filename>at.deny</filename>)
+  </para>
+  <procedure>
+   <para>
+    To prevent users except for root from scheduling jobs with <systemitem
+     class="daemon">at</systemitem>, perform the following steps.
+   </para>
+   <step>
+    <para>
+     Create an empty file <filename>/etc/at.allow</filename>:
+    </para>
+<screen>&prompt.sudo;<command>touch</command> /etc/at.allow</screen>
+   </step>
+   <step>
+    <para>
+     Allow users to schedule jobs with <systemitem
+      class="daemon">at</systemitem> by adding their usernames to the file:
+    </para>
+<screen>&prompt.sudo;<command>echo</command> "&exampleuser_plain;" >> /etc/at.allow</screen>
+   </step>
+   <step>
+    <para>
+     To verify, try scheduling a job as non-root user listed in
+     <filename>at.allow</filename>:
+    </para>
+<screen>&prompt.user;<command>at 00:00</command>
+at></screen>
+    <para>
+     Quit the <systemitem class="daemon">at</systemitem>prompt with
+     <keycombo><keycap function="control"/><keycap>C</keycap></keycombo> and
+     try the same with a user <emphasis>not</emphasis> listed in the file (or
+     before adding them in step 2 of this procedure):
+    </para>
+<screen>&prompt.user2;<command>at 00:00</command>
+You do not have permission to use at.</screen>
+   </step>
+  </procedure>
+   <note>
+   <title>Uninstalling <systemitem class="daemon">at</systemitem></title>
+   <para>
+    <systemitem class="daemon">at</systemitem> is not widely used anymore.
+    Consider uninstalling the daemon if you don't have valid users instead of
+    just creating the file.
+   </para>
+  </note>
+ </sect1>
+
+</chapter>

--- a/xml/security_cron_at.xml
+++ b/xml/security_cron_at.xml
@@ -22,7 +22,7 @@
  <sect1>
   <title>Restricting the <systemitem class="daemon">cron</systemitem> daemon</title>
   <para>
-   The Linux <systemitem class="daemon">cron</systemitem> system is used to
+   The <systemitem class="daemon">cron</systemitem> system is used to
    automatically run commands in the background at predefined times. For more
    information about <systemitem class="daemon">cron</systemitem>,
    refer to the <xref linkend="sec-suse-packages-cron"/>.
@@ -141,8 +141,8 @@ You do not have permission to use at.</screen>
    <title>Uninstalling <systemitem class="daemon">at</systemitem></title>
    <para>
     <systemitem class="daemon">at</systemitem> is not widely used anymore.
-    Consider uninstalling the daemon if you don't have valid users instead of
-    just creating the file.
+    If you do not have valid use cases, consider uninstalling the daemon instead
+    of just restricting its access.
    </para>
   </note>
  </sect1>

--- a/xml/security_cron_at.xml
+++ b/xml/security_cron_at.xml
@@ -82,12 +82,16 @@ See crontab(1) for more information</screen>
    </para>
   </important>
   <note>
-   <title>Switching to &systemd; timers</title>
+   <title>Switching to &systemd; timer units</title>
    <para>
-    You should also consider switching to &systemd; timers, as they allow for
-    more powerful and reliable task execution. By default, users cannot use them
-    to run code when they are not logged in. This limits the way users can
+    You should also consider switching to &systemd; timer units, as they allow
+    for more powerful and reliable task execution. By default, users cannot use
+    them to run code when they are not logged in. This limits the way users can
     interact with the system while not being connected to it.
+   </para>
+   <para>
+    For more information about &systemd; timer units, refer to <xref
+     linkend="sec-boot-systemd-timer-units"/>.
    </para>
   </note>
  </sect1>


### PR DESCRIPTION


### PR creator: Description

This PR migrates two chapters from the SAP HANA Hardening Guide to the SLE Security & Hardening Guide.

### PR creator: Are there any relevant issues/feature requests?

* [BSC#1176613: Migrate chapter 'Implement cron.allow' from OS Hardening Guide for SAP HANA to SLES Hardening Guide](https://bugzilla.suse.com/show_bug.cgi?id=1176613)
* [BSC#1176614: Migrate chapter 'Implement at.allow' from OS Hardening Guide for SAP HANA to SLES Hardening Guide](https://bugzilla.suse.com/show_bug.cgi?id=1176614)

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
