### PR TITLE
Tuning Guide: Rework section about IO control with cgroups

### DIFF
--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -3,7 +3,7 @@
 [
   <!ENTITY % entities SYSTEM "generic-entities.ent">
   %entities;
-  <!-- custom prompt entities for the 'Controlling I/O with Proportional Weight Policy' section --> 
+  <!-- custom prompt entities for the 'Controlling I/O with Proportional Weight Policy' section -->
   <!ENTITY reader1 "reader1:/io-cgroup #">
   <!ENTITY prompt.reader1 "<prompt role='root' xmlns='http://docbook.org/ns/docbook'>[reader1] host1:/io-cgroup # </prompt>">
   <!ENTITY prompt.reader2 "<prompt role='root' xmlns='http://docbook.org/ns/docbook'>[reader2] host1:/io-cgroup # </prompt>">
@@ -217,7 +217,7 @@ DefaultTasksMax=256
     following example demonstrates how to raise MariaDB's limit to 8192.
    </para>
 <screen>&prompt.sudo;<command>systemctl set-property mariadb.service TasksMax=8192</command>
-&prompt.user;<command>systemctl status mariadb.service</command> 
+&prompt.user;<command>systemctl status mariadb.service</command>
 ● mariadb.service - MariaDB database server
    Loaded: loaded (/usr/lib/systemd/system/mariadb.service; disabled; vendor preset: disab>
   Drop-In: /etc/systemd/system/mariadb.service.d
@@ -286,84 +286,101 @@ TasksMax=16284
    </para>
   </sect2>
  </sect1>
- <sect1>
+
 <!-- BEGIN NEW VERSION -->
+<sect1 xml:id="sec-control-io-cgroups">
 <title>I/O control with cgroups</title>
+<para>
+ TODO words go here
+</para>
 
-<sect2>
+<sect2 xml:id="sec-cgroups-prerequisites">
 <title>Prerequisites</title>
+<para>
+ TODO words go here
+</para>
 
-<sect3>
+<sect3 xml:id="sec-cgroups-filesystems">
 <title>Filesystem</title>
 <para>
-Despite the IO control is configured in terms of block devices, it is the
-filesystem and its inode abstraction that is important to exercise the policies
-(when it comes to controlling also the writeback IO).
+Despite the I/O control is configured in terms of block devices, it is the
+filesystem and its inode abstraction that is important to exercise the
+policies (when it comes to controlling also the writeback I/O).
 Therefore a cgroup aware filesystem must be chosen, the recommended SLES
 filesystems [2] added support in following upstream releases:
 <!-- [2] is https://www.susecon.com/doc/2015/sessions/TUT20066.pdf, slide 7, maybe there's better SLES docs -->
 </para>
    <itemizedlist mark="bullet" spacing="normal">
-	   <listitem>btrfs (v4.3),</listitem>
-	   <listitem>ext4 (v4.3),</listitem>
-	   <listitem>xfs (v5.3).</listitem>
+	   <listitem>
+     <para>
+      Btrfs (v4.3)
+      </para>
+      </listitem>
+	   <listitem>
+     <para>
+      Ext4 (v4.3)
+      </para>
+      </listitem>
+	   <listitem>
+     <para>
+      XFS (v5.3)
+      </para>
+      </listitem>
    </itemizedlist>
 <para>
-as of today (SLES15 SP3), any of the named filesystems can be used.
+As of &productname;&nbsp;, any of the named filesystems can be used.
 </para>
 </sect3>
 
-<sect3>
+<sect3 xml:id="sec-cgroups-unified-hierarchy">
 <title>Unified cgroup hiearchy</title>
 <para>
-To properly account also writeback IO, it is necessary to have equal IO and memory
-controller cgroup hierarchies and use cgroup v2 IO controller.
-Together, this means that one has to use so called <emphasis>unified</emphasis>
-cgroup hierarchy.
-This has to be requested explicitly in SLES by passing a kernel command line
-option <option>systemd.unified_cgroup_hierarchy=1</option>.
+To properly account also writeback I/O, it is necessary to have equal I/O
+and memory controller cgroup hierarchies and use cgroup v2 I/O controller.
+Together, this means that one has to use the <emphasis>unified</emphasis>
+cgroup hierarchy. This has to be requested explicitly in SLES by passing a
+kernel command line option <option>systemd.unified_cgroup_hierarchy=1</option>.
 </para>
 </sect3>
 
-<sect3>
-<title>Block IO scheduler</title>
+<sect3 xml:id="sec-cgroups-block-io-scheduler">
+<title>Block I/O scheduler</title>
 <para>
-The throttling policy is implemented higher in the stack therefore it doesn’t
-require no additional adjustments.
-The proportional IO control policies have two different implementations nowadays:
+The throttling policy is implemented higher in the stack therefore it
+doesn’t require any additional adjustments.
+The proportional I/O control policies have two different implementations:
 BFQ controller and cost-based model.
 We describe the BFQ controller here and in order to exert its proportional
 implementation for a particular device, we must make sure that BFQ is the
 chosen scheduler.
-Check the current scheduler
+Check the current scheduler:
 </para>
 <screen>
-$ cat /sys/class/block/$DEV/queue/scheduler
+&prompt.user;<command>cat /sys/class/block/$DEV/queue/scheduler</command>
 mq-deadline kyber [bfq] none
 </screen>
 <para>
-Switch the scheduler
+Switch the scheduler:
 </para>
 <screen>
-$ echo bfq >/sys/class/block/$DEV/queue/scheduler
+&prompt.user;<command>echo bfq >/sys/class/block/$DEV/queue/scheduler</command>
 </screen>
 <para>
-</para>
-<para>
-<command>$DEV</command> is the disk device, not a partition and the optimal way
-to set this attribute is a udev rule specific to the device (note that SLES
-ships udev rules that already enable BFQ for rotational disk drives).
+<literal>$DEV</literal> is the disk device, not a partition and the
+optimal way to set this attribute is a udev rule specific to the device
+(note that &slsa; ships udev rules that already enable BFQ for rotational
+disk drives).
 </para>
 </sect3>
 
-<sect3>
+<sect3 xml:id="sec-cgroups-hierarchy">
 <title>Cgroup hieararchy layout</title>
 <para>
-Normally, all tasks reside in the root cgroup and they compete against each other.
-When the tasks are distributed into the cgroup tree the competition occurs
-between siblings cgroups only. 
-This applies to the proportional IO control, the throttling hierarchically
-aggregates throughput of all descendants.
+Normally, all tasks reside in the root cgroup and they compete against
+each other. When the tasks are distributed into the cgroup tree the
+competition occurs between siblings cgroups only.
+This applies to the proportional I/O control, the throttling
+hierarchically aggregates throughput of all descendants.
 </para>
 <!-- this is not code but a picture -->
 <screen>
@@ -374,84 +391,83 @@ r
 `- [b]     IOWeight=200
 </screen>
 <para>
-IO is originating only from cgroups c and b. Despite c has higher weight, it
-will be treated with lower priority based on the weight of a that is
+I/O is originating only from cgroups c and b. Despite c has higher weight,
+it will be treated with lower priority based on the weight of a that is
 level-competing with b.
 </para>
+</sect3>
 
-</sect2>
-<sect2>
+<sect3 xml:id="sec-cgroups-configure-control-quantities">
 <title>Configuring control quantities</title>
 <para>
-You can apply the values to (long running) services permantently
+You can apply the values to (long running) services permanently.
 </para>
 <screen>
-systemctl set-property fast.service IOWeight=400
-systemctl set-property slow.service IOWeight=50
-systemctl set-property throttled.service IOReadBandwidthMax="/dev/sda 1M"
+&prompt.sudo;<command>systemctl set-property fast.service IOWeight=400</command>
+&prompt.sudo;<command>systemctl set-property slow.service IOWeight=50</command>
+&prompt.sudo;<command>systemctl set-property throttled.service IOReadBandwidthMax="/dev/sda 1M"</command>
 </screen>
 
 <para>
-Alternatively, you can apply IO control to individually run commands, for instance:
+Alternatively, you can apply I/O control to individually run commands, for instance:
 </para>
 <screen>
-systemd-run --scope -p IOWeight=400 prioritized_command
-systemd-run --scope -p IOWeight=50  low_prioritized_command
-systemd-run --scope -p IOReadBandwidthMax="/dev/sda 1M" dd if=/dev/sda of=/dev/null bs=1M count=10
+&prompt.sudo;<command>systemd-run --scope -p IOWeight=400 prioritized_command</command>
+&prompt.sudo;<command>systemd-run --scope -p IOWeight=50  low_prioritized_command</command>
+&prompt.sudo;<command>systemd-run --scope -p IOReadBandwidthMax="/dev/sda 1M" dd if=/dev/sda of=/dev/null bs=1M count=10</command>
 </screen>
+</sect3>
 
-</sect2>
-<sect2>
-<title>IO control behavior and setting expectations</title>
+<sect3 xml:id="sec-cgroups-control-behavior">
+<title>I/O control behavior and setting expectations</title>
+<para>
+I/O control works best for direct I/O operations (bypassing page cache),
+the situations where the actual IO is decoupled from the caller (typically
+writeback via page cache) may manifest variously – delayed I/O control or
+even no observed I/O control (consider little bursts or competing
+workloads that happen to never "meet" submitting I/O at the same time (and
+hence saturating the bandwidth). For these reasons, the resulting ratio of
+I/O throughputs does not strictly follow the ratio of configured weights.
 </para>
 <para>
-IO control works best for direct IO operations (bypassing page cache), the
-situations where the actual IO is decoupled from the caller (typically
-writeback via page cache) may manifest variously – delayed IO control or even
-no observed IO control (consider little bursts or competing workloads that
-happen to never ‘‘meet’’ submitting IO at the same time (and hence saturating
-the bandwidth)).
-For these reasons, the resulting ratio of IO throughputs does not strictly
-follow the ratio of configured weights.
+The writeback activity depends on the amount of dirty pages, besides the
+global sysctl knobs (<filename>vm.dirty_background_ratio</filename> and
+<filename>vm.dirty_ratio</filename>) memory limits of individual cgroups
+come into play when the dirty limits are distributed among cgroups and
+this in turn may affect I/O intensity of affected cgroups.
 </para>
 <para>
-The writeback activity depends on the amount of dirty pages, besides the global
-sysctl knobs (<filename>vm.dirty_background_ratio</filename> and
-<filename>vm.dirty_ratio</filename>) memory limits of individual cgroups come
-into play when the dirty limits are distributed among cgroups and this in turn
-may affect IO intensity of affected cgroups.
+Not all storages are equal. The I/O control happens at the I/O scheduler
+layer, which has ramifications for setups with devices stacked on these
+that do no actual scheduling. Consider device mapper logical volumes
+spanning multiple physical devices, MD RAID or even Btrfs RAID.
+I/O control over such setups may be challenging.
 </para>
 <para>
-Not all storages are equal.
-The IO control happens at IO scheduler layer, this has ramifications for setups
-with devices stacked on these that do no actual scheduling.
-Consider device mapper logical volumes spanning multiple physical devices, MD
-RAID or even btrfs RAID.
-IO control over such setups may be challenging.
+There is no separate setting for proportional I/O control of reads and
+writes.
 </para>
 <para>
-There is no separate setting for proportional IO control of reads and writes.
-</para>
-<para>
-Proportional IO control is only one of the policies that can interact with
+Proportional I/O control is only one of the policies that can interact with
 each other (but responsible resource design perhaps avoids that).
 </para>
 <para>
-The IO device bandwidth is not the only shared resource on the IO path,
-namely, global filesystem structures are involved too, which is relevant when
-IO control is meant to guarantee certain bandwidth – it won’t and it may
-even lead to priority inversion (prioritized cgroup waiting for a transaction
-of slower cgroup).
+The I/O device bandwidth is not the only shared resource on the I/O path,
+namely, global filesystem structures are involved too, which is relevant
+when I/O control is meant to guarantee certain bandwidth – it won’t and it
+may even lead to priority inversion (prioritized cgroup waiting for a
+transaction of slower cgroup).
 </para>
 <para>
-So far, we have been discussing only explicit IO of filesystem data but swap-
-in and swap-out can be controlled too.
-Although if such a need arises, it usually points out to improperly provisioned
-memory (or memory limits).
+So far, we have been discussing only explicit I/O of filesystem data but
+swap- in and swap-out can be controlled too. Although if such a need arises,
+it usually points out to improperly provisioned memory (or memory limits).
 </para>
+</sect3>
 </sect2>
 </sect1>
 <!-- END NEW VERSION -->
+
  <sect1>
   <title>More information</title>
 

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -287,245 +287,170 @@ TasksMax=16284
   </sect2>
  </sect1>
  <sect1>
-  <title>Controlling I/O with proportional weight policy</title>
+<!-- BEGIN NEW VERSION -->
+<title>I/O control with cgroups</title>
 
-  <para>
-   This section introduces using the Linux kernel's block I/O controller to
-   prioritize I/O operations. The cgroup blkio subsystem controls and monitors
-   access to I/O on block devices. State objects that contain the subsystem
-   parameters for a cgroup are represented as pseudo-files within the cgroup
-   virtual file system, also called a pseudo-file system.
-  </para>
+<sect2>
+<title>Prerequisites</title>
 
-  <para>
-   The examples in this section show how writing values to some of these
-   pseudo-files limits access or bandwidth, and reading values from some of
-   these pseudo-files provides information on I/O operations. Examples are
-   provided for both cgroup-v1 and cgroup-v2.
-  </para>
-
-  <para>
-   You need a test directory containing two files for testing performance and
-   changed settings. A quick way to create test files fully populated with text
-   is using the <command>yes</command> command. The following example commands
-   create a test directory, and then populate it with two 537 MB text files:
-  </para>
-
-<screen>&prompt.plain-root;mkdir /io-cgroup
-&prompt.plain-root;cd /io-cgroup
-&prompt.plain-root;yes this is a test file | head -c 537MB > file1.txt
-&prompt.plain-root;yes this is a test file | head -c 537MB > file2.txt
-</screen>
-
-  <para>
-   To run the examples open three command shells. Two shells are for reader
-   processes, and one shell is for running the steps that control I/O. In the
-   examples, each command prompt is labeled to indicate if it represents one of
-   the reader processes, or I/O.
-  </para>
-
-  <sect2>
-   <title>Using cgroup-v1</title>
-   <para>
-    The following proportional weight policy files can be used to grant a
-    reader process a higher priority for I/O operations than other reader
-    processes accessing the same disk.
-   </para>
+<sect3>
+<title>Filesystem</title>
+<para>
+Despite the IO control is configured in terms of block devices, it is the
+filesystem and its inode abstraction that is important to exercise the policies
+(when it come to controlling also the writeback IO).
+Therefore a cgroup aware filesystem must be chosen, the recommended SLES
+filesystems [2] added support in following upstream releases:
+<!-- [2] is https://www.susecon.com/doc/2015/sessions/TUT20066.pdf, slide 7, maybe there's better SLES docs -->
+</para>
    <itemizedlist mark="bullet" spacing="normal">
-    <listitem>
-     <para>
-      <filename>blkio.bfq.weight</filename> (available in kernels starting with
-      version 5.0 with blk-mq and when using the BFQ I/O scheduler)
-     </para>
-    </listitem>
+	   <listitem>btrfs (v4.3),</listitem>
+	   <listitem>ext4 (v4.3),</listitem>
+	   <listitem>xfs (v5.3).</listitem>
    </itemizedlist>
-   <para>
-    To test this, run a single reader process (in the examples, reading from an
-    SSD) without controlling its I/O, using <filename>file2.txt</filename>:
-   </para>
-<screen> 
-&prompt.io-controller;sync; echo 3 > /proc/sys/vm/drop_caches
-&prompt.io-controller;echo $$; dd if=file2.txt of=/dev/null bs=4k count=131072
-5251
-131072+0 records in
-131072+0 records out
-536870912 bytes (537 MB, 512 MiB) copied, 1.33049 s, 404 MB/s
-</screen>
-   <para>
-    Now run a background process reading from the same disk:
-   </para>
-<screen>
-&prompt.reader1;sync; echo 3 > /proc/sys/vm/drop_caches
-&prompt.reader1;echo $$; dd if=file1.txt of=/dev/null bs=4k
-5220
-...
-&prompt.reader2;echo $$; dd if=file2.txt of=/dev/null bs=4k count=131072
-5251
-131072+0 records in
-131072+0 records out
-536870912 bytes (537 MB, 512 MiB) copied, 2.61592 s, 205 MB/s
-</screen>
-   <para>
-    Each process gets half of the throughput for I/O operations. Next, set up
-    two control groups&mdash;one for each process&mdash;verify that BFQ is
-    used, and set a different weight for reader2:
-   </para>
-<screen>
-&prompt.io-controller;cd /sys/fs/cgroup/blkio/
-&prompt.blkio;mkdir reader1
-&prompt.blkio;mkdir reader2
-&prompt.blkio;echo 5220 > reader1/cgroup.procs
-&prompt.blkio;echo 5251 > reader2/cgroup.procs
-&prompt.blkio;cat /sys/block/sda/queue/scheduler
-mq-deadline kyber [bfq] none
-&prompt.blkio;cat reader1/blkio.bfq.weight
-100
-&prompt.blkio;echo 200 > reader2/blkio.bfq.weight
-&prompt.blkio;cat reader2/blkio.bfq.weight
-200
-</screen>
-   <para>
-    With these settings and reader1 in the background, reader2 should have
-    higher throughput than previously:
-   </para>
-<screen>
-&prompt.reader1;sync; echo 3 > /proc/sys/vm/drop_caches
-&prompt.reader1;echo $$; dd if=file1.txt of=/dev/null bs=4k
-5220
-...
-&prompt.reader2;echo $$; dd if=file2.txt of=/dev/null bs=4k count=131072
-5251
-131072+0 records in
-131072+0 records out
-536870912 bytes (537 MB, 512 MiB) copied, 2.06604 s, 260 MB/s
-</screen>
-   <para>
-    The higher proportional weight resulted in higher throughput for reader2.
-    Now double its weight again:
-   </para>
-<screen>
-&prompt.blkio;cat reader1/blkio.bfq.weight
-100
-&prompt.blkio;echo 400 > reader2/blkio.bfq.weight
-&prompt.blkio;cat reader2/blkio.bfq.weight
-400
-</screen>
-   <para>
-    This results in another increase in throughput for reader2:
-   </para>
-<screen>
-&prompt.reader1;sync; echo 3 > /proc/sys/vm/drop_caches
-&prompt.reader1;echo $$; dd if=file1.txt of=/dev/null bs=4k
-5220
-...
-&prompt.reader2;echo $$; dd if=file2.txt of=/dev/null bs=4k count=131072
-5251
-131072+0 records in
-131072+0 records out
-536870912 bytes (537 MB, 512 MiB) copied, 1.69026 s, 318 MB/s
-</screen>
-  </sect2>
+<para>
+as of today (SLES15 SP3), any of the named filesystems can be used.
+</para>
+</sect3>
 
-  <sect2>
-   <title>Using cgroup-v2</title>
-   <para>
-    First set up your test environment as shown at the beginning of this
-    chapter.
-   </para>
-   <para>
-    Then make sure that the Block IO controller is not active, as that is for
-    cgroup-v1. To do this, boot with kernel parameter
-    <option>cgroup_no_v1=blkio</option>. Verify that this parameter was used,
-    and that the IO controller (cgroup-v2) is available:
-   </para>
+<sect3>
+<title>Unified cgroup hiearchy</title>
+<para>
+To properly account also writeback IO, it is necessary to have equal IO and memory
+controller cgroup hierarchies and use cgroup v2 IO controller.
+Together, this means that one has to use so called <emphasis>unified</emphasis>
+cgroup hierarchy.
+This has to be requested explicitly in SLES by passing a kernel command line
+option <option>systemd.unified_cgroup_hierarchy=1</option>.
+</para>
+</sect3>
+
+<sect3>
+<title>Block IO scheduler</title>
+<para>
+The throttling policy is implemented higher in the stack therefore it doesn’t
+require on additional adjustments.
+The proportional IO control policies have two different implementations nowadays:
+BFQ controller and cost-based model.
+We describe the BFQ controller here and in order to exert its proportional
+implementation for a particular device, we must make sure that BFQ is the
+chosen scheduler.
+Check the current scheduler
+</para>
 <screen>
-&prompt.io-controller;cat /proc/cmdline
-BOOT_IMAGE=... cgroup_no_v1=blkio ...
-&prompt.io-controller;cat /sys/fs/cgroup/unified/cgroup.controllers
-io
-</screen>
-   <para>
-    Next, enable the IO controller:
-   </para>
-<screen>
-&prompt.io-controller;cd /sys/fs/cgroup/unified/
-&prompt.unified;echo '+io' > cgroup.subtree_control
-&prompt.unified;cat cgroup.subtree_control
-io
-</screen>
-   <para>
-    Now run all the test steps, similarly to the steps for cgroup-v1. Note that
-    some of the directories are different. Run a single reader process (in the
-    examples, reading from an SSD) without controlling its I/O, using
-    file2.txt:
-   </para>
-<screen>
-&prompt.unified;cd -
-&prompt.io-controller;sync; echo 3 > /proc/sys/vm/drop_caches
-&prompt.io-controller;echo $$; dd if=file2.txt of=/dev/null bs=4k count=131072
-5633
-[...]
-</screen>
-   <para>
-    Run a background process reading from the same disk and note your
-    throughput values:
-   </para>
-<screen>
-&prompt.reader1;sync; echo 3 > /proc/sys/vm/drop_caches
-&prompt.reader1;echo $$; dd if=file1.txt of=/dev/null bs=4k
-5633
-[...]
-&prompt.reader2;echo $$; dd if=file2.txt of=/dev/null bs=4k count=131072
-5703
-[...]
-</screen>
-   <para>
-    Each process gets half of the throughput for I/O operations. Set up two
-    control groups&mdash;one for each process&mdash;verify that BFQ is the
-    active scheduler, and set a different weight for reader2:
-   </para>
-<screen>
-&prompt.io-controller;cd -
-&prompt.unified;mkdir reader1
-&prompt.unified;mkdir reader2
-&prompt.unified;echo 5633 > reader1/cgroup.procs
-&prompt.unified;echo 5703 > reader2/cgroup.procs
-&prompt.unified;cat /sys/block/sda/queue/scheduler
+$ cat /sys/class/block/$DEV/queue/scheduler
 mq-deadline kyber [bfq] none
-&prompt.unified;cat reader1/io.bfq.weight
-default 100
-&prompt.unified;echo 200 > reader2/io.bfq.weight
-&prompt.unified;cat reader2/io.bfq.weight
-default 200
 </screen>
-   <para>
-    Test your throughput with the new settings. reader2 should show an increase
-    in throughput.
-   </para>
+<para>
+Switch the scheduler
+</para>
 <screen>
-&prompt.reader1;sync; echo 3 > /proc/sys/vm/drop_caches
-&prompt.reader1;echo $$; dd if=file1 of=/dev/null bs=4k
-5633
-[...]
-&prompt.reader2;echo $$; dd if=file2 of=/dev/null bs=4k count=131072
-5703
-[...]
+$ echo bfq >/sys/class/block/$DEV/queue/scheduler
 </screen>
-   <para>
-    Try doubling the weight again for reader2, and testing the new setting:
-   </para>
+<para>
+</para>
+<para>
+<command>$DEV</command> is the disk device, not a partition and the optimal way
+to set this attribute is a udev rule specific to the device (note that SLES
+ships udev rules that already enable BFQ for rotational disk drives).
+</para>
+</sect3>
+
+<sect3>
+<title>Cgroup hieararchy layout</title>
+<para>
+Normally, all tasks reside in the root cgroup and they compete against each other.
+When the tasks are distributed into the cgroup tree the competition occurs
+between siblings cgroups only. 
+This applies to the proportional IO control, the throttling hierarchically
+aggregates throughput of all descendants.
+</para>
+<!-- this is not code but a picture -->
 <screen>
-&prompt.reader2;echo 400 > reader1/blkio.bfq.weight
-&prompt.reader2;cat reader2/blkio.bfq.weight
-400
-&prompt.reader1;sync; echo 3 > /proc/sys/vm/drop_caches
-&prompt.reader1;echo $$; dd if=file1.txt of=/dev/null bs=4k
-[...]
-&prompt.reader2;echo $$; dd if=file2.txt of=/dev/null bs=4k count=131072
-[...]
+r
+`-  a      io.bfq.weight=100
+    `- [c] io.bfq.weight=300
+    `-  d  io.bfq.weight=100
+`- [b]     io.bfq.weight=200
 </screen>
-  </sect2>
- </sect1>
+<para>
+IO is originating only from cgroups c and b. Despite c has higher weight, it
+will be treated with lower priority based on the weight of a that is
+level-competing with b.
+</para>
+
+</sect2>
+<sect2>
+<title>Configuring control quantities</title>
+<para>
+You can apply the values to (long running) services permantently
+</para>
+<screen>
+systemctl set-property fast.service IOWeight=400
+systemctl set-property slow.service IOWeight=50
+systemctl set-property throttled.service IOReadBandwidthMax="/dev/sda 1M"
+</screen>
+
+<para>
+Alternatively, you can apply IO control to individually run commands, for instance:
+</para>
+<screen>
+systemd-run --scope -p IOWeight=400 prioritized_command
+systemd-run --scope -p IOWeight=50  low_prioritized_command
+systemd-run --scope -p IOReadBandwidthMax="/dev/sda 1M" dd if=/dev/sda of=/dev/null bs=1M count=10
+</screen>
+
+</sect2>
+<sect2>
+<title>IO control behavior and setting expectations</title>
+</para>
+<para>
+IO control works best for direct IO operations (bypassing page cache), the
+situations where the actual IO is decoupled from the caller (typically
+writeback via page cache) may manifest variously – delayed IO control or even
+no observed IO control (consider little bursts or competing workloads that
+happen to never ‘‘meet’’ submitting IO at the same time (and hence saturating
+the bandwidth)).
+For these reasons, the resulting ratio of IO throughtputs does not strictly
+follow the ratio of configured weights.
+</para>
+<para>
+The writeback activity depends on the amount of dirty pages, besides the global
+sysctl knobs memory limits of individual cgroups come into play when the dirty
+limits are distributed among cgroups and this in turn may affect IO intensity
+of affected cgroups.
+</para>
+<para>
+Not all storages are equal.
+The IO control happens at IO scheduler layer, this has ramifications for setups
+with devices stacked on these that do no actual scheduling.
+Consider device mapper logical volumes spanning multiple physical devices, MD
+RAID or even btrfs RAID.
+IO control over such setups may be challenging.
+</para>
+<para>
+There is no separate setting for proportional IO control of reads and writes.
+</para>
+<para>
+Proportional IO control is only one of the policies that can interact with
+each other (but responsible resource design perhaps avoids that).
+</para>
+<para>
+The IO device bandwidth is not the only shared resource on the IO path,
+namely, global filesystem structures are involved too, which is relevant when
+IO control is meant to guarantee certain bandwidth – it won’t and it may
+even lead to priority inversion (prioritized cgroup waiting for a transaction
+of slower cgroup).
+</para>
+<para>
+So far, we have been discussing only explicit IO of filesystem data but swap-
+in and swap-out can be controlled too.
+Although if such a need arises, it usually points out to improperly provisioned
+memory (or memory limits).
+</para>
+</sect2>
+</sect1>
+<!-- END NEW VERSION -->
  <sect1>
   <title>More information</title>
 

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -363,7 +363,7 @@ mq-deadline kyber bfq [none]
 Switch the scheduler:
 </para>
 <screen>
-&prompt.user;<command>echo bfq >/sys/class/block/$DEV/queue/scheduler</command>
+&prompt.sudo;<command>echo bfq >/sys/class/block/$DEV/queue/scheduler</command>
 </screen>
 <para>
 <literal>$DEV</literal> is the disk device, not a partition and the

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -441,6 +441,11 @@ come into play when the dirty limits are distributed among cgroups and
 this in turn may affect I/O intensity of affected cgroups.
 </para>
 <para>
+As explained in the introduction, inodes are the unit of writeback charging,
+therefore cgroups whose write I/O consists mainly of writes into a single file
+won't be fully differentiated with proportional control.
+</para>
+<para>
 Not all storages are equal. The I/O control happens at the I/O scheduler
 layer, which has ramifications for setups with devices stacked on these
 that do no actual scheduling. Consider device mapper logical volumes

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -292,9 +292,9 @@ TasksMax=16284
 <title>I/O control with cgroups</title>
 <para>
 This section introduces using the Linux kernel's block I/O controller to
-prioritize or throttle I/O operations,
-it leverages the means provided by systemd to configure cgroups.
-Finally, it discusses probable pitfalls when dealing with proportional I/O control.
+prioritize or throttle I/O operations. This leverages the means provided by
+systemd to configure cgroups, and discusses probable pitfalls when dealing
+with proportional I/O control.
 </para>
 
 <sect2 xml:id="sec-cgroups-prerequisites">
@@ -308,7 +308,7 @@ during runtime.
 <sect3 xml:id="sec-cgroups-filesystems">
 <title>Filesystem</title>
 <para>
-You must use a cgroup-aware filesystem. The recommended SLES
+You must use a cgroup-writeback-aware filesystem. The recommended SLES
 filesystems added support in the following upstream releases:
 <!-- [2] is https://www.susecon.com/doc/2015/sessions/TUT20066.pdf, slide 7, maybe there's better SLES docs
 cjs: that slide is old! We must find something newer.
@@ -332,45 +332,45 @@ cjs: that slide is old! We must find something newer.
       </listitem>
    </itemizedlist>
 <para>
-As of &productname;&nbsp;3, any of the named filesystems can be used.
+As of &productname;&nbsp;SP3, any of the named filesystems can be used.
 </para>
 </sect3>
 
 <sect3 xml:id="sec-cgroups-unified-hierarchy">
 <title>Unified cgroup hiearchy</title>
 <para>
-To properly account also writeback I/O, it is necessary to have equal I/O
-and memory controller cgroup hierarchies and use cgroup v2 I/O controller.
-Together, this means that one has to use the <emphasis>unified</emphasis>
-cgroup hierarchy. This has to be requested explicitly in SLES by passing a
-kernel command line option <option>systemd.unified_cgroup_hierarchy=1</option>.
+To properly account writeback I/O, it is necessary to have equal I/O
+and memory controller cgroup hierarchies, and to use the cgroup v2 I/O
+controller. Together, this means that one has to use the
+<emphasis>unified</emphasis> cgroup hierarchy. This has to be requested
+explicitly in SLES by passing a kernel command line option,
+<option>systemd.unified_cgroup_hierarchy=1</option>.
 </para>
 </sect3>
 
 <sect3 xml:id="sec-cgroups-block-io-scheduler">
 <title>Block I/O scheduler</title>
 <para>
-The throttling policy is implemented higher in the stack therefore it
-doesn’t require any additional adjustments.
+The throttling policy is implemented higher in the stack, therefore it
+does not require any additional adjustments.
 The proportional I/O control policies have two different implementations:
-BFQ controller and cost-based model.
-We describe the BFQ controller here and in order to exert its proportional
+the BFQ controller, and the cost-based model.
+We describe the BFQ controller here. In order to exert its proportional
 implementation for a particular device, we must make sure that BFQ is the
-chosen scheduler.
-Check the current scheduler:
+chosen scheduler. Check the current scheduler:
 </para>
 <screen>
-&prompt.user;<command>cat /sys/class/block/$DEV/queue/scheduler</command>
+&prompt.user;<command>cat /sys/class/block/<replaceable>sda</replaceable>/queue/scheduler</command>
 mq-deadline kyber bfq [none]
 </screen>
 <para>
-Switch the scheduler:
+Switch the scheduler to BFQ:
 </para>
 <screen>
- &prompt.root;<command>echo bfq >/sys/class/block/<replaceable>sda1</replaceable>/queue/scheduler</command>
+ &prompt.root;<command>echo bfq > /sys/class/block/<replaceable>sda</replaceable>/queue/scheduler</command>
 </screen>
 <para>
-<literal>$DEV</literal> is the disk device, not a partition and the
+You must specify the disk device (not a partition). The
 optimal way to set this attribute is a udev rule specific to the device
 (note that &slsa; ships udev rules that already enable BFQ for rotational
 disk drives).
@@ -378,13 +378,14 @@ disk drives).
 </sect3>
 
 <sect3 xml:id="sec-cgroups-hierarchy">
-<title>Cgroup hieararchy layout</title>
+<title>Cgroup hierarchy layout</title>
 <para>
 Normally, all tasks reside in the root cgroup and they compete against
 each other. When the tasks are distributed into the cgroup tree the
-competition occurs between siblings cgroups only.
-This applies to the proportional I/O control, the throttling
-hierarchically aggregates throughput of all descendants.
+competition occurs between sibling cgroups only.
+This applies to the proportional I/O control; the throttling
+hierarchically aggregates throughput of all descendants (see the following
+diagram).
 </para>
 <!-- this is not code but a picture -->
 <screen>
@@ -395,9 +396,9 @@ r
 `- [b]     IOWeight=200
 </screen>
 <para>
-I/O is originating only from cgroups c and b. Despite c has higher weight,
-it will be treated with lower priority based on the weight of a that is
-level-competing with b.
+I/O is originating only from cgroups c and b. Even though c has a higher
+weight, it will be treated with lower priority because it is level-competing
+with b.
 </para>
 </sect3>
 </sect2>
@@ -408,18 +409,19 @@ level-competing with b.
 You can apply the values to (long running) services permanently.
 </para>
 <screen>
-&prompt.sudo;<command>systemctl set-property fast.service IOWeight=400</command>
-&prompt.sudo;<command>systemctl set-property slow.service IOWeight=50</command>
-&prompt.sudo;<command>systemctl set-property throttled.service IOReadBandwidthMax="/dev/sda 1M"</command>
+&prompt.sudo;<command>systemctl set-property <replaceable>fast.service IOWeight=400</replaceable></command>
+&prompt.sudo;<command>systemctl set-property <replaceable>slow.service IOWeight=50</replaceable></command>
+&prompt.sudo;<command>systemctl set-property <replaceable>throttled.service IOReadBandwidthMax="/dev/sda 1M"</replaceable></command>
 </screen>
 
 <para>
-Alternatively, you can apply I/O control to individually run commands, for instance:
+Alternatively, you can apply I/O control to individual commands, for
+example:
 </para>
 <screen>
-&prompt.sudo;<command>systemd-run --scope -p IOWeight=400 prioritized_command</command>
-&prompt.sudo;<command>systemd-run --scope -p IOWeight=50  low_prioritized_command</command>
-&prompt.sudo;<command>systemd-run --scope -p IOReadBandwidthMax="/dev/sda 1M" dd if=/dev/sda of=/dev/null bs=1M count=10</command>
+&prompt.sudo;<command>systemd-run --scope -p IOWeight=400 <replaceable>high_prioritized_command</replaceable></command>
+&prompt.sudo;<command>systemd-run --scope -p IOWeight=50  <replaceable>low_prioritized_command</replaceable></command>
+&prompt.sudo;<command>systemd-run --scope -p <replaceable>IOReadBandwidthMax="/dev/sda 1M" dd if=/dev/sda of=/dev/null bs=1M count=10</replaceable></command>
 </screen>
 </sect2>
 
@@ -433,11 +435,11 @@ Alternatively, you can apply I/O control to individually run commands, for insta
 <listitem>
 <para>
 I/O control works best for direct I/O operations (bypassing page cache),
-the situations where the actual IO is decoupled from the caller (typically
-writeback via page cache) may manifest variously – delayed I/O control or
-even no observed I/O control (consider little bursts or competing
-workloads that happen to never "meet" submitting I/O at the same time (and
-hence saturating the bandwidth). For these reasons, the resulting ratio of
+the situations where the actual I/O is decoupled from the caller (typically
+writeback via page cache) may manifest variously. For example, delayed I/O
+control or even no observed I/O control (consider little bursts or competing
+workloads that happen to never "meet", submitting I/O at the same time, and
+saturating the bandwidth). For these reasons, the resulting ratio of
 I/O throughputs does not strictly follow the ratio of configured weights.
 </para>
 </listitem>
@@ -451,16 +453,9 @@ weight range), hence the resulting throughput ratios also differ.
 <para>
 The writeback activity depends on the amount of dirty pages, besides the
 global sysctl knobs (<filename>vm.dirty_background_ratio</filename> and
-<filename>vm.dirty_ratio</filename>) memory limits of individual cgroups
-come into play when the dirty limits are distributed among cgroups and
+<filename>vm.dirty_ratio</filename>)). Memory limits of individual cgroups
+come into play when the dirty limits are distributed among cgroups, and
 this in turn may affect I/O intensity of affected cgroups.
