### PR TITLE
rpi: Tidy armreg entity

### DIFF
--- a/xml/generic-entities.ent
+++ b/xml/generic-entities.ent
@@ -227,7 +227,7 @@ use &deng;! -->
 <!ENTITY x86-64                 "&amd64;/&intel64;">
 
 <!ENTITY arm                    "Arm">
-<!ENTITY armreg                 "Arm*">
+<!ENTITY armreg                 "&arm;*">
 <!ENTITY armv7                  "Armv7">
 <!ENTITY armv8                  "Armv8">
 <!ENTITY aarch64                "AArch64">


### PR DESCRIPTION
Revert to reusing entity arm for entity armreg.

### PR creator: Description

Long pending entity cleanup of 136704951c ("Proofread of RasPI Quick Start").
Originally part of author's `rpi-x11` queue for SLE15 SP2.


### PR creator: Are there any relevant issues/feature requests?

No, non-user-visible cleanup to enforce correct spelling going forward.


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1 -- xml/entity-decl.ent instead of xml/generic-entities.ent
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
