### PR TITLE
A note about addons from SMT/RMT/SCC

### DIFF
--- a/xml/ay_software.xml
+++ b/xml/ay_software.xml
@@ -318,6 +318,14 @@
      products can be added from almost every other location during an &ay;
      installation.
     </para>
+    <note>
+     <title>Repositories from registration server (SMT/RMT/SCC)</title>
+     <para>
+      If you want to use add-ons from a registration server (SMT, RMT or SCC)
+      then define them in the <literal>suse_register</literal> section.
+      See <xref linkend="CreateProfile-Register-Extension"/>.
+     </para>
+    </note>
     <para>
       Even repositories which do not have any product or module information
       can be added during the installation. These are called <literal>other add-ons</literal>.

--- a/xml/ay_software.xml
+++ b/xml/ay_software.xml
@@ -321,7 +321,7 @@
     <note>
      <title>Repositories served by a registration server</title>
      <para>
-      If you want to use add-ons from a registration server (SMT, RMT, or SCC)
+      If you want to use add-ons from a registration server (SMT, RMT, or SCC),
       define them in the <literal>suse_register</literal> section.
       See <xref linkend="CreateProfile-Register-Extension"/>.
      </para>

--- a/xml/ay_software.xml
+++ b/xml/ay_software.xml
@@ -319,7 +319,7 @@
      installation.
     </para>
     <note>
-     <title>Repositories from registration server (SMT/RMT/SCC)</title>
+     <title>Repositories served by a registration server</title>
      <para>
       If you want to use add-ons from a registration server (SMT, RMT, or SCC)
       then define them in the <literal>suse_register</literal> section.

--- a/xml/ay_software.xml
+++ b/xml/ay_software.xml
@@ -321,7 +321,7 @@
     <note>
      <title>Repositories from registration server (SMT/RMT/SCC)</title>
      <para>
-      If you want to use add-ons from a registration server (SMT, RMT or SCC)
+      If you want to use add-ons from a registration server (SMT, RMT, or SCC)
       then define them in the <literal>suse_register</literal> section.
       See <xref linkend="CreateProfile-Register-Extension"/>.
      </para>

--- a/xml/ay_software.xml
+++ b/xml/ay_software.xml
@@ -322,7 +322,7 @@
      <title>Repositories served by a registration server</title>
      <para>
       If you want to use add-ons from a registration server (SMT, RMT, or SCC)
-      then define them in the <literal>suse_register</literal> section.
+      define them in the <literal>suse_register</literal> section.
       See <xref linkend="CreateProfile-Register-Extension"/>.
      </para>
     </note>


### PR DESCRIPTION

### Description

Clarify that the addons from a registration server must be defined in the `suse_register` section.

### Bugzilla

- Related to https://bugzilla.suse.com/show_bug.cgi?id=1196600

### Which product versions do the changes apply to?

This is a minor change, just to clarify the current situation, no back port is needed.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