-</para>
-</listitem>
-<listitem>
-<para>
-As explained in the introduction, inodes are the unit of writeback charging,
-therefore cgroups whose write I/O consists mainly of writes into a single file
-won't be fully differentiated with proportional control.
 </para>
 </listitem>
 <listitem>
@@ -468,7 +463,7 @@ won't be fully differentiated with proportional control.
 Not all storages are equal. The I/O control happens at the I/O scheduler
 layer, which has ramifications for setups with devices stacked on these
 that do no actual scheduling. Consider device mapper logical volumes
-spanning multiple physical devices, MD RAID or even Btrfs RAID.
+spanning multiple physical devices, MD RAID, or even Btrfs RAID.
 I/O control over such setups may be challenging.
 </para>
 </listitem>
@@ -486,18 +481,18 @@ each other (but responsible resource design perhaps avoids that).
 </listitem>
 <listitem>
 <para>
-The I/O device bandwidth is not the only shared resource on the I/O path,
-namely, global filesystem structures are involved too, which is relevant
-when I/O control is meant to guarantee certain bandwidth – it won’t and it
+The I/O device bandwidth is not the only shared resource on the I/O path.
+Global filesystem structures are involved, which is relevant
+when I/O control is meant to guarantee certain bandwidth; it won’t and it
 may even lead to priority inversion (prioritized cgroup waiting for a
 transaction of slower cgroup).
 </para>
 </listitem>
 <listitem>
 <para>
