### PR TITLE
Update ay_partitioning.xml

### DIFF
--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -382,6 +382,9 @@
        <literal>CT_MD</literal> for software RAID devices.
       </para>
       <para>
+       <literal>CT_DMMULTIPATH</literal> for Multipath devices (deprecated, implied with CT_DISK).
+      </para>
+      <para>
        <literal>CT_BCACHE</literal> for software &bcache; devices.
       </para>
       <para>
@@ -1886,7 +1889,7 @@
 <screen><![CDATA[<general>
   <storage>
     <start_multipath config:type="boolean">true</start_multipath>
-  <storage>
+  </storage>
 </general>
 <partitioning>
   <drive>


### PR DESCRIPTION
There is an unclosed section for the example of multipath.
There is a conflicting note under Multipath support that mentions CT_DMMULTIPATH is deprecated, but the TID at https://www.suse.com/support/kb/doc/?id=000019015 says otherwise. Wouldn't it be safer to add CT_DMMULTIPATH in the list and mention that it's deprecated as well?

### PR creator: Are there any relevant issues/feature requests?

* no issues related, found this out while helping with case 00334685

### PR creator: Which product versions do the changes apply to?

- SLE 15/openSUSE Leap 15.x
  - [X] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [X] SLE 15 SP3/openSUSE Leap 15.3
  - [X] SLE 15 SP2/openSUSE Leap 15.2
  - [X] SLE 15 SP1
  - [X] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
