### PR TITLE
Added section on GRUB authorization (jsc#SLE-14813)

### DIFF
--- a/xml/grub2.xml
+++ b/xml/grub2.xml
@@ -674,7 +674,7 @@
     set a boot password.
    </para>
    <important>
-    <title>Booting requires password</title>
+    <title>Booting requires a password</title>
     <para>
      If set, the boot password is required on every boot, which means the
      system does not boot automatically.
@@ -722,6 +722,92 @@ password_pbkdf2 root grub.pbkdf2.sha512.10000.9CA4611006FE96BC77A...</screen>
     <link
     xlink:href="https://www.gnu.org/software/grub/manual/grub.html#Security"/>.
    </para>
+  </sect2>
+  <sect2 xml:id="sec-grub2-authorization">
+   <title>Authorized access to boot menu entries</title>
+   <para>
+    You can configure &grub; to allow access to boot menu entries depending
+    on the level of authorization. You can configure multiple user accounts
+    protected with passwords and assign them access to different menu entries.
+    To configure authorization in &grub;, follow these steps:
+   </para>
+   <procedure>
+    <step>
+     <para>
+      Create and encrypt one password for each user account you want to use in
+      &grub;.  Use the <command>grub2-mkpasswd-pbkdf2</command> command as
+      described in <xref linkend="sec-grub2-password"/>.
+     </para>
+    </step>
+    <step>
+     <para>
+      Delete the content of the <filename>/etc/grub.d/10_linux</filename> file
+      and save it. This prevents outputting the default &grub; menu entries.
+     </para>
+    </step>
+    <step>
+     <para>
+      Edit the <filename>/boot/grub2/custom.cfg</filename> file and add custom
+      menu entries manually, for example:
+     </para>
+<screen>
+set superusers=admin
+password admin <replaceable>ADMIN_PASSWORD</replaceable>
+password maintainer <replaceable>MAINTAINER_PASSWORD</replaceable>
+
+menuentry 'Operational mode' {
+  insmod ext2
+  set root=hd0,1
+  echo 'Loading Linux ...'
+  linux /boot/vmlinuz root=/dev/vda1 $GRUB_CMDLINE_LINUX_DEFAULT $GRUB_CMDLINE_LINUX mode=operation
+  echo 'Loading Initrd ...'
+  initrd /boot/initrd
+}
+
+menuentry 'Maintenance mode' --users maintainer {
+  insmod ext2
+  set root=hd0,1
+  echo 'Loading Linux ...'
+  linux /boot/vmlinuz root=/dev/vda1 $GRUB_CMDLINE_LINUX_DEFAULT $GRUB_CMDLINE_LINUX  mode=maintenance
+  echo 'Loading Initrd ...'
+  initrd /boot/initrd
+</screen>
+    </step>
+    <step>
+     <para>
+      Import the changes into the main configuration file:
+     </para>
+     <screen>&prompt.sudo;grub2-mkconfig -o /boot/grub2/grub.cfg</screen>
+    </step>
+   </procedure>
+   <para>
+    In the above example:
+   </para>
+   <itemizedlist>
+    <listitem>
+     <para>
+      The &grub; menu has two entries - <guimenu>Operational mode</guimenu>
+      and <guimenu>Maintenance mode</guimenu>.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      If no user is specified, both boot menu entries are accessible, but
+      no-one can access &grub; command line nor edit existing menu entries.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <literal>admin</literal> user can access &grub; command line and edit
+      existing menu entries.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <literal>maintenance</literal> user can select the recovery menu item.
+     </para>
+    </listitem>
+   </itemizedlist>
   </sect2>
  </sect1>
  <xi:include href="grub2_yast_i.xml"/>

--- a/xml/grub2.xml
+++ b/xml/grub2.xml
@@ -735,7 +735,7 @@ password_pbkdf2 root grub.pbkdf2.sha512.10000.9CA4611006FE96BC77A...</screen>
     <step>
      <para>
       Create and encrypt one password for each user account you want to use in
-      &grub;.  Use the <command>grub2-mkpasswd-pbkdf2</command> command as
+      &grub;. Use the <command>grub2-mkpasswd-pbkdf2</command> command as
       described in <xref linkend="sec-grub2-password"/>.
      </para>
     </step>
@@ -748,7 +748,8 @@ password_pbkdf2 root grub.pbkdf2.sha512.10000.9CA4611006FE96BC77A...</screen>
     <step>
      <para>
       Edit the <filename>/boot/grub2/custom.cfg</filename> file and add custom
-      menu entries manually, for example:
+      menu entries manually. The following template is just an example, adjust
+      it to better match your use case:
      </para>
 <screen>
 set superusers=admin

--- a/xml/grub2.xml
+++ b/xml/grub2.xml
@@ -769,7 +769,7 @@ menuentry 'Maintenance mode' --users maintainer {
   insmod ext2
   set root=hd0,1
   echo 'Loading Linux ...'
-  linux /boot/vmlinuz root=/dev/vda1 $GRUB_CMDLINE_LINUX_DEFAULT $GRUB_CMDLINE_LINUX  mode=maintenance
+  linux /boot/vmlinuz root=/dev/vda1 $GRUB_CMDLINE_LINUX_DEFAULT $GRUB_CMDLINE_LINUX mode=maintenance
   echo 'Loading Initrd ...'
   initrd /boot/initrd
 </screen>
@@ -787,14 +787,14 @@ menuentry 'Maintenance mode' --users maintainer {
    <itemizedlist>
     <listitem>
      <para>
-      The &grub; menu has two entries - <guimenu>Operational mode</guimenu>
+      The &grub; menu has two entries, <guimenu>Operational mode</guimenu>
       and <guimenu>Maintenance mode</guimenu>.
      </para>
     </listitem>
     <listitem>
      <para>
       If no user is specified, both boot menu entries are accessible, but
-      no-one can access &grub; command line nor edit existing menu entries.
+      no one can access &grub; command line nor edit existing menu entries.
      </para>
     </listitem>
     <listitem>


### PR DESCRIPTION
### PR creator: Description

GRIB bootloader can be manually configured to provide authorization to specific boot menu entries.
This update provides an example of such configuration.


### PR creator: Are there any relevant issues/feature requests?

* jsc#SLE-14813


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
