### PR TITLE
Update of Apache (+PHP) chapter (bsc#1177654)

### DIFF
--- a/xml/apache2.xml
+++ b/xml/apache2.xml
@@ -387,7 +387,7 @@
       <term><filename>server-tuning.conf</filename></term>
       <listitem>
        <para>
-        Contains configuration directives for the different M.PMs (see
+        Contains configuration directives for the different MPMs (see
         <xref linkend="sec-apache2-modules-mpm"/>) and general configuration
         options that control Apache's performance. Properly test your Web
         server when making changes here.

--- a/xml/apache2.xml
+++ b/xml/apache2.xml
@@ -2534,6 +2534,12 @@ An optional company name []:<co xml:id="co-ssl-self-optional"/></screen>
       <para>
        <link xlink:href="http://www.php.net/manual/en/install.unix.apache2.php"/>
       </para>
+      <para>
+       You can obtain detailed information about
+       <systemitem>mod_php&php-version;</systemitem> configuration in its
+       well-commented main configuration file
+       <filename>/etc/php&php-version;/apache2/php.ini</filename>.
+      </para>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/xml/apache2.xml
+++ b/xml/apache2.xml
@@ -13,8 +13,7 @@
     and <link xlink:href="https://w3techs.com/"/>, the Apache HTTP Server
     (Apache) is one of the world's most popular Web servers. Developed by the
     Apache Software Foundation
-    (<link
-     xlink:href="http://www.apache.org/"/>), it is available for
+    (<link xlink:href="http://www.apache.org/"/>), it is available for
     most operating systems. &productnamereg; includes Apache version 2.4. This
     chapter describes how to install, configure, and set up Apache. It also
     shows how to use additional modules, such as SSL, and how to troubleshoot
@@ -113,7 +112,7 @@
     <literal>graphical.target</literal>, execute the following command:
    </para>
 <screen>&prompt.sudo;systemctl enable apache2.service</screen>
-   <para></para>
+  
    <para>
     For more information about the
     <systemitem class="daemon">systemd</systemitem> targets in &productname;
@@ -317,8 +316,8 @@
       <term><filename>global.conf</filename></term>
       <listitem>
        <para>
-        General configuration of the main Web server process, such as the path
-        to access or error logs, or the level of logging.
+        General configuration of the main Web server process, such as the access
+        path, error logs, or the level of logging.
        </para>
       </listitem>
      </varlistentry>

--- a/xml/apache2.xml
+++ b/xml/apache2.xml
@@ -9,13 +9,16 @@
  <info>
   <abstract>
    <para>
-    According to the survey from <link xlink:href="http://www.netcraft.com/"/>,
-    the Apache HTTP Server (Apache) is the world's most widely-used Web server.
-    Developed by the Apache Software Foundation
-    (<link xlink:href="http://www.apache.org/"/>), it is available for most
-    operating systems. &productnamereg; includes Apache version 2.4. In this
-    chapter, learn how to install, configure and set up a Web server; how to
-    use SSL, CGI, and additional modules; and how to troubleshoot Apache.
+    According to the surveys from <link xlink:href="http://www.netcraft.com/"/>
+    and <link xlink:href="https://w3techs.com/"/>, the Apache HTTP Server
+    (Apache) is one of the world's most popular Web servers. Developed by the
+    Apache Software Foundation
+    (<link
+     xlink:href="http://www.apache.org/"/>), it is available for
+    most operating systems. &productnamereg; includes Apache version 2.4. This
+    chapter describes how to install, configure, and set up Apache. It also
+    shows how to use additional modules, such as SSL, and how to troubleshoot
+    Apache.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -86,7 +89,7 @@
     </step>
     <step>
      <para>
-      Choose <menuchoice> <guimenu>View</guimenu> <guimenu>Patterns</guimenu>
+      Choose <menuchoice> <guimenu>Filter</guimenu> <guimenu>Patterns</guimenu>
       </menuchoice> and select <guimenu>Web and LAMP Server</guimenu>.
      </para>
     </step>
@@ -109,14 +112,8 @@
     targets <literal>multi-user.target</literal> and
     <literal>graphical.target</literal>, execute the following command:
    </para>
-<screen>&prompt.sudo;systemctl enable apache2</screen>
-   <para>
-    <remark>taroth 2014-02-11: commenting the following procedure as it is unsure
-      how to enable a service for certain targets with &yast; Services Manager,
-      filed bnc# 863333 for it
-     UPDATE tbazant 2015-08-20: still not clear, leaving commented out
-     </remark>
-   </para>
+<screen>&prompt.sudo;systemctl enable apache2.service</screen>
+   <para></para>
    <para>
     For more information about the
     <systemitem class="daemon">systemd</systemitem> targets in &productname;
@@ -125,7 +122,7 @@
    </para>
    <para>
     To manually start Apache using the shell, run <command>systemctl start
-    apache2</command>.
+    apache2.service</command>.
    </para>
    <procedure>
     <title>Checking if Apache is running</title>
@@ -186,7 +183,7 @@
    <para>
     Most configuration changes require a reload (some also a restart) of Apache
     to take effect. Manually reload Apache with <command>systemctl reload
-    apache2</command> or use one of the restart options as described in
+    apache2.service</command> or use one of the restart options as described in
     <xref linkend="sec-apache2-start-stop"/>.
    </para>
    <para>

--- a/xml/apache2.xml
+++ b/xml/apache2.xml
@@ -251,14 +251,17 @@
      |
      |- default-server.conf
      |- errors.conf
+     |- global.conf
      |- httpd.conf
      |- listen.conf
+     |- loadmodule.conf
      |- magic
      |- mime.types
      |- mod_*.conf
+     |- protocols.conf
      |- server-tuning.conf
-     |- ssl.*
      |- ssl-global.conf
+     |- ssl.*
      |- sysconfig.d
      |   |
      |   |- global.conf
@@ -307,6 +310,15 @@
         Defines how Apache responds to errors. To customize these messages for
         all virtual hosts, edit this file. Otherwise overwrite these directives
         in your virtual host configurations.
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
+      <term><filename>global.conf</filename></term>
+      <listitem>
+       <para>
+        General configuration of the main Web server process, such as the path
+        to access or error logs, or the level of logging.
        </para>
       </listitem>
      </varlistentry>
@@ -364,10 +376,18 @@
       </listitem>
      </varlistentry>
      <varlistentry>
+      <term><filename>protocols.conf</filename></term>
+      <listitem>
+       <para>
+        Configuration directives for serving pages over HTTP2 connection.
+       </para>
+      </listitem>
+     </varlistentry>
+     <varlistentry>
       <term><filename>server-tuning.conf</filename></term>
       <listitem>
        <para>
-        Contains configuration directives for the different MPMs (see
+        Contains configuration directives for the different M.PMs (see
         <xref linkend="sec-apache2-modules-mpm"/>) and general configuration
         options that control Apache's performance. Properly test your Web
         server when making changes here.
@@ -741,7 +761,7 @@ Allow from all</screen>
 
   <variablelist>
    <varlistentry>
-    <term><command>systemctl status apache2</command></term>
+    <term><command>systemctl status apache2.service</command></term>
     <listitem>
      <para>
       Checks if Apache is started.
@@ -749,41 +769,23 @@ Allow from all</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><command>systemctl start apache2</command></term>
+    <term><command>systemctl start apache2.service</command></term>
     <listitem>
      <para>
       Starts Apache if it is not already running.
      </para>
     </listitem>
    </varlistentry>
-<!-- taroth 2014-02-11: startssl no longer supported, can be achieched
-    differently now, see
-    http://httpd.apache.org/docs/2.4/programs/apachectl.html-->
-<!--
-  <varlistentry>
-    <term><option>startssl</option>
-   </term>
-    <listitem>
-     <para>
-      Starts Apache with SSL support if it is not already running. For more
-      information about SSL support, refer to
-      <xref
-        linkend="sec-apache2-ssl"/>.
-     </para>
-    </listitem>
-   </varlistentry>
-  -->
    <varlistentry>
-    <term><command>systemctl stop apache2</command></term>
+    <term><command>systemctl stop apache2.service</command></term>
     <listitem>
      <para>
       Stops Apache by terminating the parent process.
      </para>
     </listitem>
    </varlistentry>
-<!--   -->
    <varlistentry>
-    <term><command>systemctl restart apache2</command></term>
+    <term><command>systemctl restart apache2.service</command></term>
     <listitem>
      <para>
       Stops and then restarts Apache. Starts the Web server if it was not
@@ -792,7 +794,7 @@ Allow from all</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><command>systemctl try-restart apache2</command></term>
+    <term><command>systemctl try-restart apache2.service</command></term>
     <listitem>
      <para>
       Stops then restarts Apache only if it is already running.
@@ -800,7 +802,7 @@ Allow from all</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term><command>systemctl reload apache2</command></term>
+    <term><command>systemctl reload apache2.service</command></term>
     <listitem>
      <para>
       Stops the Web server by advising all forked Apache processes to first
@@ -844,7 +846,7 @@ Allow from all</screen>
     </listitem>
    </varlistentry> -->
    <varlistentry>
-    <term><command>systemctl stop apache2</command></term>
+    <term><command>systemctl stop apache2.service</command></term>
     <listitem>
      <para>
       Stops the Web server after a defined period of time configured with
@@ -942,7 +944,7 @@ sknorr, 2017-06-07 -->
   </para>
 
   <para>
-   Apache modules can be divided into four different categories:
+   Apache modules are organized into the following categories:
   </para>
 
   <variablelist>
@@ -1012,8 +1014,8 @@ sknorr, 2017-06-07 -->
    <title>Activation and deactivation</title>
    <para>
     Activate or deactivate particular modules either manually or with &yast;.
-    In &yast;, script language modules (PHP 5 and Python) need to be enabled or
-    disabled with the module configuration described in
+    In &yast;, script language modules (PHP &php-version; and Python) need to
+    be enabled or disabled with the module configuration described in
     <xref linkend="sec-apache2-configuration-yast-wizard"/>. All other modules
     can be enabled or disabled as described in
     <xref linkend="sec-apache2-configuration-yast-server-configuration-modules"/>.
@@ -1398,7 +1400,8 @@ sknorr, 2017-06-07 -->
      <listitem>
       <para>
        Adds support to Apache to provide &aa; confinement to individual CGI
-       scripts handled by modules like <systemitem>mod_php5</systemitem>.
+       scripts handled by modules like
+       <systemitem>mod_php&php-version;</systemitem>.
       </para>
       <simplelist><member>
         Package Name: <systemitem>apache2-mod_apparmor</systemitem></member><member>
@@ -1407,16 +1410,14 @@ sknorr, 2017-06-07 -->
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><systemitem>mod_php5</systemitem></term>
+     <term><systemitem>mod_php&php-version;</systemitem></term>
      <listitem>
       <para>
        PHP is a server-side, cross-platform HTML embedded scripting language.
       </para>
       <simplelist><member>
-        Package Name: <systemitem>apache2-mod_php5</systemitem></member><member>
-        Configuration File: <filename>/etc/apache2/conf.d/php5.conf</filename></member><member>
-        More Information:
-        <filename>/usr/share/doc/packages/apache2-mod_php5</filename></member>
+        Package Name: <systemitem>apache2-mod_php&php-version;</systemitem></member><member>
+        Configuration File: <filename>/etc/apache2/conf.d/php&php-version;.conf</filename></member>
       </simplelist>
      </listitem>
     </varlistentry>
@@ -1632,7 +1633,7 @@ sknorr, 2017-06-07 -->
      <para>
       <emphasis>Have you reloaded the server after having changed the
       configuration?</emphasis> If not, reload with <command>systemctl reload
-      apache2</command>.
+      apache2.service</command>.
      </para>
     </listitem>
     <listitem>
@@ -2121,7 +2122,7 @@ An optional company name []:<co xml:id="co-ssl-self-optional"/></screen>
    You can run the default Apache instance as usual:
   </para>
 
-<screen>&prompt.sudo;systemctl start apache2</screen>
+<screen>&prompt.sudo;systemctl start apache2.service</screen>
 
   <para>
    It reads the default <filename>/etc/sysconfig/apache2</filename> file. If
@@ -2436,8 +2437,8 @@ An optional company name []:<co xml:id="co-ssl-self-optional"/></screen>
       <command>systemctl</command> commands instead (described in
       <xref
       linkend="sec-apache2-start-stop"/>). <command>systemctl
-      status apache2</command> is verbose about errors, and it even provides
-      tips and hints for fixing configuration errors.
+      status apache2.service</command> is verbose about errors, and it even
+      provides tips and hints for fixing configuration errors.
      </para>
     </listitem>
    </varlistentry>
@@ -2457,8 +2458,8 @@ An optional company name []:<co xml:id="co-ssl-self-optional"/></screen>
       <para>
        Watch the Apache log messages with the command <command>tail -F
        /var/log/apache2/<replaceable>MY_ERROR_LOG</replaceable></command>. Then
-       run <command>systemctl restart apache2</command>. Now, try to connect
-       with a browser and check the output.
+       run <command>systemctl restart apache2.service</command>. Now, try to
+       connect with a browser and check the output.
       </para>
      </tip>
     </listitem>
@@ -2493,7 +2494,7 @@ An optional company name []:<co xml:id="co-ssl-self-optional"/></screen>
    The package <systemitem>apache2-doc</systemitem> contains the complete
    Apache manual in various localizations for local installation and reference.
    It is not installed by default&mdash;the quickest way to install it is to
-   use the command <command>zypper in apache2-doc</command>. having been
+   use the command <command>zypper in apache2-doc</command>. Having been
    installed, the Apache manual is available at
    <link xlink:href="http://localhost/manual/"/>. You may also access it on the
    Web at <link xlink:href="http://httpd.apache.org/docs-2.4/"/>. SUSE-specific
@@ -2528,7 +2529,7 @@ An optional company name []:<co xml:id="co-ssl-self-optional"/></screen>
      </listitem>
     </varlistentry>
     <varlistentry>
-     <term><systemitem>mod_php5</systemitem></term>
+     <term><systemitem>mod_php&php-version;</systemitem></term>
      <listitem>
       <para>
        <link xlink:href="http://www.php.net/manual/en/install.unix.apache2.php"/>

--- a/xml/apache2_yast_i.xml
+++ b/xml/apache2_yast_i.xml
@@ -189,27 +189,6 @@
       </para>
      </listitem>
     </varlistentry>
-<!--  This option is no longer available -->
-<!--
-    <varlistentry>
-     <term><systemitem>Server Resolution</systemitem></term>
-     <listitem>
-      <para>
-       This option refers to <xref
-        linkend="sec-apache2-configuration-manually-vhost"/>.
-       <guimenu>Determine Request Server by HTTP Headers</guimenu> lets
-       a <literal>VirtualHost</literal> answer on a request to its
-       server name (see <xref
-        linkend="sec-apache2-configuration-manually-vhost-named-vhosts"/>).
-       <guimenu>Determine Request Server by Server IP Address</guimenu>
-       makes Apache select the requested host by the HTTP header
-       information the client sends. See <xref
-        linkend="sec-apache2-configuration-manually-vhost-ip-vhosts"/>
-       for more details on IP-based virtual hosts.
-      </para>
-     </listitem>
-    </varlistentry>
--->
    </variablelist>
    <para>
     After finishing with the <guimenu>Default Host</guimenu> step, click

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -10,6 +10,8 @@
 <!ENTITY productnumber          "<phrase xmlns='http://docbook.org/ns/docbook' role='productnumber'><phrase os='osuse'>15.4</phrase><phrase os='sles;sled'>&product-ga; SP&product-sp;</phrase><phrase os='slemicro'>5.2</phrase></phrase>">
 
 
+<!ENTITY php-version            "8">
+
 <!-- PROJECT REPOSITORY URL -->
 <!ENTITY repo-url               "https://github.com/SUSE/doc-sle">
 <!ENTITY github.url             "&repo-url;">


### PR DESCRIPTION
### PR creator: Description

Some info in the Apache chapter is outdated, this update tries to align it.
!!!IMPORTANT: check the &php-version; entity after backporting

### PR creator: Are there any relevant issues/feature requests?
Fixes https://bugzilla.suse.com/show_bug.cgi?id=1177654


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
