### PR TITLE
Lowest metric has highest routing priority (bsc#1187740)

### DIFF
--- a/xml/net_yast.xml
+++ b/xml/net_yast.xml
@@ -899,8 +899,8 @@
        If more default routes are used, it is possible to specify the metric
        option to determine which route has a higher priority. To specify the
        metric option, enter <option>- metric
-        <replaceable>NUMBER</replaceable></option> in
-       <guimenu>Options</guimenu>. The route with the lowest metric has the
+       <replaceable>NUMBER</replaceable></option> in <guimenu>Options</guimenu>.
+       The lowest possible metric is 0. The route with the lowest metric has the
        highest priority and is used as default. If the network device is
        disconnected, its route will be removed and the next one will be used.
       </para>

--- a/xml/net_yast.xml
+++ b/xml/net_yast.xml
@@ -899,10 +899,10 @@
        If more default routes are used, it is possible to specify the metric
        option to determine which route has a higher priority. To specify the
        metric option, enter <option>- metric
-       <replaceable>NUMBER</replaceable></option> in
-       <guimenu>Options</guimenu>. The route with the highest metric is used as
-       default. If the network device is disconnected, its route will be
-       removed and the next one will be used.
+        <replaceable>NUMBER</replaceable></option> in
+       <guimenu>Options</guimenu>. The route with the lowest metric has the
+       highest priority and is used as default. If the network device is
+       disconnected, its route will be removed and the next one will be used.
       </para>
      </note>
     </step>


### PR DESCRIPTION
### PR creator: Description

This update fixes a misleading info about routing  metric priority


### PR creator: Are there any relevant issues/feature requests?

Closes bsc#1187740



### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4
  - [x] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
