### PR TITLE
SEO fixes of broken links_SLE12SP4

### DIFF
--- a/xml/storage_nvmeof.xml
+++ b/xml/storage_nvmeof.xml
@@ -397,9 +397,6 @@ Parameter traddr is now '10.0.0.1'.</screen>
    <listitem>
     <para><link xlink:href="https://storpool.com/blog/demystifying-what-is-nvmeof"/></para>
    </listitem>
-   <listitem>
-    <para><link xlink:href="https://medium.com/@metebalci/a-quick-tour-of-nvm-express-nvme-3da2246ce4ef"/></para>
-   </listitem>
-  </itemizedlist>
+   </itemizedlist>
  </sect1>
 </chapter>

--- a/xml/vt_best_practices.xml
+++ b/xml/vt_best_practices.xml
@@ -4292,12 +4292,6 @@ ln -sf /dev/xvda1 /dev/hda1
    </listitem>
    <listitem>
     <para>
-     <link xlink:href="http://wiki.mikejung.biz/KVM_/_Xen">&kvm; / &xen;
-     tweaks</link>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
      <link
        xlink:href="http://events.linuxfoundation.org/sites/events/files/slides/CloudOpen2013_Khoa_Huynh_v3.pdf">Dr.
      Khoa Huynh, IBM Linux Technology Center</link>


### PR DESCRIPTION
Applied broken link fixes for SEO purposes.

Changes will be done for each version separately, so no backports needed.

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [x] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
