### PR TITLE
Added getting openSUSE; got rid of lone sect1

### DIFF
--- a/xml/ay_general_options.xml
+++ b/xml/ay_general_options.xml
@@ -394,7 +394,7 @@
    further information about this feature.
   </para>
   <!--taroth 2019-09-12: same note used in deployment_yast_installer.xml-->
-  <important>
+  <important os="sles;sled">
    <title>Quarterly media update: self-update disabled</title>
    <para>
     The installer self-update is only available if you use the

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -300,13 +300,13 @@
        URL. The server to be used is determined in the following order:
       </para>
       <orderedlist spacing="normal">
-       <listitem os="sles;sled">
+       <listitem>
         <para>
          By evaluating the <literal>regurl</literal> boot
          parameter (<xref linkend="sec-boot-parameters-advanced-smt"/>).
         </para>
        </listitem>
-       <listitem os="sles;sled">
+       <listitem>
         <para>
          By evaluating the <literal>/suse_register/reg_server</literal> profile
          element if you are using &ay;.
@@ -320,7 +320,7 @@
          registration server.
         </para>
        </listitem>
-       <listitem os="sles;sled">
+       <listitem>
         <para>
          By querying the &scc;.
         </para>

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -189,7 +189,7 @@
   </para>
 
 <!--taroth 2019-09-12: same note used in ay_bigfile.xml-->
-  <important>
+  <important os="sles;sled">
    <title>Quarterly media update: self-update disabled</title>
    <para>
     The installer self-update is only available if you use the <literal>GM</literal>
@@ -300,7 +300,7 @@
        URL. The server to be used is determined in the following order:
       </para>
       <orderedlist spacing="normal">
-       <listitem os="sles;sled">  
+       <listitem os="sles;sled">
         <para>
          By evaluating the <literal>regurl</literal> boot
          parameter (<xref linkend="sec-boot-parameters-advanced-smt"/>).

--- a/xml/installation-opensuse.xml
+++ b/xml/installation-opensuse.xml
@@ -26,633 +26,666 @@
     &productname; on the x86_64 architecture.
    </para>
    <para>
-    For installing the &aarch64; and &power; variants, see <link
-    xlink:href="https://en.opensuse.org/Portal:ARM"/> and <link xlink:href="https://en.opensuse.org/Portal:PowerPC"/>.
+    For more detailed installation instructions see <xref
+    linkend="cha-install"/>.  For installing the &aarch64; and &power;
+    variants, see <link xlink:href="https://en.opensuse.org/Portal:ARM"/> and
+    <link xlink:href="https://en.opensuse.org/Portal:PowerPC"/>.
    </para>
   </abstract>
  </info>
- <sect1 xml:id="sec-osuse-installquick">
-  <title>Welcome to &productname;</title>
-
+ <sect1 xml:id="sec-osuse-installquick-get">
+  <title>Getting openSUSE</title>
   <para>
-   For more detailed installation instructions see <xref linkend="cha-install"/>.
+   To download &productname;, visit <link
+   xlink:href="https://get.opensuse.org/leap/"/>. On the
+   <guimenu>Download</guimenu> tab you will find download links for different
+   architectures:
   </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     Intel or AMD 64-bit desktops, laptops, and servers (<quote>Regular</quote>
+     computers and laptops).
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     UEFI Arm 64-bit servers, desktops, laptops and boards (RaspBerry PI,
+     laptops and computers with an ARM CPU).
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Power PC / IBM Z (IBM server machines)
+    </para>
+   </listitem>
+  </itemizedlist>
+  <para>
+   You also have the choice between two different images for download: Offline
+   Image and Network Image. Check the documentation on the download page under
+   <citetitle>Choosing Which Media to Download</citetitle> for more
+   information.
+  </para>
+  <para>
+   Documentation on how to create a bootable installation media is also
+   available on the download page under <citetitle>Easy Ways to Switch to
+   openSUSE Leap</citetitle>.
+  </para>
+ </sect1>
+ <sect1 xml:id="sec-osuse-installquick-sysreqs">
+  <title>Minimum system requirements</title>
+  <itemizedlist mark="bullet" spacing="normal">
+   <listitem>
+    <para>
+     Any AMD64/Intel* EM64T processor (32-bit processors are not supported)
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     1 GB physical RAM (at least 1.5 GB when using online repos, 4 GB or more strongly recommended)
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     10 GB available disk space for a minimal installation, 16 GB for a
+     graphical desktop (more is recommended). In case you plan to use Btrfs
+     snapshots a minimum of 40 GB for the root partition is recommended.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Supports most modern sound and graphics cards, 1024 x 768 display
+     resolution (higher recommended)
+    </para>
+   </listitem>
+  </itemizedlist>
+ </sect1>
+ <sect1 xml:id="sec-opensuse-installquick-install">
+  <title>Installing &productname;</title>
+  <para>
+   Use these instructions if there is no existing Linux system on your
+   machine, or if you want to replace an existing Linux system.
+  </para>
+  <sect2 xml:id="sec-opensuse-installquick-boot">
+   <title>Booting the installation system</title>
+   <para>
+    Insert a DVD or a bootable USB stick containing the installation image for
+    &productname;, then reboot the computer to start the installation
+    program. On machines with a traditional BIOS you will see the graphical
+    boot screen shown below. On machines equipped with UEFI, a slightly
+    different boot screen is used. Secure boot on UEFI machines is supported.
+   </para>
+   <informalfigure>
+    <mediaobject>
+     <imageobject role="fo">
+      <imagedata fileref="install_boot_osuse.png" width="75%"/>
+     </imageobject>
+     <imageobject role="html">
+      <imagedata fileref="install_boot_osuse.png" width="100%"/>
+     </imageobject>
+    </mediaobject>
+   </informalfigure>
+   <para>
+    On BIOS machines, use <keycap>F2</keycap> to change the language for the
+    installer. A corresponding keyboard layout is chosen automatically. See
+    <xref linkend="sec-boot-parameters-screen"/> or <xref
+    linkend="sec-boot-parameters-uefi"/> for more information about changing
+    boot parameters. On UEFI machines adjust the language and keyboard
+    settings in the next step.
+   </para>
+   <para>
+    Select <guimenu>Installation</guimenu> on the boot screen, then press
+    <keycap function="enter"/>. This boots the system and loads the
+    &productname; installer.
+   </para>
+  </sect2>
+  <sect2 xml:id="sec-opensuse-installquick-language">
+   <title>Language, keyboard and license agreement</title>
+   <informalfigure>
+    <mediaobject>
+     <imageobject role="fo">
+      <imagedata fileref="install_welcome_osuse.png" width="75%"/>
+     </imageobject>
+     <imageobject role="html">
+      <imagedata fileref="install_welcome_osuse.png" width="100%"/>
+     </imageobject>
+    </mediaobject>
+   </informalfigure>
+   <para>
+    On systems with a traditional BIOS the <guimenu>Language</guimenu> and
+    <guimenu>Keyboard Layout</guimenu> settings are initialized with the
+    language you chose at the boot screen. If you did not change the default,
+    or are using a UEFI machine it will be English (US). Change the settings
+    here, if necessary. Use the <guimenu>Keyboard Test</guimenu> text box to
+    test the layout.
+   </para>
+   <para>
+    Read the License Agreement. It is presented in the language you have
+    chosen. Other <guimenu>License Translations</guimenu> are
+    available. Proceed with <guimenu>Next</guimenu>.
+   </para>
+  </sect2>
+  <sect2 xml:id="sec-opensuse-installquick-network">
+   <title>Network settings</title>
+   <informalfigure>
+    <mediaobject>
+     <imageobject role="fo">
+      <imagedata fileref="install_network_osuse.png" width="75%"/>
+     </imageobject>
+     <imageobject role="html">
+      <imagedata fileref="install_network_osuse.png" width="100%"/>
+     </imageobject>
+    </mediaobject>
+   </informalfigure>
+   <para>
+    If the network can not be configured automatically, the <guimenu>Network
+    Settings</guimenu> dialog opens. Choose a network interface from the list
+    and configure it with <guimenu>Edit</guimenu>. Alternatively,
+    <guimenu>Add</guimenu> an interface manually.  See <xref
+    linkend="sec-yast-install-network"/> and <xref
+    linkend="sec-network-yast"/> for more information.  If you prefer to do
+    an installation without network access, skip this step without making any
+    changes and proceed with <guimenu>Next</guimenu>.
+   </para>
+  </sect2>
 
