### PR TITLE
Update ULP section with information from libpulp 0.2.0 (jsc#SLE-20214)

### DIFF
--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -110,7 +110,7 @@
      </para>
 <screen>&prompt.user;readelf -S <replaceable>SHARED_OBJECT</replaceable> | grep .ulp</screen>
      <para>
-     If the output shows that there are both .ulp and .ulp.rev sections in the
+     If the output shows that there are both <literal>.ulp</literal> and <literal>.ulp.rev</literal> sections in the
     shared object, then it is a livepatch container.
    </para>
    </sect3>

--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -133,7 +133,7 @@
      live-patching operation was successful.
    </para>
    <para>
-    It is also possible to apply multiple livepatches by using wildcards. For instance:
+    It is also possible to apply multiple livepatches by using wildcards. For example:
    </para>
    <screen>ulp trigger -p <replaceable>PID</replaceable> '*.so'</screen>
    <para>

--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -104,7 +104,7 @@
    <sect3 xml:id="sec-ulp-livepatch-container-check">
      <title>Checking if a <filename>.so</filename> file is a livepatch container</title>
      <para>
-       A shared object (<literal>.so</literal>) is a livepatch container if it contains the ulp patch
+       A shared object (<filename>.so</filename>) is a livepatch container if it contains the ULP patch
        description embedded into it. You can check if it is embedded with the
        following command:
      </para>

--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -102,7 +102,7 @@
 <screen>ulp livepatchable <replaceable>LIBRARY</replaceable></screen>
    </sect3>
    <sect3 xml:id="sec-ulp-livepatch-container-check">
-     <title>Checking if a .so file is a livepatch container</title>
+     <title>Checking if a <filename>.so</filename> file is a livepatch container</title>
      <para>
        A shared object (<literal>.so</literal>) is a livepatch container if it contains the ulp patch
        description embedded into it. You can check if it is embedded with the

--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -164,7 +164,7 @@
      and apply a new one, without the target application running potentially
      unsecure code. For example:
     </para>
-<screen>ulp trigger -p <replaceable>PID</replaceable>  --revert-all=libcrypto.so.1.1 new_livepatch2.so</screen>
+<screen>&prompt.user;ulp trigger -p <replaceable>PID</replaceable>  --revert-all=libcrypto.so.1.1 new_livepatch2.so</screen>
    </sect3>
   </sect2>
  </sect1>

--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -148,7 +148,7 @@
      are two ways to revert live patches. You can revert a live patch by
      using the <option>--revert</option> switch and passing the livepatch container:
     </para>
-<screen>ulp trigger -p <replaceable>PID</replaceable> --revert <replaceable>LIVEPATCH</replaceable>.so</screen>
+<screen>&prompt.user;ulp trigger -p <replaceable>PID</replaceable> --revert <replaceable>LIVEPATCH</replaceable>.so</screen>
     <para>
      Alternatively, it is possible to remove all patches associated with a
      particular library. For example:

--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -101,13 +101,28 @@
     </para>
 <screen>ulp livepatchable <replaceable>LIBRARY</replaceable></screen>
    </sect3>
+   <sect3 xml:id="sec-ulp-livepatch-container-check">
+     <title>Checking if a .so file is a livepatch container</title>
+     <para>
+       A shared object (<literal>.so</literal>) is a livepatch container if it contains the ulp patch
+       description embedded into it. You can check if it is embedded with the
+       following command:
+     </para>
+     <screen>readelf -S SHARED_OBJECT | grep .ulp</screen>
+     <para>
+     If the output shows that there are both .ulp and .ulp.rev sections in the
+    shared object, then it is a livepatch container.
+   </para>
+   </sect3>
+
+
    <sect3 xml:id="sec-ulp-apply-livepatch">
     <title>Applying live patches</title>
     <para>
      Live patches are applied using the <systemitem>ulp trigger</systemitem>
      command, for example:
     </para>
-<screen>ulp trigger -p <replaceable>PID</replaceable> <replaceable>LIVEPATCH</replaceable>.ulp</screen>
+<screen>ulp trigger -p <replaceable>PID</replaceable> <replaceable>LIVEPATCH</replaceable>.so</screen>
     <para>
      In this example, <literal>PID</literal> is the PID of the running process
      that uses the library to be patched and <literal>LIVEPATCH.ulp</literal>
@@ -116,16 +131,24 @@
     <para>
      The <literal>live patching succeeded</literal> message indicates that the
      live-patching operation was successful.
-    </para>
+   </para>
+   <para>
+    It is also possible to apply multiple livepatches by using wildcards. For instance:
+   </para>
+   <screen>ulp trigger -p <replaceable>PID</replaceable> '*.so'</screen>
+   <para>
+     This command will try to apply every patch in the current folder to the process holding
+     <literal>PID</literal>. In the end, the tool will show how many patches it successfully applied.
+ </para>
    </sect3>
    <sect3 xml:id="sec-ulp-revert-livepatch">
     <title>Reverting live patches</title>
     <para>
      <command>ulp trigger</command> can be used to revert live patches. There
      are two ways to revert live patches. You can revert a live patch by
-     applying the appropriate <filename>.rev</filename> patch:
+     using the <literal>--revert</literal> switch and passing the livepatch container:
     </para>
-<screen>ulp trigger -p <replaceable>PID</replaceable> <replaceable>LIVEPATCH</replaceable>.rev</screen>
+<screen>ulp trigger -p <replaceable>PID</replaceable> --revert <replaceable>LIVEPATCH</replaceable>.so</screen>
     <para>
      Alternatively, it is possible to remove all patches associated with a
      particular library. For example:
@@ -141,7 +164,7 @@
      and apply a new one, without the target application running potentially
      unsecure code. For example:
     </para>
-<screen>ulp trigger -p <replaceable>PID</replaceable>  --revert-all=libcrypto.so.1.1 new_livepatch2.ulp</screen>
+<screen>ulp trigger -p <replaceable>PID</replaceable>  --revert-all=libcrypto.so.1.1 new_livepatch2.so</screen>
    </sect3>
   </sect2>
  </sect1>

--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -146,7 +146,7 @@
     <para>
      <command>ulp trigger</command> can be used to revert live patches. There
      are two ways to revert live patches. You can revert a live patch by
-     using the <literal>--revert</literal> switch and passing the livepatch container:
+     using the <option>--revert</option> switch and passing the livepatch container:
     </para>
 <screen>ulp trigger -p <replaceable>PID</replaceable> --revert <replaceable>LIVEPATCH</replaceable>.so</screen>
     <para>

--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -105,7 +105,7 @@
      <title>Checking if a <filename>.so</filename> file is a livepatch container</title>
      <para>
        A shared object (<filename>.so</filename>) is a livepatch container if it contains the ULP patch
-       description embedded into it. You can check if it is embedded with the
+       description embedded into it. You can verify it with the
        following command:
      </para>
      <screen>readelf -S SHARED_OBJECT | grep .ulp</screen>

--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -135,7 +135,7 @@
    <para>
     It is also possible to apply multiple livepatches by using wildcards. For example:
    </para>
-   <screen>ulp trigger -p <replaceable>PID</replaceable> '*.so'</screen>
+   <screen>&prompt.user;ulp trigger -p <replaceable>PID</replaceable> '*.so'</screen>
    <para>
      This command will try to apply every patch in the current folder to the process holding
      <literal>PID</literal>. In the end, the tool will show how many patches it successfully applied.

--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -108,7 +108,7 @@
        description embedded into it. You can verify it with the
        following command:
      </para>
-     <screen>readelf -S SHARED_OBJECT | grep .ulp</screen>
+<screen>&prompt.user;readelf -S <replaceable>SHARED_OBJECT</replaceable> | grep .ulp</screen>
      <para>
      If the output shows that there are both .ulp and .ulp.rev sections in the
     shared object, then it is a livepatch container.


### PR DESCRIPTION
Libpulp 0.2.0 changed a few things about how livepatch files are
distributed. This PR updates the information in this document to reflect those
changes.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>

- [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
