### PR TITLE
Xen limits improvements

### DIFF
--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -76,8 +76,8 @@
     <para>
      &arm64; is a continuously evolving platform. It does not have a
      traditional standards and compliance certification program to enable
-     interoperability with operating systems and hypervisors. Ask your
-     vendor for the support statement on &sls;.
+     interoperability with operating systems and hypervisors. Ask your vendor
+     for the support statement on &sls;.
     </para>
    </note>
    <note os="sles">
@@ -108,7 +108,7 @@
   <para>
    Only packages that are part of the official repositories for &sls; are
    supported. Conversely, all optional subpackages and plug-ins (for &qemu;,
-   &libvirt;) provided at 
+   &libvirt;) provided at
    <link xmlns:xlink="http://www.w3.org/1999/xlink"
      xlink:href="https://packagehub.suse.com/">packagehub</link>
    are not supported.
@@ -181,8 +181,8 @@
      <listitem>
       <para>
        <emphasis>Maximum virtual CPUs per VM</emphasis>: See recommendations in
-       the <citetitle>Virtualization Best Practices Guide</citetitle> regarding over-commitment of
-       physical CPUs at
+       the <citetitle>Virtualization Best Practices Guide</citetitle> regarding
+       over-commitment of physical CPUs at
        <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/article-virtualization-best-practices.html#sec-vt-best-perf-cpu-assign"/>.
        The total virtual CPUs should be proportional to the available physical
        CPUs.
@@ -350,7 +350,7 @@
 
   <itemizedlist>
    <title>The following third-party host environments are supported</title>
-   <!-- better refer to the appropriate website instead of providing the exact version which is always moving... -->
+<!-- better refer to the appropriate website instead of providing the exact version which is always moving... -->
    <listitem>
     <para>
      <link xlink:href="https://xenserver.org/">Citrix XenServer</link>
@@ -510,8 +510,9 @@
    <listitem>
     <para>
      All guest operating systems are supported both fully virtualized and
-     paravirtualized. The exception is Windows systems, which are only supported
-     fully virtualized (but they can use PV drivers: <link
+     paravirtualized. The exception is Windows systems, which are only
+     supported fully virtualized (but they can use PV drivers:
+     <link
      xlink:href="https://www.suse.com/products/vmdriverpack/"/>),
      and OES operating systems, which are supported only paravirtualized.
     </para>
@@ -1263,9 +1264,9 @@
       <para>
        &suse; strives to support live migration of virtual machines from a host
        running a service pack under LTSS to a host running a newer service
-       pack, within the same major version of &sls;. For example, virtual machine
-       migration from a SLES 12 SP2 host to a SLES 12 SP5 host. &suse; only
-       performs minimal testing of LTSS-to-newer migration scenarios and
+       pack, within the same major version of &sls;. For example, virtual
+       machine migration from a SLES 12 SP2 host to a SLES 12 SP5 host. &suse;
+       only performs minimal testing of LTSS-to-newer migration scenarios and
        recommends thorough on-site testing before attempting to migrate
        critical virtual machines.
       </para>
@@ -1814,9 +1815,9 @@
    is mostly used for testing purposes. In &sls;, nested virtualization is a
    Technology Preview. It is only provided for testing purposes and is not
    supported. Bugs can be reported but they will be treated with low priority.
-   Any attempt to live-migrate or to save or restore VMs in the presence of nested
-   virtualization is also explicitly unsupported.
+   Any attempt to live-migrate or to save or restore VMs in the presence of
+   nested virtualization is also explicitly unsupported.
   </para>
  </sect1>
- <!-- End X86_64 only -->
+<!-- End X86_64 only -->
 </chapter>

--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -551,8 +551,8 @@
     </listitem>
     <listitem>
      <para>
-      The <package>kernel-default+xen-kmp</package> on HVM domU  was replaced
-      by <package>kernel-default</package>.
+      The <package>kernel-default+xen-kmp</package> on HVM domU was replaced by
+      <package>kernel-default</package>.
      </para>
     </listitem>
    </itemizedlist>

--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -208,7 +208,8 @@
        </entry>
        <entry>
         <para>
-         128 (HVM), 64 (HVM Windows guest) or 512 (PV)
+         32 (general HVM recommendation), 64 (HVM Windows guest), 128 (trusted
+         HVMs), or 512 (PV)
         </para>
        </entry>
       </row>
@@ -269,7 +270,7 @@
        </entry>
        <entry>
         <para>
-         16&nbsp;TiB
+         Recommendation is to stay below the 16&nbsp;TiB address boundary.
         </para>
        </entry>
       </row>
@@ -528,8 +529,41 @@
    <para>
     To improve the performance of the guest operating system, paravirtualized
     drivers are provided when available. Although they are not required, it is
-    strongly recommended to use them. The paravirtualized drivers are available
-    as follows:
+    strongly recommended to use them.
+   </para>
+   <para>
+    Starting with &sls; 12 SP2, we switched to a PVops kernel. We are no longer
+    using a dedicated <package>kernel-xen</package> package:
+   </para>
+   <itemizedlist>
+    <listitem>
+     <para>
+      The <package>kernel-default+kernel-xen</package> on dom0 was replaced by
+      the <package>kernel-default</package> package.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      The <package>kernel-xen</package> package on PV domU was replaced by the
+      <package>kernel-default</package> package.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      The <package>kernel-default+xen-kmp</package> on HVM domU  was replaced
+      by <package>kernel-default</package>.
+     </para>
+    </listitem>
+   </itemizedlist>
+   <para>
+    Dom0 toolstack still loads all back-end drivers.
+   </para>
+   <para>
+    For &sls; 12 SP1 and older (down to 10 SP4), the paravirtualized drivers
+    are included in a dedicated <package>kernel-xen</package> package.
+   </para>
+   <para>
+    The paravirtualized drivers are available as follows:
    </para>
    <variablelist>
     <varlistentry os="osuse">
@@ -585,19 +619,6 @@
      </listitem>
     </varlistentry>
    </variablelist>
-   <note>
-    <title>PVops kernel</title>
-    <para>
-     Starting from &sls; 12 SP2, we switched to a PVops kernel. We are no longer
-     using a dedicated <package>kernel-xen</package> package. Dom0
-     <package>kernel-default+kernel-xen</package> was replaced with
-     <package>kernel-default</package>, domU PV <package>kernel-xen</package>
-     was replaced by <package>kernel-default</package>, domU
-     HVM <package>kernel-default+xen-kmp</package> was replaced by
-     <package>kernel-default</package>. The dom0 toolstack still loads all back-end
-     drivers.
-    </para>
-   </note>
   </sect2>
  </sect1>
  <sect1 xml:id="virt-migration-support">

--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -557,9 +557,6 @@
     </listitem>
    </itemizedlist>
    <para>
-    Dom0 toolstack still loads all back-end drivers.
-   </para>
-   <para>
     For &sls; 12 SP1 and older (down to 10 SP4), the paravirtualized drivers
     are included in a dedicated <package>kernel-xen</package> package.
    </para>


### PR DESCRIPTION
### PR creator: Description

There is a space for improvements in the Xen limits specifications. This update tries to squeeze this space :-)

Rendered PDF is attached 
[cha-virt-support_color_en.pdf](https://github.com/SUSE/doc-sle/files/7588399/cha-virt-support_color_en.pdf)



### PR creator: Are there any relevant issues/feature requests?

* bsc#1192256


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