-  <sect2 xml:id="sec-osuse-installquick-sysreqs">
-   <title>Minimum system requirements</title>
-   <itemizedlist mark="bullet" spacing="normal">
+  <sect2 xml:id="sec-opensuse-installquick-online-repos">
+   <title>Online repositories</title>
+   <para>
+    A system analysis is performed, where the installer probes for storage
+    devices, and tries to find other installed systems. If a network
+    connection with Internet access is available, you will be asked to
+    activate the online repositories. Answer with <guimenu>Yes</guimenu> to
+    proceed. In case you do not have Internet access, this step will be
+    skipped.
+   </para>
+   <informalfigure>
+    <mediaobject>
+     <imageobject role="fo">
+      <imagedata fileref="install_onlinerepos_ask_osuse.png" width="75%"/>
+     </imageobject>
+     <imageobject role="html">
+      <imagedata fileref="install_onlinerepos_ask_osuse.png" width="100%"/>
+     </imageobject>
+    </mediaobject>
+   </informalfigure>
+   <para>
+    The online repositories are official &opensuse; package sources. They not
+    only offer additional packages not included on the installation media, but
+    also the update repositories containing security and bug fixes.  Using the
+    default selection is recommended. Add at least the <guimenu>Main Update
+    Repository</guimenu>, because it makes sure the system is installed with
+    the latest security patches.
+   </para>
+   <informalfigure>
+    <mediaobject>
+     <imageobject role="fo">
+      <imagedata fileref="install_onlinerepos_osuse.png" width="75%"/>
+     </imageobject>
+     <imageobject role="html">
+      <imagedata fileref="install_onlinerepos_osuse.png" width="100%"/>
+     </imageobject>
+    </mediaobject>
+   </informalfigure>
+   <para>
+    You have the following choices:
+   </para>
+   <itemizedlist>
     <listitem>
      <para>
-      Any AMD64/Intel* EM64T processor (32-bit processors are not supported)
+      The <guimenu>Main Repository</guimenu> contains open source
+      software (OSS). Compared to the DVD installation media, it contains
+      many additional software packages, among them many additional
+      desktop systems.
      </para>
     </listitem>
     <listitem>
      <para>
-      1 GB physical RAM (at least 1.5 GB when using online repos, 4 GB or more strongly recommended)
+      The <guimenu>Update repository with updates from SUSE Linux Enterprise
+      15</guimenu> and the <guimenu>Update repository from openSUSE
+      Backports</guimenu> contain updates for the Main Repository. Choosing
+      this repository is recommended for all installation scenarios.
      </para>
     </listitem>
     <listitem>
      <para>
-      10 GB available disk space for a minimal installation, 16 GB for a
-      graphical desktop (more is recommended). In case you plan to use Btrfs
-      snapshots a minimum of 40 GB for the root partition is recommended.
+      The <guimenu>Non-OSS Repository</guimenu> contains packages with
+      a proprietary software license. Choosing it is not required for
+      installing a custom desktop system.
      </para>
     </listitem>
     <listitem>
      <para>
-      Supports most modern sound and graphics cards, 1024 x 768 display
-      resolution (higher recommended)
+      Choosing <guimenu>Update Repository (Non-OSS)</guimenu> is
+      recommended when also having chosen the <guimenu>Non-OSS
+      Repository</guimenu>. It contains the respective updates and
+      security fixes.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      All other repositories are intended for experienced users and
+      developers. Click on a repository name to get more information.
      </para>
     </listitem>
    </itemizedlist>
-  </sect2>
-  <sect2 xml:id="sec-opensuse-installquick-install">
-   <title>Installing &productname;</title>
    <para>
-    Use these instructions if there is no existing Linux system on your
-    machine, or if you want to replace an existing Linux system.
+    Confirm your selection with <guimenu>Next</guimenu>. Depending on your
+    choice, you need to confirm one or more license agreements. Do so by
+    choosing <guimenu>Next</guimenu> until you proceed to the <guimenu>System
+    Role</guimenu> screen. Now choose <guimenu>Next</guimenu> to proceed.
    </para>
