### PR TITLE
SEO fix: broken link replacements in SLE12SP5

### DIFF
--- a/xml/smt_install.xml
+++ b/xml/smt_install.xml
@@ -174,7 +174,7 @@
     <listitem>
      <para>At the same time upgrade &smt; to version 11 SP3 as
       described at <link
-       xlink:href="&dsc;/smt/11.3/html/SLE-smt/smt.installation.html#smt.installation.upgrade"/>.</para>
+       xlink:href="&dsc;/smt/11.3/"/>.</para>
     </listitem>
     <listitem>
      <para>Follow the steps described in <xref

--- a/xml/storage_filesystems.xml
+++ b/xml/storage_filesystems.xml
@@ -1,4 +1,4 @@
-<!-- <?xml version="1.0" encoding="UTF-8"?> -->
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE chapter
 [
   <!ENTITY % entities SYSTEM "entity-decl.ent">

--- a/xml/storage_filesystems.xml
+++ b/xml/storage_filesystems.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<!-- <?xml version="1.0" encoding="UTF-8"?> -->
 <!DOCTYPE chapter
 [
   <!ENTITY % entities SYSTEM "entity-decl.ent">
@@ -2160,12 +2160,6 @@ Label: none uuid: 40123456-cb2c-4678-8b3d-d014d1c78c78
     <para>
      Introducing Ext3:
      <link xlink:href="http://www.ibm.com/developerworks/linux/library/l-fs7/"/>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     The OCFS2 Project:
-     <link xlink:href="https://oss.oracle.com/projects/ocfs2/"/>
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/storage_iscsi.xml
+++ b/xml/storage_iscsi.xml
@@ -1542,31 +1542,26 @@ mptscsih,scsi_transport_spi</screen>
   <para>
    The iSCSI protocol has been available for several years. There are many
    reviews comparing iSCSI with SAN solutions, benchmarking performance, and
-   there also is documentation describing hardware solutions. Important pages
-   for more information about open-iscsi are:
+   there also is documentation describing hardware solutions. Important sources
+   of more information about open-iscsi are:
   </para>
 
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     <citetitle>Open-iSCSI Project</citetitle>
+      The <citetitle>Open-iSCSI Project</citetitle>
      (<link xlink:href="http://www.open-iscsi.com/"/>)
     </para>
    </listitem>
    <listitem>
     <para>
-     <citetitle>AppNote: iFolder on Open Enterprise Server Linux Cluster using
-     iSCSI</citetitle>
-     (<link xlink:href="http://www.novell.com/coolsolutions/appnote/15394.html"/>)
+    The online documentation and man pages for
+    <command>iscsiadm</command>, <command>iscsid</command>,
+    <filename>ietd.conf</filename>, and <command>ietd</command> and the example
+    configuration file <filename>/etc/iscsid.conf</filename>.
     </para>
    </listitem>
   </itemizedlist>
 
-  <para>
-   There is also some online documentation available. See the man pages for
-   <command>iscsiadm</command>, <command>iscsid</command>,
-   <filename>ietd.conf</filename>, and <command>ietd</command> and the example
-   configuration file <filename>/etc/iscsid.conf</filename>.
-  </para>
  </sect1>
 </chapter>

--- a/xml/tuning_kexec.xml
+++ b/xml/tuning_kexec.xml
@@ -1326,7 +1326,7 @@ PID: 9446   TASK: ffff88003a57c3c0  CPU: 1   COMMAND: "bash"
     <para>
      A white paper with a comprehensive description of the crash utility
      usage can be found at
-     <link xlink:href="http://people.redhat.com/anderson/crash_whitepaper/"/>.
+     <link xlink:href="https://crash-utility.github.io/crash_whitepaper.html"/>.
     </para>
    </listitem>
    <listitem>


### PR DESCRIPTION
### PR creator: Description

SEO squad: Fix/replace/remove broken links. All branches done separately, therefore no backports.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [x ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
