### PR TITLE
vt-doc: Add a Troubleshooting section

### DIFF
--- a/xml/book_virtualization.xml
+++ b/xml/book_virtualization.xml
@@ -112,6 +112,16 @@
   <xi:include href="qemu_running_vms_qemukvm.xml"/>
   <xi:include href="qemu_monitor.xml"/>
  </part>
+
+<!-- ===================================================================== -->
+<!-- Troubleshooting part                                                             -->
+<!-- ===================================================================== -->
+ <part xml:id="part-virt-troubleshoot">
+  <title>Troubleshooting</title>
+  <xi:include href="virt_help.xml"/>
+  <xi:include href="virt_logs.xml"/>
+ </part>
+
 <!-- ===================================================================== -->
 <!-- LXC part                                                              -->
 <!-- ===================================================================== -->

--- a/xml/virt_help.xml
+++ b/xml/virt_help.xml
@@ -14,12 +14,12 @@
   </dm:docmanager>
  </info>
  <para>
-  The various virtualization packages provide commands for managing many aspects
+  Various virtualization packages provide commands for managing many aspects
   of a virtualization host. It is not possible or expected to remember all
-  options supported by these commands. A base installation of a &xen; or &kvm;
+  options supported by these commands. A basic installation of a &xen; or &kvm;
   host includes manual pages and integrated help for shell commands. The
   documentation sub-packages provide additional content beyond what is provided
-  by the base installation.
+  by the basic installation.
  </para>
  <variablelist>
   <varlistentry>
@@ -29,7 +29,7 @@
      Most commands include a manual page that provides detailed information about
      the command, describes any options, and in some cases gives example command
      usage. For example, to see the manual for the <command>virt-install</command>
-     command type
+     command type:
     </para>
 <screen>&prompt.user;man virt-install</screen>
    </listitem>
@@ -39,13 +39,13 @@
    <listitem>
     <para>
      Commands also include integrated help, providing more compact and topic-driven
-     documentation. For example to see a brief description of the
-     <command>virt-install</command> command type
+     documentation. For example, to see a brief description of the
+     <command>virt-install</command> command type:
     </para>
     <screen>&prompt.user;virt-install --help</screen>
     <para>
      Integrated help can also be used to see the details of a specific option. For
-     example, to see the sub-options supported by the disk option type
+     example, to see the sub-options supported by the disk option type:
     </para>
 <screen>&prompt.user;virt-install --disk help</screen>
    </listitem>
@@ -56,10 +56,10 @@
     <para>
      Many of the virtualization packages provide additional content in their
      documentation sub-package. As an example, the <package>libvirt-doc</package> package contains
-     all of the documentation available at <link xlink:href="http://libvirt.org"/>, plus sample code
-     demonstrating use of the libvirt C API. Use the <command>rpm</command> command
-     to view the contents of a documentation sub-package. For example to see the
-     contents of <package>libvirt-doc</package>
+     all the documentation available at <link xlink:href="http://libvirt.org"/>, plus sample code
+     demonstrating the use of the libvirt C API. Use the <command>rpm</command> command
+     to view the contents of a documentation sub-package. For example, to see the
+     contents of <package>libvirt-doc</package>:
     </para>
 <screen>rpm -ql libvirt-doc</screen>
    </listitem>

--- a/xml/virt_help.xml
+++ b/xml/virt_help.xml
@@ -17,21 +17,21 @@
   The various virtualization packages provide commands for managing many aspects
   of a virtualization host. It is not possible or expected to remember all
   options supported by these commands. A base installation of a &xen; or &kvm;
-  host includes man pages and integrated help for shell commands. The
+  host includes manual pages and integrated help for shell commands. The
   documentation sub-packages provide additional content beyond what is provided
   by the base installation.
  </para>
  <variablelist>
   <varlistentry>
-   <term>Man pages for shell commands</term>
+   <term>Manual pages for shell commands</term>
    <listitem>
     <para>