-So far, we have been discussing only explicit I/O of filesystem data but
-swap- in and swap-out can be controlled too. Although if such a need arises,
-it usually points out to improperly provisioned memory (or memory limits).
+So far, we have been discussing only explicit I/O of filesystem data, but
+swap-in and swap-out can also be controlled. Although if such a need
+arises, it usually points out to improperly provisioned memory (or memory limits).
 </para>
 </listitem>
 </itemizedlist>

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -416,9 +416,10 @@ follow the ratio of configured weights.
 </para>
 <para>
 The writeback activity depends on the amount of dirty pages, besides the global
-sysctl knobs memory limits of individual cgroups come into play when the dirty
-limits are distributed among cgroups and this in turn may affect IO intensity
-of affected cgroups.
+sysctl knobs (<filename>vm.dirty_background_ratio</filename> and
+<filename>vm.dirty_ratio</filename>) memory limits of individual cgroups come
+into play when the dirty limits are distributed among cgroups and this in turn
+may affect IO intensity of affected cgroups.
 </para>
 <para>
 Not all storages are equal.

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -430,6 +430,10 @@ hence saturating the bandwidth). For these reasons, the resulting ratio of
 I/O throughputs does not strictly follow the ratio of configured weights.
 </para>
 <para>
+systemd performs scaling of configured weights (to adjust for narrower BFQ
+weight range), hence the resulting throughput ratios also differ.
+</para>
+<para>
 The writeback activity depends on the amount of dirty pages, besides the
 global sysctl knobs (<filename>vm.dirty_background_ratio</filename> and
 <filename>vm.dirty_ratio</filename>) memory limits of individual cgroups

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -368,10 +368,10 @@ aggregates throughput of all descendants.
 <!-- this is not code but a picture -->
 <screen>
 r
