### PR TITLE
Remove mention of SLED

### DIFF
--- a/xml/libvirt_management_vagrant.xml
+++ b/xml/libvirt_management_vagrant.xml
@@ -85,7 +85,7 @@
       <para>
        &suse; provides official &vagrant; Boxes for &sle; using the
        &virtualbox; and &libvirt;  providers. &sls; boxes are available for the
-       &x86-64; and &aarch64; architectures, &sled; only for &x86-64;.
+       &x86-64; and &aarch64; architectures.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
### PR creator: Description

We no longer ship SLED vagrant boxes.


### PR creator: Are there any relevant issues/feature requests?



### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
