### PR TITLE
Replaced AY Security SElinux settings by LSM settings

### DIFF
--- a/xml/ay_security_settings.xml
+++ b/xml/ay_security_settings.xml
@@ -133,7 +133,7 @@
   <para>
     In &sle;&nbsp;15.4 and up, the installation control file has a new
     option, <literal>&lt;lsm_select&gt;</literal> for configuring
-    which 'major' Linux Security Module (LSM) will be activated by
+    which major Linux Security Module (LSM) will be activated by
     default after installation: &aa;, &selnx;, or none.
   </para>
 
@@ -157,6 +157,5 @@
     </listitem>
    </varlistentry>
   </variablelist>
- </sect2>
- 
+ </sect2> 
 </sect1>

--- a/xml/ay_security_settings.xml
+++ b/xml/ay_security_settings.xml
@@ -58,6 +58,7 @@
   &lt;uid_max&gt;60000&lt;/uid_max&gt;
   &lt;uid_min&gt;500&lt;/uid_min&gt;
   &lt;selinux_mode&gt;permissive&lt;/selinux_mode&gt;
+  &lt;lsm_select&gt;selinux&lt;/lsm_select&gt;
 &lt;/security&gt;</screen>
  </example>
 
@@ -131,160 +132,31 @@
   <title>Linux Security Module (LSM) settings</title>
   <para>
     In &sle;&nbsp;15.4 and up, the installation control file has a new
-    section, <literal>&lt;lsm></literal>. This new section is for configuring
-    which Linux Security Major Module (LSM) will be activated by
-    default after installation: &aa;, &selnx;, or none. It also exposes the 
-    confirmation dialog in the confirmation proposal, for 
-    selecting a specific module, or disabling the LSM configuration 
-    completely. The <literal>&lt;lsm></literal> is optional and not
-    required. &aa; is the default if you make no selection.
+    option, <literal>&lt;lsm_select></literal> for configuring
+    which 'major' Linux Security Module (LSM) will be activated by
+    default after installation: &aa;, &selnx;, or none.
   </para>
-  <para>
-    The following table describes the four available configuration options.
-  </para>
-  <informaltable>
-   <tgroup cols="3">
-    <thead>
-     <row>
-      <entry>
-       <para>
-        Attribute
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Value
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Description
-       </para>
-      </entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>
-       <para>
-        <literal>select</literal>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Text
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Linux Security Module to be selected during installation. Values:
-         <literal>selinux</literal>, <literal>apparmor</literal>, or <literal>none</literal>.
-       </para>
-      </entry>
-      </row>
-      <row>
-      <entry>
-       <para>
-        <literal>configurable</literal>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Boolean
-       </para>
-      </entry>
-      <entry>
-       <para>
-         Whether the Linux Security Module configuration will be offered 
-         during the installation, or not. If you enter 
-         <literal>disabled</literal>, it will not modify the 
-         kernel default Linux Security Module compiled configuration via the 
-         kernel boot parameters.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <literal>selectable</literal>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Boolean
-       </para>
-      </entry>
-      <entry>
-       <para>
-         Whether or not the dialog for selecting between the different Linux 
-         Security Modules will be shown in the proposal confirmation dialog.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <literal>patterns</literal>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Text
-       </para>
-      </entry>
-      <entry>
-      <para>
-        Space-separated list of required or suggested patterns for the 
-        module.
-       </para>
-      </entry>
-     </row>
 