-     Most commands include a man page that provides detailed information about
+     Most commands include a manual page that provides detailed information about
      the command, describes any options, and in some cases gives example command
      usage. For example, to see the manual for the <command>virt-install</command>
      command type
     </para>
-<screen>man virt-install</screen>
+<screen>&prompt.user;man virt-install</screen>
    </listitem>
   </varlistentry>
   <varlistentry>
@@ -42,12 +42,12 @@
      documentation. For example to see a brief description of the
      <command>virt-install</command> command type
     </para>
-    <screen>virt-install --help</screen>
+    <screen>&prompt.user;virt-install --help</screen>
     <para>
      Integrated help can also be used to see the details of a specific option. For
      example, to see the sub-options supported by the disk option type
     </para>
-<screen>virt-install --disk help</screen>
+<screen>&prompt.user;virt-install --disk help</screen>
    </listitem>
   </varlistentry>
   <varlistentry>
@@ -55,11 +55,11 @@
    <listitem>
     <para>
      Many of the virtualization packages provide additional content in their
-     documentation sub-package. As an example, the libvirt-doc package contains
-     all of the documentation available at libvirt.org, plus sample code
-     demonstrating use of the libvirt C API. <command>rpm</command> can be used
+     documentation sub-package. As an example, the <package>libvirt-doc</package> package contains
+     all of the documentation available at <link xlink:href="http://libvirt.org"/>, plus sample code
+     demonstrating use of the libvirt C API. Use the <command>rpm</command> command
      to view the contents of a documentation sub-package. For example to see the
-     contents of libvirt-doc
+     contents of <package>libvirt-doc</package>
     </para>
 <screen>rpm -ql libvirt-doc</screen>
    </listitem>

--- a/xml/virt_help.xml
+++ b/xml/virt_help.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE chapter
+[
+  <!ENTITY % entities SYSTEM "generic-entities.ent">
+    %entities;
+]>
+
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-virt-help">
+ <title>Integrated help and package documentation</title>
+ <info>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker></dm:bugtracker>
+   <dm:translation>yes</dm:translation>
+  </dm:docmanager>
+ </info>
+ <para>
+  The various virtualization packages provide commands for managing many aspects
+  of a virtualization host. It is not possible or expected to remember all
+  options supported by these commands. A base installation of a &xen; or &kvm;
+  host includes man pages and integrated help for shell commands. The
+  documentation sub-packages provide additional content beyond what is provided
+  by the base installation.
+ </para>
+ <variablelist>
+  <varlistentry>
+   <term>Man pages for shell commands</term>
+   <listitem>
+    <para>
+     Most commands include a man page that provides detailed information about
+     the command, describes any options, and in some cases gives example command
+     usage. For example, to see the manual for the <command>virt-install</command>
+     command type
+    </para>
+<screen>man virt-install</screen>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term>Integrated help for shell commands</term>
+   <listitem>
+    <para>
+     Commands also include integrated help, providing more compact and topic-driven
+     documentation. For example to see a brief description of the
+     <command>virt-install</command> command type
+    </para>
+    <screen>virt-install --help</screen>
+    <para>
+     Integrated help can also be used to see the details of a specific option. For
+     example, to see the sub-options supported by the disk option type
+    </para>
+<screen>virt-install --disk help</screen>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term>Documentation sub-packages</term>
+   <listitem>
+    <para>
+     Many of the virtualization packages provide additional content in their
+     documentation sub-package. As an example, the libvirt-doc package contains
+     all of the documentation available at libvirt.org, plus sample code
+     demonstrating use of the libvirt C API. <command>rpm</command> can be used
+     to view the contents of a documentation sub-package. For example to see the
+     contents of libvirt-doc
+    </para>
+<screen>rpm -ql libvirt-doc</screen>
+   </listitem>
+  </varlistentry>
+ </variablelist>
+</chapter>

--- a/xml/virt_logs.xml
+++ b/xml/virt_logs.xml
@@ -85,7 +85,7 @@
    internal issues often require DEBUG level messages. As an example,
    consider a potential bug in the interaction between &libvirt; and the
    &qemu; monitor. In this case, we only need to see the debug messages of