-`-  a      io.bfq.weight=100
-    `- [c] io.bfq.weight=300
-    `-  d  io.bfq.weight=100
-`- [b]     io.bfq.weight=200
+`-  a      IOWeight=100
+    `- [c] IOWeight=300
+    `-  d  IOWeight=100
+`- [b]     IOWeight=200
 </screen>
 <para>
 IO is originating only from cgroups c and b. Despite c has higher weight, it

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -308,7 +308,7 @@ during runtime.
 <sect3 xml:id="sec-cgroups-filesystems">
 <title>Filesystem</title>
 <para>
-You should use a cgroup-writeback-aware filesystem (otherwise writeback charing is not possible).
+You should use a cgroup-writeback-aware filesystem (otherwise writeback charging is not possible).
 The recommended SLES filesystems added support in the following upstream
 releases:
 <!-- [2] is https://www.susecon.com/doc/2015/sessions/TUT20066.pdf, slide 7, maybe there's better SLES docs
@@ -338,7 +338,7 @@ As of &productname;&nbsp;15&nbsp;SP3, any of the named filesystems can be used.
 </sect3>
 
 <sect3 xml:id="sec-cgroups-unified-hierarchy">
-<title>Unified cgroup hiearchy</title>
+<title>Unified cgroup hierarchy</title>
 <para>
 To properly account writeback I/O, it is necessary to have equal I/O
 and memory controller cgroup hierarchies, and to use the cgroup v2 I/O

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -300,20 +300,19 @@ Finally, it discusses probable pitfalls when dealing with proportional I/O contr
 <sect2 xml:id="sec-cgroups-prerequisites">
 <title>Prerequisites</title>
 <para>