-    </tbody>
-   </tgroup>
-  </informaltable>
-  <para>
-    Each module has its own section for configuring installation options
-    during the proposal confirmation, and the patterns needed to configure it 
-    properly. For example, if the <literal>selinux</literal> module is 
-    declared as selectable but not configurable, it will use the specificed 
-    SELinux <literal>mode</literal>, but any modifications will be disabled.
-  </para>
-  <example>
-    <title>Linux Security Module configuration</title>
-<screen>&lt;security&gt;
-  &lt;lsm&gt;
-    &lt;select&gt;selinux&lt;/select&gt;
-    &lt;configurable config:type="boolean"&gt;true&lt;/configurable&gt;
-    &lt;selectable config:type="boolean"&gt;true&lt;/selectable&gt;
-    &lt;apparmor&gt;
-      &lt;selectable config:type="boolean"&gt;true&lt;/selectable&gt;
-      &lt;configurable config:type="boolean"&gt;true&lt;/configurable&gt;
-      &lt;!-- Pattern to be installed in case of selected --&gt;
-      &lt;patterns&gt;microos_apparmor&lt;/patterns&gt;
-    &lt;/apparmor&gt;
-    &lt;none&gt;
-      &lt;!-- The option will not be available in the confirmation proposal for selecting it --&gt;
-      &lt;selectable config:type="boolean"&gt;false&lt;/selectable&gt;
-    &lt;/none&gt;
-    &lt;selinux&gt;
-      &lt;mode&gt;enforcing&lt;/mode&gt;
-      &lt;selectable config:type="boolean"&gt;true&lt;/selectable&gt;
-      &lt;!-- Selecting a different mode will be disabled in the confirmation proposal --&gt;
-      &lt;configurable config:type="boolean"&gt;false&lt;/configurable&gt;
-      &lt;!-- Pattern to be installed in case of selected --&gt;
-      &lt;patterns&gt;microos_selinux&lt;/patterns&gt;
-    &lt;/selinux&gt;
-  &lt;/lsm&gt;
-&lt;/security&gt;</screen>
-  </example>
-  <note>
-    <title>Missing options will be read from the installation control file</title>
-    <para>
-      None of the options are required. When some options are not specified, 
-      defaults will be read from the installation control file.
-    </para>
-  </note>
+  <variablelist>
+   <varlistentry>
+    <term>selinux_mode</term>
+    <listitem>
+     <para>
+       Optional. Configure the SELinux mode. Values:
+       <literal>permissive,enforcing</literal> and <literal>disabled</literal>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>lsm_select</term>
+    <listitem>
+     <para>
+      Optional. Major Linux Security Module to be selected during installation. Values:
+      <literal>selinux</literal>, <literal>apparmor</literal>, or <literal>none</literal>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
  </sect2>
  
 </sect1>

--- a/xml/ay_security_settings.xml
+++ b/xml/ay_security_settings.xml
@@ -132,7 +132,7 @@
   <title>Linux Security Module (LSM) settings</title>
   <para>
     In &sle;&nbsp;15.4 and up, the installation control file has a new
-    option, <literal>&lt;lsm_select></literal> for configuring
+    option, <literal>&lt;lsm_select&gt;</literal> for configuring
     which 'major' Linux Security Module (LSM) will be activated by
     default after installation: &aa;, &selnx;, or none.
   </para>

--- a/xml/ay_security_settings.xml
+++ b/xml/ay_security_settings.xml
@@ -127,14 +127,20 @@
    Set the minimum and maximum possible user and group IDs.
   </para>
  </sect2>
-
  <sect2 xml:id="CreateProfile-Security-selinux">
-  <title>Linux Security Module settings (LSM)</title>
+  <title>Linux Security Module (LSM) settings</title>
   <para>
-    The &lt;lsm&gt; section allows to select which Linux Security Major Module will be activaded by
-    default after the installation as well as it allows to influence the confirmation proposal
-    exposing the dialog for selecting an specific module or disabling the LSM configuration 
-    completely.
+    In &sle;&nbsp;15.4 and up, the installation control file has a new
+    section, <literal>&lt;lsm></literal>. This new section is for configuring
+    which Linux Security Major Module (LSM) will be activated by
+    default after installation: &aa;, &selnx;, or none. It also exposes the 
+    confirmation dialog in the confirmation proposal, for 
+    selecting a specific module, or disabling the LSM configuration 
+    completely. The <literal>&lt;lsm></literal> is optional and not
+    required. &aa; is the default if you make no selection.
+  </para>
+  <para>
+    The following table describes the four available configuration options.
   </para>
   <informaltable>
    <tgroup cols="3">
@@ -171,9 +177,8 @@
       </entry>
       <entry>
        <para>
-        Linux Security Major module to be selected during installation. Values:
-         <literal>selinux</literal>, <literal>apparmor</literal>, or <literal>none</literal>. The
-         <literal>none</literal> value will disable the others.
+        Linux Security Module to be selected during installation. Values:
+         <literal>selinux</literal>, <literal>apparmor</literal>, or <literal>none</literal>.
        </para>
       </entry>
       </row>
