### PR TITLE
testing validation failures

### DIFF
--- a/xml/vt_cachemodes.xml
+++ b/xml/vt_cachemodes.xml
@@ -46,6 +46,7 @@
    </mediaobject>
   </figure>
  </sect1>
+ 
  <sect1 xml:id="benefits-disk-cache">
   <title>Benefits of disk caching</title>
 

--- a/xml/vt_cachemodes.xml
+++ b/xml/vt_cachemodes.xml
@@ -34,6 +34,7 @@
    disk.
   </para>
 
+  <!-- commenting out because validation failure "Fatal error: The following images are missing: virt-disk-cache" cjs Dec 1 2021"
   <figure xml:id="fig-caching">
    <title>Caching mechanism</title>
    <mediaobject>
@@ -44,7 +45,7 @@
      <imagedata fileref="virt-disk-cache.png" width="85%"/>
     </imageobject>
    </mediaobject>
-  </figure>
+  </figure> -->
  </sect1>
  
  <sect1 xml:id="benefits-disk-cache">


### PR DESCRIPTION
### PR creator: Description
Validation fails with "Fatal error: The following images are missing:
virt-disk-cache". Commenting out the <figure/> stanza clears the error.

@sknorr @tbazant I reverted my revert, and got the same errors. Created a new branch to test, still the same error. Commented out the ditaa figure stanza, no validation errors.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
