### PR TITLE
Remove '19 Certificate Store' section from Security Guide until it is…

### DIFF
--- a/xml/apps_libreoffice.xml
+++ b/xml/apps_libreoffice.xml
@@ -684,11 +684,12 @@
    <guimenu>Sign Document</guimenu></menuchoice>. Select the certificate you
    want to use for signing, then click <guimenu>OK</guimenu>.
   </para>
-
+ <!-- commented out until "cha-certstore" is updated. cschroder
+   21 December 2021
   <para>
    &productname; allows you to access certificates from the certificate store.
    For more information, refer to <xref linkend="cha-certstore"/>.
-  </para>
+  </para>-->
  </sect1>
 
  <sect1 xml:id="sec-lo-oview-cust">

--- a/xml/book_security.xml
+++ b/xml/book_security.xml
@@ -60,9 +60,12 @@
   <xi:include href="security_yast2_security.xml"/>
   <xi:include href="security_policy_kit.xml"/>
   <xi:include href="security_acls.xml"/>
-  <xi:include href="security_certificatestore.xml"/>
+<!-- this is very outdated, removing until I can rewrite
+  it with updated information cschroder 12 Dec 2021   
+  <xi:include href="security_certificatestore.xml"/>-->
   <xi:include href="security_aide.xml"/>
  </part>
+ 
 
  <part xml:id="part-network-security">
   <title>Network security</title>

--- a/xml/nm.xml
+++ b/xml/nm.xml
@@ -701,11 +701,13 @@ http://www.heise.de/netze/artikel/WLAN-und-LAN-sichern-mit-IEEE-802-1X-und-Radiu
 <!--  <phrase os="sled;osuse">For more information about &gnome; Keyring, refer to
     <xref linkend="cha-gnome-crypto"
     /></phrase>.-->
+ <!-- commented out until "cha-certstore" is updated. cschroder
+   21 December 2021
    <para>
     &nm; can also retrieve its certificates for secure connections (for
     example, encrypted wired, wireless or VPN connections) from the certificate
     store. For more information, refer to <xref linkend="cha-certstore"/>.
-   </para>
+   </para>-->
   </sect2>
   <sect2 xml:id="sec-nm-sec-firewall" os="sles;sled">
    <title>Firewall zones</title>


### PR DESCRIPTION
… updated

Re: Doc Day feedback from engineering


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