-   <sect3 xml:id="sec-opensuse-installquick-boot">
-    <title>Booting the installation system</title>
-    <para>
-     Insert a DVD or a bootable USB stick containing the installation image for
-     &productname;, then reboot the computer to start the installation
-     program. On machines with a traditional BIOS you will see the graphical
-     boot screen shown below. On machines equipped with UEFI, a slightly
-     different boot screen is used. Secure boot on UEFI machines is supported.
-    </para>
-    <informalfigure>
-     <mediaobject>
-      <imageobject role="fo">
-       <imagedata fileref="install_boot_osuse.png" width="75%"/>
-      </imageobject>
-      <imageobject role="html">
-       <imagedata fileref="install_boot_osuse.png" width="100%"/>
-      </imageobject>
-     </mediaobject>
-    </informalfigure>
-    <para>
-     On BIOS machines, use <keycap>F2</keycap> to change the language for the
-     installer. A corresponding keyboard layout is chosen automatically. See
-     <xref linkend="sec-boot-parameters-screen"/> or <xref
-     linkend="sec-boot-parameters-uefi"/> for more information about changing
-     boot parameters. On UEFI machines adjust the language and keyboard
-     settings in the next step.
-    </para>
-    <para>
-     Select <guimenu>Installation</guimenu> on the boot screen, then press
-     <keycap function="enter"/>. This boots the system and loads the
-     &productname; installer.
-    </para>
-   </sect3>
-   <sect3 xml:id="sec-opensuse-installquick-language">
-    <title>Language, keyboard and license agreement</title>
-    <informalfigure>
-     <mediaobject>
-      <imageobject role="fo">
-       <imagedata fileref="install_welcome_osuse.png" width="75%"/>
-      </imageobject>
-      <imageobject role="html">
-       <imagedata fileref="install_welcome_osuse.png" width="100%"/>
-      </imageobject>
-     </mediaobject>
-    </informalfigure>
-    <para>
-     On systems with a traditional BIOS the <guimenu>Language</guimenu> and
-     <guimenu>Keyboard Layout</guimenu> settings are initialized with the
-     language you chose at the boot screen. If you did not change the default,
-     or are using a UEFI machine it will be English (US). Change the settings
-     here, if necessary. Use the <guimenu>Keyboard Test</guimenu> text box to
-     test the layout.
-    </para>
-    <para>
-     Read the License Agreement. It is presented in the language you have
-     chosen. Other <guimenu>License Translations</guimenu> are
-     available. Proceed with <guimenu>Next</guimenu>.
-    </para>
-   </sect3>
-   <sect3 xml:id="sec-opensuse-installquick-network">
-    <title>Network settings</title>
-    <informalfigure>
-     <mediaobject>
-      <imageobject role="fo">
-       <imagedata fileref="install_network_osuse.png" width="75%"/>
-      </imageobject>
-      <imageobject role="html">
-       <imagedata fileref="install_network_osuse.png" width="100%"/>
-      </imageobject>
-     </mediaobject>
-    </informalfigure>
-    <para>
-     If the network can not be configured automatically, the <guimenu>Network
-     Settings</guimenu> dialog opens. Choose a network interface from the list
-     and configure it with <guimenu>Edit</guimenu>. Alternatively,
-     <guimenu>Add</guimenu> an interface manually.  See <xref
-     linkend="sec-yast-install-network"/> and <xref
-     linkend="sec-network-yast"/> for more information.  If you prefer to do
-     an installation without network access, skip this step without making any
-     changes and proceed with <guimenu>Next</guimenu>.
-    </para>
-   </sect3>
+  </sect2>
 
-   <sect3 xml:id="sec-opensuse-installquick-online-repos">
-    <title>Online repositories</title>
+  <sect2 xml:id="sec-opensuse-installquick-ui">
+   <title>System role</title>
+   <informalfigure>
+    <mediaobject>
+     <imageobject role="fo">
+      <imagedata fileref="install_ui_osuse.png" width="75%"/>
+     </imageobject>
+     <imageobject role="html">
+      <imagedata fileref="install_ui_osuse.png" width="100%"/>
+     </imageobject>
+    </mediaobject>
+   </informalfigure>
+   <para>
+    Choose a general software and system configuration with this step by
+    selecting a desktop or server configuration.
+   </para>
+   <para>
+    For a desktop installation, choose between <guimenu>Desktop with KDE
+    Plasma</guimenu>, <guimenu>Desktop with GNOME</guimenu>, <guimenu>Desktop
+    with Xfce</guimenu> or <guimenu>Generic Desktop</guimenu>. KDE and Xfce
+    are somewhat similar to Windows. GNOME offers an alternative, innovative
+    environment. If you prefer an alternative to the KDE, GNOME, or Xfce
+    desktops, choose <guimenu>Generic Desktop</guimenu>. You will be able to
+    choose between the LXDE, MATE and others later in the installation
+    process by selecting <guimenu>Software</guimenu> in the
+    <guimenu>Installation Settings dialog</guimenu>.
+   </para>
+   <para>
+    If you are setting up a server, you probably do not need a graphical user
+    interface. Choose <guimenu>Server (Text Mode)</guimenu> in this
+    case. Alternatively, set up a server system with a read-only root
+    partition and transactional updates by choosing <guimenu>Transactional
+    Server</guimenu>. This selection also is a prerequisite for setting up
+    openSUSE Kubic. See <link
+    xlink:href="https://kubic.opensuse.org/blog/2018-04-04-transactionalupdates/"/>
+    for more information on transactional updates.
+   </para>
+   <para>
+    You can also manually choose the software configuration for your
+    system. Select <guimenu>Custom</guimenu> and then <guimenu>Next</guimenu>
+    to get to the <guimenu>Software Selection and System Tasks</guimenu>
+    dialog. Choose one or more patterns for installation. By clicking
+    <guimenu>Details</guimenu>, you can select individual packages.
+   </para>
+   <tip>
+    <title>Release notes</title>
     <para>
-     A system analysis is performed, where the installer probes for storage
-     devices, and tries to find other installed systems. If a network
-     connection with Internet access is available, you will be asked to
-     activate the online repositories. Answer with <guimenu>Yes</guimenu> to
-     proceed. In case you do not have Internet access, this step will be
-     skipped.
+     From this point on, the Release Notes can be viewed from any screen
+     during the installation process by selecting <guimenu>Release
+     Notes</guimenu>.
     </para>
-    <informalfigure>
-     <mediaobject>
-      <imageobject role="fo">
-       <imagedata fileref="install_onlinerepos_ask_osuse.png" width="75%"/>
-      </imageobject>
-      <imageobject role="html">
-       <imagedata fileref="install_onlinerepos_ask_osuse.png" width="100%"/>
-      </imageobject>
-     </mediaobject>
-    </informalfigure>
-    <para>
-     The online repositories are official &opensuse; package sources. They not
-     only offer additional packages not included on the installation media, but
-     also the update repositories containing security and bug fixes.  Using the
-     default selection is recommended. Add at least the <guimenu>Main Update
-     Repository</guimenu>, because it makes sure the system is installed with
-     the latest security patches.
-    </para>
-    <informalfigure>
-     <mediaobject>
-      <imageobject role="fo">
-       <imagedata fileref="install_onlinerepos_osuse.png" width="75%"/>
-      </imageobject>
-      <imageobject role="html">
-       <imagedata fileref="install_onlinerepos_osuse.png" width="100%"/>
-      </imageobject>
-     </mediaobject>
-    </informalfigure>
-    <para>
-     You have the following choices:
-    </para>
-    <itemizedlist>
+   </tip>
+  </sect2>
+
+  <sect2 xml:id="sec-opensuse-installquick-partitioning">
+   <title>Suggested partitioning</title>
+   <informalfigure>
+    <mediaobject>
+     <imageobject role="fo">
+      <imagedata fileref="install_partitioner_osuse.png" width="75%"/>
+     </imageobject>
+     <imageobject role="html">
+      <imagedata fileref="install_partitioner_osuse.png" width="100%"/>
+     </imageobject>
+    </mediaobject>
+   </informalfigure>
+   <para>
+    Define a partition setup for &productname; in this step.  Review the
+    partition setup proposed by the system. If necessary, change it. You have
+    the following options:
+   </para>
+   <variablelist>
+    <varlistentry>
+     <term><guimenu>Guided setup</guimenu>
+     </term>
      <listitem>
       <para>
