### PR TITLE
Add FIPS section to Security and Hardening Guide

### DIFF
--- a/l10n/sles/ar-ar/xml/security_fips.xml
+++ b/l10n/sles/ar-ar/xml/security_fips.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_fips.xml

--- a/l10n/sles/cs-cz/xml/security_fips.xml
+++ b/l10n/sles/cs-cz/xml/security_fips.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_fips.xml

--- a/l10n/sles/de-de/xml/security_fips.xml
+++ b/l10n/sles/de-de/xml/security_fips.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_fips.xml

--- a/l10n/sles/es-es/xml/security_fips.xml
+++ b/l10n/sles/es-es/xml/security_fips.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_fips.xml

--- a/l10n/sles/fr-fr/xml/security_fips.xml
+++ b/l10n/sles/fr-fr/xml/security_fips.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_fips.xml

--- a/l10n/sles/hu-hu/xml/security_fips.xml
+++ b/l10n/sles/hu-hu/xml/security_fips.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_fips.xml

--- a/l10n/sles/it-it/xml/security_fips.xml
+++ b/l10n/sles/it-it/xml/security_fips.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_fips.xml

--- a/l10n/sles/ja-jp/xml/security_fips.xml
+++ b/l10n/sles/ja-jp/xml/security_fips.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_fips.xml

--- a/l10n/sles/ko-kr/xml/security_fips.xml
+++ b/l10n/sles/ko-kr/xml/security_fips.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_fips.xml

--- a/l10n/sles/pl-pl/xml/security_fips.xml
+++ b/l10n/sles/pl-pl/xml/security_fips.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_fips.xml

--- a/l10n/sles/pt-br/xml/security_fips.xml
+++ b/l10n/sles/pt-br/xml/security_fips.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_fips.xml

--- a/l10n/sles/ru-ru/xml/security_fips.xml
+++ b/l10n/sles/ru-ru/xml/security_fips.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_fips.xml

--- a/l10n/sles/zh-cn/xml/security_fips.xml
+++ b/l10n/sles/zh-cn/xml/security_fips.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_fips.xml

--- a/l10n/sles/zh-tw/xml/security_fips.xml
+++ b/l10n/sles/zh-tw/xml/security_fips.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_fips.xml

--- a/xml/book_security.xml
+++ b/xml/book_security.xml
@@ -66,6 +66,7 @@
   <xi:include href="security_firewall.xml"/>
   <xi:include href="security_vpnserver.xml"/>
   <xi:include href="security_yast2_ca.xml"/>
+  <xi:include href="security_fips.xml"/>
  </part>
 
  <part xml:id="part-apparmor">

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -353,6 +353,19 @@
 <!ENTITY dsc-ses        "&dsc;/ses">
 <!ENTITY dsc-suma        "&dsc;/suma">
 
+<!-- ============================================================= -->
+<!--        Entities for compatibility with newer releases         -->
+<!-- ============================================================= -->
+
+<!ENTITY prompt.root            "<prompt role='root' xmlns='http://docbook.org/ns/docbook'># </prompt>">
+<!ENTITY prompt.user            "<prompt xmlns='http://docbook.org/ns/docbook'>&gt; </prompt>">
+<!ENTITY prompt.sudo            "<prompt xmlns='http://docbook.org/ns/docbook'>&gt; </prompt><command xmlns='http://docbook.org/ns/docbook'>sudo</command> ">
+<!ENTITY sle                    "&suse; Linux Enterprise">
+<!ENTITY sles                   "&sle; Server">
+<!ENTITY suse                   "SUSE">
+<!ENTITY samba                  "Samba">
+<!ENTITY storage_guide  "<citetitle xmlns='http://docbook.org/ns/docbook'>Storage Administration Guide</citetitle>">
+
 
 <!-- ============================================================= -->
 <!--                    Book Abstracts                             -->