-   the communication between &libvirt; and &qemu;. The follow example
+   the communication between &libvirt; and &qemu;. The following example
    creates a log filter to select debug messages from the &qemu; driver
    and send them to a file named <filename>/tmp/libvirtd.log</filename>
   </para>

--- a/xml/virt_logs.xml
+++ b/xml/virt_logs.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE chapter
+[
+  <!ENTITY % entities SYSTEM "generic-entities.ent">
+    %entities;
+]>
+
+<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-virt-logs">
+ <title>Gathing system information and logs</title>
+ <info>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker></dm:bugtracker>
+   <dm:translation>yes</dm:translation>
+  </dm:docmanager>
+ </info>
+ <para>
+  When a virtualization host encounters a problem it is often necessary to
+  collect a detailed system report, which can be done with the help of the
+  <command>supportconfig</command> tool. See <xref linkend="cha-adm-support"/>
+  for more information about <command>supportconfig</command>.
+ </para>
+ <para>
+  In some cases the information gathered by <command>supportconfig</command>
+  is insufficient and logs generated from a custom logging or debugging
+  configuration might be required to determine the cause of a problem.
+ </para>
+ <sect1 xml:id="sec-logs-libvirt">
+  <title>&libvirt; log controls</title>
+
+  <para>
+   &libvirt; provides logging facilities for both the library and the daemon.
+   Behavior of the logging facility is controlled by adjusting the log level,
+   filter, and output settings.
+  </para>
+  
+  <itemizedlist mark="bullet" spacing="normal">
+   <listitem>
+    <formalpara>
+     <title>Log level</title>
+     <para>
+      &libvirt; log messages are classified into four priority levels: DEBUG,
+      INFO, WARNING, and ERROR. The DEBUG level is very verbose and capable of
+      generating gigabytes of information in a short time. The volume of log
+      messages becomes progressively less with the INFO, WARNING, and ERROR
+      log levels. Error is the default log level.
+     </para>
+    </formalpara>
+   </listitem>
+   <listitem>
+    <formalpara>
+     <title>Log filters</title>
+     <para>
+      Log filters provide a way to log only messages matching a specific
+      component and log level. Log filters allow collecting the verbose DEBUG
+      log messages of specific components, but only ERROR level log messages
+      from the rest of the system. By default, no log filters are defined.
+     </para>
+    </formalpara>
+   </listitem>
+   <listitem>
+    <formalpara>
+     <title>Log outputs</title>
+     <para>
+      Log outputs allow specifying where the filtered log messages are sent.
+      Messages can be sent to a file, the standard error stream of the process,
+      or journald. By default filtered log messages are sent to journald.
+     </para>
+    </formalpara>
+   </listitem>
+  </itemizedlist>
+  <para>
+   See <link xlink:href="https://libvirt.org/logging.html"/> for more details
+   on &libvirt;'s log controls.
+  </para>
+
+  <para>
+   A default &libvirt; installation has log level set to ERROR, no log filters
+   defined, and log outputs set to journald. Log messages from the &libvirt;
+   daemon can be viewed with the <command>journalctl</command> command:
+  </para>
+<screen>jounalctl --unit libvirtd</screen>
+  <para>
+   The default log facility settings are fine for normal operations and
+   provide useful messages for applications and users of &libvirt;, but
+   internal issues often require debug level messages. As an example,
+   consider a potential bug in the interaction between &libvirt; and the
+   &qemu; monitor. In this case we only need to see the debug messages of
+   the communication between &libvirt; and &qemu;. The follow example
+   creates a log filter to select debug messages from the &qemu; driver
+   and send them to a file named <filename>/tmp/libvirtd.log</filename>
+  </para>
+<screen>
+   log_filters="1:qemu.qemu_monitor_json"
+   log_outputs="1:file:/tmp/libvirtd.log"
+</screen>
+  <para>
+   Log controls for the &libvirt; daemon can be found in
+   <filename>/etc/libvirt/libvirtd.conf</filename>. The daemon must be
+   restarted after making any changes to the configuration file.
+  </para>
+<screen>systemctl restart libvirtd.service</screen>
+ </sect1>
+</chapter>

