### PR TITLE
add explanation about hibernation handling in autoyast bootloader

### DIFF
--- a/xml/ay_bootloader.xml
+++ b/xml/ay_bootloader.xml
@@ -110,10 +110,10 @@
       key with the device path. The recommended way to get stable results is
       configuring your own partitioning, and having a swap device with a
       label:
+    </para>
       <screen>
         &lt;append&gt;quiet resume=/dev/disk/by-label/my_swap&lt;/append&gt;
       </screen>
-     </para>
     <para>
       If you do not use <literal>resume</literal> or
       <literal>noresume</literal>, or if <literal>resume</literal> specifies

--- a/xml/ay_bootloader.xml
+++ b/xml/ay_bootloader.xml
@@ -93,6 +93,35 @@
    <command>yast2-bootloader</command>. Unless you have some special
    requirements, do not specify the boot loader configuration in the XML file.
   </para>
+  <tip>
+    <title>Hibernation</title>
+    <para>
+     If there is a need for specific hibernation settings then
+     <literal>resume</literal> or <literal>noresume</literal> in
+     <literal>append</literal> configuration can be used. It has specific
+     handling.
+    </para>
+    <para>
+      To disable hibernation regardless what installation proposes then specify
+      <literal>noresume</literal> as kernel parameter in
+      <literal>append</literal> section.
+    </para>
+    <para>
+      To specify hibernation device use <literal>resume</literal> key with
+      value which is device path. Recommended way to get stable result is using
+      own partitioning and having swap device with label. Example with labeled
+      swap:
+      <screen>
+        &lt;append&gt;quiet resume=/dev/disk/by-label/my_swap&lt;/append&gt;
+      </screen>
+    </para>
+    <para>
+      If <literal>resume</literal> neither <literal>noresume</literal> is used
+      or if resume contains device that won't exist on installed system then
+      hibernation is proposed by installer, either enabled or disabled and also
+      hibernation device will be proposed.
+    </para>
+  </tip>
 <screen>&lt;global&gt;
   &lt;activate&gt;true&lt;/activate&gt;
   &lt;timeout config:type="integer"&gt;10&lt;/timeout&gt;

--- a/xml/ay_bootloader.xml
+++ b/xml/ay_bootloader.xml
@@ -118,7 +118,9 @@
       If you do not use <literal>resume</literal> or
       <literal>noresume</literal>, or if <literal>resume</literal> specifies
       a device that will not exist on the installed system, then
-      hibernation will be proposed by installer, either enabled or disabled, and the installer will also propose a hibernation device.
+      the installer may propose a correct value for
+      <literal>resume</literal>, or it may remove the hibernation parameter
+      completely, depending on installer logic.
     </para>
   </tip>
 <screen>&lt;global&gt;

--- a/xml/ay_bootloader.xml
+++ b/xml/ay_bootloader.xml
@@ -96,30 +96,29 @@
   <tip>
     <title>Hibernation</title>
     <para>
-     If there is a need for specific hibernation settings then
-     <literal>resume</literal> or <literal>noresume</literal> in
-     <literal>append</literal> configuration can be used. It has specific
-     handling.
+     If there is a need for specific hibernation settings, then
+     <literal>resume</literal> or <literal>noresume</literal> in the
+     <literal>append</literal> configuration can be used.
     </para>
     <para>
-      To disable hibernation regardless what installation proposes then specify
-      <literal>noresume</literal> as kernel parameter in
+      To disable hibernation regardless of what the installer proposes,
+      specify <literal>noresume</literal> as a kernel parameter in the
       <literal>append</literal> section.
     </para>
     <para>
-      To specify hibernation device use <literal>resume</literal> key with
-      value which is device path. Recommended way to get stable result is using
-      own partitioning and having swap device with label. Example with labeled
-      swap:
+      To specify the hibernation device, use the <literal>resume</literal>
+      key with the device path. The recommended way to get stable results is
+      configuring your own partitioning, and having a swap device with a
+      label:
       <screen>
         &lt;append&gt;quiet resume=/dev/disk/by-label/my_swap&lt;/append&gt;
       </screen>
-    </para>
+     </para>
     <para>
-      If <literal>resume</literal> neither <literal>noresume</literal> is used
-      or if resume contains device that won't exist on installed system then
-      hibernation is proposed by installer, either enabled or disabled and also
-      hibernation device will be proposed.
+      If you do not use <literal>resume</literal> or
+      <literal>noresume</literal>, or if <literal>resume</literal> specifies
+      a device that will not exist on the installed system, then
+      hibernation will be proposed by installer, either enabled or disabled, and the installer will also propose a hibernation device.
     </para>
   </tip>
 <screen>&lt;global&gt;


### PR DESCRIPTION
### PR creator: Description

Adds explanation how hibernation is handled as part of kernel parameters.
Related pull request with explanation: https://github.com/yast/yast-bootloader/pull/666/

Please note that for SP3 and SP4 parts will work only if installer self update is enabled as it is not in default insts-sys.
And the part that won't work is detection if device will exist. So invalid device is just applied without self-update.


### PR creator: Are there any relevant issues/feature requests?

* https://bugzilla.suse.com/show_bug.cgi?id=1187690
* https://bugzilla.suse.com/show_bug.cgi?id=1197192


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
