### PR TITLE
relurl now supported for self_update parameter on install media

### DIFF
--- a/xml/ay_general_options.xml
+++ b/xml/ay_general_options.xml
@@ -431,8 +431,9 @@
     <term><tag class="element">self_update_url</tag></term>
     <listitem>
      <para>
-      Location of the update repository to use during the &yast; self-update.
-      For more information, refer to the &deploy;.
+      Location of the update repository to use during the
+      &yast; self-update. For more information, refer to
+      <xref linkend="sec-yast-install-self-update-custom"/>.
      </para>
      <important>
       <title>Installer self-update repository only</title>

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -387,17 +387,67 @@
    <title>Custom self-update repositories</title>
 
    <para>
-    &yast; can use a user-defined repository instead of the official one by
-    specifying a URL through the <literal>self_update</literal> boot parameter.
-    However, the following points should be considered:
+    &yast; can use a user-defined repository instead of the official
+    repository by specifying a URL through the
+    <literal>self_update</literal> boot parameter.
    </para>
-
    <itemizedlist mark="bullet" spacing="normal">
     <listitem>
      <para>
-      Only HTTP/HTTPS and FTP repositories are supported.
+      HTTP/HTTPS and FTP repositories are supported.
      </para>
     </listitem>
+    <listitem>
+     <para>
+      Starting with <package>yast2-installation-4.4.30</package>, the
+      <literal>relurl://</literal> schema is supported, as a boot
+      parameter or in an &ay; profile. The URL is relative to the main
+      installation repository, and you may navigate the file tree with the
+      usual <literal>../</literal> notation, for example
+      <replaceable>relurl://../self_update</replaceable>. This is useful
+      when serving the packages via a local installation server, or when
+      building a custom installation medium which includes a self-update
+      repository.
+     </para>
+     <para>
+      The following examples assume the installation repository is at the
+      medium root (/), and the self-update repository in the
+      <filename>self_update</filename> subdirectory. This structure makes
+      the <literal>relurl://</literal> portable, and it will work anywhere
+      without changes as a boot parameter, copied to an USB stick, hard
+      disk, network server, or in an &ay; profile.
+    <variablelist>
+     <varlistentry>
+      <term>Custom DVD/USB medium</term>
+    <listitem>
+     <para>
+      Add the <literal>self_update=relurl://self_update</literal>
+      boot option directly to the default boot parameters, and it will work
+      properly even if the medium is copied to an USB stick, hard disk, or a
+      network server.
+     </para>
+    </listitem>
+   </varlistentry>
+     <varlistentry>
+      <term>Installation server</term>
+    <listitem>
+     <para>
+      Assume that the installation packages are available via
+      <replaceable>http://example.com/repo</replaceable> and a self-update repository is available at
+      <replaceable>http://example.com/self_update</replaceable>.
+      </para>
+      <para>
+       Then you can use the
+       <replaceable>http://example.com/repo</replaceable> and
+       <replaceable>http://example.com/self_update</replaceable> boot
+       parameters, without having to change the
+       <literal>self_update</literal> parameter when the repositories are moved to a different location.
+      </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </para>
+ </listitem>
     <listitem>
      <para>
       Only RPM-MD repositories are supported (required by &rmt;).
@@ -424,6 +474,7 @@
      </para>
     </listitem>
    </itemizedlist>
+
 
    <note>
     <title>Only one repository</title>

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -416,6 +416,7 @@
       the <literal>relurl://</literal> portable, and it will work anywhere
       without changes as a boot parameter, copied to an USB stick, hard
       disk, network server, or in an &ay; profile.
+     </para>
     <variablelist>
      <varlistentry>
       <term>Custom DVD/USB medium</term>
@@ -446,7 +447,6 @@
     </listitem>
    </varlistentry>
   </variablelist>
- </para>
  </listitem>
     <listitem>
      <para>


### PR DESCRIPTION
and in AutoYast profiles.
Resolves jsc#DOCTEAM-470 'Self-update section' Deployment Guide

### PR creator: Are there any relevant issues/feature requests?

 jsc#DOCTEAM-470

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
