### PR TITLE
Added note about Win guests reboot (bsc#1194621)

### DIFF
--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -431,6 +431,15 @@
    hypervisors.
   </para>
 
+  <important>
+   <para>
+    &mswin; guests can be rebooted by &libvirt;/&virsh; only if paravirtualized
+    drivers are installed in the guest. Refer to
+    <link xlink:href="https://www.suse.com/products/vmdriverpack/"/> for more
+    details on downloading and installing PV drivers.
+   </para>
+  </important>
+
   <itemizedlist>
    <title>The following guest operating systems are fully supported (L3):</title>
    <listitem>


### PR DESCRIPTION
### PR creator: Description
Win guests fail to reboot without VP drivers. This update informs about that.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1194621


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4
  - [x] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
