### PR TITLE
DOCTEAM-409 contribution para changed

### DIFF
--- a/xml/common_intro_feedback_i.xml
+++ b/xml/common_intro_feedback_i.xml
@@ -91,26 +91,6 @@
     </para>
    </listitem>
   </varlistentry>
-  <varlistentry condition="beta">
-   <term>Beta program requests</term>
-   <listitem>
-    <para>
-     &suse; Beta Software is bound by the &suse; Beta EULA.
-     This EULA is shipped with the software and can also be read
-     at <link xlink:href="https://documentation.suse.com/beta/eula"/>.
-     &suse; can only provide support via the Beta Program Channel.
-    </para>
-    <para>
-     To open a bug report, follow the instructions on the appropriate
-     product page under <link xlink:href="https://suse.com/betaprogram/beta/"/>.
-     For enhancement requests or any other inquiries, contact us via the
-     product-specific public beta mailing lists. They are listed at
-     <link xlink:href="https://suse.com/betaprogram/beta/"/>.
-     For private requests, contact us directly via
-     <link xlink:href="mailto:beta-programs@lists.suse.com"/>.
-    </para>
-   </listitem>
-  </varlistentry>
   <varlistentry os="osuse">
    <term>Help</term>
    <listitem>

--- a/xml/common_intro_feedback_i.xml
+++ b/xml/common_intro_feedback_i.xml
@@ -15,8 +15,8 @@
  </info>
 
  <para>
-  We welcome feedback on, and contributions to, this documentation.
-  There are several channels for this::
+  Your feedback and contributions to this documentation are welcome.
+  The following channels for giving feedback are available:
  </para>
 
  <variablelist>

--- a/xml/common_intro_feedback_i.xml
+++ b/xml/common_intro_feedback_i.xml
@@ -59,6 +59,14 @@
      document. They take you to the source code on GitHub, where you can open a
      pull request. A GitHub account is required.
     </para>
+    <note>
+     <title><guimenu>Edit Source</guimenu> only available for English</title>
+     <para>
+      The <guimenu>Edit Source</guimenu> links are only available for the
+      English version of each document. For all other languages, use the
+      <guimenu>Report Documentation Bug</guimenu> links instead.
+     </para>
+    </note>
     <para>
      For more information about the documentation environment used for this
      documentation, see

--- a/xml/common_intro_feedback_i.xml
+++ b/xml/common_intro_feedback_i.xml
@@ -15,8 +15,8 @@
  </info>
 
  <para>
-  Your feedback and contributions to this documentation are welcome! Several
-  channels are available:
+  We welcome feedback on, and contributions to, this documentation.
+  There are several channels for this::
  </para>
 
  <variablelist>
@@ -24,13 +24,14 @@
    <term>Service requests and support</term>
    <listitem>
     <para>
-     For services and support options available for your product, refer to
+     For services and support options available for your product, see
      <link xlink:href="https://www.suse.com/support/"/>.
     </para>
     <para>
-     To open a service request, you need a subscription at &scc;. Go to
-     <link xlink:href="https://scc.suse.com/support/requests"/>, log in, and
-     click <guimenu>Create New</guimenu>.
+     To open a service request, you need a &suse; subscription registered
+     at &scc;. 
+     Go to <link xlink:href="https://scc.suse.com/support/requests"/>, log in,
+     and click <guimenu>Create New</guimenu>.
     </para>
    </listitem>
   </varlistentry>
@@ -69,10 +70,9 @@
     </note>
     <para>
      For more information about the documentation environment used for this
-     documentation, see
+     documentation, see the repository's README
      <link
-      xlink:href="&github.url;/blob/master/README.adoc">the
-     repository's README</link>.
+      xlink:href="&github.url;/blob/master/README.adoc"></link>.
      <!--taroth 2020-01-09: Link needs to be adjusted in case the README changes
       format. In case the READMEs differ between the branches, better just point
       to &github.url;-->
@@ -83,11 +83,31 @@
    <term>Mail</term>
    <listitem>
     <para>
-     Alternatively, you can report errors and send feedback concerning the
-     documentation to <email>doc-team@suse.com</email>. Make sure to include
-     the document title, the product version and the publication date of the
-     documentation. Refer to the relevant section number and title (or include
-     the URL) and provide a concise description of the problem.
+     You can also report errors and send feedback concerning the
+     documentation to <email>doc-team@suse.com</email>. Include the
+     document title, the product version, and the publication date of the
+     document. Additionally, include the relevant section number and title (or
+     provide the URL) and provide a concise description of the problem.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry condition="beta">
+   <term>Beta program requests</term>
+   <listitem>
+    <para>
+     &suse; Beta Software is bound by the &suse; Beta EULA.
+     This EULA is shipped with the software and can also be read
+     at <link xlink:href="https://documentation.suse.com/beta/eula"/>.
+     &suse; can only provide support via the Beta Program Channel.
+    </para>
+    <para>
+     To open a bug report, follow the instructions on the appropriate
+     product page under <link xlink:href="https://suse.com/betaprogram/beta/"/>.
+     For enhancement requests or any other inquiries, contact us via the
+     product-specific public beta mailing lists. They are listed at
+     <link xlink:href="https://suse.com/betaprogram/beta/"/>.
+     For private requests, contact us directly via
+     <link xlink:href="mailto:beta-programs@lists.suse.com"/>.
     </para>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
### PR creator: Description

Introduction para for contributing to documentation for foreign languages changed. As 'Edit source' is no longer available for other languages then English.
Changes also need to be done in the other product repos.


### PR creator: Are there any relevant issues/feature requests?

* jsc#DOCTEAM-409


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4
  - [x] SLE 12 SP3
- SLE 11
  - [x] SLE 11 SP4
### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
