### PR TITLE
rpi: Update bluez instructions for SLES 15 SP2

### DIFF
--- a/xml/art_sles_rpi_quick.xml
+++ b/xml/art_sles_rpi_quick.xml
@@ -1183,26 +1183,7 @@ Successfully registered system</screen>
     various purposes, such as wireless keyboards, mice, or audio devices.
    </para>
    <para>
-    If not done already, you will need to enable the 
-    <emphasis role="italic">Desktop Applications Module</emphasis>.
-    Assuming you have registered the base product already, as described in
-    <xref linkend="sec-rpi-registration"/>, the fastest way to enable the module
-    is:
-   </para>
-   <screen>&prompt.root;SUSEConnect -p sle-module-desktop-applications/&product-ga;.&product-sp;/aarch64
-Registering system to SUSE Customer Center
-
-Updating system details on https://scc.suse.com ...
-
-Activating sle-module-desktop-applications &product-ga;.&product-sp; aarch64 ...
--> Adding service to system ...
--> Installing release package ...
-
-Successfully registered system
-</screen>
-   <para>
-    You can then install the <emphasis role="italic">BlueZ</emphasis> software
-    stack:
+    To install the <emphasis role="italic">BlueZ</emphasis> software stack:
    </para>
    <screen>&prompt.root;zypper install bluez</screen>
    <para>


### PR DESCRIPTION
In SLES 15 SP2, `bluez` was moved to Base System module.
Therefore the Desktop Applications module no longer needs to be added by users.

### PR creator: Description

Update (simplify) instructions for using Bluetooth on Raspberry Pi on SLES 15 SP2 (only).
Originally part of author's pending `rpi-x11` queue.


### PR creator: Are there any relevant issues/feature requests?

Unknown.


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3 -- SP3 and later need a different update
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
