### PR TITLE
Replace deprecated hci… commands for RPi bluetooth

### DIFF
--- a/xml/art_raspberry-pi.xml
+++ b/xml/art_raspberry-pi.xml
@@ -1222,9 +1222,15 @@ Successfully registered system
     various purposes, such as wireless keyboards, mice, or audio devices.
    </para>
    <para>
-    You can use <command>hciconfig hci0 up</command> to bring the device
-    up and use <command>hcitool scan</command> to scan the environment for
-    discoverable devices.
+    To use the bluetooth controller, install the <literal>bluez</literal> package:
+   </para>
+   <screen>&prompt.root;zypper install bluez</screen>
+   <para>
+    Then start and enable the <literal>bluetooth</literal> systemd service:
+   </para>
+   <screen>&prompt.root;systemctl enable --now bluetooth</screen>
+   <para>
+    You can use <command>bluetoothctl</command> to operate the bluetooth device.
    </para>
   </sect2>
  </sect1>


### PR DESCRIPTION
### PR creator: Description

This is an amendment to https://github.com/SUSE/doc-sle/pull/1161
to replace some deprecated commands.


### PR creator: Are there any relevant issues/feature requests?

* jsc#SLE-17223
* bsc#1193693


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done