@@ -190,9 +195,11 @@
       </entry>
       <entry>
        <para>
-         Whether the Linux Security Module configuration will be offered during the installation or
-         not. In case of disabled it will not modify the kernel default Linux Security Module 
-         compiled configuration via the kernel boot parameters.
+         Whether the Linux Security Module configuration will be offered 
+         during the installation, or not. If you enter 
+         <literal>disabled</literal>, it will not modify the 
+         kernel default Linux Security Module compiled configuration via the 
+         kernel boot parameters.
        </para>
       </entry>
      </row>
@@ -209,8 +216,8 @@
       </entry>
       <entry>
        <para>
-         Whether the dialog for selecting between the different Linux Security Modules will be 
-         shown in the proposal confirmation dialog or not.
+         Whether or not the dialog for selecting between the different Linux 
+         Security Modules will be shown in the proposal confirmation dialog.
        </para>
       </entry>
      </row>
@@ -227,7 +234,8 @@
       </entry>
       <entry>
       <para>
-        Space-separated list of required / suggested patterns for the module.
+        Space-separated list of required or suggested patterns for the 
+        module.
        </para>
       </entry>
      </row>
@@ -236,10 +244,11 @@
    </tgroup>
   </informaltable>
   <para>
-    Each module has its own section allowing to decide which one will be selectable or configurable
-    during the proposal confirmation and the patterns needed to configure it properly. For example,
-    if the <literal>selinux</literal> module is declared as selectable but not configurable it will
-    use the specificed SELinux <literal>mode</literal> but any modification will be disabled.
+    Each module has its own section for configuring installation options
+    during the proposal confirmation, and the patterns needed to configure it 
+    properly. For example, if the <literal>selinux</literal> module is 
+    declared as selectable but not configurable, it will use the specificed 
+    SELinux <literal>mode</literal>, but any modifications will be disabled.
   </para>
   <example>
     <title>Linux Security Module configuration</title>
@@ -272,9 +281,10 @@
   <note>
     <title>Missing options will be read from the installation control file</title>
     <para>
-      All the options are optional and when not specified the defaults will be read from the 
-      installation control file.
+      None of the options are required. When some options are not specified, 
+      defaults will be read from the installation control file.
     </para>
   </note>
  </sect2>
+ 
 </sect1>

--- a/xml/ay_security_settings.xml
+++ b/xml/ay_security_settings.xml
@@ -143,7 +143,7 @@
     <listitem>
      <para>
        Optional. Configure the SELinux mode. Values:
-       <literal>permissive,enforcing</literal> and <literal>disabled</literal>.
+       <literal>permissive</literal>, <literal>enforcing</literal> and <literal>disabled</literal>.
      </para>
     </listitem>
    </varlistentry>

--- a/xml/ay_security_settings.xml
+++ b/xml/ay_security_settings.xml
@@ -129,10 +129,152 @@
  </sect2>
 
  <sect2 xml:id="CreateProfile-Security-selinux">
-  <title>SELinux settings</title>
+  <title>Linux Security Module settings (LSM)</title>
   <para>
-   Configuring SELinux mode. Possible values are
-   <literal>permissive,enforcing</literal> and <literal>disabled</literal>.
+    The &lt;lsm&gt; section allows to select which Linux Security Major Module will be activaded by
+    default after the installation as well as it allows to influence the confirmation proposal
+    exposing the dialog for selecting an specific module or disabling the LSM configuration 
+    completely.
   </para>