-       The <guimenu>Main Repository</guimenu> contains open source
-       software (OSS). Compared to the DVD installation media, it contains
-       many additional software packages, among them many additional
-       desktop systems.
+       Starts a wizard which lets you refine the partitioning proposal.
+       Options available here depend on your system setup. In case it contains
+       more than a single hard disk, you may choose which disk(s) to use and
+       where to place the root partition. If the disk(s) already contain
+       partitions, decide whether to remove or resize them.
+      </para>
+      <para>
+       In subsequent steps you may also add LVM support and disk
+       encryption. You can change the file system for the root partition and
+       decide whether to have a separate home partition or not.
       </para>
      </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><guimenu>Expert partitioner</guimenu>
+     </term>
      <listitem>
       <para>
-       The <guimenu>Update repository with updates from SUSE Linux Enterprise
-       15</guimenu> and the <guimenu>Update repository from openSUSE
-       Backports</guimenu> contain updates for the Main Repository. Choosing
-       this repository is recommended for all installation scenarios.
+       Opens the <guimenu>Expert Partitioner</guimenu> described in <xref
+       linkend="sec-expert-partitioner"/>. This gives you full control over
+       the partitioning setup and lets you create a custom setup. This option
+       is intended for experts.
       </para>
      </listitem>
+    </varlistentry>
+   </variablelist>
+
+   <note>
+    <title>Separate home partition</title>
+    <para>
+     The default proposal no longer suggests to create a separate partition
+     for <filename>/home</filename>. The <filename>/home</filename> directory
+     contains the user's data and personal configuration files. Placing it on
+     a separate directory makes it easier to rebuild the system in the future,
+     or allows to share it with different Linux installations on the same
+     machine.
+    </para>
+    <para>
+     In case you want to change the proposal to create a separate partition
+     for <filename>/home</filename>, choose <guimenu>Guided Setup</guimenu>
+     and click <guimenu>Next</guimenu> until you reach the <guimenu>Filesystem
+     Options</guimenu> screen. Check <guimenu>Propose Separate Home
+     Partition</guimenu>. By default it will be formatted with
+     <guimenu>XFS</guimenu>, but you can choose to use a different file
+     system. Close the dialog by clicking <guimenu>Next</guimenu> again.
+    </para>
+   </note>
+
+   <para>
+    To accept the proposed setup without any changes, choose
+    <guimenu>Next</guimenu> to proceed.
+   </para>
+  </sect2>
+
+  <sect2 xml:id="sec-opensuse-installquick-time">
+   <title>Clock and time zone</title>
+   <informalfigure>
+    <mediaobject>
+     <imageobject role="fo">
+      <imagedata fileref="install_timezone_osuse.png" width="75%"/>
+     </imageobject>
+     <imageobject role="html">
+      <imagedata fileref="install_timezone_osuse.png" width="100%"/>
+     </imageobject>
+    </mediaobject>
+   </informalfigure>
+   <para>
+    Select the clock and time zone to use in your system. To manually adjust
+    the time or to configure an NTP server for time synchronization, choose
+    <guimenu>Other Settings</guimenu>. See <xref
+    linkend="sec-yast-install-date-time"/> for detailed information. Proceed
+    with <guimenu>Next</guimenu>.
+   </para>
+  </sect2>
+
+  <sect2 xml:id="sec-opensuse-installquick-user">
+   <title>Local user</title>
+   <informalfigure>
+    <mediaobject>
+     <imageobject role="fo">
+      <imagedata fileref="install_user_osuse.png" width="75%"/>
+     </imageobject>
+     <imageobject role="html">
+      <imagedata fileref="install_user_osuse.png" width="100%"/>
+     </imageobject>
+    </mediaobject>
+   </informalfigure>
+   <para>
+    To create a local user, type the first and last name in the
+    <guimenu>User’s Full Name</guimenu> field, the login name in the
+    <guimenu>Username</guimenu> field, and the password in the
+    <guimenu>Password</guimenu> field.
+   </para>
+   <para>
+    The password should be at least eight characters long and should contain
+    both uppercase and lowercase letters and numbers. The maximum length for
+    passwords is 72 characters, and passwords are case-sensitive.
+   </para>
+   <para>
+    For security reasons it is also strongly recommended
+    <emphasis>not</emphasis> to enable the <guimenu>Automatic
+    Login</guimenu>. You should also <emphasis>not</emphasis> <guimenu>Use
+    this Password for the System Administrator</guimenu> but rather provide a
+    separate &rootuser; password in the next installation step.
+   </para>
+   <para>
+    If you install on a system where a previous Linux installation was found,
+    you may <guimenu>Import User Data from a Previous
+    Installation</guimenu>. Click <guimenu>Choose User</guimenu> for a list of
+    available user accounts. Select one or more user.
+   </para>
+   <para>
+    In an environment where users are centrally managed (for example by NIS or
+    LDAP) you may want to skip the creation of local users. Select
+    <guimenu>Skip User Creation</guimenu> in this case.
+   </para>
+   <para>
+    Proceed with <guimenu>Next</guimenu>.
+   </para>
+  </sect2>
+
+  <sect2 xml:id="sec-opensuse-installquick-root">
+   <title>
+    Authentication for the System Administrator <quote>root</quote>
+   </title>
+   <informalfigure>
+    <mediaobject>
+     <imageobject role="fo">
+      <imagedata fileref="install_root_osuse.png" width="75%"/>
+     </imageobject>
+     <imageobject role="html">
+      <imagedata fileref="install_root_osuse.png" width="100%"/>
+     </imageobject>
+    </mediaobject>
+   </informalfigure>
+   <para>
+    Provide a password for the system administrator account (called the
+    &rootuser; user).
+   </para>
+   <para>
+    You should never forget the &rootuser; password! After you entered it
+    here, the password cannot be retrieved. See
+    <xref linkend="sec-yast-install-user-root"/> for more information. Proceed
+    with <guimenu>Next</guimenu>.
+   </para>
+   <tip>
+    <title>Passwords and keyboard layout</title>
+    <para>
+     It is recommended to only use US ASCII characters. In case of a system
+     error or when you need to start your system in rescue mode, the keyboard
+     may not be localized.
+    </para>
+   </tip>
+   <para>
+    In case you would like to enable password-less authentication via SSH
+    login, you can import a key via <guimenu>Import Public SSH
+    Key</guimenu>. If you want to completely disable &rootuser; login via
+    password, upload a key only and do not provide a root password. A login
+    as system administrator will only be possible via SSH using the respective
+    keyin this case.
+   </para>
+  </sect2>
+
+  <sect2 xml:id="sec-opensuse-installquick-inst-settings">
+   <title>Installation settings</title>
+   <informalfigure>
+    <mediaobject>
+     <imageobject role="fo">
+      <imagedata fileref="install_summary_osuse.png" width="75%"/>
+     </imageobject>
+     <imageobject role="html">
+      <imagedata fileref="install_summary_osuse.png" width="100%"/>
+     </imageobject>
+    </mediaobject>
+   </informalfigure>
+   <para>
+    Use the <guimenu>Installation Settings</guimenu> screen to review
+    and&mdash;if necessary&mdash;change several proposed
+    installation settings. The current configuration is listed for each
+    setting. To change it, click the headline. Some settings, such as
+    firewall or SSH can directly be changed by clicking the respective
+    links.
+   </para>
+   <important>
+    <title>Remote access</title>
+    <para>
+     Changes you can make here, can also be made later at any time from the
+     installed system. However, if you need remote access directly after the
+     installation, you have to adjust the <guimenu>Security</guimenu> settings.
+    </para>
+   </important>
+   <variablelist>
+    <varlistentry>
+     <term><guimenu>Booting</guimenu>
+     </term>
      <listitem>
       <para>