-The following subsections describe steps that you must take in advance when you
-design and configure your system since those aspects cannot be changed during
-runtime.
+The following subsections describe steps that you must take in advance when
+you design and configure your system, since those aspects cannot be changed
+during runtime.
 </para>
 
 <sect3 xml:id="sec-cgroups-filesystems">
 <title>Filesystem</title>
 <para>
-Despite the I/O control is configured in terms of block devices, it is the
-filesystem and its inode abstraction that is important to exercise the
-policies (when it comes to controlling also the writeback I/O).
-Therefore a cgroup aware filesystem must be chosen, the recommended SLES
-filesystems [2] added support in following upstream releases:
-<!-- [2] is https://www.susecon.com/doc/2015/sessions/TUT20066.pdf, slide 7, maybe there's better SLES docs -->
+You must use a cgroup-aware filesystem. The recommended SLES
+filesystems added support in the following upstream releases:
+<!-- [2] is https://www.susecon.com/doc/2015/sessions/TUT20066.pdf, slide 7, maybe there's better SLES docs
+cjs: that slide is old! We must find something newer.
+-->
 </para>
    <itemizedlist mark="bullet" spacing="normal">
 	   <listitem>
@@ -333,7 +332,7 @@ filesystems [2] added support in following upstream releases:
       </listitem>
    </itemizedlist>
 <para>
