### PR TITLE
AutoYaST: Add helpers for detecting EFI boot (jsc#SLE-18819)

### DIFF
--- a/xml/ay_erb_templates.xml
+++ b/xml/ay_erb_templates.xml
@@ -465,5 +465,24 @@ xml:id="erb-templates">
 &lt;/products&gt;</screen>
    </example>
   </sect2>
+  <sect2 xml:id="erb-boot-efi-helper">
+   <title><literal>boot_efi?</literal></title>
+   <para>
+     The <literal>boot_efi?</literal> helper returns true when it is detected 
+     that the system was booted using EFI and false otherwise.
+   </para>
+   <example>
+    <title>Select the loader type depending on the EFI boot</title>
+<screen>&lt;bootloader&gt;
+  &lt;loader_type&gt;
+    &lt;% if boot_efi? %&gt;
+      grub2-efi
+    &lt;% else %&gt;
+      grub2
+    &lt;% end %&gt;
+  &lt;/loader_type&gt;
+&lt;/bootloader&gt;</screen>
+   </example>
+  </sect2>
  </sect1>
 </chapter>

--- a/xml/ay_rules_classes.xml
+++ b/xml/ay_rules_classes.xml
@@ -762,6 +762,23 @@ fi;
       <row>
        <entry>
         <para>
+         <literal>efi</literal>
+        </para>
+       </entry>
+       <entry>
+        <para>
+         EFI boot detected (yes or no)
+        </para>
+       </entry>
+       <entry>
+        <para>
+         Exact match required
+        </para>
+       </entry>
+      </row>
+      <row>
+       <entry>
+        <para>
          <literal>custom1-5</literal>
         </para>
        </entry>


### PR DESCRIPTION
### PR creator: Description

We have introduced a new **AutoYaST rules schema element** for detecting a **EFI boot** as well as a **ERB template helper** which needs to be documented.

More information can be found here https://jira.suse.com/browse/SLE-20219 or in the implementation [PR](https://github.com/yast/yast-autoinstallation/pull/808) itself

### PR creator: Are there any relevant issues/feature requests?

* [jsc#SLE-18819](https://jira.suse.com/browse/SLE-18819)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [X] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
