### PR TITLE
Updated description of  OVMF firmware packages (jsc#SLE-21134)

### DIFF
--- a/xml/vt_installation.xml
+++ b/xml/vt_installation.xml
@@ -275,7 +275,7 @@
   <para>
    The <package>qemu-ovmf-x86_64</package> package contains the following
    important UEFI firmware images. They provide &uefisecboot; capability for
-   &mswin;, &opensuse;, and &sle;-based &vmguest;s, respectively:
+   various &vmguest;s:
   </para>
 
 <screen>
@@ -289,6 +289,27 @@
 /usr/share/qemu/ovmf-x86_64-smm-suse-vars.bin
 [...]
 </screen>
+
+  <itemizedlist>
+   <listitem>
+    <para>
+     To use &uefisecboot; for &sle; guests, use the
+     <filename>ovmf-x86_64-smm-suse-code.bin</filename> firmware.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     To use &uefisecboot; for &opensuse; guests, use the
+     <filename>ovmf-x86_64-smm-opensuse-code.bin</filename> firmware.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     To use &uefisecboot; for &mswin; guests, use the
+     <filename>ovmf-x86_64-smm-ms-code.bin</filename> firmware.
+    </para>
+   </listitem>
+  </itemizedlist>
 
   <para>
    For the &aarch64; architecture, the package is named

--- a/xml/vt_installation.xml
+++ b/xml/vt_installation.xml
@@ -4,17 +4,16 @@
   <!ENTITY % entities SYSTEM "entity-decl.ent">
     %entities;
 ]>
-
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-vt-installation">
  <title>Installation of virtualization components</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:bugtracker>
-   </dm:bugtracker>
+   <dm:bugtracker></dm:bugtracker>
   </dm:docmanager>
  </info>
  <sect1 xml:id="introduction-install-virtualization-components">
   <title>Introduction</title>
+
   <para>
    In order to run a virtualization server (&vmhost;) that can host one or more
    guest systems (&vmguest;s), you need to install required virtualization
@@ -22,12 +21,14 @@
    virtualization technology you want to use.
   </para>
  </sect1>
-<sect1 xml:id="install-virtualization-components">
+ <sect1 xml:id="install-virtualization-components">
   <title>Installing virtualization components</title>
+
   <para>
    You can install the virtualization tools required to run a &vmhost; in one
    of the following ways:
   </para>
+
   <itemizedlist>
    <listitem>
     <para>
@@ -48,6 +49,7 @@
     </para>
    </listitem>
   </itemizedlist>
+
   <sect2 xml:id="install-virtualization-components-system-role">
    <title>Specifying a system role</title>
    <para>
@@ -80,6 +82,7 @@
     </para>
    </tip>
   </sect2>
+
   <sect2 xml:id="install-virtualization-components-yast">
    <title>Running the <emphasis>&yast; Virtualization</emphasis> module</title>
    <para>
@@ -174,6 +177,7 @@
     </step>
    </procedure>
   </sect2>
+
   <sect2 xml:id="install-virtualization-components-pattern">
    <title>Installing specific installation patterns</title>
    <para>
@@ -231,39 +235,47 @@
  </sect1>
  <sect1 xml:id="sec-vt-installation-ovmf">
   <title>Installing UEFI support</title>
+
   <note>
    <para>
-    &kvm; guests support &uefisecboot; by using the OVMF firmware.
-    &xen; HVM guests support booting from the OVMF firmware as well, but they do not support &uefisecboot;.
+    &kvm; guests support &uefisecboot; by using the OVMF firmware. &xen; HVM
+    guests support booting from the OVMF firmware as well, but they do not
+    support &uefisecboot;.
    </para>
   </note>
+
   <para>
-   UEFI support is provided by <emphasis>OVMF</emphasis>
-   (<emphasis>Open Virtual Machine Firmware</emphasis>). To enable UEFI
-   boot, first install the <package>qemu-ovmf-x86_64</package> or
-   <package>qemu-uefi-aarch64</package> package depending on the architecture of the guest.
+   UEFI support is provided by <emphasis>OVMF</emphasis> (<emphasis>Open
+   Virtual Machine Firmware</emphasis>). To enable UEFI boot, first install the
+   <package>qemu-ovmf-x86_64</package> or <package>qemu-uefi-aarch64</package>
+   package depending on the architecture of the guest.
   </para>
