### PR TITLE
Added new section on CPU removal

### DIFF
--- a/xml/art_virtualization-best-practices.xml
+++ b/xml/art_virtualization-best-practices.xml
@@ -3173,7 +3173,7 @@ LC_ALL=C PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     the virtual machine is running.
    </para>
    <para>
-    For safe removal of CPUs, first deactivate them by executing
+    For the safe removal of CPUs, deactivate them first by executing
    </para>
    <screen>&prompt.root;<command>echo 0 > /sys/devices/system/cpu/cpu<replaceable>X</replaceable>/online</command></screen>
    <para>

--- a/xml/art_virtualization-best-practices.xml
+++ b/xml/art_virtualization-best-practices.xml
@@ -3166,6 +3166,22 @@ LC_ALL=C PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
     &lt;qemu:arg value='virtio-balloon-pci,id=balloon0'/&gt;
 &lt;/qemu:commandline&gt;</screen>
   </sect2>
+  <sect2 xml:id="sec-vm-guest-vcpu">
+   <title>Adding and removing CPUs</title>
+   <para>
+    Some virtualization environments allow adding or removing CPUs while
+    the virtual machine is running.
+   </para>
+   <para>
+    For safe removal of CPUs, first deactivate them by executing
+   </para>
+   <screen>&prompt.root;<command>echo 0 > /sys/devices/system/cpu/cpu<replaceable>X</replaceable>/online</command></screen>
+   <para>
+    Replace <replaceable>X</replaceable> with the CPU number. To bring a
+    CPU back online, execute
+   </para>
+<screen>&prompt.root;<command>echo 1 > /sys/devices/system/cpu/cpu<replaceable>X</replaceable>/online</command></screen>
+ </sect2>
  </sect1>
 <!-- TODO
       <sect2 id="vt-best-guest-clock">


### PR DESCRIPTION
### PR creator: Description

This section was part of the deployment guide originally, but belonged here.



### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
