### PR TITLE
aligned prompts to sudo an added recommendations for ARM64 arcjitecture

### DIFF
--- a/xml/qemu_running_vms_qemukvm.xml
+++ b/xml/qemu_running_vms_qemukvm.xml
@@ -53,10 +53,37 @@
   <tip>
    <title>&aarch64; architecture</title>
    <para>
-    Running &qemu; on the &aarch64; architecture requires you to specify
-    a firmware image file with the <option>-bios</option> option. For example:
+    &kvm; support is available only for 64-bit ARM architecture (&aarch64;).
+    Running &qemu; on the &aarch64; architecture requires you to specify:
    </para>
-<screen>&prompt.user;qemu-system-arm [...] -bios /usr/share/qemu/qemu-uefi-aarch64.bin</screen>
+   <itemizedlist>
+    <listitem>
+     <para>
+      A firmware image file using the <option>-bios</option> option.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      A CPU type with the same features as the host machine using the
+      <option>-cpu</option> option.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      A generic machine type designed for use in virtual machines using the
+      <option>-machine</option> option.
+     </para>
+    </listitem>
+   </itemizedlist>
+   <para>
+    For example:
+   </para>
+<screen>
+&prompt.sudo;qemu-system-aarch64 [...] \
+ -bios /usr/share/qemu/qemu-uefi-aarch64.bin \
+ -cpu host \
+ -machine virt
+</screen>
   </tip>
  </sect1>
  <sect1 xml:id="cha-qemu-running-gen-opts">
@@ -217,7 +244,7 @@
      The following is an example of a working
      <command>qemu-system-ARCH</command> command line:
     </para>
-<screen>&prompt.user;qemu-system-x86_64 -name "SLES 12 SP2" -M pc-i440fx-2.7 -m 512 \
+<screen>&prompt.sudo;qemu-system-x86_64 -name "SLES 12 SP2" -M pc-i440fx-2.7 -m 512 \
 -machine accel=kvm -cpu kvm64 -smp 2 -drive format=raw,file=/images/sles.raw</screen>
     <figure>
      <title>&qemu; window with SLES as &vmguest;</title>
@@ -280,7 +307,7 @@
        file. It can be consequently re-used with the
        <literal>-readconfig</literal> option.
       </para>
-<screen>&prompt.user;qemu-system-x86_64 -name "SLES 12 SP2" -machine accel=kvm -M pc-i440fx-2.7 -m 512 -cpu kvm64 \
+<screen>&prompt.sudo;qemu-system-x86_64 -name "SLES 12 SP2" -machine accel=kvm -M pc-i440fx-2.7 -m 512 -cpu kvm64 \
 -smp 2 /images/sles.raw -writeconfig /images/sles.cfg
 (exited)
 &prompt.user;cat /images/sles.cfg
@@ -321,7 +348,7 @@
        You can also specify the initial time of the &vmguest;'s clock with the
        <literal>base</literal> option:
       </para>
-<screen>&prompt.user;qemu-system-x86_64 [...] -rtc clock=vm,base=2010-12-03T01:02:00</screen>
+<screen>&prompt.sudo;qemu-system-x86_64 [...] -rtc clock=vm,base=2010-12-03T01:02:00</screen>
       <para>
        Instead of a time stamp, you can specify <literal>utc</literal> or
        <literal>localtime</literal>. The former instructs &vmguest; to start at
@@ -546,7 +573,7 @@
      single IOThread with ID <literal>iothread0</literal> which is then used
      as the event loop for two virtio-blk devices.
     </para>
-<screen>&prompt.user;qemu-system-x86_64 [...] -object iothread,id=iothread0\
+<screen>&prompt.sudo;qemu-system-x86_64 [...] -object iothread,id=iothread0\
 -drive if=none,id=drive0,cache=none,aio=native,\
 format=raw,file=filename -device virtio-blk-pci,drive=drive0,scsi=off,\
 iothread=iothread0 -drive if=none,id=drive1,cache=none,aio=native,\
@@ -556,7 +583,7 @@ iothread=iothread0 [...]</screen>
       The following qemu command line example illustrates a 1:1 virtio device
       to IOThread mapping:
     </para>
-<screen>&prompt.user;qemu-system-x86_64 [...] -object iothread,id=iothread0\
+<screen>&prompt.sudo;qemu-system-x86_64 [...] -object iothread,id=iothread0\
 -object iothread,id=iothread1 -drive if=none,id=drive0,cache=none,aio=native,\
 format=raw,file=filename -device virtio-blk-pci,drive=drive0,scsi=off,\
 iothread=iothread0 -drive if=none,id=drive1,cache=none,aio=native,\
@@ -826,7 +853,7 @@ based iSCSI:
         useful shortcuts, for example, to toggle between the console and the
         &qemu; monitor.
        </para>
-<screen>&prompt.user;qemu-system-x86_64 -hda /images/sles_base.raw -nographic
+<screen>&prompt.sudo;qemu-system-x86_64 -hda /images/sles_base.raw -nographic
 
 C-a h    print this help
 C-a x    exit emulator
