### PR TITLE
vt-doc: Mention unprivileged_userfaultfd setting provided by libvirt

### DIFF
--- a/xml/libvirt_managing.xml
+++ b/xml/libvirt_managing.xml
@@ -979,12 +979,18 @@ Metadata:       yes
    </para>
    <important>
     <para>
-     For the post-copy type of live migration, &kvm; hosts with kernels version
-     5.11 or newer require setting the
+     In order to use the post-copy live migration option, &kvm; hosts with
+     kernel version 5.11 or newer require setting the
      <varname>unprivileged_userfaultfd</varname> system value to
-     <literal>1</literal> before the migration starts:
+     <literal>1</literal>:
     </para>
 <screen>&prompt.sudo;sysctl -w vm.unprivileged_userfaultfd=1</screen>
+    <para>
+     Since kernel versions prior to 5.11 did not require setting
+     unprivileged_userfaultfd to use the post-copy option, &libvirt; provides
+     the setting in <filename>/usr/lib/sysctl.d/60-qemu-postcopy-migration.conf</filename>
+     file to preserve the old behavior.
+    </para>
    </important>
    <itemizedlist>
     <listitem>


### PR DESCRIPTION
### PR creator: Description

To allow post-copy migration with a KVM host kernel >= 5.11, the
vm.unprivileged_userfaultfd sysctl setting must be set to 1.
libvirt 8.0.0 and newer provide a /usr/lib/sysctl.d/ file for this.
Mention it in the existing note about vm.unprivileged_userfaultfd.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1191511


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