-       The <guimenu>Non-OSS Repository</guimenu> contains packages with
-       a proprietary software license. Choosing it is not required for
-       installing a custom desktop system.
+       This section shows the boot loader configuration. Changing the
+       defaults is only recommended if really needed. Refer to
+       <xref linkend="cha-grub2"/> for details.
       </para>
      </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><guimenu>Software</guimenu>
+     </term>
      <listitem>
       <para>
-       Choosing <guimenu>Update Repository (Non-OSS)</guimenu> is
-       recommended when also having chosen the <guimenu>Non-OSS
-       Repository</guimenu>. It contains the respective updates and
-       security fixes.
+       The default scope of software includes the base system and X Window
+       with the selected desktop. Clicking <guimenu>Software</guimenu> opens
+       the <guimenu>Software Selection and System Tasks</guimenu> screen,
+       where you can change the software selection by selecting or deselecting
+       patterns. Each pattern contains several software packages needed for
+       specific functions (for example, Web and LAMP server or a print
+       server). For a more detailed selection based on software packages to
+       install, select <guimenu>Details</guimenu> to switch to the &yast;
+       <guimenu>Software Manager</guimenu>. See <xref
+       linkend="cha-yast-software"/> for more information.
       </para>
      </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><guimenu>Default systemd target</guimenu>
+     </term>
      <listitem>
       <para>
-       All other repositories are intended for experienced users and
-       developers. Click on a repository name to get more information.
+       If you have chosen to install a desktop system, the system boots into
+       the <guimenu>graphical</guimenu> target, with network, multiuser and
+       display manager support. If you have not installed a desktop, the
+       system boots into a login shell (<guimenu>Text Mode</guimenu>).
       </para>
      </listitem>
-    </itemizedlist>
-    <para>
-     Confirm your selection with <guimenu>Next</guimenu>. Depending on your
-     choice, you need to confirm one or more license agreements. Do so by
-     choosing <guimenu>Next</guimenu> until you proceed to the <guimenu>System
-     Role</guimenu> screen. Now choose <guimenu>Next</guimenu> to proceed.
-    </para>
-   </sect3>
+    </varlistentry>
+    <varlistentry>
+     <term><guimenu>System</guimenu>
+     </term>
+     <listitem>
+      <para>
+       View detailed hardware information by clicking
+       <guimenu>System</guimenu>. In the resulting screen you can also change
+       <guimenu>Kernel Settings</guimenu>&mdash;see <xref
+       linkend="sec-yast-install-proposal-system"/> for more information.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><guimenu>Security</guimenu>
+     </term>
+     <listitem>
+      <para>
+       The <guimenu>CPU Mitigations</guimenu> refer to kernel boot command
+       line parameters for software mitigations that have been deployed
+       to prevent CPU side-channel attacks. Click the highlighted
+       entry to choose a different option. For details, see <xref
+       linkend="vle-grub2-yast2-cpu-mitigations"/>.
+      </para>
+      <para>
+       By default, the Firewall is enabled with all network interfaces
+       configured for the <literal>public</literal> zone, where all ports are
+       closed by default, ensuring maximum security. See <xref
+       linkend="cha-security-firewall"/> for configuration details.
+      </para>
+      <para>
+       The SSH service is disabled by default, its port (22) is closed.
+       Therefore logging in from remote is not possible by default. Click
+       <guimenu>enable</guimenu> and <guimenu>open</guimenu> to toggle these
+       settings.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><guimenu>Network configuration</guimenu>
+     </term>
+     <listitem>
+      <para>
+       Displays the current network configuration. Click
+       <guimenu>Network Configuration</guimenu> to change the settings. For
+       details, see <xref linkend="sec-network-yast"/>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </sect2>
 
