### PR TITLE
SEO remove SES links

### DIFF
--- a/xml/art_sle_modules_quick.xml
+++ b/xml/art_sle_modules_quick.xml
@@ -818,25 +818,6 @@
        <entry>
         <para>
          <link
-           xlink:href="https://www.suse.com/products/suse-enterprise-storage/">&suse;
-         Enterprise Storage</link>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Basesystem, Server Applications
-        </para>
-       </entry>
-       <entry>
-        <para>
-         SLES<!--, ??? -->
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <link
           xlink:href="https://www.suse.com/products/workstation-extension">&slewe;</link>
         </para>
        </entry>

--- a/xml/security_preface.xml
+++ b/xml/security_preface.xml
@@ -400,14 +400,16 @@
    </listitem>
    <listitem>
     <para><link
-    xlink:href="https://www.bsi.bund.de/DE/Service/Aktuell/Cert_Bund_Meldungen/cert_bund_meldungen_node.html"
-    />, <emphasis>German Federal Office for Information
-    Security</emphasis> vulnerability feed</para>
+    xlink:href="https://www.bsi.bund.de/DE/Home/home_node.html"/>,
+    <emphasis>German Federal Office for Information Security
+    </emphasis>vulnerability feed
+    </para>
    </listitem>
    <listitem>
     <para>
     <link
-    xlink:href="https://www.first.org/cvss/"/>, information about the Common    Vulnerability Scoring System
+    xlink:href="https://www.first.org/cvss/"/>, information about the Common
+    Vulnerability Scoring System
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/security_preface.xml
+++ b/xml/security_preface.xml
@@ -348,9 +348,7 @@
   </para>
   <para>
    &suse; provides a feed of security advisories. It is available at
-   <link xlink:href="https://www.suse.com/en-us/support/update/" />.
-   There is also a list of security updates by CVE number available at
-   <link xlink:href="https://www.suse.com/en-us/security/cve/" />.
+   <link xlink:href="https://www.suse.com/support/update/"/>.
   </para>
   <note os="sles;sled">
    <title>Backports and Version Numbers</title>

--- a/xml/storage_filesystems.xml
+++ b/xml/storage_filesystems.xml
@@ -2155,13 +2155,7 @@ Label: none uuid: 40123456-cb2c-4678-8b3d-d014d1c78c78
      <link xlink:href="http://www.ibm.com/developerworks/linux/library/l-fs7/"/>
     </para>
    </listitem>
-   <listitem>
-    <para>
-     The OCFS2 Project:
-     <link xlink:href="https://oss.oracle.com/projects/ocfs2/"/>
-    </para>
-   </listitem>
-  </itemizedlist>
+   </itemizedlist>
 
   <para>
    A comprehensive multi-part tutorial about Linux file systems can be found at

--- a/xml/tuning_kexec.xml
+++ b/xml/tuning_kexec.xml
@@ -1425,7 +1425,7 @@ PID: 9446   TASK: ffff88003a57c3c0  CPU: 1   COMMAND: "bash"
     <para>
      A white paper with a comprehensive description of the crash utility
      usage can be found at
-     <link xlink:href="http://people.redhat.com/anderson/crash_whitepaper/"/>.
+     <link xlink:href="https://crash-utility.github.io/crash_whitepaper.html"/>.
     </para>
    </listitem>
    <listitem>

--- a/xml/tuning_systemtap.xml
+++ b/xml/tuning_systemtap.xml
@@ -2009,6 +2009,6 @@ probe kernel.function("tcp_accept").return?,
     http://en.wikipedia.org/wiki/Systemtap
     https://sourceware.org/systemtap/
     https://sourceware.org/systemtap/documentation.html
-    https://sourceware.org/systemtap/langref/>
+    https://sourceware.org/systemtap/langref/-->
  </sect1>
 </chapter>

--- a/xml/tuning_systemtap.xml
+++ b/xml/tuning_systemtap.xml
@@ -2009,6 +2009,6 @@ probe kernel.function("tcp_accept").return?,
     http://en.wikipedia.org/wiki/Systemtap
     https://sourceware.org/systemtap/
     https://sourceware.org/systemtap/documentation.html
-    https://sourceware.org/systemtap/langref/-->
+    https://sourceware.org/systemtap/langref/>
  </sect1>
 </chapter>


### PR DESCRIPTION
### PR creator: Description

A total of seven links were removed or updated (SES, CVE, storage etc.) due to product updates and/or discontinuance.
Changes will be done for each branch separately, so no backport.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
