### PR TITLE
Add BCI on Pub Cloud note

### DIFF
--- a/xml/containers-get.xml
+++ b/xml/containers-get.xml
@@ -336,18 +336,6 @@
    available updates and fixes. The &susereg;'s Web user interface lists
    a subset of the available images.
   </para>
-  <important>
-  <title>&slea; BCI support for managed Kubernetes services in the public cloud</title>
-  <para>
-  The support status of a &slea; Base Container Image (BCI) is determined by the
-  runtime used to run containers. &slea; Base Containers are supported when used
-  with containerd, CRI-O and &docker;, and &podman;. Container images based on
-  &sle; 12 SP5 through &sle; 15 SP4 are fully supported on Amazon Elastic
-  Container Service for Kubernetes. Although Microsoft Azure Kubernetes Service,
-  Google Kubernetes Engine, and Alibaba Container Service for Kubernetes use
-  runtimes that can be used for running BCIs, they haven't been fully tested.
-  </para>
-  </important>
  </sect1>
 <sect1 xml:id="sec-verify-containers">
   <title>Verifying containers</title>

--- a/xml/containers-get.xml
+++ b/xml/containers-get.xml
@@ -336,6 +336,18 @@
    available updates and fixes. The &susereg;'s Web user interface lists
    a subset of the available images.
   </para>
+  <important>
+  <title>&slea; BCI support for managed Kubernetes services in the public cloud</title>
+  <para>
+  The support status of a &slea; Base Container Image (BCI) is determined by the
+  runtime used to run containers. &slea; Base Containers are supported when used
+  with containerd, CRI-O and &docker;, and &podman;. Container images based on
+  &sle; 12 SP5 through &sle; 15 SP4 are fully supported on Amazon Elastic
+  Container Service for Kubernetes. Although Microsoft Azure Kubernetes Service,
+  Google Kubernetes Engine, and Alibaba Container Service for Kubernetes use
+  runtimes that can be used for running BCIs, they haven't been fully tested.
+  </para>
+  </important>
  </sect1>
 <sect1 xml:id="sec-verify-containers">
   <title>Verifying containers</title>

--- a/xml/containers-support.xml
+++ b/xml/containers-support.xml
@@ -41,6 +41,18 @@
    <literal>/proc</literal> is limited to the most common scenarios needed by
    unprivileged uses.
   </para>
+  <important>
+  <title>&slea; BCI support for managed Kubernetes services in the public cloud</title>
+  <para>
+  The support status of a &slea; Base Container Image (BCI) is determined by the
+  runtime used to run containers. &slea; Base Containers are supported when used
+  with containerd, CRI-O and &docker;, and &podman;. Container images based on
+  &sle; 12 SP5 through &sle; 15 SP4 are fully supported on Amazon Elastic
+  Container Service for Kubernetes. Although Microsoft Azure Kubernetes Service,
+  Google Kubernetes Engine, and Alibaba Container Service for Kubernetes provide
+  runtimes that can be used for running BCIs, they haven't been fully tested.
+  </para>
+  </important>
  </sect1>
  <sect1 xml:id="sec-sle-container-support-plans">
   <title>Support plans</title>


### PR DESCRIPTION
### PR creator: Description

SLE BCI support for Managed Kubernetes Services in the Public Cloud

### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