-   <sect3 xml:id="sec-opensuse-installquick-ui">
-    <title>System role</title>
-    <informalfigure>
-     <mediaobject>
-      <imageobject role="fo">
-       <imagedata fileref="install_ui_osuse.png" width="75%"/>
-      </imageobject>
-      <imageobject role="html">
-       <imagedata fileref="install_ui_osuse.png" width="100%"/>
-      </imageobject>
-      </mediaobject>
-    </informalfigure>
-    <para>
-     Choose a general software and system configuration with this step by
-     selecting a desktop or server configuration.
-    </para>
-    <para>
-     For a desktop installation, choose between <guimenu>Desktop with KDE
-     Plasma</guimenu>, <guimenu>Desktop with GNOME</guimenu>, <guimenu>Desktop
-     with Xfce</guimenu> or <guimenu>Generic Desktop</guimenu>. KDE and Xfce
-     are somewhat similar to Windows. GNOME offers an alternative, innovative
-     environment. If you prefer an alternative to the KDE, GNOME, or Xfce
-     desktops, choose <guimenu>Generic Desktop</guimenu>. You will be able to
-     choose between the LXDE, MATE and others later in the installation
-     process by selecting <guimenu>Software</guimenu> in the
-     <guimenu>Installation Settings dialog</guimenu>.
-    </para>
-    <para>
-     If you are setting up a server, you probably do not need a graphical user
-     interface. Choose <guimenu>Server (Text Mode)</guimenu> in this
-     case. Alternatively, set up a server system with a read-only root
-     partition and transactional updates by choosing <guimenu>Transactional
-     Server</guimenu>. This selection also is a prerequisite for setting up
-     openSUSE Kubic. See <link
-     xlink:href="https://kubic.opensuse.org/blog/2018-04-04-transactionalupdates/"/>
-     for more information on transactional updates.
-    </para>
-    <para>
-     You can also manually choose the software configuration for your
-     system. Select <guimenu>Custom</guimenu> and then <guimenu>Next</guimenu>
-     to get to the <guimenu>Software Selection and System Tasks</guimenu>
-     dialog. Choose one or more patterns for installation. By clicking
-     <guimenu>Details</guimenu>, you can select individual packages.
-    </para>
-    <tip>
-     <title>Release notes</title>
-     <para>
-      From this point on, the Release Notes can be viewed from any screen
-      during the installation process by selecting <guimenu>Release
-      Notes</guimenu>.
-     </para>
-    </tip>
-   </sect3>
+  <sect2 xml:id="sec-opensuse-installquick-confirm">
+   <title>Start the installation</title>
+   <informalfigure>
+    <mediaobject>
+     <imageobject role="fo">
+      <imagedata fileref="install_confirm_osuse.png" width="75%"/>
+     </imageobject>
+     <imageobject role="html">
+      <imagedata fileref="install_confirm_osuse.png" width="100%"/>
+     </imageobject>
+    </mediaobject>
+   </informalfigure>
+   <para>
+    After you have finalized the system configuration on the
+    <guimenu>Installation Settings</guimenu> screen, click
+    <guimenu>Install</guimenu>. Depending on your software selection you may
+    need to agree to license agreements before the installation confirmation
+    screen pops up. Up to this point no changes have been made to your
+    system. After you click <guimenu>Install</guimenu> a second time, the
+    installation process starts.
+   </para>
+  </sect2>
 