--- a/xml/security_fips.xml
+++ b/xml/security_fips.xml
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect1
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+    %entities;
+]>
+
+<chapter xmlns="http://docbook.org/ns/docbook"
+       xmlns:xi="http://www.w3.org/2001/XInclude"
+       xmlns:xlink="http://www.w3.org/1999/xlink"
+       version="5.0"
+       xml:id="cha-security-fips">
+ <title>Enabling compliance with FIPS 140-2</title>
+ <info>
+  <abstract>
+   <para>
+     If your organization does any work for the United States federal
+     government, it is likely that your cryptography applications (such
+     as openSSL, GnuTLS, and OpenJDK) will be required to be in
+     compliance with Federal Information Processing Standards (FIPS)
+     140-2. FIPS 140-2 is a security accreditation program for validating
+     cryptographic modules produced by private companies. If your
+     organization is not required by compliance rules to run &sle; in
+     FIPS mode, it is most likely best to not do it. This chapter
+     provides guidance on enabling FIPS mode, and links to resources with
+     detailed information.
+   </para>
+  </abstract>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker></dm:bugtracker>
+   <dm:translation>yes</dm:translation>
+  </dm:docmanager>
+ </info>
+
+<sect1 xml:id="sec-fips-concept">
+  <title>FIPS 140-2 overview</title>
+
+  <warning>
+    <title>FIPS requires expertise</title>
+    <para>
+      Administering FIPS is complex and requires significant expertise.
+      Implementing it correctly, testing, and troubleshooting all require
+      a high degree of knowledge.
+    </para>
+  </warning>
+
+  <para>
+    Every vendor that develops and maintains cryptographic applications, and
+    wants them to be tested for FIPS compliance, must submit them to the
+    Cryptographic Module Validation Program (CMVP) (see
+    <link xlink:href="https://csrc.nist.gov/projects/cryptographic-module-validation-program"/>).
+  </para>
+  <para>
+    There are currently two FIPS cryptographic standards, FIPS 140-2 and FIPS
+    140-3. The FIPS 140-2 standard was finalized in 2002, and is valid until
+    September 22, 2026. The FIPS 140-3 standard was approved in March 2019,
+    and is replacing 140-2. CMVP is no longer accepting modules for
+    FIPS 140-2 testing, but only FIPS 140-3.
+  </para>
+  <para>
+    &suse; maintains a list of certified modules at
+    <link xlink:href="https://www.suse.com/support/security/certifications/"/>, along with a lot of other useful information.
+  </para>
+</sect1>
+
+<sect1 xml:id="sec-fips-use-case">
+  <title>When to enable FIPS mode</title>
+  <para>
+    The use case for enabling FIPS mode on &sle; is simple: run your
+    server in FIPS mode it when it is required to meet compliance rules.
+  </para>
+  <para>
+     When you are not required to meet compliance rules, running your systems
+     in FIPS mode is most likely not a good idea. These are some of the reasons to not use FIPS mode:
+  </para>
+  <itemizedlist>
+    <listitem>
+      <para>
+        FIPS is restrictive. It enforces the use of specific validated
+        cryptographic algorithms, and specific certified binaries that
+        implement these validated algorithms. You must use only the certified
+        binaries.
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        Upgrades may break functionality.
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+         The approval process is very long, so certified binaries are always
+         several releases behind the newest release.
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        Certified binaries, such as ssh, sshd, and sftp-server, run their own
+        self-checks at startup, and run only when these checks succeed.
+        This creates some small performance degradation.
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        Administering FIPS is complex and requires significant expertise.
+      </para>
+    </listitem>
+  </itemizedlist>
+</sect1>
+
+<sect1 xml:id="sec-fips-install">
+  <title>Installing FIPS</title>
+  <para>
+    It is best to install the
+    <package>patterns-server-enterprise-fips</package> pattern on a new
+    installation. Then, after the installation is complete, enable FIPS mode
+    by running the steps in <xref linkend="sec-fips-enable"/>.
+  </para>
+  <para>
+    You may install <package>patterns-server-enterprise-fips</package>
+    and enable FIPS mode on a running system, but then it is likely you will
+    have to make adjustments, such as regenerating keys, and auditing your
+    setup to ensure it is set up correctly.
+  </para>
+</sect1>
+
+<sect1 xml:id="sec-fips-enable">
+  <title>Enabling FIPS mode</title>
+
+<!-- The file paths for the two READMEs are different than in earlier
+  releases. In SLE 15 SP2 and older the path is /usr/share/doc/packages/openssh/
+  cschroder Jan 13, 2022 -->
+<para>
+  Enabling FIPS takes a few steps. First, read the
+  <filename>/usr/share/doc/packages/openssh-common/README.FIPS</filename> and
+  <filename>/usr/share/doc/packages/openssh-common/README.SUSE</filename>
+  files, from the <package>openssh-common</package> package. These contain
+  important information about FIPS on &sle;.
+  </para>
+  <para>
+    Check if FIPS is already enabled:
+  </para>
+  <screen>&prompt.sudo;<command>sysctl -a | grep fips</command>
+crypto.fips_enabled = 0</screen>
+  <para>
+  <literal>crypto.fips_enabled = 0</literal> indicates that it is not enabled. A return value of 1 means that it is enabled.
+  </para>
+  <para>
+    Then edit <filename>/etc/default/grub</filename>. If
+    <filename>/boot</filename> is not on a separate partition, add
+    <literal>fips=1</literal> to
+    <literal>GRUB_CMDLINE_LINUX_DEFAULT</literal>, like the following
+    example:
+  </para>
+  <screen>GRUB_CMDLINE_LINUX_DEFAULT="splash=silent mitigations=auto quiet fips=1"</screen>
+  <para>
+    If <filename>/boot</filename> is on a separate partition, specify which
+    partition, like the following example, substituting the name of your boot
+    partition:
+  </para>
+  <screen>GRUB_CMDLINE_LINUX_DEFAULT="splash=silent mitigations=auto quiet fips=1 boot=<replaceable>/dev/sda1"</replaceable></screen>
+  <para>
+    Save your changes, and rebuild your GRUB configuration and initramfs
+    image (replace <replaceable>NAME</replaceable>
+      with the name of the current initrd and
+      <replaceable>KERNELVERSION</replaceable> with the currently running
+      kernel):
+  </para>
+  <screen>&prompt.sudo;<command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>
+&prompt.sudo;<command>/usr/bin/dracut --logfile /var/log/YaST2/mkinitrd.log --force /boot/$initrd-<replaceable>NAME</replaceable> $<replaceable>KERNELVERSION</replaceable></command></screen>
+  <para>
+  Reboot, then verify your changes. The following example shows that
+  FIPS is enabled:
+  </para>
+<screen>&prompt.sudo;<command>sysctl -a | grep fips</command>
+crypto.fips_enabled = 1</screen>
+  <para>
+  After enabling FIPS it is possible that your system will not boot. If this
+  happens, reboot to bring up the GRUB menu. Press <keycap>E</keycap> to edit
+  your boot entry, and delete the <literal>fips</literal> entry from the
+  <literal>linux</literal> line. Press the <keycap>F10</keycap> key to boot.
+  This is a temporary change, and most likely the problem is an error in
+  <filename>/etc/default/grub</filename>. Correct it, rebuild GRUB and
+  initramfs, then reboot.
+  </para>
+ </sect1>
+
+ <sect1 xml:id="sec-fips-samba-cifs">
+  <title>MD5 not supported in Samba/CIFS</title>
+  <para>
+   According to the FIPS standards, MD5 is not a secure hashing
+   algorithm, and it must not be used for authentication. If you run a
+   FIPS-compliant network environment, and you have clients or servers
+   that run in FIPS-compliant mode, you must use a Kerberos service for
+   authenticating Samba/CIFS users. This is necessary as all other Samba
+   authentication modes include MD5.
+  </para>
+  <para>
+   See the &samba; section of the &storage_guide; for more information on
+   running a &samba; server.
+  </para>
+ </sect1>
+</chapter>


### PR DESCRIPTION
### PR creator: Description
Backport FIPS section of Security and Hardening Guide from codestream 15


### PR creator: Are there any relevant issues/feature requests?

jira #DOCTEAM-580


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
