### PR TITLE
Commented out reference to missing figure virt-disk-cache.png

### DIFF
--- a/xml/vt_cachemodes.xml
+++ b/xml/vt_cachemodes.xml
@@ -34,6 +34,7 @@
    disk.
   </para>
 
+  <!-- commenting out because the image is missing. cjs 1 December 2021
   <figure xml:id="fig-caching">
    <title>Caching mechanism</title>
    <mediaobject>
@@ -44,7 +45,7 @@
      <imagedata fileref="virt-disk-cache.png" width="85%"/>
     </imageobject>
    </mediaobject>
-  </figure>
+  </figure> -->
  </sect1>
  <sect1 xml:id="benefits-disk-cache">
   <title>Benefits of disk caching</title>


### PR DESCRIPTION
### PR creator: Description

virt-disk-cache.png is missing, causing validation failures. I commented out the <figure/> reference in vt_cachemodes.xml

@tbazant see https://github.com/SUSE/doc-sle/pull/1023

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
