### PR TITLE
SEO fix: broken link replacements in SLES12 SP3 de

### DIFF
--- a/en/xml/selinux.xml
+++ b/en/xml/selinux.xml
@@ -415,7 +415,7 @@ system_u:object_r:var_t var</screen>
    package <package>selinux-policy-minimum</package>. The examples in
    this chapter refer to this policy if not stated otherwise.
   </para>
-
+<!-- jjaeger: both packages and links don't exist anymore.
   <tip>
    <para>
     To install a different policy, you need to download it from
@@ -423,7 +423,7 @@ system_u:object_r:var_t var</screen>
     and install:</para>
 <screen>sudo zypper in selinux-policy-targeted-<replaceable>VERSION_NUMBER</replaceable>.noarch.rpm</screen>
   </tip>
-
+ -->
   <para>
    After installing the policy, you are ready to start file system labeling.
    Run

--- a/en/xml/storage_filesystems.xml
+++ b/en/xml/storage_filesystems.xml
@@ -1974,18 +1974,6 @@ Label: none uuid: 40123456-cb2c-4678-8b3d-d014d1c78c78
      <link xlink:href="http://www.ibm.com/developerworks/linux/library/l-fs7/"/>
     </para>
    </listitem>
-   <listitem>
-    <para>
-     XFS: A High-Performance Journaling File System:
-     <link xlink:href="http://oss.sgi.com/projects/xfs/"/>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     The OCFS2 Project:
-     <link xlink:href="http://oss.oracle.com/projects/ocfs2/"/>
-    </para>
-   </listitem>
   </itemizedlist>
 
   <para>

--- a/en/xml/storage_iscsi.xml
+++ b/en/xml/storage_iscsi.xml
@@ -1543,7 +1543,7 @@ mptscsih,scsi_transport_spi</screen>
   <para>
    The iSCSI protocol has been available for several years. There are many
    reviews comparing iSCSI with SAN solutions, benchmarking performance, and
-   there also is documentation describing hardware solutions. Important pages
+   there also is documentation describing hardware solutions. Important sources 
    for more information about open-iscsi are:
   </para>
 
@@ -1556,18 +1556,11 @@ mptscsih,scsi_transport_spi</screen>
    </listitem>
    <listitem>
     <para>
-     <citetitle>AppNote: iFolder on Open Enterprise Server Linux Cluster using
-     iSCSI</citetitle>
-     (<link xlink:href="http://www.novell.com/coolsolutions/appnote/15394.html"/>)
+    The man pages for <command>iscsiadm</command>, <command>iscsid</command>,
+    <filename>ietd.conf</filename>, and <command>ietd</command> and the example
+    configuration file <filename>/etc/iscsid.conf</filename>.
     </para>
    </listitem>
   </itemizedlist>
-
-  <para>
-   There is also some online documentation available. See the man pages for
-   <command>iscsiadm</command>, <command>iscsid</command>,
-   <filename>ietd.conf</filename>, and <command>ietd</command> and the example
-   configuration file <filename>/etc/iscsid.conf</filename>.
-  </para>
  </sect1>
 </chapter>

--- a/sles/de/xml/net_dhcp.xml
+++ b/sles/de/xml/net_dhcp.xml
@@ -475,7 +475,7 @@ fixed-address 192.168.2.100;
   <title>Weiterführende Informationen</title>
 
   <para>
-   Weitere Informationen zu DHCP finden Sie auf der Website des <emphasis>Internet Systems Consortium</emphasis> (<link xlink:href="http://www.isc.org/products/DHCP/"/>). Weitere Informationen finden Sie zudem auf den man-Seiten <option>dhcpd</option>, <option>dhcpd.conf</option>, <option>dhcpd.leases</option> und <option>dhcp-options</option>.
+   Weitere Informationen zu DHCP finden Sie auf der Website des <emphasis>Internet Systems Consortium</emphasis> (<link xlink:href="https://isc.org/dhcp/"/>). Weitere Informationen finden Sie zudem auf den man-Seiten <option>dhcpd</option>, <option>dhcpd.conf</option>, <option>dhcpd.leases</option> und <option>dhcp-options</option>.
   </para><indexterm class="endofrange" startref="idx-DHCP"/>
  </sect1>
 </chapter>


### PR DESCRIPTION
### PR creator: Description

SEO squad: link fixes (replace, delete) for SLE 12 SP3 de. All branches will be handled separately, therefore no backports.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [x] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
