### PR TITLE
Document new automatic patch retraction, which removes buggy patches with no user intervention

### DIFF
--- a/xml/zypper.xml
+++ b/xml/zypper.xml
@@ -608,21 +608,51 @@ Reading installed packages...
       <term>List retracted patches</term>
       <listitem>
         <para>
-          Starting with &sle;&nbsp;15.2, some patches are automatically 
+          In the &sle;&nbsp;15 codestream, some patches are automatically 
           retracted. Maintenance updates are carefully tested, because there 
           is a risk that an update contains a new bug. If an update proves to
           contain a bug, a new update (with a higher version number) is 
-          issued to replace the buggy update, and the buggy update is blocked 
+          issued to revert the buggy update, and the buggy update is blocked 
           from being installed again. You can list retracted patches with
           <command>zypper</command>:
         </para>
-        <screen>&prompt.user;<command>zypper lr --all |grep retracted</command>
+        <screen>&prompt.user;<command>zypper lp --all |grep retracted</command>
 SLE-Module-Basesystem15-SP3-Updates | SUSE-SLE-Module-Basesystem-15-SP3-2021-1965 
  | recommended | important | ---    | retracted  | Recommended update for multipath-tools 
 SLE-Module-Basesystem15-SP3-Updates | SUSE-SLE-Module-Basesystem-15-SP3-2021-2689 
  | security    | important | ---    | retracted  | Security update for cpio
 SLE-Module-Basesystem15-SP3-Updates | SUSE-SLE-Module-Basesystem-15-SP3-2021-3655 
- | security    | important | reboot | retracted  | Security update for the Linux Kernel</screen>      
+ | security    | important | reboot | retracted  | Security update for the Linux Kernel</screen> 
+        <para>
+          See complete information on a retracted (or any) patch:
+        </para>
+        <screen>&prompt.user;<command>zypper patch-info SUSE-SLE-Product-SLES-15-2021-2689</command>
+Loading repository data...
+Reading installed packages...
+
+Information for patch SUSE-SLE-Product-SLES-15-2021-2689:
+---------------------------------------------------------
+Repository  : SLE-Product-SLES15-LTSS-Updates
+Name        : SUSE-SLE-Product-SLES-15-2021-2689
+Version     : 1
+Arch        : noarch
+Vendor      : maint-coord@suse.de
+Status      : retracted
+Category    : security
+Severity    : important
+Created On  : Mon 16 Aug 2021 03:44:00 AM PDT
+Interactive : ---
+Summary     : Security update for cpio
+Description : 
+    This update for cpio fixes the following issues:
+
+    It was possible to trigger Remote code execution due to a integer overflow 
+    (CVE-2021-38185, bsc#1189206)
+
+    UPDATE:
+    This update was buggy and could lead to hangs, so it has been retracted. 
+    There will be a follow up update.
+    [...]</screen>   
       </listitem>
      </varlistentry>
     </variablelist>

--- a/xml/zypper.xml
+++ b/xml/zypper.xml
@@ -484,7 +484,6 @@ Zypper subcommands available from elsewhere on your $PATH
     use the <literal>with-update</literal> command option as follows:
    </para>
 <screen>&prompt.sudo;zypper patch --with-update</screen>
-<!--taroth 2016-07-04: fate#320447-->
    <para>
     To install also optional patches, use:
    </para>
@@ -605,7 +604,28 @@ Reading installed packages...
 <screen>&prompt.user;zypper list-patches --bugzilla=CVE-2016-2315,CVE-2016-2324</screen>
      </listitem>
     </varlistentry>
-   </variablelist>
+    <varlistentry>
+      <term>List retracted patches</term>
+      <listitem>
+        <para>
+          Starting with &sle;&nbsp;15.2, some patches are automatically 
+          retracted. Maintenance updates are carefully tested, because there 
+          is a risk that an update contains a new bug. If an update proves to
+          contain a bug, a new update (with a higher version number) is 
+          issued to replace the buggy update, and the buggy update is blocked 
+          from being installed again. You can list retracted patches with
+          <command>zypper</command>:
+        </para>
+        <screen>&prompt.user;<command>zypper lr --all |grep retracted</command>
+SLE-Module-Basesystem15-SP3-Updates | SUSE-SLE-Module-Basesystem-15-SP3-2021-1965 
+ | recommended | important | ---    | retracted  | Recommended update for multipath-tools 
+SLE-Module-Basesystem15-SP3-Updates | SUSE-SLE-Module-Basesystem-15-SP3-2021-2689 
+ | security    | important | ---    | retracted  | Security update for cpio
+SLE-Module-Basesystem15-SP3-Updates | SUSE-SLE-Module-Basesystem-15-SP3-2021-3655 
+ | security    | important | reboot | retracted  | Security update for the Linux Kernel</screen>      
+      </listitem>
+     </varlistentry>
+    </variablelist>
    <para>
     To list all patches regardless of whether they are needed, use the option
     <option>--all</option> additionally. For example, to list all patches with


### PR DESCRIPTION
Resolves Jira SLE-8906

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
