### PR TITLE
Added note about not supporting older TLS protocol (jsc#SLE-21818)

### DIFF
--- a/xml/yast2_ftp.xml
+++ b/xml/yast2_ftp.xml
@@ -218,16 +218,17 @@
 
   <para>
    If you want encrypted communication between clients and the server, you can
-   <guimenu>Enable SSL</guimenu> and additionally <guimenu>Enable TLS</guimenu>
-   as well. Specify the RSA certificate to be used for SSL encrypted
+   <guimenu>Enable SSL</guimenu> and, additionally, <guimenu>Enable
+   TLS</guimenu>. Specify the RSA certificate to be used for SSL encrypted
    connections.
   </para>
 
   <important>
    <para>
-    New versions of the <systemitem class="daemon">vsftpd</systemitem> daemon
-    do not accept TLS connections via protocol version prior to 1.2 by default.
-    If you use an FTP client that requires older version of TLS protocol,
+    By default, new versions of the <systemitem class="daemon">vsftpd
+    </systemitem> daemon do not accept TLS connections via protocol version prior
+    to 1.2.
+    If you use an FTP client that requires an older version of the TLS protocol,
     you need to add the following configuration to the
     <filename>/etc/vsftpd.conf</filename> configuration file:
    </para>
@@ -237,7 +238,7 @@ ssl_tlsv1_1 = YES
 </screen>
    <para>
     Then restart the <systemitem class="daemon">vsftpd</systemitem> daemon to
-    re-read the configuration:
+    reread the configuration:
    </para>
 <screen>&prompt.sudo;systemctl restart vsftpd.service</screen>
   </important>

--- a/xml/yast2_ftp.xml
+++ b/xml/yast2_ftp.xml
@@ -229,7 +229,7 @@
     </systemitem> daemon have the TLS protocol older than version 1.2 disabled.
     If you use an FTP client that requires an older version of the TLS protocol,
     you need to add the following configuration to the
-    <filename>/etc/vsftpd.conf</filename> configuration file:
+    <filename>/etc/vsftpd.conf</filename> file:
    </para>
 <screen>
 ssl_tlsv1 = YES

--- a/xml/yast2_ftp.xml
+++ b/xml/yast2_ftp.xml
@@ -226,8 +226,7 @@
   <important>
    <para>
     By default, new versions of the <systemitem class="daemon">vsftpd
-    </systemitem> daemon do not accept TLS connections via protocol version prior
-    to 1.2.
+    </systemitem> daemon have the TLS protocol older than version 1.2 disabled.
     If you use an FTP client that requires an older version of the TLS protocol,
     you need to add the following configuration to the
     <filename>/etc/vsftpd.conf</filename> configuration file:

--- a/xml/yast2_ftp.xml
+++ b/xml/yast2_ftp.xml
@@ -218,14 +218,29 @@
 
   <para>
    If you want encrypted communication between clients and the server, you can
-   <guimenu>Enable SSL</guimenu>. Check the versions of the protocol to be
-   supported and specify the RSA certificate to be used for SSL encrypted
+   <guimenu>Enable SSL</guimenu> and additionally <guimenu>Enable TLS</guimenu>
+   as well. Specify the RSA certificate to be used for SSL encrypted
    connections.
-<!--use the FTPS protocol (FTP/SSH). However note that FTPS is different
-   from the much more common SFTP (SSH File Transport Protocol) protocol.
-    If you want to use the FTPS, you can set SSL options in the
-    <guimenu>Expert Settings</guimenu> dialog.-->
   </para>
+
+  <important>
+   <para>
+    New versions of the <systemitem class="daemon">vsftpd</systemitem> daemon
+    do not accept TLS connections via protocol version prior to 1.2 by default.
+    If you use an FTP client that requires older version of TLS protocol,
+    you need to add the following configuration to the
+    <filename>/etc/vsftpd.conf</filename> configuration file:
+   </para>
+<screen>
+ssl_tlsv1 = YES
+ssl_tlsv1_1 = YES
+</screen>
+   <para>
+    Then restart the <systemitem class="daemon">vsftpd</systemitem> daemon to
+    re-read the configuration:
+   </para>
+<screen>&prompt.sudo;systemctl restart vsftpd.service</screen>
+  </important>
 
   <para>
    If your system is protected by a firewall, check <guimenu>Open Port in


### PR DESCRIPTION
### PR creator: Description

New version of vsftpd does not support older versions of TLS protocol by default. One needs to manually update the configuration file to enable the old behaviour.


### PR creator: Are there any relevant issues/feature requests?

* jsc#SLE-21818


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