-As of &productname;&nbsp;, any of the named filesystems can be used.
+As of &productname;&nbsp;3, any of the named filesystems can be used.
 </para>
 </sect3>
 
@@ -368,7 +367,7 @@ mq-deadline kyber bfq [none]
 Switch the scheduler:
 </para>
 <screen>
-&prompt.sudo;<command>echo bfq >/sys/class/block/$DEV/queue/scheduler</command>
+ &prompt.root;<command>echo bfq >/sys/class/block/<replaceable>sda1</replaceable>/queue/scheduler</command>
 </screen>
 <para>
 <literal>$DEV</literal> is the disk device, not a partition and the
@@ -427,6 +426,12 @@ Alternatively, you can apply I/O control to individually run commands, for insta
 <sect2 xml:id="sec-cgroups-control-behavior">
 <title>I/O control behavior and setting expectations</title>
 <para>
+ The following list items describe I/O control behavior, and what you
+ should expect under various conditions.
+</para>
+<itemizedlist>
+<listitem>
+<para>
 I/O control works best for direct I/O operations (bypassing page cache),
 the situations where the actual IO is decoupled from the caller (typically
 writeback via page cache) may manifest variously – delayed I/O control or
@@ -435,10 +440,14 @@ workloads that happen to never "meet" submitting I/O at the same time (and
 hence saturating the bandwidth). For these reasons, the resulting ratio of
 I/O throughputs does not strictly follow the ratio of configured weights.
 </para>
