### PR TITLE
Fix validation errors from GeekoDoc 2.1.1

### DIFF
--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -129,7 +129,7 @@
      optional and can be skipped.
     </para>
    </step>
-   <step os="sles;sled:osuse">
+   <step os="sles;sled;osuse">
     <para>
      Select <phrase os="osuse">a desktop or</phrase> a role for your
      system. Among other things, this defines the default list of packages to

--- a/xml/libvirt_guest_installation.xml
+++ b/xml/libvirt_guest_installation.xml
@@ -435,7 +435,7 @@
       It is possible to directly specify the Kernel and Initrd of the
       installer, for example from a network source.
       <phrase
-      os="sles;sled;">To set up a network source, see
+      os="sles;sled">To set up a network source, see
       <xref linkend="sec-deployment-instserver-http"/>.</phrase>
      </para>
      <para>


### PR DESCRIPTION
### PR creator: Description

The new GeekoDoc release found some validation errors. This PR will fix them.


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4
  - [x] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
