### PR TITLE
Add new section on configuring LUKS volumes in /etc/fstab

### DIFF
--- a/xml/security_cryptctl.xml
+++ b/xml/security_cryptctl.xml
@@ -4,12 +4,12 @@
   <!ENTITY % entities SYSTEM "generic-entities.ent">
     %entities;
 ]>
-<chapter xmlns="http://docbook.org/ns/docbook" 
-         xmlns:xi="http://www.w3.org/2001/XInclude" 
-         xmlns:xlink="http://www.w3.org/1999/xlink" 
-         version="5.0" 
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         version="5.0"
          xml:id="cha-configure-cryptctl">
-    
+
   <title>Storage encryption for hosted applications with cryptctl</title>
    <para>
     Databases and similar applications are often hosted on external
@@ -482,6 +482,30 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
     <filename>/var/lib/cryptctl/keydb/<replaceable>PARTITION_UUID</replaceable></filename>.
    </para>
   </sect1>
+
+  <sect1 xml:id="sec-cryptctl-luks-fstab">
+   <title>Configuring /etc/fstab for LUKS volumes</title>
+   <para>
+    When configuring the mount point for a new file system encrypted with
+    LUKS, &yast; will use, by default, the name of the encrypted device
+    in <filename>/etc/fstab</filename>.
+    (For example, <filename>/dev/mapper/cr_sda1</filename>.) Using the
+    device name, rather than the UUID or label, results in a more robust
+    operation of systemd generators and other related tools.
+   </para>
+   <para>
+    You have the option to adjust that default behavior for each device,
+    either with the Expert Partitioner in the installer, or via &ay;.
+   </para>
+   <para>
+    This change does not affect upgrades or any other scenario in which the
+    mount points are already defined in <filename>/etc/fstab</filename>.
+    Only newly created mount points are affected, such as during the
+    installation of a new system, or creating new partitions on running
+    systems.
+   </para>
+   </sect1>
+
   <sect1 xml:id="sec-configure-cryptctl-status">
    <title>Checking partition unlock status using server-side commands</title>
    <para>


### PR DESCRIPTION
For SLE 15 SP4 and up. It is preferable to configure LUKS volumes in /etc/fstab by their 
device names, rather than UUIDs or labels


### PR creator: Are there any relevant issues/feature requests?

jsc#SLE-21345


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
