### PR TITLE
add note (bsc#1194343, bsc#1193785)

### DIFF
--- a/xml/storage_multipath.xml
+++ b/xml/storage_multipath.xml
@@ -4284,6 +4284,16 @@ multipaths {
      </para>
     </listitem>
    </itemizedlist>
+   <note>
+    <title>Using <command>iostat</command> in multipath setups</title>
+    <para>
+     In multipath environments, the <command>iostat</command> command might
+     lead to unexpected results. By default, <command>iostat</command>
+     filters out all block devices with no I/O. To make <command>iostat</command>
+     show <emphasis>all</emphasis> devices, use:
+    </para>
+    <screen>iostat -p ALL</screen>
+   </note>
   </sect2>
 
   <sect2 xml:id="sec-multipath-best-practice-io-error">

--- a/xml/storage_nvmeof.xml
+++ b/xml/storage_nvmeof.xml
@@ -209,19 +209,13 @@
    <note>
     <title>Using <command>iostat</command> in multipath setups</title>
     <para>
-     If you use the <command>iostat</command> command, it does not list all
+     If you use the <command>iostat</command> command, it might not list all
      controllers that are listed by <command>nvme list-subsys</command>.
      By default, <command>iostat</command> filters out all block devices
      with no I/O, therefore not all paths in an &nvmeof; are shown. To
-     show all devices instead use:
+     show <emphasis>all</emphasis> devices instead use:
     </para>
     <screen>iostat -p ALL</screen>
-    <para>
-     When &nvme; native multipathing is enabled, the I/O path selector
-     chooses which paths are used according to the policy settings. With
-     NUMA (the default I/O path selector in the &nvme; subsystem) not all
-     paths will be used.
-    </para>
    </note>
   </sect2>
  </sect1>

--- a/xml/storage_nvmeof.xml
+++ b/xml/storage_nvmeof.xml
@@ -212,7 +212,7 @@
      If you use the <command>iostat</command> command, it might not list all
      controllers that are listed by <command>nvme list-subsys</command>.
      By default, <command>iostat</command> filters out all block devices
-     with no I/O, therefore not all paths in an &nvmeof; are shown. To
+     with no I/O, therefore not all paths in an &nvmeof; might be shown. To
      show <emphasis>all</emphasis> devices instead use:
     </para>
     <screen>iostat -p ALL</screen>

--- a/xml/storage_nvmeof.xml
+++ b/xml/storage_nvmeof.xml
@@ -206,6 +206,23 @@
      </listitem>
     </varlistentry>
    </variablelist>
+   <note>
+    <title>Using <command>iostat</command> in multipath setups</title>
+    <para>
+     If you use the <command>iostat</command> command, it does not list all
+     controllers that are listed by <command>nvme list-subsys</command>.
+     By default, <command>iostat</command> filters out all block devices
+     with no I/O, therefore not all paths in an &nvmeof; are shown. To
+     show all devices instead use:
+    </para>
+    <screen>iostat -p ALL</screen>
+    <para>
+     When &nvme; native multipathing is enabled, the I/O path selector
+     chooses which paths are used according to the policy settings. With
+     NUMA (the default I/O path selector in the &nvme; subsystem) not all
+     paths will be used.
+    </para>
+   </note>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-nvmeof-target-configuration">

--- a/xml/storage_nvmeof.xml
+++ b/xml/storage_nvmeof.xml
@@ -209,11 +209,11 @@
    <note>
     <title>Using <command>iostat</command> in multipath setups</title>
     <para>
-     If you use the <command>iostat</command> command, it might not list all
+     The <command>iostat</command> command might not show all
      controllers that are listed by <command>nvme list-subsys</command>.
      By default, <command>iostat</command> filters out all block devices
-     with no I/O, therefore not all paths in an &nvmeof; might be shown. To
-     show <emphasis>all</emphasis> devices instead use:
+     with no I/O. To make <command>iostat</command> show
+     <emphasis>all</emphasis> devices, use:
     </para>
     <screen>iostat -p ALL</screen>
    </note>


### PR DESCRIPTION
### Description

Add note about using `iostat` in NVMe multipath setups.

### Are there any relevant issues/feature requests?

* bsc#1194343: 1194343 - iostat and multipath nvme setups 
* related: bsc#1193785


### Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
