### PR TITLE
SEO: remove editurls from l10n SLE15SP2

### DIFF
--- a/l10n/sled/de-de/xml/MAIN.SLEDS.xml
+++ b/l10n/sled/de-de/xml/MAIN.SLEDS.xml
@@ -37,12 +37,11 @@
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker>
     <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-    <dm:component>Dokumentation</dm:component>
-    <dm:product>Öffentliche Betaversion von SUSE Linux Enterprise Server 15 SP2</dm:product>
+    <dm:component>Documentation</dm:component>
+    <dm:product>SUSE Linux Enterprise Server 15 SP2</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/master/xml/</dm:editurl>
-   <dm:translation>Ja</dm:translation>
+   <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>
  </info>

--- a/l10n/sled/zh-cn/xml/MAIN.SLEDS.xml
+++ b/l10n/sled/zh-cn/xml/MAIN.SLEDS.xml
@@ -36,12 +36,11 @@
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker>
     <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-    <dm:component>文档</dm:component>
+    <dm:component>Documentation</dm:component>
     <dm:product>SUSE Linux Enterprise Server 15SP2</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP2/xml/</dm:editurl>
-   <dm:translation>是</dm:translation>
+   <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>
  </info>

--- a/l10n/sled/zh-cn/xml/MAIN.SLEDS.xml
+++ b/l10n/sled/zh-cn/xml/MAIN.SLEDS.xml
@@ -37,7 +37,7 @@
    <dm:bugtracker>
     <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
     <dm:component>Documentation</dm:component>
-    <dm:product>SUSE Linux Enterprise Server 15SP2</dm:product>
+    <dm:product>SUSE Linux Enterprise Server 15 SP2</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
    <dm:translation>yes</dm:translation>

--- a/l10n/sles/de-de/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/de-de/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP2</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP2/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sles/es-es/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/es-es/xml/MAIN.SLEDS.xml
@@ -39,7 +39,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP2</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP2/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sles/fr-fr/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/fr-fr/xml/MAIN.SLEDS.xml
@@ -39,7 +39,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP2</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP2/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sles/it-it/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/it-it/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP2</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP2/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sles/ja-jp/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/ja-jp/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP2</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP2/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sles/ko-kr/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/ko-kr/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP2</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP2/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sles/pt-br/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/pt-br/xml/MAIN.SLEDS.xml
@@ -39,7 +39,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP2</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP2/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>

--- a/l10n/sles/zh-cn/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/zh-cn/xml/MAIN.SLEDS.xml
@@ -37,7 +37,7 @@
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
           <dm:component>Documentation</dm:component>
-          <dm:product>SUSE Linux Enterprise Server 15SP2</dm:product>
+          <dm:product>SUSE Linux Enterprise Server 15 SP2</dm:product>
           <dm:assignee>fs@suse.com</dm:assignee>
         </dm:bugtracker>
         <dm:translation>yes</dm:translation>

--- a/l10n/sles/zh-cn/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/zh-cn/xml/MAIN.SLEDS.xml
@@ -36,12 +36,11 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>文档</dm:component>
+          <dm:component>Documentation</dm:component>
           <dm:product>SUSE Linux Enterprise Server 15SP2</dm:product>
           <dm:assignee>fs@suse.com</dm:assignee>
         </dm:bugtracker>
-        <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP2/xml/</dm:editurl>
-        <dm:translation>是</dm:translation>
+        <dm:translation>yes</dm:translation>
       </dm:docmanager>
       <xi:include href="common_authors.xml"/>
     </info>

--- a/l10n/sles/zh-cn/xml/art_jeos_quickstart.xml
+++ b/l10n/sles/zh-cn/xml/art_jeos_quickstart.xml
@@ -13,12 +13,11 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
           <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-          <dm:component>文档</dm:component>
+          <dm:component>Documentation</dm:component>
           <dm:product>SUSE Linux Enterprise Server 15SP2</dm:product>
           <dm:assignee>dpopov@suse.com</dm:assignee>
         </dm:bugtracker>
-        <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP2/xml/</dm:editurl>
-        <dm:translation>是</dm:translation>
+        <dm:translation>yes</dm:translation>
       </dm:docmanager>
       <abstract>
         <para>

--- a/l10n/sles/zh-cn/xml/art_pcidss.xml
+++ b/l10n/sles/zh-cn/xml/art_pcidss.xml
@@ -21,7 +21,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP2</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP2/xml/</dm:editurl>
    <dm:translation>no</dm:translation>
   </dm:docmanager>
   <!-- abstract: -->

--- a/l10n/sles/zh-cn/xml/art_sles_rpi_quick.xml
+++ b/l10n/sles/zh-cn/xml/art_sles_rpi_quick.xml
@@ -10,7 +10,7 @@
    <dm:bugtracker>
     <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
     <dm:component>Documentation</dm:component>
-    <dm:product>SUSE Linux Enterprise Server 15SP2</dm:product>
+    <dm:product>SUSE Linux Enterprise Server 15 SP2</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
    <dm:translation>yes</dm:translation>

--- a/l10n/sles/zh-cn/xml/art_sles_rpi_quick.xml
+++ b/l10n/sles/zh-cn/xml/art_sles_rpi_quick.xml
@@ -9,12 +9,11 @@
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker>
     <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-    <dm:component>文档</dm:component>
+    <dm:component>Documentation</dm:component>
     <dm:product>SUSE Linux Enterprise Server 15SP2</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP2/xml/</dm:editurl>
-   <dm:translation>是</dm:translation>
+   <dm:translation>yes</dm:translation>
   </dm:docmanager>
       <productname><phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server for Arm</phrase></phrase> <phrase role="productnumber"><phrase os="sles;sled">15 SP2</phrase></phrase></productname>
       <author>

--- a/l10n/sles/zh-tw/xml/MAIN.SLEDS.xml
+++ b/l10n/sles/zh-tw/xml/MAIN.SLEDS.xml
@@ -40,7 +40,6 @@
     <dm:product>SUSE Linux Enterprise Server 15 SP2</dm:product>
     <dm:assignee>fs@suse.com</dm:assignee>
    </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/maintenance/SLE15SP2/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <xi:include href="common_authors.xml"/>


### PR DESCRIPTION
### PR creator: Description

dm:editurls tag removed for all languages of SLE 15 SP2.

Will be done for each branch version separately therefore no backports needed