### PR TITLE
Timeline snapshots are enabled by default (bsc#1194030)

### DIFF
--- a/xml/snapper.xml
+++ b/xml/snapper.xml
@@ -186,8 +186,8 @@
       <para>
        A single snapshot is created every hour. Old snapshots are automatically
        deleted. By default, the first snapshot of the last ten days, months,
-       and years are kept. Timeline snapshots are enabled by default for disks
-       larger than 16GB, except for the root partition.
+       and years are kept. Using the &yast; OS installation method (default),
+       timeline snapshots are enabled, except for the root file system.
       </para>
      </listitem>
     </varlistentry>
@@ -263,8 +263,8 @@
         </para>
        </formalpara>
        <para>
-        Timeline snapshots are enabled by default for disks larger than 16GB,
-        except for the root partition.
+        Using the &yast; OS installation method (default), timeline snapshots
+        are enabled, except for the root file system.
        </para>
       </listitem>
      </varlistentry>

--- a/xml/snapper.xml
+++ b/xml/snapper.xml
@@ -186,7 +186,8 @@
       <para>
        A single snapshot is created every hour. Old snapshots are automatically
        deleted. By default, the first snapshot of the last ten days, months,
-       and years are kept. Timeline snapshots are disabled by default.
+       and years are kept. Timeline snapshots are enabled by default, except
+       for the root partition.
       </para>
      </listitem>
     </varlistentry>

--- a/xml/snapper.xml
+++ b/xml/snapper.xml
@@ -186,8 +186,8 @@
       <para>
        A single snapshot is created every hour. Old snapshots are automatically
        deleted. By default, the first snapshot of the last ten days, months,
-       and years are kept. Timeline snapshots are enabled by default, except
-       for the root partition.
+       and years are kept. Timeline snapshots are enabled by default for disks
+       larger than 16GB, except for the root partition.
       </para>
      </listitem>
     </varlistentry>
@@ -263,8 +263,8 @@
         </para>
        </formalpara>
        <para>
-        Timeline snapshots are enabled by default, except for the root
-        partition.
+        Timeline snapshots are enabled by default for disks larger than 16GB,
+        except for the root partition.
        </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
### PR creator: Description

A small fix in an unclear documentation.


### PR creator: Are there any relevant issues/feature requests?

* bsc#bsc#1194030


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [x] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