--- a/xml/virt_logs.xml
+++ b/xml/virt_logs.xml
@@ -78,7 +78,7 @@
    defined, and log outputs set to journald. Log messages from the &libvirt;
    daemon can be viewed with the <command>journalctl</command> command:
   </para>
-<screen>jounalctl --unit libvirtd</screen>
+<screen>&prompt.root;jounalctl --unit libvirtd</screen>
   <para>
    The default log facility settings are fine for normal operations and
    provide useful messages for applications and users of &libvirt;, but
@@ -98,6 +98,6 @@
    <filename>/etc/libvirt/libvirtd.conf</filename>. The daemon must be
    restarted after making any changes to the configuration file.
   </para>
-<screen>systemctl restart libvirtd.service</screen>
+<screen>&prompt.root;systemctl restart libvirtd.service</screen>
  </sect1>
 </chapter>

--- a/xml/virt_logs.xml
+++ b/xml/virt_logs.xml
@@ -14,14 +14,14 @@
   </dm:docmanager>
  </info>
  <para>
-  When a virtualization host encounters a problem it is often necessary to
+  When a virtualization host encounters a problem, it is often necessary to
   collect a detailed system report, which can be done with the help of the
   <command>supportconfig</command> tool. See <link xlink:href="https://documentation.suse.com/sles/15-SP4/html/SLES-all/cha-adm-support.html"/>
   for more information about <command>supportconfig</command>.
  </para>
  <para>
-  In some cases the information gathered by <command>supportconfig</command>
-  is insufficient and logs generated from a custom logging or debugging
+  In some cases, the information gathered by <command>supportconfig</command>
+  is insufficient, and logs generated from a custom logging or debugging
   configuration might be required to determine the cause of a problem.
  </para>
  <sect1 xml:id="sec-logs-libvirt">
@@ -29,7 +29,7 @@
 
   <para>
    &libvirt; provides logging facilities for both the library and the daemon.
-   Behavior of the logging facility is controlled by adjusting the log level,
+   The behavior of the logging facility is controlled by adjusting the log level,
    filter, and output settings.
   </para>
   
@@ -41,7 +41,7 @@
     &libvirt; log messages are classified into four priority levels: DEBUG,
     INFO, WARNING, and ERROR. The DEBUG level is very verbose and capable of
     generating gigabytes of information in a short time. The volume of log
-    messages becomes progressively less with the INFO, WARNING, and ERROR log
+    messages progressively decreases with the INFO, WARNING, and ERROR log
     levels. ERROR is the default log level.
    </para>
   </listitem>
@@ -74,7 +74,7 @@
   </para>
 
   <para>
-   A default &libvirt; installation has log level set to ERROR, no log filters
+   A default &libvirt; installation has the log level set to ERROR, no log filters
    defined, and log outputs set to journald. Log messages from the &libvirt;
    daemon can be viewed with the <command>journalctl</command> command:
   </para>
@@ -82,9 +82,9 @@
   <para>
    The default log facility settings are fine for normal operations and
    provide useful messages for applications and users of &libvirt;, but
-   internal issues often require debug level messages. As an example,
+   internal issues often require DEBUG level messages. As an example,
    consider a potential bug in the interaction between &libvirt; and the
-   &qemu; monitor. In this case we only need to see the debug messages of
+   &qemu; monitor. In this case, we only need to see the debug messages of
    the communication between &libvirt; and &qemu;. The follow example
    creates a log filter to select debug messages from the &qemu; driver
    and send them to a file named <filename>/tmp/libvirtd.log</filename>

--- a/xml/virt_logs.xml
+++ b/xml/virt_logs.xml
@@ -33,41 +33,41 @@
    filter, and output settings.
   </para>
   
