### PR TITLE
change URL from master/ to main/

### DIFF
--- a/xml/common_intro_feedback_i.xml
+++ b/xml/common_intro_feedback_i.xml
@@ -29,7 +29,7 @@
     </para>
     <para>
      To open a service request, you need a &suse; subscription registered
-     at &scc;. 
+     at &scc;.
      Go to <link xlink:href="https://scc.suse.com/support/requests"/>, log in,
      and click <guimenu>Create New</guimenu>.
     </para>
@@ -72,10 +72,11 @@
      For more information about the documentation environment used for this
      documentation, see the repository's README
      <link
-      xlink:href="&github.url;/blob/master/README.adoc"></link>.
+      xlink:href="&github.url;/blob/main/README.adoc"></link>
+
      <!--taroth 2020-01-09: Link needs to be adjusted in case the README changes
       format. In case the READMEs differ between the branches, better just point
-      to &github.url;-->
+      to &github.url;  https://github.com/SUSE/doc-sle/blob/main/README.adoc.-->
     </para>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
### PR creator: Description

update README.adoc URL from https://github.com/SUSE/doc-sle/blob/master/README.adoc to https://github.com/SUSE/doc-sle/blob/main/README.adoc


### PR creator: Are there any relevant issues/feature requests?
Jira #SLE-22017


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
