### PR TITLE
SEO fix: Broken link replacements in SLE12SP4

### DIFF
--- a/xml/docker_docupdates.xml
+++ b/xml/docker_docupdates.xml
@@ -146,7 +146,7 @@
         <para>
          There is no need to disable copy-on-write for a
          <filename>/var/lib/docker</filename> partition on Btrfs, see <xref
-         linkend="Container-Drivers"/> (<link xlink:href="&dc;34198"/>).
+         linkend="Container-Drivers"/> (doc comment #34198).
         </para>
        </listitem>
 

--- a/xml/storage_filesystems.xml
+++ b/xml/storage_filesystems.xml
@@ -2164,12 +2164,6 @@ Label: none uuid: 40123456-cb2c-4678-8b3d-d014d1c78c78
    </listitem>
    <listitem>
     <para>
-     XFS: A High-Performance Journaling File System:
-     <link xlink:href="http://oss.sgi.com/projects/xfs/"/>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
      The OCFS2 Project:
      <link xlink:href="http://oss.oracle.com/projects/ocfs2/"/>
     </para>

--- a/xml/storage_iscsi.xml
+++ b/xml/storage_iscsi.xml
@@ -1542,8 +1542,8 @@ mptscsih,scsi_transport_spi</screen>
   <para>
    The iSCSI protocol has been available for several years. There are many
    reviews comparing iSCSI with SAN solutions, benchmarking performance, and
-   there also is documentation describing hardware solutions. Important pages
-   for more information about open-iscsi are:
+   there also is documentation describing hardware solutions. Important sources of 
+   more information about open-iscsi are:
   </para>
 
   <itemizedlist mark="bullet" spacing="normal">
@@ -1555,18 +1555,13 @@ mptscsih,scsi_transport_spi</screen>
    </listitem>
    <listitem>
     <para>
-     <citetitle>AppNote: iFolder on Open Enterprise Server Linux Cluster using
-     iSCSI</citetitle>
-     (<link xlink:href="http://www.novell.com/coolsolutions/appnote/15394.html"/>)
+     The online document and man pages for
+     <command>iscsiadm</command>, <command>iscsid</command>,
+     <filename>ietd.conf</filename>, and <command>ietd</command> and the example
+     configuration file <filename>/etc/iscsid.conf</filename>.
     </para>
    </listitem>
   </itemizedlist>
 
-  <para>
-   There is also some online documentation available. See the man pages for
-   <command>iscsiadm</command>, <command>iscsid</command>,
-   <filename>ietd.conf</filename>, and <command>ietd</command> and the example
-   configuration file <filename>/etc/iscsid.conf</filename>.
-  </para>
- </sect1>
+  </sect1>
 </chapter>

--- a/xml/tuning_kexec.xml
+++ b/xml/tuning_kexec.xml
@@ -1317,7 +1317,7 @@ PID: 9446   TASK: ffff88003a57c3c0  CPU: 1   COMMAND: "bash"
     <para>
      A white paper with a comprehensive description of the crash utility
      usage can be found at
-     <link xlink:href="http://people.redhat.com/anderson/crash_whitepaper/"/>.
+     <link xlink:href="https://crash-utility.github.io/crash_whitepaper.html"/>.
     </para>
    </listitem>
    <listitem>


### PR DESCRIPTION
### PR creator: Description

SEO squad: Fixing and replacing broken links. All branches will be handled separately, therefore no backports.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [x ] SLE 12 SP4
  - [ ] SLE 12 SP3