-  <itemizedlist>
-   <listitem>
-    <formalpara>
-     <title>Log level</title>
-     <para>
-      &libvirt; log messages are classified into four priority levels: DEBUG,
-      INFO, WARNING, and ERROR. The DEBUG level is very verbose and capable of
-      generating gigabytes of information in a short time. The volume of log
-      messages becomes progressively less with the INFO, WARNING, and ERROR
-      log levels. Error is the default log level.
-     </para>
-    </formalpara>
-   </listitem>
-   <listitem>
-    <formalpara>
-     <title>Log filters</title>
-     <para>
-      Log filters provide a way to log only messages matching a specific
-      component and log level. Log filters allow collecting the verbose DEBUG
-      log messages of specific components, but only ERROR level log messages
-      from the rest of the system. By default, no log filters are defined.
-     </para>
-    </formalpara>
-   </listitem>
-   <listitem>
-    <formalpara>
-     <title>Log outputs</title>
-     <para>
-      Log outputs allow specifying where the filtered log messages are sent.
-      Messages can be sent to a file, the standard error stream of the process,
-      or journald. By default filtered log messages are sent to journald.
-     </para>
-    </formalpara>
-   </listitem>
-  </itemizedlist>
+<variablelist>
+ <varlistentry>
+  <term>Log level</term>
+  <listitem>
+   <para>
+    &libvirt; log messages are classified into four priority levels: DEBUG,
+    INFO, WARNING, and ERROR. The DEBUG level is very verbose and capable of
+    generating gigabytes of information in a short time. The volume of log
+    messages becomes progressively less with the INFO, WARNING, and ERROR log
+    levels. ERROR is the default log level.
+   </para>
+  </listitem>
+ </varlistentry>
+ <varlistentry>
+  <term>Log filters</term>
+  <listitem>
+   <para>
+    Log filters provide a way to log only messages matching a specific
+    component and log level. Log filters allow collecting the verbose DEBUG
+    log messages of specific components, but only ERROR level log messages from
+    the rest of the system. By default, no log filters are defined.
+   </para>
+  </listitem>
+ </varlistentry>
+ <varlistentry>
+  <term>Log outputs</term>
+  <listitem>
+   <para>
+    Log outputs allow specifying where the filtered log messages are sent.
+    Messages can be sent to a file, the standard error stream of the process,
+    or journald. By default, filtered log messages are sent to journald.
+   </para>
+  </listitem>
+ </varlistentry>
+</variablelist>
   <para>
    See <link xlink:href="https://libvirt.org/logging.html"/> for more details
    on &libvirt;'s log controls.

--- a/xml/virt_logs.xml
+++ b/xml/virt_logs.xml
@@ -6,7 +6,7 @@
 ]>
 
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-virt-logs">
- <title>Gathing system information and logs</title>
+ <title>Gathering system information and logs</title>
  <info>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker></dm:bugtracker>

--- a/xml/virt_logs.xml
+++ b/xml/virt_logs.xml
@@ -16,7 +16,7 @@
  <para>
   When a virtualization host encounters a problem it is often necessary to
   collect a detailed system report, which can be done with the help of the
-  <command>supportconfig</command> tool. See <xref linkend="cha-adm-support"/>
+  <command>supportconfig</command> tool. See <link xlink:href="https://documentation.suse.com/sles/15-SP4/html/SLES-all/cha-adm-support.html"/>
   for more information about <command>supportconfig</command>.
  </para>
  <para>

--- a/xml/virt_logs.xml
+++ b/xml/virt_logs.xml
@@ -33,7 +33,7 @@
    filter, and output settings.
   </para>
   
-  <itemizedlist mark="bullet" spacing="normal">
+  <itemizedlist>
    <listitem>
     <formalpara>
      <title>Log level</title>


### PR DESCRIPTION
### PR creator: Description

The beginnings of a troubleshooting section for the Virtualization
Guide. More info can be added later, for example items sepcific to
Xen and KVM.Describe the overall goals of this pull request.

!!!!!NOTE: when backporting to 15 SP3, update the external link to supportconfig in the Admin guide!!!!!

### PR creator: Are there any relevant issues/feature requests?


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
