### PR TITLE
storage_filesystems: remove obsolete GRUB2 Btrfs compression note

### DIFF
--- a/xml/storage_filesystems.xml
+++ b/xml/storage_filesystems.xml
@@ -227,14 +227,6 @@
    <sect3 xml:id="sec-filesystems-major-btrfs-compress">
     <title>Mounting compressed Btrfs file systems</title>
     <remark>toms 2015-09-16: FATE#316463</remark>
-    <note>
-     <title>&grub; and compressed root</title>
-     <para>
-      &grub; cannot boot from lzo or zstd compressed root file systems. Use
-      zlib compression, or create a separate <filename>/boot</filename>
-      partition if you wish to use lzo or zstd compression for root.
-     </para>
-    </note>
     <para>
      The Btrfs file system supports transparent compression. While enabled,
      Btrfs compresses file data when written and uncompresses file data when


### PR DESCRIPTION
As raised by Andreas Taschner, GRUB2 has carried support for lzo and
zstd compressed files on Btrfs for some time, via upstream GRUB2 commits
095f077e6d and 3861286486 respectively.

Signed-off-by: David Disseldorp <ddiss@suse.de>

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
