### PR TITLE
remove misleading or no longer valid example

### DIFF
--- a/xml/tuning_taskscheduler.xml
+++ b/xml/tuning_taskscheduler.xml
@@ -538,11 +538,7 @@ kernel.sched_wakeup_granularity_ns = 10000000</screen>
       <para>
        A freshly forked child runs before the parent continues execution.
        Setting this parameter to <literal>1</literal> is beneficial for an
-       application in which the child performs an execution after fork. For
-       example <command>make</command>
-       <option>-j<replaceable>&lt;NO_CPUS&gt;</replaceable></option>
-       performs better when sched_child_runs_first is turned off. The
-       default value is <literal>0</literal>.
+       application in which the child performs an execution after fork.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
The documentation says make -j NO_CPUS will benefit from this setting  off.. this may have been the case 7 or 8 years ago when it was added, but in 2016 make was changed to use vfork everywhere.. later make was modified to execute jobs using posix_spawn. both ways are always child_first (the calling process is suspended) 
So this example is at least out of date or at most never quite true.