### PR TITLE
Extend manual for disconnected RMT setup

### DIFF
--- a/xml/rmt_mirroring.xml
+++ b/xml/rmt_mirroring.xml
@@ -457,8 +457,9 @@ Clean finished. An estimated 157 MB were removed.
    </step>
    <step>
     <para>
-     If not yet done, set up RMT on <literal>sirius</literal> using "yast2 rmt". 
-     In case of an offline RMT setup, choose "Skip" on the "Organization Credentials" screen.
+     If not yet done, set up &rmt; on <literal>sirius</literal> by running the
+     <command>yast2 rmt</command>. 
+     In case of an offline &rmt; setup, select <guimenu>Skip</guimenu> on the <guimenu>Organization Credentials</guimenu> screen.
     </para>
    </step>
    <step>

--- a/xml/rmt_mirroring.xml
+++ b/xml/rmt_mirroring.xml
@@ -457,6 +457,12 @@ Clean finished. An estimated 157 MB were removed.
    </step>
    <step>
     <para>
+     If not yet done, set up RMT on <literal>sirius</literal> using "yast2 rmt". 
+     In case of an offline RMT setup, choose "Skip" on the "Organization Credentials" screen.
+    </para>
+   </step>
+   <step>
+    <para>
      Connect the USB drive to <literal>sirius</literal> and
      mount it in <filename>/mnt/external</filename>.
     </para>


### PR DESCRIPTION
### PR creator: Description

Describe the overall goals of this pull request.

Describe missing step of setting up the disconnected RMT, and point to the "skip" button. 

### PR creator: Are there any relevant issues/feature requests?

* https://suse.slack.com/archives/C02AYV7UJSD/p1648626093379629

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

I'd like to apply it also to all other versions. 

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
