### PR TITLE
add note on ftp links firefox (bsc#1190667)

### DIFF
--- a/xml/apps_firefox.xml
+++ b/xml/apps_firefox.xml
@@ -665,6 +665,19 @@ The orange indicator was removed with Firefox 4 or so. There still is a
  <sect1 xml:id="sec-firefox-security">
   <title>Security</title>
 
+<note>
+ <title>FTP support stopped</title>
+ <para>
+  For security reasons <productname>Mozilla</productname> has removed the default
+  support for clicking on FTP links in <productname>Firefox</productname>. You
+  can enable this support by adding
+  <command>network.gio.supported-protocols=ftp:,sftp:,ssh:</command> via the
+  <command>about:config</command> settings.
+  This will enable desktop support via the &gnome; Virtual File System (GVfs).
+  See the GVfs documentation for all supported protocols.
+ </para>
+</note>
+
   <para>
    Since browsing the Internet has become more risky,
    <productname>Firefox</productname> offers various


### PR DESCRIPTION
PR creator: Description

Added a note that Firefox does not support clicking on ftp links by default anymore.


PR creator: Are there any relevant issues/feature requests?

* bsc#1190667

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
