### PR TITLE
consistency using the wild card concept

### DIFF
--- a/xml/newbie_bash.xml
+++ b/xml/newbie_bash.xml
@@ -1105,7 +1105,7 @@ drwxr-xr-x 1 tux users  70733 2015-06-21 09:35 public_html
   </variablelist>
 
   <sect2 xml:id="sec-new-bash-feat-ex">
-   <title>Examples for using history, completion and wildcards</title>
+   <title>Examples for using history, completion and wild cards</title>
    <para>
     The following examples illustrate how to make use of these convenient
     features of Bash.
@@ -1169,7 +1169,7 @@ Desktop/ Documents/ Downloads/
     </step>
    </procedure>
    <procedure>
-    <title>Using wildcards</title>
+    <title>Using wild cards</title>
     <para>
      Now suppose that your home directory contains several files with
      various file extensions. It also holds several versions of one file
@@ -1287,12 +1287,12 @@ Desktop/ Documents/ Downloads/
     files with the extension <filename>.txt</filename> available.
    </para>
    <note>
-    <title>Using wildcards in <command>rm</command> commands</title>
+    <title>Using wild cards in <command>rm</command> commands</title>
     <para>
-     Wildcards in a <command>rm </command> command can be very useful but
+     Wild cards in a <command>rm </command> command can be very useful but
      also dangerous: you might delete more files from your directory than
      intended. To see which files would be affected by the
-     <command>rm</command>, run your wildcard string with
+     <command>rm</command>, run your wild card string with
      <command>ls</command> instead of <command>rm</command> first.
     </para>
    </note>


### PR DESCRIPTION
Since I'm not native English speaker and  mostly is used the term "wild card" in the document I send this PR to fix that. I prefer the term "wildcard".

### PR creator: Description

Fix consistency using the term "wild card" over "wildcard"


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [X] SLE 15 SP3/openSUSE Leap 15.3
  - [X] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
