### PR TITLE
add l10n links for new image file yast2_retracted_patches.png

### DIFF
--- a/l10n/sled/ar-ar/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sled/ar-ar/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sled/cs-cz/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sled/cs-cz/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sled/de-de/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sled/de-de/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sled/es-es/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sled/es-es/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sled/fr-fr/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sled/fr-fr/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sled/hu-hu/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sled/hu-hu/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sled/it-it/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sled/it-it/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sled/ja-jp/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sled/ja-jp/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sled/ko-kr/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sled/ko-kr/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sled/pl-pl/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sled/pl-pl/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sled/pt-br/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sled/pt-br/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sled/ru-ru/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sled/ru-ru/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sled/zh-cn/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sled/zh-cn/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sled/zh-tw/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sled/zh-tw/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sles/ar-ar/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sles/ar-ar/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sles/cs-cz/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sles/cs-cz/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sles/de-de/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sles/de-de/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sles/es-es/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sles/es-es/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sles/fr-fr/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sles/fr-fr/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sles/hu-hu/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sles/hu-hu/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sles/it-it/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sles/it-it/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sles/ja-jp/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sles/ja-jp/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sles/ko-kr/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sles/ko-kr/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sles/pl-pl/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sles/pl-pl/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sles/pt-br/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sles/pt-br/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sles/ru-ru/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sles/ru-ru/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sles/zh-cn/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sles/zh-cn/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png

--- a/l10n/sles/zh-tw/images/src/png/yast2_retracted_patches.png
+++ b/l10n/sles/zh-tw/images/src/png/yast2_retracted_patches.png
@@ -1,0 +1,1 @@
+../../../../../../images/src/png/yast2_retracted_patches.png


### PR DESCRIPTION

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
