### PR TITLE
Minor update to zypper description and output (jsc#SLE-22621)

### DIFF
--- a/doc-kit.conf
+++ b/doc-kit.conf
@@ -3,5 +3,5 @@ variant: license-gfdl
 
 file: dc865ed00674536288a1e5a78ba07fe138aaabde  .gitignore
 file: c6b4745307e90c9b88905b434cbbaddc54e4541b  .editorconfig
-file: 77ca4e1e85b155aaaf525ac94df8c4a682008a62  xml/generic-entities.ent
+file: 52057b72aa89089dc36d5edc422a2ecb4c6ca48b  xml/generic-entities.ent
 file: e18430714fe3af85fe62bea62b50140d8b5edf5a  xml/network-entities.ent

--- a/xml/generic-entities.ent
+++ b/xml/generic-entities.ent
@@ -548,3 +548,6 @@ use &deng;! -->
 <!ENTITY mgrinstguide           "<citetitle xmlns='http://docbook.org/ns/docbook'>Installation &amp; Troubleshooting Guide</citetitle>">
 <!ENTITY mgrproxyquick          "<citetitle xmlns='http://docbook.org/ns/docbook'>Proxy Quick Start</citetitle>">
 <!ENTITY mgrquick               "<citetitle xmlns='http://docbook.org/ns/docbook'>Quick Start</citetitle>">
+
+<!-- SLE, old guide names -->
+<!ENTITY sle_jeos_quick        "<citetitle xmlns='http://docbook.org/ns/docbook'>&jeos; Quick Start</citetitle>">

--- a/xml/zypper.xml
+++ b/xml/zypper.xml
@@ -130,11 +130,12 @@
  <sect2 xml:id="sec-zypper-subcommands">
   <title>Using Zypper subcommands</title>
   <para>
-   Zypper subcommands are executables that are stored in the zypper_execdir,
-   <filename>/usr/lib/zypper/commands</filename>. If a subcommand is not found
-   in the zypper_execdir, Zypper automatically searches the rest of your $PATH
-   for it. This enables writing your own local extensions and storing them in
-   userspace.
+   Zypper subcommands are executables that are stored in the directory
+   specified by the <option>zypper_execdir</option>. It is
+   <filename>/usr/lib/zypper/commands</filename> by deafault. If a subcommand
+   is not found there, Zypper automatically searches the rest of your $PATH
+   locations for it. This enables writing your own local extensions and storing
+   them in userspace.
   </para>
   <para>
    Executing subcommands in the Zypper shell, and using global Zypper options
@@ -154,7 +155,9 @@ Available zypper subcommands in '/usr/lib/zypper/commands'
 
 Zypper subcommands available from elsewhere on your $PATH
 
-  &lt;none> </screen>
+  log                   Zypper logfile reader
+                            (/usr/sbin/zypper-log)
+</screen>
   <para>
    View the help screen for a subcommand:
   </para>

--- a/xml/zypper.xml
+++ b/xml/zypper.xml
@@ -132,10 +132,10 @@
   <para>
    Zypper subcommands are executables that are stored in the directory
    specified by the <option>zypper_execdir</option> configuration option. It is
-   <filename>/usr/lib/zypper/commands</filename> by deafault. If a subcommand
+   <filename>/usr/lib/zypper/commands</filename> by default. If a subcommand
    is not found there, Zypper automatically searches the rest of your $PATH
-   locations for it. This enables writing your own local extensions and storing
-   them in userspace.
+   locations for it. This enables you to create your own local extensions and store
+   them in user space.
   </para>
   <para>
    Executing subcommands in the Zypper shell, and using global Zypper options

--- a/xml/zypper.xml
+++ b/xml/zypper.xml
@@ -131,7 +131,7 @@
   <title>Using Zypper subcommands</title>
   <para>
    Zypper subcommands are executables that are stored in the directory
-   specified by the <option>zypper_execdir</option>. It is
+   specified by the <option>zypper_execdir</option> configuration option. It is
    <filename>/usr/lib/zypper/commands</filename> by deafault. If a subcommand
    is not found there, Zypper automatically searches the rest of your $PATH
    locations for it. This enables writing your own local extensions and storing


### PR DESCRIPTION
### PR creator: Description

SUSEConnect got rewritten to be self-contained and slightly affects `search-packages` subcommand of zypper


### PR creator: Are there any relevant issues/feature requests?

* jsc#SLE-22621


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
