### PR TITLE
Set vm.unprivileged userfaultfd to 1 when doing a live migration (bsc#1191511)

### DIFF
--- a/xml/libvirt_managing.xml
+++ b/xml/libvirt_managing.xml
@@ -977,6 +977,14 @@ Metadata:       yes
     To successfully migrate a &vmguest; to another &vmhost;, the following
     requirements need to be met:
    </para>
+   <important>
+    <para>
+     &kvm; hosts require setting the
+     <varname>unprivileged_userfaultfd</varname> system value to
+     <literal>1</literal> before live migration:
+    </para>
+<screen>&prompt.sudo;sysctl -w vm.unprivileged_userfaultfd=1</screen>
+   </important>
    <itemizedlist>
     <listitem>
      <para>

--- a/xml/libvirt_managing.xml
+++ b/xml/libvirt_managing.xml
@@ -979,9 +979,10 @@ Metadata:       yes
    </para>
    <important>
     <para>
-     &kvm; hosts require setting the
+     For the post-copy type of live migration, &kvm; hosts with kernels version
+     5.11 or newer require setting the
      <varname>unprivileged_userfaultfd</varname> system value to
-     <literal>1</literal> before live migration:
+     <literal>1</literal> before the migration starts:
     </para>
 <screen>&prompt.sudo;sysctl -w vm.unprivileged_userfaultfd=1</screen>
    </important>

--- a/xml/libvirt_managing.xml
+++ b/xml/libvirt_managing.xml
@@ -69,8 +69,7 @@
    </para>
    <variablelist>
     <varlistentry>
-     <term>List all running guests
-     </term>
+     <term>List all running guests</term>
      <listitem>
 <screen>&prompt.user;virsh list</screen>
      </listitem>
@@ -177,15 +176,13 @@
     </para>
     <variablelist>
      <varlistentry>
-      <term>Connect to guest with the ID <literal>8</literal>
-      </term>
+      <term>Connect to guest with the ID <literal>8</literal></term>
       <listitem>
 <screen>&prompt.user;virt-viewer 8</screen>
       </listitem>
      </varlistentry>
      <varlistentry>
-      <term>Connect to the inactive guest named <literal>sles12</literal>; the
-      connection window will open once the guest starts</term>
+      <term>Connect to the inactive guest named <literal>sles12</literal>; the connection window will open once the guest starts</term>
       <listitem>
 <screen>&prompt.user;virt-viewer --wait sles12</screen>
        <para>
@@ -416,7 +413,7 @@
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Resume (a suspended  &vmguest;)</term>
+     <term>Resume (a suspended &vmguest;)</term>
      <listitem>
 <screen>&prompt.user;virsh resume sles12</screen>
      </listitem>
@@ -560,15 +557,13 @@
    </para>
    <variablelist>
     <varlistentry>
-     <term>Save the guest named <literal>opensuse13</literal>
-     </term>
+     <term>Save the guest named <literal>opensuse13</literal></term>
      <listitem>
 <screen>&prompt.user;virsh save opensuse13 /virtual/saves/opensuse13.vmsav</screen>
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term>Save the guest with the ID <literal>37</literal>
-     </term>
+     <term>Save the guest with the ID <literal>37</literal></term>
      <listitem>
 <screen>&prompt.user;virsh save 37 /virtual/saves/opensuse13.vmsave</screen>
      </listitem>
@@ -631,11 +626,11 @@
        made read-only, while a new qcow2 file is created to hold the changes.
        The original file is sometimes called a 'backing' or 'base' file, while
        the new file with all the changes is called an 'overlay' or 'derived'
-       file. External snapshots are useful when performing backups of &vmguest;s.
-       However, external snapshots are not supported by &vmm;, and
-       cannot be deleted by <command>virsh</command> directly.
-       For more information on external snapshots in &qemu;, refer
-       to <xref linkend="cha-qemu-guest-inst-qemu-img-effect"/>.
+       file. External snapshots are useful when performing backups of
+       &vmguest;s. However, external snapshots are not supported by &vmm;, and
+       cannot be deleted by <command>virsh</command> directly. For more
+       information on external snapshots in &qemu;, refer to
+       <xref linkend="cha-qemu-guest-inst-qemu-img-effect"/>.
       </para>
      </listitem>
     </varlistentry>
@@ -887,9 +882,9 @@ Metadata:       yes
    <sect3 xml:id="sec-libvirt-managing-snapshots-virsh-delete">
     <title>Deleting a snapshot</title>
     <para>
-     External snapshots cannot be deleted with <command>virsh</command>.
-     To delete an internal snapshot of a &vmguest; and restore the disk space
-     it occupies, use the <literal>snapshot-delete</literal> command:
+     External snapshots cannot be deleted with <command>virsh</command>. To
+     delete an internal snapshot of a &vmguest; and restore the disk space it
+     occupies, use the <literal>snapshot-delete</literal> command:
     </para>
 <screen>&prompt.user;virsh snapshot-delete --domain admin_server --snapshotname "Snapshot 2"</screen>
    </sect3>
@@ -1025,8 +1020,8 @@ Metadata:       yes
     </listitem>
     <listitem>
      <para>
-      All &vmhost;s participating in migration must have the same UID for
-      the qemu user and the same GIDs for the kvm, qemu, and libvirt groups.
+      All &vmhost;s participating in migration must have the same UID for the
+      qemu user and the same GIDs for the kvm, qemu, and libvirt groups.
      </para>
     </listitem>
     <listitem>
@@ -1098,9 +1093,9 @@ Metadata:       yes
     </listitem>
     <listitem>
      <para>
-      All hosts should be on the same level of microcode (especially the spectre
-      microcode updates). This can be achieved by installing the latest updates
-      of &productname; on all hosts.
+      All hosts should be on the same level of microcode (especially the
+      spectre microcode updates). This can be achieved by installing the latest
+      updates of &productname; on all hosts.
      </para>
     </listitem>
    </itemizedlist>
@@ -1200,8 +1195,7 @@ Metadata:       yes
    </para>
    <variablelist>
     <varlistentry>
-     <term><option>--live</option>
-     </term>
+     <term><option>--live</option></term>
      <listitem>
       <para>
        Does a live migration. If not specified, the guest will be paused during
@@ -1210,8 +1204,7 @@ Metadata:       yes
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><option>--suspend</option>
-     </term>
+     <term><option>--suspend</option></term>
      <listitem>
       <para>
        Does an offline migration and does not restart the &vmguest; on the
@@ -1220,8 +1213,7 @@ Metadata:       yes
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><option>--persistent</option>
-     </term>
+     <term><option>--persistent</option></term>
      <listitem>
       <para>
        By default a migrated &vmguest; will be migrated temporarily, so its
@@ -1231,8 +1223,7 @@ Metadata:       yes
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><option>--undefinesource</option>
-     </term>
+     <term><option>--undefinesource</option></term>
      <listitem>
       <para>
        When specified, the &vmguest; definition on the source host will be
@@ -1247,10 +1238,10 @@ Metadata:       yes
       <para>
        Parallel migration can be used to increase migration data throughput in
        cases where a single migration thread is not capable of saturating the
-       network link between source and destination hosts. On hosts with 40&nbsp;GB
-       network interfaces, it may require four migration threads to saturate the
-       link. With parallel migration, the time required to migrate large memory
-       VMs can be significantly reduced.
+       network link between source and destination hosts. On hosts with
+       40&nbsp;GB network interfaces, it may require four migration threads to
+       saturate the link. With parallel migration, the time required to migrate
+       large memory VMs can be significantly reduced.
       </para>
      </listitem>
     </varlistentry>
@@ -1562,16 +1553,12 @@ CPU: 6.1%  Mem: 3072 MB (3072 MB by guests)
     By default the output is sorted by ID. Use the following key combinations
     to change the sort field:
    </para>
-   <simplelist>
-    <member><keycombo><keycap function="shift"/><keycap>P</keycap></keycombo>: CPU
+   <simplelist><member><keycombo><keycap function="shift"/><keycap>P</keycap></keycombo>: CPU
      usage
-    </member>
-    <member><keycombo><keycap function="shift"/><keycap>M</keycap></keycombo>:
+    </member><member><keycombo><keycap function="shift"/><keycap>M</keycap></keycombo>:
      Total memory allocated by the guest
-    </member>
-    <member><keycombo><keycap function="shift"/><keycap>T</keycap></keycombo>: Time
-    </member>
-    <member><keycombo><keycap function="shift"/><keycap>I</keycap></keycombo>: ID
+    </member><member><keycombo><keycap function="shift"/><keycap>T</keycap></keycombo>: Time
+    </member><member><keycombo><keycap function="shift"/><keycap>I</keycap></keycombo>: ID
     </member>
    </simplelist>
    <para>
@@ -1586,11 +1573,7 @@ CPU: 6.1%  Mem: 3072 MB (3072 MB by guests)
     <command>virt-top</command> also supports different views on the &vmguest;s
     data, which can be changed on-the-fly by pressing the following keys:
    </para>
-   <simplelist>
-    <member><keycap>0</keycap>: default view</member>
-    <member><keycap>1</keycap>: show physical CPUs</member>
-    <member><keycap>2</keycap>: show network interfaces</member>
-    <member><keycap>3</keycap>: show virtual disks</member>
+   <simplelist><member><keycap>0</keycap>: default view</member><member><keycap>1</keycap>: show physical CPUs</member><member><keycap>2</keycap>: show network interfaces</member><member><keycap>3</keycap>: show virtual disks</member>
    </simplelist>
    <para>
     <command>virt-top</command> supports more hot keys to change the view of


### PR DESCRIPTION
### PR creator: Description

SLES 15 SP4 has changed the behavior of live guest migrations. KVM hosts need to be adjusted so tthat the migration suceeds.
Rendered PDF of the section is attached 
[sec-libvirt-admin-migrate_color_en.pdf](https://github.com/SUSE/doc-sle/files/7762825/sec-libvirt-admin-migrate_color_en.pdf)




### PR creator: Are there any relevant issues/feature requests?

* bsc#1191511


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
