### PR TITLE
rpi: Update Bluetooth instructions

### DIFF
--- a/xml/art_raspberry-pi.xml
+++ b/xml/art_raspberry-pi.xml
@@ -1222,44 +1222,7 @@ Successfully registered system
     various purposes, such as wireless keyboards, mice, or audio devices.
    </para>
    <para>
-    If not done already, you will need to enable the 
-    <emphasis role="italic">Desktop Applications Module</emphasis>.
-    Assuming you have registered the base product already, as described in
-    <xref linkend="sec-rpi-registration"/>, the fastest way to enable the module
-    is:
-   </para>
-   <screen>&prompt.root;SUSEConnect -p sle-module-desktop-applications/&product-ga;.&product-sp;/aarch64
-Registering system to SUSE Customer Center
-
-Updating system details on https://scc.suse.com ...
-
-Activating sle-module-desktop-applications &product-ga;.&product-sp; aarch64 ...
--> Adding service to system ...
--> Installing release package ...
-
-Successfully registered system
-</screen>
-   <para>
-    You can then install the <emphasis role="italic">BlueZ</emphasis> software
-    stack:
-   </para>
-   <screen>&prompt.root;zypper install bluez</screen>
-   <para>
-    To enable the &btreg; controller for use with
-    <command>bluetoothctl</command> and related applications,
-    for example, on &rpi3; Model&nbsp;B with the default UART configuration, run:
-   </para>
-<screen>&prompt.root;hciattach /dev/ttyAMA1 bcm43xx 921600
-bcm43xx_init
-Flash firmware /lib/firmware/<replaceable>BCM43430A1</replaceable>.hcd
-Set Controller UART speed to 921600 bit/s
-Device setup complete</screen>
-   <para>
-    Note: The command is the same for &rpi4; Model&nbsp;B,
-    just the chipset name and thus firmware filename in the output will be different.
-   </para>
-   <para>
-    You can then use <command>hciconfig hci0 up</command> to bring the device
+    You can use <command>hciconfig hci0 up</command> to bring the device
     up and use <command>hcitool scan</command> to scan the environment for
     discoverable devices.
    </para>


### PR DESCRIPTION
### PR creator: Description

Update (fix) user instructions for using Bluetooth on Raspberry Pi.
Might later be extended with instructions for how to enable/disable via `extraconfig.txt`.


### PR creator: Are there any relevant issues/feature requests?

* jsc#SLE-17223
* bsc#1193693


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2 - instead has #1156
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