+</listitem>
+<listitem>
 <para>
 systemd performs scaling of configured weights (to adjust for narrower BFQ
 weight range), hence the resulting throughput ratios also differ.
 </para>
+</listitem>
+<listitem>
 <para>
 The writeback activity depends on the amount of dirty pages, besides the
 global sysctl knobs (<filename>vm.dirty_background_ratio</filename> and
@@ -446,11 +455,15 @@ global sysctl knobs (<filename>vm.dirty_background_ratio</filename> and
 come into play when the dirty limits are distributed among cgroups and
 this in turn may affect I/O intensity of affected cgroups.
 </para>
+</listitem>
+<listitem>
 <para>
 As explained in the introduction, inodes are the unit of writeback charging,
 therefore cgroups whose write I/O consists mainly of writes into a single file
 won't be fully differentiated with proportional control.
 </para>
+</listitem>
+<listitem>
 <para>
 Not all storages are equal. The I/O control happens at the I/O scheduler
 layer, which has ramifications for setups with devices stacked on these
@@ -458,14 +471,20 @@ that do no actual scheduling. Consider device mapper logical volumes
 spanning multiple physical devices, MD RAID or even Btrfs RAID.
 I/O control over such setups may be challenging.
 </para>
+</listitem>
+<listitem>
 <para>
 There is no separate setting for proportional I/O control of reads and
 writes.
 </para>
+</listitem>
+<listitem>
 <para>
 Proportional I/O control is only one of the policies that can interact with
 each other (but responsible resource design perhaps avoids that).
 </para>
+</listitem>
+<listitem>
 <para>
 The I/O device bandwidth is not the only shared resource on the I/O path,
 namely, global filesystem structures are involved too, which is relevant
@@ -473,11 +492,15 @@ when I/O control is meant to guarantee certain bandwidth – it won’t and it
 may even lead to priority inversion (prioritized cgroup waiting for a
 transaction of slower cgroup).
 </para>
+</listitem>
+<listitem>
 <para>
 So far, we have been discussing only explicit I/O of filesystem data but
 swap- in and swap-out can be controlled too. Although if such a need arises,
 it usually points out to improperly provisioned memory (or memory limits).
 </para>
+</listitem>
+</itemizedlist>
 </sect2>
 </sect1>
 <!-- END NEW VERSION -->

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -333,7 +333,7 @@ cjs: that slide is old! We must find something newer.
       </listitem>
    </itemizedlist>
 <para>
-As of &productname;&nbsp;SP3, any of the named filesystems can be used.
+As of &productname;&nbsp;15&nbsp;SP3, any of the named filesystems can be used.
 </para>
 </sect3>
 

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -308,8 +308,9 @@ during runtime.
 <sect3 xml:id="sec-cgroups-filesystems">
 <title>Filesystem</title>
 <para>
-You must use a cgroup-writeback-aware filesystem. The recommended SLES
-filesystems added support in the following upstream releases:
+You should use a cgroup-writeback-aware filesystem (otherwise writeback charing is not possible).
+The recommended SLES filesystems added support in the following upstream
+releases:
 <!-- [2] is https://www.susecon.com/doc/2015/sessions/TUT20066.pdf, slide 7, maybe there's better SLES docs
 cjs: that slide is old! We must find something newer.
 -->

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -410,9 +410,9 @@ with b.
 You can apply the values to (long running) services permanently.
 </para>
 <screen>
-&prompt.sudo;<command>systemctl set-property <replaceable>fast.service IOWeight=400</replaceable></command>
-&prompt.sudo;<command>systemctl set-property <replaceable>slow.service IOWeight=50</replaceable></command>
-&prompt.sudo;<command>systemctl set-property <replaceable>throttled.service IOReadBandwidthMax="/dev/sda 1M"</replaceable></command>
+&prompt.sudo;<command>systemctl set-property <replaceable>fast.service</replaceable> IOWeight=<replaceable>400</replaceable></command>
+&prompt.sudo;<command>systemctl set-property <replaceable>slow.service</replaceable> IOWeight=<replaceable>50</replaceable></command>
+&prompt.sudo;<command>systemctl set-property <replaceable>throttled.service</replaceable> IOReadBandwidthMax="<replaceable>/dev/sda 1M</replaceable>"</command>
 </screen>
 
 <para>
@@ -420,9 +420,9 @@ Alternatively, you can apply I/O control to individual commands, for
 example:
 </para>
 <screen>
-&prompt.sudo;<command>systemd-run --scope -p IOWeight=400 <replaceable>high_prioritized_command</replaceable></command>
-&prompt.sudo;<command>systemd-run --scope -p IOWeight=50  <replaceable>low_prioritized_command</replaceable></command>
-&prompt.sudo;<command>systemd-run --scope -p <replaceable>IOReadBandwidthMax="/dev/sda 1M" dd if=/dev/sda of=/dev/null bs=1M count=10</replaceable></command>
+&prompt.sudo;<command>systemd-run --scope -p IOWeight=<replaceable>400</replaceable> <replaceable>high_prioritized_command</replaceable></command>
+&prompt.sudo;<command>systemd-run --scope -p IOWeight=<replaceable>50</replaceable> <replaceable>low_prioritized_command</replaceable></command>
+&prompt.sudo;<command>systemd-run --scope -p IOReadBandwidthMax="<replaceable>/dev/sda 1M</replaceable>" <replaceable>dd if=/dev/sda of=/dev/null bs=1M count=10</replaceable></command>
 </screen>
 </sect2>
 

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -297,7 +297,9 @@ TasksMax=16284
 <sect2 xml:id="sec-cgroups-prerequisites">
 <title>Prerequisites</title>
 <para>
- TODO words go here
+The following subsections describe steps that you must take in advance when you
+design and configure your system since those aspects cannot be changed during
+runtime.
 </para>
 
 <sect3 xml:id="sec-cgroups-filesystems">

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -357,7 +357,7 @@ Check the current scheduler:
 </para>
 <screen>
 &prompt.user;<command>cat /sys/class/block/$DEV/queue/scheduler</command>
-mq-deadline kyber [bfq] none
+mq-deadline kyber bfq [none]
 </screen>
 <para>
 Switch the scheduler:

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -298,7 +298,7 @@ TasksMax=16284
 <para>
 Despite the IO control is configured in terms of block devices, it is the
 filesystem and its inode abstraction that is important to exercise the policies
-(when it come to controlling also the writeback IO).
+(when it comes to controlling also the writeback IO).
 Therefore a cgroup aware filesystem must be chosen, the recommended SLES
 filesystems [2] added support in following upstream releases:
 <!-- [2] is https://www.susecon.com/doc/2015/sessions/TUT20066.pdf, slide 7, maybe there's better SLES docs -->
@@ -329,7 +329,7 @@ option <option>systemd.unified_cgroup_hierarchy=1</option>.
 <title>Block IO scheduler</title>
 <para>
 The throttling policy is implemented higher in the stack therefore it doesn’t
-require on additional adjustments.
+require no additional adjustments.
 The proportional IO control policies have two different implementations nowadays:
 BFQ controller and cost-based model.
 We describe the BFQ controller here and in order to exert its proportional
@@ -411,7 +411,7 @@ writeback via page cache) may manifest variously – delayed IO control or even
 no observed IO control (consider little bursts or competing workloads that
 happen to never ‘‘meet’’ submitting IO at the same time (and hence saturating
 the bandwidth)).
-For these reasons, the resulting ratio of IO throughtputs does not strictly
+For these reasons, the resulting ratio of IO throughputs does not strictly
 follow the ratio of configured weights.
 </para>
 <para>

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -291,7 +291,10 @@ TasksMax=16284
 <sect1 xml:id="sec-control-io-cgroups">
 <title>I/O control with cgroups</title>
 <para>
- TODO words go here
+This section introduces using the Linux kernel's block I/O controller to
+prioritize or throttle I/O operations,
+it leverages the means provided by systemd to configure cgroups.
+Finally, it discusses probable pitfalls when dealing with proportional I/O control.
 </para>
 
 <sect2 xml:id="sec-cgroups-prerequisites">

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -492,6 +492,11 @@ it usually points out to improperly provisioned memory (or memory limits).
    </listitem>
    <listitem>
     <para>
+     <command>man systemd.resource-control</command>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
      <link xlink:href="https://lwn.net/Articles/604609/"/>&mdash;Brown, Neil:
      Control Groups Series (2014, 7 parts).
     </para>

--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -398,8 +398,9 @@ it will be treated with lower priority based on the weight of a that is
 level-competing with b.
 </para>
 </sect3>
+</sect2>
 
-<sect3 xml:id="sec-cgroups-configure-control-quantities">
+<sect2 xml:id="sec-cgroups-configure-control-quantities">
 <title>Configuring control quantities</title>
 <para>
 You can apply the values to (long running) services permanently.
@@ -418,9 +419,9 @@ Alternatively, you can apply I/O control to individually run commands, for insta
 &prompt.sudo;<command>systemd-run --scope -p IOWeight=50  low_prioritized_command</command>
 &prompt.sudo;<command>systemd-run --scope -p IOReadBandwidthMax="/dev/sda 1M" dd if=/dev/sda of=/dev/null bs=1M count=10</command>
 </screen>
-</sect3>
+</sect2>
 
-<sect3 xml:id="sec-cgroups-control-behavior">
+<sect2 xml:id="sec-cgroups-control-behavior">
 <title>I/O control behavior and setting expectations</title>
 <para>
 I/O control works best for direct I/O operations (bypassing page cache),
@@ -474,7 +475,6 @@ So far, we have been discussing only explicit I/O of filesystem data but
 swap- in and swap-out can be controlled too. Although if such a need arises,
 it usually points out to improperly provisioned memory (or memory limits).
 </para>
-</sect3>
 </sect2>
 </sect1>
 <!-- END NEW VERSION -->


### PR DESCRIPTION
### PR creator: Description

Very rough draft to capture (replacement PR of #1150):
- simple(r) IO control setup with systemd,
- prerequisites of such setups and mainly
- expectations when configuring IO control.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1195915
* bsc#1175160
* jsc#SLE-22013 (loosely related)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

It also assumes systemd version >v243 (and ideally needs some more
backports both into systemd and kernel to work good enough in described
scenarios).



### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