+
   <para>
    The firmware used by virtual machines is auto-selected. The auto-selection
    is based on the JSON files in the firmware package described above. The
    &libvirt; &qemu; driver parses those files when loading so it knows the
    capabilities of the various types of firmware. Then when the user selects
    the type of firmware and any desired features (for example, support for
-   &uefisecboot;), &libvirt; will be able to find a firmware file that satisfies the
-   user's requirements.
+   &uefisecboot;), &libvirt; will be able to find a firmware file that
+   satisfies the user's requirements.
   </para>
+
   <para>
    For example, to specify EFI with &uefisecboot;, use the following
    configuration:
   </para>
+
 <screen>
 &lt;os firmware='efi'>
  &lt;loader secure='yes'/>
 &lt;/os>
 </screen>
+
   <para>
    The UEFI firmware packages contains the following files:
   </para>
+
 <screen>
 &prompt.root;<command>rpm -ql qemu-ovmf-x86_64</command>
 [...]
@@ -275,6 +287,7 @@
 /usr/share/qemu/ovmf-x86_64-suse.bin
 [...]
 </screen>
+
 <screen>
 &prompt.root;<command>rpm -ql qemu-uefi-aarch32</command>
 [...]
@@ -284,28 +297,31 @@
 /usr/share/qemu/firmware/60-aavmf-aarch32.json
 /usr/share/qemu/qemu-uefi-aarch32.bin
 </screen>
+
   <para>
-   The <filename>*-code.bin</filename> files are the UEFI firmware files.
-   The <filename>*-vars.bin</filename> files are corresponding variable
-   store images that can be used as a template for a per-VM non-volatile
-   store. &libvirt; copies the specified <literal>vars</literal>
-   template to a per-VM path under
-   <filename>/var/lib/libvirt/qemu/nvram/</filename> when first
+   The <filename>*-code.bin</filename> files are the UEFI firmware files. The
+   <filename>*-vars.bin</filename> files are corresponding variable store
+   images that can be used as a template for a per-VM non-volatile store.
+   &libvirt; copies the specified <literal>vars</literal> template to a per-VM
+   path under <filename>/var/lib/libvirt/qemu/nvram/</filename> when first
    creating the VM. Files without <literal>code</literal> or
-   <literal>vars</literal> in the name can be used as a single UEFI
-   image. They are not as useful since no UEFI variables persist
-   across power cycles of the VM.
+   <literal>vars</literal> in the name can be used as a single UEFI image. They
+   are not as useful since no UEFI variables persist across power cycles of the
+   VM.
   </para>
+
   <para>
-   The <filename>*-ms*.bin</filename> files contain UEFI CA keys as
-   found on real hardware. Therefore, they are configured as the default in
-   &libvirt;. Likewise, the <filename>*-suse*.bin</filename> files
-   contain preinstalled &suse; keys. There is also a set
-   of files with no preinstalled keys.
+   The <filename>*-ms*.bin</filename> files contain UEFI CA keys as found on
+   real hardware. Therefore, they are configured as the default in &libvirt;.
+   Likewise, the <filename>*-suse*.bin</filename> files contain preinstalled
+   &suse; keys. There is also a set of files with no preinstalled keys.
   </para>
+
   <para>
    For details, see <xref linkend="vle-libvirt-inst-virt-install-ovmf"
-   /> and <link xlink:href=
+   />
+   and
+   <link xlink:href=
    "http://www.linux-kvm.org/downloads/lersek/ovmf-whitepaper-c770f8c.txt"
    />.
   </para>
@@ -349,7 +365,7 @@
     <listitem>
      <para>
       A virtual machine running on L1. It is called a <emphasis>nested
-       guest</emphasis>.
+      guest</emphasis>.
      </para>
     </listitem>
    </varlistentry>
@@ -363,8 +379,8 @@
   <itemizedlist>
    <listitem>
     <para>
-     Manage your own virtual machines directly with your hypervisor of choice in
-     cloud environments.
+     Manage your own virtual machines directly with your hypervisor of choice
+     in cloud environments.
     </para>
    </listitem>
    <listitem>
