### PR TITLE
JeOS to Minimal Image rename

### DIFF
--- a/xml/art_raspberry-pi.xml
+++ b/xml/art_raspberry-pi.xml
@@ -432,10 +432,10 @@
     <title>Writing the image to the card using <command>dd</command></title>
     <para>
      This command decompresses the image
-     <literal>SLES&product-ga;-SP&product-sp;-JeOS.aarch64-&product-ga;.&product-sp;-RaspberryPi-GM.raw.xz</literal> to the SD
+     <literal>SLES&product-ga;-SP&product-sp;-Minimal-Image.aarch64-&product-ga;.&product-sp;-RaspberryPi-GM.raw.xz</literal> to the SD
      card <literal>mmcblk0</literal>:
     </para>
-<screen>&prompt.user;xz -cd SLES&product-ga;-SP&product-sp;-JeOS.aarch64-&product-ga;.&product-sp;-RaspberryPi-GM.raw.xz | sudo dd of=/dev/mmcblk0 bs=4096 iflag=fullblock status=progress</screen>
+<screen>&prompt.user;xz -cd SLES&product-ga;-SP&product-sp;-Minimal-Image.aarch64-&product-ga;.&product-sp;-RaspberryPi-GM.raw.xz | sudo dd of=/dev/mmcblk0 bs=4096 iflag=fullblock status=progress</screen>
    </example>
   </sect2>
 
@@ -568,7 +568,7 @@
       of=/dev/disk<replaceable>X</replaceable></command>, where <replaceable>X</replaceable> is the disk
       number and <replaceable>imageFile.raw</replaceable> is the name of the uncompressed image.
      </para>
-<screen>&prompt.sudo;dd bs=4096 if=SLES&product-ga;-SP&product-sp;-JeOS.aarch64-&product-ga;.&product-sp;-RaspberryPi-GM.raw.xz of=/dev/disk4
+<screen>&prompt.sudo;dd bs=4096 if=SLES&product-ga;-SP&product-sp;-Minimal-Image.aarch64-&product-ga;.&product-sp;-RaspberryPi-GM.raw.xz of=/dev/disk4
 Password:
 5550+0 records in
 5550+0 records out


### PR DESCRIPTION
### PR creator: Description

Rename all occurrences of JeOS to Minimal Image. Keep jeos-firstboot.


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