-   <sect3 xml:id="sec-opensuse-installquick-partitioning">
-    <title>Suggested partitioning</title>
-    <informalfigure>
-     <mediaobject>
-      <imageobject role="fo">
-       <imagedata fileref="install_partitioner_osuse.png" width="75%"/>
-      </imageobject>
-      <imageobject role="html">
-       <imagedata fileref="install_partitioner_osuse.png" width="100%"/>
-      </imageobject>
-     </mediaobject>
-    </informalfigure>
-    <para>
-     Define a partition setup for &productname; in this step.  Review the
-     partition setup proposed by the system. If necessary, change it. You have
-     the following options:
-    </para>
-    <variablelist>
-     <varlistentry>
-      <term><guimenu>Guided setup</guimenu>
-      </term>
-      <listitem>
-       <para>
-        Starts a wizard which lets you refine the partitioning proposal.
-        Options available here depend on your system setup. In case it contains
-        more than a single hard disk, you may choose which disk(s) to use and
-        where to place the root partition. If the disk(s) already contain
-        partitions, decide whether to remove or resize them.
-       </para>
-       <para>
-        In subsequent steps you may also add LVM support and disk
-        encryption. You can change the file system for the root partition and
-        decide whether to have a separate home partition or not.
-       </para>
-      </listitem>
-     </varlistentry>
-     <varlistentry>
-      <term><guimenu>Expert partitioner</guimenu>
-      </term>
-      <listitem>
-       <para>
-        Opens the <guimenu>Expert Partitioner</guimenu> described in <xref
-        linkend="sec-expert-partitioner"/>. This gives you full control over
-        the partitioning setup and lets you create a custom setup. This option
-        is intended for experts.
-       </para>
-      </listitem>
-     </varlistentry>
-    </variablelist>
-
-    <note>
-     <title>Separate home partition</title>
-     <para>
-      The default proposal no longer suggests to create a separate partition
-      for <filename>/home</filename>. The <filename>/home</filename> directory
-      contains the user's data and personal configuration files. Placing it on
-      a separate directory makes it easier to rebuild the system in the future,
-      or allows to share it with different Linux installations on the same
-      machine.
-     </para>
-     <para>
-      In case you want to change the proposal to create a separate partition
-      for <filename>/home</filename>, choose <guimenu>Guided Setup</guimenu>
-      and click <guimenu>Next</guimenu> until you reach the <guimenu>Filesystem
-      Options</guimenu> screen. Check <guimenu>Propose Separate Home
-      Partition</guimenu>. By default it will be formatted with
-      <guimenu>XFS</guimenu>, but you can choose to use a different file
-      system. Close the dialog by clicking <guimenu>Next</guimenu> again.
-     </para>
-    </note>
-
-    <para>
-     To accept the proposed setup without any changes, choose
-     <guimenu>Next</guimenu> to proceed.
-    </para>
-   </sect3>
-
-   <sect3 xml:id="sec-opensuse-installquick-time">
-    <title>Clock and time zone</title>
-    <informalfigure>
-     <mediaobject>
-      <imageobject role="fo">
-       <imagedata fileref="install_timezone_osuse.png" width="75%"/>
-      </imageobject>
-      <imageobject role="html">
-       <imagedata fileref="install_timezone_osuse.png" width="100%"/>
-      </imageobject>
-     </mediaobject>
-    </informalfigure>
-    <para>
-     Select the clock and time zone to use in your system. To manually adjust
-     the time or to configure an NTP server for time synchronization, choose
-     <guimenu>Other Settings</guimenu>. See <xref
-     linkend="sec-yast-install-date-time"/> for detailed information. Proceed
-     with <guimenu>Next</guimenu>.
-    </para>
-   </sect3>
-
-   <sect3 xml:id="sec-opensuse-installquick-user">
-    <title>Local user</title>
-    <informalfigure>
-     <mediaobject>
-      <imageobject role="fo">
-       <imagedata fileref="install_user_osuse.png" width="75%"/>
-      </imageobject>
-      <imageobject role="html">
-       <imagedata fileref="install_user_osuse.png" width="100%"/>
-      </imageobject>
-     </mediaobject>
-    </informalfigure>
-    <para>
-     To create a local user, type the first and last name in the
-     <guimenu>User’s Full Name</guimenu> field, the login name in the
-     <guimenu>Username</guimenu> field, and the password in the
-     <guimenu>Password</guimenu> field.
-    </para>
-    <para>
-     The password should be at least eight characters long and should contain
-     both uppercase and lowercase letters and numbers. The maximum length for
-     passwords is 72 characters, and passwords are case-sensitive.
-    </para>
-    <para>
-     For security reasons it is also strongly recommended
-     <emphasis>not</emphasis> to enable the <guimenu>Automatic
-     Login</guimenu>. You should also <emphasis>not</emphasis> <guimenu>Use
-     this Password for the System Administrator</guimenu> but rather provide a
-     separate &rootuser; password in the next installation step.
-    </para>
-    <para>
-     If you install on a system where a previous Linux installation was found,
-     you may <guimenu>Import User Data from a Previous
-     Installation</guimenu>. Click <guimenu>Choose User</guimenu> for a list of
-     available user accounts. Select one or more user.
-    </para>
-    <para>
-     In an environment where users are centrally managed (for example by NIS or
-     LDAP) you may want to skip the creation of local users. Select
-     <guimenu>Skip User Creation</guimenu> in this case.
-    </para>
-    <para>
-     Proceed with <guimenu>Next</guimenu>.
-    </para>
-   </sect3>
-
-   <sect3 xml:id="sec-opensuse-installquick-root">
-    <title>
-     Authentication for the System Administrator <quote>root</quote>
-    </title>
-    <informalfigure>
-     <mediaobject>
-      <imageobject role="fo">
-       <imagedata fileref="install_root_osuse.png" width="75%"/>
-      </imageobject>
-      <imageobject role="html">
-       <imagedata fileref="install_root_osuse.png" width="100%"/>
-      </imageobject>
-     </mediaobject>
-    </informalfigure>
-    <para>
-     Provide a password for the system administrator account (called the
-     &rootuser; user).
-    </para>
-    <para>
-     You should never forget the &rootuser; password! After you entered it
-     here, the password cannot be retrieved. See
-     <xref linkend="sec-yast-install-user-root"/> for more information. Proceed
-     with <guimenu>Next</guimenu>.
-    </para>
-    <tip>
-     <title>Passwords and keyboard layout</title>
-     <para>
-      It is recommended to only use US ASCII characters. In case of a system
-      error or when you need to start your system in rescue mode, the keyboard
-      may not be localized.
-     </para>
-    </tip>
-    <para>
-     In case you would like to enable password-less authentication via SSH
-     login, you can import a key via <guimenu>Import Public SSH
-     Key</guimenu>. If you want to completely disable &rootuser; login via
-     password, upload a key only and do not provide a root password. A login
-     as system administrator will only be possible via SSH using the respective
-     keyin this case.
-    </para>
-   </sect3>
-
-   <sect3 xml:id="sec-opensuse-installquick-inst-settings">
-    <title>Installation settings</title>
-    <informalfigure>
-     <mediaobject>
-      <imageobject role="fo">
-       <imagedata fileref="install_summary_osuse.png" width="75%"/>
-      </imageobject>
-      <imageobject role="html">
-       <imagedata fileref="install_summary_osuse.png" width="100%"/>
-      </imageobject>
-     </mediaobject>
-    </informalfigure>
-    <para>
-     Use the <guimenu>Installation Settings</guimenu> screen to review
-     and&mdash;if necessary&mdash;change several proposed
-     installation settings. The current configuration is listed for each
-     setting. To change it, click the headline. Some settings, such as
-     firewall or SSH can directly be changed by clicking the respective
-     links.
-    </para>
-    <important>
-     <title>Remote access</title>
-     <para>
-      Changes you can make here, can also be made later at any time from the
-      installed system. However, if you need remote access directly after the
-      installation, you have to adjust the <guimenu>Security</guimenu> settings.
-     </para>
-    </important>
-    <variablelist>
-     <varlistentry>
-      <term><guimenu>Booting</guimenu>
-      </term>
-      <listitem>
-       <para>
-        This section shows the boot loader configuration. Changing the
-        defaults is only recommended if really needed. Refer to
-        <xref linkend="cha-grub2"/> for details.
-       </para>
-      </listitem>
-     </varlistentry>
-     <varlistentry>
-      <term><guimenu>Software</guimenu>
-      </term>
-      <listitem>
-       <para>
-        The default scope of software includes the base system and X Window
-        with the selected desktop. Clicking <guimenu>Software</guimenu> opens
-        the <guimenu>Software Selection and System Tasks</guimenu> screen,
-        where you can change the software selection by selecting or deselecting
-        patterns. Each pattern contains several software packages needed for
-        specific functions (for example, Web and LAMP server or a print
-        server). For a more detailed selection based on software packages to
-        install, select <guimenu>Details</guimenu> to switch to the &yast;
-        <guimenu>Software Manager</guimenu>. See <xref
-        linkend="cha-yast-software"/> for more information.
-       </para>
-      </listitem>
-     </varlistentry>
-     <varlistentry>
-      <term><guimenu>Default systemd target</guimenu>
-      </term>
-      <listitem>
-       <para>
-        If you have chosen to install a desktop system, the system boots into
-        the <guimenu>graphical</guimenu> target, with network, multiuser and
-        display manager support. If you have not installed a desktop, the
-        system boots into a login shell (<guimenu>Text Mode</guimenu>).
-       </para>
-      </listitem>
-     </varlistentry>
-     <varlistentry>
-      <term><guimenu>System</guimenu>
-      </term>
-      <listitem>
-       <para>
-        View detailed hardware information by clicking
-        <guimenu>System</guimenu>. In the resulting screen you can also change
-        <guimenu>Kernel Settings</guimenu>&mdash;see <xref
-        linkend="sec-yast-install-proposal-system"/> for more information.
-       </para>
-      </listitem>
-     </varlistentry>
-     <varlistentry>
-      <term><guimenu>Security</guimenu>
-      </term>
-      <listitem>
-       <para>
-        The <guimenu>CPU Mitigations</guimenu> refer to kernel boot command
-        line parameters for software mitigations that have been deployed
-        to prevent CPU side-channel attacks. Click the highlighted
-        entry to choose a different option. For details, see <xref
-        linkend="vle-grub2-yast2-cpu-mitigations"/>.
-       </para>
-       <para>
-        By default, the Firewall is enabled with all network interfaces
-        configured for the <literal>public</literal> zone, where all ports are
-        closed by default, ensuring maximum security. See <xref
-        linkend="cha-security-firewall"/> for configuration details.
-       </para>
-       <para>
-        The SSH service is disabled by default, its port (22) is closed.
-        Therefore logging in from remote is not possible by default. Click
-        <guimenu>enable</guimenu> and <guimenu>open</guimenu> to toggle these
-        settings.
-       </para>
-      </listitem>
-     </varlistentry>
-     <varlistentry>
-      <term><guimenu>Network configuration</guimenu>
-      </term>
-      <listitem>
-       <para>
-        Displays the current network configuration. Click
-        <guimenu>Network Configuration</guimenu> to change the settings. For
-        details, see <xref linkend="sec-network-yast"/>.
-       </para>
-      </listitem>
-     </varlistentry>
-    </variablelist>
-   </sect3>
-
-   <sect3 xml:id="sec-opensuse-installquick-confirm">
-    <title>Start the installation</title>
-    <informalfigure>
-     <mediaobject>
-      <imageobject role="fo">
-       <imagedata fileref="install_confirm_osuse.png" width="75%"/>
-      </imageobject>
-      <imageobject role="html">
-       <imagedata fileref="install_confirm_osuse.png" width="100%"/>
-      </imageobject>
-     </mediaobject>
-    </informalfigure>
-    <para>
-     After you have finalized the system configuration on the
-     <guimenu>Installation Settings</guimenu> screen, click
-     <guimenu>Install</guimenu>. Depending on your software selection you may
-     need to agree to license agreements before the installation confirmation
-     screen pops up. Up to this point no changes have been made to your
-     system. After you click <guimenu>Install</guimenu> a second time, the
-     installation process starts.
-    </para>
-   </sect3>
-
-   <sect3 xml:id="sec-opensuse-installquick-inst-process">
-    <title>The installation process</title>
-    <informalfigure>
-     <mediaobject>
-      <imageobject role="fo">
-       <imagedata fileref="install_perform_osuse.png" width="75%"/>
-      </imageobject>
-      <imageobject role="html">
-       <imagedata fileref="install_perform_osuse.png" width="100%"/>
-      </imageobject>
-     </mediaobject>
-    </informalfigure>
-    <para>
-     During the installation, the progress is shown in detail on the
-     <guimenu>Details</guimenu> tab. The <guimenu>&productname; Release
-     Notes</guimenu> tab shows important information; reading them is
-     recommended.
-    </para>
-    <para>
-     After the installation routine has finished, the computer is rebooted into
-     the installed system. Log in and start &yast; to fine-tune the system. If
-     you are not using a graphical desktop or are working from remote, refer to
-     <xref linkend="cha-yast-text"/> for information on using &yast; from a
-     terminal.
-    </para>
-   </sect3>
+  <sect2 xml:id="sec-opensuse-installquick-inst-process">
+   <title>The installation process</title>
+   <informalfigure>
+    <mediaobject>
+     <imageobject role="fo">
+      <imagedata fileref="install_perform_osuse.png" width="75%"/>
+     </imageobject>
+     <imageobject role="html">
+      <imagedata fileref="install_perform_osuse.png" width="100%"/>
+     </imageobject>
+    </mediaobject>
+   </informalfigure>
+   <para>
+    During the installation, the progress is shown in detail on the
+    <guimenu>Details</guimenu> tab. The <guimenu>&productname; Release
+    Notes</guimenu> tab shows important information; reading them is
+    recommended.
+   </para>
+   <para>
+    After the installation routine has finished, the computer is rebooted into
+    the installed system. Log in and start &yast; to fine-tune the system. If
+    you are not using a graphical desktop or are working from remote, refer to
+    <xref linkend="cha-yast-text"/> for information on using &yast; from a
+    terminal.
+   </para>
   </sect2>
  </sect1>
  <!--

