### PR TITLE
Changed explanation for creating initrd with dracut

### DIFF
--- a/xml/bootconcept.xml
+++ b/xml/bootconcept.xml
@@ -391,31 +391,36 @@
      <procedure xml:id="pro-generate-initramfs">
       <title>Generate an initramfs</title>
       <para>
-       Note that all commands in the following procedure need to be executed as
-       user &rootuser;.
+       Note that all commands in the following procedure need to be executed 
+       as the &rootuser; user.
       </para>
       <step>
+      <para>
+        Enter your <filename>/boot</filename> directory:
+      </para>
+      <screen>&prompt.root;cd /boot</screen>
+      </step>
+      <step>
        <para>
-        Generate a new <systemitem>initramfs</systemitem> file by running
+        Generate a new <systemitem>initramfs</systemitem> file with
+        <command>dracut</command>, replacing 
+        <replaceable>MY_INITRAMFS</replaceable> with a file name of
+        your choice:
        </para>
-       <screen>dracut <replaceable>MY_INITRAMFS</replaceable></screen>
+       <screen>&prompt.root;dracut <replaceable>MY_INITRAMFS</replaceable></screen>
        <para>
-        Replace <replaceable>MY_INITRAMFS</replaceable> with a file name of
-        your choice. The new <systemitem>initramfs</systemitem> will be created
-        as <filename><replaceable>MY_INITRAMFS</replaceable></filename>.
-       </para>
-       <para>
-        Alternatively, run <command>dracut -f</command>. This will overwrite
-        the currently used, existing file.
+        Alternatively, run <command>dracut -f</command>
+        <replaceable>FILENAME</replaceable></command> 
+        to replace an existing init file.
        </para>
       </step>
       <step>
        <para>
         (Skip this step if you ran <command>dracut -f</command> in the previous
-        step.) Create a link to the <systemitem>initramfs</systemitem> file you
-        created in the previous step:
+        step.) Create a symlink from the <systemitem>initramfs</systemitem> 
+        file you created in the previous step to <systemitem>initrd</systemitem>:
        </para>
-       <screen>(cd /boot &amp;&amp; ln -sf <replaceable>MY_INITRAMFS</replaceable> initrd)</screen>
+       <screen></screen>
       </step>
       <step arch="zseries">
        <para>

--- a/xml/bootconcept.xml
+++ b/xml/bootconcept.xml
@@ -402,7 +402,7 @@
        <para>
         Replace <replaceable>MY_INITRAMFS</replaceable> with a file name of
         your choice. The new <systemitem>initramfs</systemitem> will be created
-        as <filename>/boot/<replaceable>MY_INITRAMFS</replaceable></filename>.
+        as <filename><replaceable>MY_INITRAMFS</replaceable></filename>.
        </para>
        <para>
         Alternatively, run <command>dracut -f</command>. This will overwrite


### PR DESCRIPTION
### PR creator: Description

This update fixes misleading info about creating initrd with dracut

### PR creator: Are there any relevant issues/feature requests?

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [X] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [X] SLE 15 SP3/openSUSE Leap 15.3
  - [X] SLE 15 SP2/openSUSE Leap 15.2
  - [X] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [X] SLE 12 SP5
  - [X] SLE 12 SP4
  - [X] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
