### PR TITLE
Removed obsolete link pointing to non-existent SDN whitepaper

### DIFF
--- a/xml/net_sdn.xml
+++ b/xml/net_sdn.xml
@@ -544,27 +544,11 @@ BOOTPROTO='none'</screen>
  </sect2>
 
  <sect2 xml:id="sec-network-openvswitch-more">
-  <title>More information</title>
-  <variablelist>
-   <varlistentry>
-    <term><link xlink:href="https://docs.openvswitch.org/en/latest/#documentation"/>
-    </term>
-    <listitem>
-     <para>
-      The documentation section of the &ovs; project Web site
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><link xlink:href="https://www.opennetworking.org/images/stories/downloads/sdn-resources/white-papers/wp-sdn-newnorm.pdf"/>
-    </term>
-    <listitem>
-     <para>
-      Whitepaper by the Open Networking Foundation about software-defined
-      networking and the <phrase role="productname">OpenFlow</phrase> protocol
-     </para>
-    </listitem>
-   </varlistentry>
-  </variablelist>
+   <title>More information</title>
+
+   <para>
+     For more information on SDN, refer to the documentation section of the
+     &ovs; project Web site at <link xlink:href="https://docs.openvswitch.org/en/latest/#documentation"/>.
+   </para>
  </sect2>
 </sect1>


### PR DESCRIPTION
### PR creator: Description

Removed non-existent link and killed single item itemized list.


### PR creator: Are there any relevant issues/feature requests?


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4
  - [x] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