--- a/xml/installation-opensuse.xml
+++ b/xml/installation-opensuse.xml
@@ -44,19 +44,24 @@
   <itemizedlist>
    <listitem>
     <para>
-     Intel or AMD 64-bit desktops, laptops, and servers (<quote>Regular</quote>
-     computers and laptops).
+     Intel or AMD 64-bit desktops, laptops, and servers
+     (<literal>&x86-64;</literal>)
     </para>
    </listitem>
    <listitem>
     <para>
-     UEFI &arm; 64-bit servers, desktops, laptops and boards (RaspBerry PI,
-     laptops and computers with an &arm; CPU).
+     UEFI &arm; 64-bit servers, desktops, laptops and boards
+     (<literal>&aarch64;</literal>)
     </para>
    </listitem>
    <listitem>
     <para>
-     PowerPC / &zseries; (&ibm; server machines)
+     PowerPC servers (little-endian, <literal>&ppc64le;</literal>)
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     &zseries; and &linuxone; (&ibm; servers, <literal>s390x</literal>)
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/installation-opensuse.xml
+++ b/xml/installation-opensuse.xml
@@ -27,14 +27,14 @@
    </para>
    <para>
     For more detailed installation instructions see <xref
-    linkend="cha-install"/>.  For installing the &aarch64; and &power;
+    linkend="cha-install"/>. For installing the &aarch64; and &power;
     variants, see <link xlink:href="https://en.opensuse.org/Portal:ARM"/> and
     <link xlink:href="https://en.opensuse.org/Portal:PowerPC"/>.
    </para>
   </abstract>
  </info>
  <sect1 xml:id="sec-osuse-installquick-get">
-  <title>Getting openSUSE</title>
+  <title>Getting &leap;</title>
   <para>
    To download &productname;, visit <link
    xlink:href="https://get.opensuse.org/leap/"/>. On the
@@ -50,13 +50,13 @@
    </listitem>
    <listitem>
     <para>
-     UEFI Arm 64-bit servers, desktops, laptops and boards (RaspBerry PI,
-     laptops and computers with an ARM CPU).
+     UEFI &arm; 64-bit servers, desktops, laptops and boards (RaspBerry PI,
+     laptops and computers with an &arm; CPU).
     </para>
    </listitem>
    <listitem>
     <para>
-     Power PC / IBM Z (IBM server machines)
+     PowerPC / &zseries; (&ibm; server machines)
     </para>
    </listitem>
   </itemizedlist>
@@ -256,10 +256,9 @@
     </listitem>
     <listitem>
      <para>
-      Choosing <guimenu>Update Repository (Non-OSS)</guimenu> is
-      recommended when also having chosen the <guimenu>Non-OSS
-      Repository</guimenu>. It contains the respective updates and
-      security fixes.
+      Select <guimenu>Update Repository (Non-OSS)</guimenu> if you enabled the
+      <guimenu>Non-OSS Repository</guimenu>. It contains the respective
+      updates and security fixes.
      </para>
     </listitem>
     <listitem>


### PR DESCRIPTION
On customer request by mail:
* adding information on where toi get openSUSE
* removing annotations on quarterly updates for openSUSE
* in addition, removed lone sect


Applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] openSUSE Leap 15.3

Lep 15.3 backpüort needs to be done.