@@ -920,7 +947,7 @@ QEMU 2.3.1 monitor - type 'help' for more information
         <literal>format</literal> option is used rather than detecting the
         format.
        </para>
-<screen>&prompt.user;qemu-system-x86_64 [...] -usbdevice
+<screen>&prompt.sudo;qemu-system-x86_64 [...] -usbdevice
         disk:format=raw:/virt/usb_disk.raw</screen>
       </listitem>
      </varlistentry>
@@ -1832,7 +1859,7 @@ sudo tunctl -d $tap<co xml:id="co-qemu-net-bridge-deltap"/></screen>
    An example VNC usage:
   </para>
 
-<screen>&prompt.user;qemu-system-x86_64 [...] -vnc :5
+<screen>&prompt.sudo;qemu-system-x86_64 [...] -vnc :5
 # (on the client:)
 &prompt.user2;vncviewer &wsII;:5 &amp;</screen>
 

--- a/xml/qemu_running_vms_qemukvm.xml
+++ b/xml/qemu_running_vms_qemukvm.xml
@@ -50,7 +50,7 @@
     </para>
    </callout>
   </calloutlist>
-  <tip>
+  <important>
    <title>&aarch64; architecture</title>
    <para>
     &kvm; support is available only for 64-bit ARM architecture (&aarch64;).
@@ -61,17 +61,38 @@
      <para>
       A firmware image file using the <option>-bios</option> option.
      </para>
+     <tip>
+      <para>
+       You can specify the firmware image files alternatively using the
+       <option>-drive</option> options, for example:
+      </para>
+<screen>
+-drive file=/usr/share/edk2/aarch64/QEMU_EFI-pflash.raw,if=pflash,format=raw
+-drive file=/var/lib/libvirt/qemu/nvram/opensuse_VARS.fd,if=pflash,format=raw
+</screen>
+     </tip>
     </listitem>
     <listitem>
      <para>
-      A CPU type with the same features as the host machine using the
-      <option>-cpu</option> option.
+      A CPU of the &vmhost; using the <option>-cpu host</option> option.
      </para>
     </listitem>
     <listitem>
      <para>
-      A generic machine type designed for use in virtual machines using the
-      <option>-machine</option> option.
+      A machine type designed for &qemu; ARM virtual machines using the
+      <option>-machine virt-<replaceable>VERSION_NUMBER</replaceable></option>
+      option.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      The same Generic Interrupt Controller (GIC) version as the host using
+      the <option>-machine gic-version=host</option> option.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      A graphic device of type <literal>virtio-gpu-pci</literal>.
      </para>
     </listitem>
    </itemizedlist>
@@ -82,9 +103,10 @@
 &prompt.sudo;qemu-system-aarch64 [...] \
  -bios /usr/share/qemu/qemu-uefi-aarch64.bin \
  -cpu host \
- -machine virt
+ -device virtio-gpu-pci \
+ -machine virt,accel=kvm,gic-version=host
 </screen>
-  </tip>
+  </important>
  </sect1>
  <sect1 xml:id="cha-qemu-running-gen-opts">
   <title>General <command>qemu-system-ARCH</command> options</title>

--- a/xml/qemu_running_vms_qemukvm.xml
+++ b/xml/qemu_running_vms_qemukvm.xml
@@ -59,6 +59,13 @@
    <itemizedlist>
     <listitem>
      <para>
+      A machine type designed for &qemu; ARM virtual machines using the
+      <option>-machine virt-<replaceable>VERSION_NUMBER</replaceable></option>
+      option.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
       A firmware image file using the <option>-bios</option> option.
      </para>
      <tip>
@@ -74,25 +81,21 @@
     </listitem>
     <listitem>
      <para>
-      A CPU of the &vmhost; using the <option>-cpu host</option> option.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      A machine type designed for &qemu; ARM virtual machines using the
-      <option>-machine virt-<replaceable>VERSION_NUMBER</replaceable></option>
-      option.
+      A CPU of the &vmhost; using the <option>-cpu host</option> option
+      (default is <option>cortex-15</option>).
      </para>
     </listitem>
     <listitem>
      <para>
       The same Generic Interrupt Controller (GIC) version as the host using
-      the <option>-machine gic-version=host</option> option.
+      the <option>-machine gic-version=host</option> option (default is
+      <option>2</option>).
      </para>
     </listitem>
     <listitem>
      <para>
-      A graphic device of type <literal>virtio-gpu-pci</literal>.
+      If a graphic mode is needed, a graphic device of type
+      <literal>virtio-gpu-pci</literal>.
      </para>
     </listitem>
    </itemizedlist>


### PR DESCRIPTION
### PR creator: Description

Aligned prompts to use `sudo` + make preconditions to run qemu on ARM64 architecture more clear.
Rendered PDF is attached 
[cha-qemu-running-basic_color_en.pdf](https://github.com/SUSE/doc-sle/files/7562656/cha-qemu-running-basic_color_en.pdf)



### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
