### PR TITLE
Replaced 'Y' with '1' for the KVM's 'nested' boot parameter (bsc#1194040)

### DIFF
--- a/xml/vt_installation.xml
+++ b/xml/vt_installation.xml
@@ -421,14 +421,14 @@
      For Intel CPUs, edit <filename>/etc/modprobe.d/kvm_intel.conf</filename>
      and add the following line:
     </para>
-    <screen>options kvm_intel nested=Y</screen>
+    <screen>options kvm_intel nested=1</screen>
    </listitem>
    <listitem>
     <para>
      For AMD CPUs, edit <filename>/etc/modprobe.d/kvm_amd.conf</filename> and
      add the following line:
     </para>
-    <screen>options kvm_amd nested=Y</screen>
+    <screen>options kvm_amd nested=1</screen>
    </listitem>
   </itemizedlist>
 


### PR DESCRIPTION
### PR creator: Description

This update fixes wrong value used for the `nested` parameter.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1194040


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
