### PR TITLE
New capability for sudoers.ldap: user negation now works

### DIFF
--- a/xml/security_ldap_install.xml
+++ b/xml/security_ldap_install.xml
@@ -430,13 +430,12 @@ binddn = cn=Directory Manager
     </callout>
    </calloutlist>
   </example>  
-       <warning>
+       <important>
        <title>New negation feature in sudoers.ldap</title>
        <para>
-         If you are using sudoers.ldap, instead of the traditional 
-         <command>sudo</command> command, one of its limitations is 
-         negation does not work as you might expect in the 
-         <literal>sudoUser</literal>, 
+         In <package>sudo</package> versions older than 1.9.9, 
+         negation in sudoers.ldap does 
+         not work for the <literal>sudoUser</literal>, 
          <literal>sudoRunAsUser</literal>, or 
          <literal>sudoRunAsGroup</literal> attributes. For example:
        </para>
@@ -448,10 +447,10 @@ sudoUser: !joe
 # instead, it matches everyone including Joe
 sudoUser: ALL
 sudoUser: !joe</screen>
-     </warning>
+     </important>
   <para>
-    In <command>sudo</command> version 1.9.9 and higher, negation works 
-    correctly for the <literal>sudoUser</literal> attribute. See 
+    In <command>sudo</command> version 1.9.9 and higher, negation is 
+    enabled for the <literal>sudoUser</literal> attribute. See 
     <command>man 5 sudoers.ldap</command> for more information.
   </para>
  </sect2>

--- a/xml/security_ldap_install.xml
+++ b/xml/security_ldap_install.xml
@@ -429,6 +429,30 @@ binddn = cn=Directory Manager
      </para>
     </callout>
    </calloutlist>
-  </example>
+  </example>  
+       <warning>
+       <title>New negation feature in sudoers.ldap</title>
+       <para>
+         If you are using sudoers.ldap, instead of the traditional 
+         <command>sudo</command> command, one of its limitations is 
+         negation does not work as you might expect in the 
+         <literal>sudoUser</literal>, 
+         <literal>sudoRunAsUser</literal>, or 
+         <literal>sudoRunAsGroup</literal> attributes. For example:
+       </para>
+       <screen> # does not match all but joe
+# instead, it does not match anyone
+sudoUser: !joe
+
+# does not match all but joe
+# instead, it matches everyone including Joe
+sudoUser: ALL
+sudoUser: !joe</screen>
+     </warning>
+  <para>
+    In <command>sudo</command> version 1.9.9 and higher, negation works 
+    correctly for the <literal>sudoUser</literal> attribute. See 
+    <command>man 5 sudoers.ldap</command> for more information.
+  </para>
  </sect2>
 </sect1>


### PR DESCRIPTION
resolves Jira SLE-21385
This will be backported to SLE 12 SP3, after the changes appears in the maintenance update repos.
See the epic at Jira SLE-20068.

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4
  - [x] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