+  <informaltable>
+   <tgroup cols="3">
+    <thead>
+     <row>
+      <entry>
+       <para>
+        Attribute
+       </para>
+      </entry>
+      <entry>
+       <para>
+        Value
+       </para>
+      </entry>
+      <entry>
+       <para>
+        Description
+       </para>
+      </entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>
+       <para>
+        <literal>select</literal>
+       </para>
+      </entry>
+      <entry>
+       <para>
+        Text
+       </para>
+      </entry>
+      <entry>
+       <para>
+        Linux Security Major module to be selected during installation. Values:
+         <literal>selinux</literal>, <literal>apparmor</literal>, or <literal>none</literal>. The
+         <literal>none</literal> value will disable the others.
+       </para>
+      </entry>
+      </row>
+      <row>
+      <entry>
+       <para>
+        <literal>configurable</literal>
+       </para>
+      </entry>
+      <entry>
+       <para>
+        Boolean
+       </para>
+      </entry>
+      <entry>
+       <para>
+         Whether the Linux Security Module configuration will be offered during the installation or
+         not. In case of disabled it will not modify the kernel default Linux Security Module 
+         compiled configuration via the kernel boot parameters.
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
+        <literal>selectable</literal>
+       </para>
+      </entry>
+      <entry>
+       <para>
+        Boolean
+       </para>
+      </entry>
+      <entry>
+       <para>
+         Whether the dialog for selecting between the different Linux Security Modules will be 
+         shown in the proposal confirmation dialog or not.
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
+        <literal>patterns</literal>
+       </para>
+      </entry>
+      <entry>
+       <para>
+        Text
+       </para>
+      </entry>
+      <entry>
+      <para>
+        Space-separated list of required / suggested patterns for the module.
+       </para>
+      </entry>
+     </row>
+
+    </tbody>
+   </tgroup>
+  </informaltable>
+  <para>
+    Each module has its own section allowing to decide which one will be selectable or configurable
+    during the proposal confirmation and the patterns needed to configure it properly. For example,
+    if the <literal>selinux</literal> module is declared as selectable but not configurable it will
+    use the specificed SELinux <literal>mode</literal> but any modification will be disabled.
+  </para>
+  <example>
+    <title>Linux Security Module configuration</title>
+<screen>&lt;security&gt;
+  &lt;lsm&gt;
+    &lt;select&gt;selinux&lt;/select&gt;
+    &lt;configurable config:type="boolean"&gt;true&lt;/configurable&gt;
+    &lt;selectable config:type="boolean"&gt;true&lt;/selectable&gt;
+    &lt;apparmor&gt;
+      &lt;selectable config:type="boolean"&gt;true&lt;/selectable&gt;
+      &lt;configurable config:type="boolean"&gt;true&lt;/configurable&gt;
+      &lt;!-- Pattern to be installed in case of selected --&gt;
+      &lt;patterns&gt;microos_apparmor&lt;/patterns&gt;
+    &lt;/apparmor&gt;
+    &lt;none&gt;
+      &lt;!-- The option will not be available in the confirmation proposal for selecting it --&gt;
+      &lt;selectable config:type="boolean"&gt;false&lt;/selectable&gt;
+    &lt;/none&gt;
+    &lt;selinux&gt;
+      &lt;mode&gt;enforcing&lt;/mode&gt;
+      &lt;selectable config:type="boolean"&gt;true&lt;/selectable&gt;
+      &lt;!-- Selecting a different mode will be disabled in the confirmation proposal --&gt;
+      &lt;configurable config:type="boolean"&gt;false&lt;/configurable&gt;
+      &lt;!-- Pattern to be installed in case of selected --&gt;
+      &lt;patterns&gt;microos_selinux&lt;/patterns&gt;
+    &lt;/selinux&gt;
+  &lt;/lsm&gt;
+&lt;/security&gt;</screen>
+  </example>
+  <note>
+    <title>Missing options will be read from the installation control file</title>
+    <para>
+      All the options are optional and when not specified the defaults will be read from the 
+      installation control file.
+    </para>
+  </note>
  </sect2>
 </sect1>


### PR DESCRIPTION
### PR creator: Description

It has been requested to unify the way **Selinux** or **AppArmor** are selected / configured during the installation

In order to choose which **Linux Security Module** should be used by default we have added a new section **lsm** to the installation control file <s>as well as we have added almost the same options to the security **AutoYaST** schema. The default **LSM** will be set by the **select** tag falling back to **apparmor** in case of missing.</s>

<s>This PR tries to document the new section and the different options</s>

**Note** It has been decided to only allow to select the desired **Major Linux Security Module** to be activated after the installation and the **SELinux Mode** in case of selected (see https://github.com/yast/yast-security/pull/123).

### PR creator: Are there any relevant issues/feature requests?

* jsc#SLE-22069


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [X] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
