### PR TITLE
rpi: X11 pattern

### DIFF
--- a/xml/art_raspberry-pi.xml
+++ b/xml/art_raspberry-pi.xml
@@ -1178,6 +1178,43 @@ Successfully registered system</screen>
    you can now use various components of the system.
   </para>
 
+  <sect2 xml:id="sec-rpi-x11">
+   <title>Desktop</title>
+   <para>
+    &appliancename; 15&nbsp;GA had packages for a minimal X11 desktop (IceWM)
+    preinstalled.
+   </para>
+   <para>
+    &appliancename; &productnumber; comes as a tiny text-based appliance,
+    allowing you to install any available desktop of your choice or none for
+    headless usage.
+    Should you want to recreate the package selection of the previous images,
+    a pattern <literal>x11_raspberrypi</literal> is provided for convenience.
+   </para>
+   <para>
+    If not done already, you will need to enable the 
+    <emphasis role="italic">Desktop Applications Module</emphasis>.
+    Assuming you have registered the base product already, as described in
+    <xref linkend="sec-rpi-registration"/>, the fastest way to enable the module
+    is:
+   </para>
+   <screen>&prompt.root;SUSEConnect -p sle-module-desktop-applications/&product-ga;.&product-sp;/aarch64
+Registering system to SUSE Customer Center
+
+Updating system details on https://scc.suse.com ...
+
+Activating sle-module-desktop-applications &product-ga;.&product-sp; aarch64 ...
+-> Adding service to system ...
+-> Installing release package ...
+
+Successfully registered system
+</screen>
+   <para>
+    You can then install the desktop packages pattern:
+   </para>
+   <screen>&prompt.root;zypper install -t pattern x11_raspberrypi</screen>
+  </sect2>
+
   <sect2 xml:id="sec-rpi-bt">
    <title>&bt;</title>
    <para>


### PR DESCRIPTION
Add section on how to install pattern introduced with SLES 15 SP1.

### PR creator: Description

Add user instructions on how to install the Raspberry Pi specific X11 pattern available since SLES 15 SP1 to recreate the minimal desktop that used to be preinstalled in the SLES 15 GA image.
Instructions are likely incomplete and may require further configuration steps after pattern installation. From author's pending `rpi-x11` queue.


### PR creator: Are there any relevant issues/feature requests?

* jsc#SLE-3817


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)* - note: following Bluetooth section to be deleted once merged
  - [x] SLE 15 SP3/openSUSE Leap 15.3 - note: following Bluetooth section to be deleted once merged
  - [x] SLE 15 SP2/openSUSE Leap 15.2 - no conflict expected with update of following Bluetooth section (#1156)
  - [x] SLE 15 SP1 - only here the duplicated module installation instructions would remain
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