@@ -411,8 +427,8 @@
 
   <para>
    To enable nesting permanently, enable the <option>nested</option> &kvm;
-   module parameter in the <filename>/etc/modprobe.d/kvm_*.conf</filename> file,
-   depending on your CPU:
+   module parameter in the <filename>/etc/modprobe.d/kvm_*.conf</filename>
+   file, depending on your CPU:
   </para>
 
   <itemizedlist>
@@ -421,14 +437,14 @@
      For Intel CPUs, edit <filename>/etc/modprobe.d/kvm_intel.conf</filename>
      and add the following line:
     </para>
-    <screen>options kvm_intel nested=1</screen>
+<screen>options kvm_intel nested=1</screen>
    </listitem>
    <listitem>
     <para>
      For AMD CPUs, edit <filename>/etc/modprobe.d/kvm_amd.conf</filename> and
      add the following line:
     </para>
-    <screen>options kvm_amd nested=1</screen>
+<screen>options kvm_amd nested=1</screen>
    </listitem>
   </itemizedlist>
 
@@ -452,17 +468,17 @@
     </para>
    </listitem>
   </itemizedlist>
+
   <sect2 xml:id="sec-vt-installation-nested-vms-esxi">
    <title>&esx; as a guest hypervisor</title>
    <para>
     If you use &esx; as a guest hypervisor on top of &kvm; bare metal
-    hypervisor, you may experience unstable network communication.
-    This problem happens especially between nested &kvm; guests and
-    the &kvm; bare metal hypervisor or external network.
-    The following default CPU configuration of the nested &kvm; guest is
-    causing the problem:
+    hypervisor, you may experience unstable network communication. This problem
+    happens especially between nested &kvm; guests and the &kvm; bare metal
+    hypervisor or external network. The following default CPU configuration of
+    the nested &kvm; guest is causing the problem:
    </para>
-   <screen>&lt;cpu mode='host-model' check='partial'/></screen>
+<screen>&lt;cpu mode='host-model' check='partial'/></screen>
    <para>
     To fix it, modify the CPU configuration as follow:
    </para>

--- a/xml/vt_installation.xml
+++ b/xml/vt_installation.xml
@@ -273,20 +273,27 @@
 </screen>
 
   <para>
-   The UEFI firmware packages contains the following files:
+   The <package>qemu-ovmf-x86_64</package> package contains the following
+   important UEFI firmware images. They provide &uefisecboot; capability for
+   &mswin;, &opensuse;, and &sle;-based &vmguest;s, respectively:
   </para>
 
 <screen>
 &prompt.root;<command>rpm -ql qemu-ovmf-x86_64</command>
 [...]
-/usr/share/qemu/ovmf-x86_64-ms-code.bin
-/usr/share/qemu/ovmf-x86_64-ms-vars.bin
-/usr/ddshare/qemu/ovmf-x86_64-ms.bin
-/usr/share/qemu/ovmf-x86_64-suse-code.bin
-/usr/share/qemu/ovmf-x86_64-suse-vars.bin
-/usr/share/qemu/ovmf-x86_64-suse.bin
+/usr/share/qemu/ovmf-x86_64-smm-ms-code.bin
+/usr/share/qemu/ovmf-x86_64-smm-ms-vars.bin
+/usr/share/qemu/ovmf-x86_64-smm-opensuse-code.bin
+/usr/share/qemu/ovmf-x86_64-smm-opensuse-vars.bin
+/usr/share/qemu/ovmf-x86_64-smm-suse-code.bin
+/usr/share/qemu/ovmf-x86_64-smm-suse-vars.bin
 [...]
 </screen>
+
+  <para>
+   For the &aarch64; architecture, the package is named
+   <package>qemu-uefi-aarch32</package>:
+  </para>
 
 <screen>
 &prompt.root;<command>rpm -ql qemu-uefi-aarch32</command>


### PR DESCRIPTION
Render PDF is attached
[sec-vt-installation-ovmf_color_en.pdf](https://github.com/SUSE/doc-sle/files/7993544/sec-vt-installation-ovmf_color_en.pdf)


### PR creator: Are there any relevant issues/feature requests?

* jsc#SLE-21134


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
