### PR TITLE
add section to LDAP chapter, negation is enabled for the sudoUser att…

### DIFF
--- a/xml/security_ldap.xml
+++ b/xml/security_ldap.xml
@@ -778,6 +778,32 @@ added member: uid=&exampleuserII;,ou=people,dc=example,dc=com</screen>
   </procedure>
  </sect2>
 
+ <sect2 xml:id="sec-security-ldap-sudoer">
+  <title>New negation feature in sudoers.ldap</title>
+       <para>
+         If you are using sudoers.ldap, there is a useful change
+         in <package>sudo</package> versions 1.9.9 and up.
+         In versions older than 1.9.9, negation in sudoers.ldap does
+         not work for the <literal>sudoUser</literal>,
+         <literal>sudoRunAsUser</literal>, or
+         <literal>sudoRunAsGroup</literal> attributes. For example:
+       </para>
+       <screen># does not match all but joe
+# instead, it does not match anyone
+sudoUser: !joe
+
+# does not match all but joe
+# instead, it matches everyone including Joe
+sudoUser: ALL
+sudoUser: !joe</screen>
+  <para>
+    In <command>sudo</command> version 1.9.9 and higher, negation is
+    enabled for the <literal>sudoUser</literal> attribute, so you may
+    exclude individual users. See
+    <command>man 5 sudoers.ldap</command> for more information.
+  </para>
+ </sect2>
+
  <sect2 xml:id="sec-security-ldap-server-sssd">
   <title>Setting Up SSSD</title>
   <para>


### PR DESCRIPTION
…ribute

### PR creator: Description
sudoUser negation is enabled in sudoers.ldap as of sudo 1.9.9

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
