### PR TITLE
GNOME user guide:spellcheck

### DIFF
--- a/xml/apps_firefox.xml
+++ b/xml/apps_firefox.xml
@@ -1136,7 +1136,7 @@ The orange indicator was removed with Firefox 4 or so. There still is a
    </member>
    <member><emphasis>Preferences reference</emphasis>: <link xlink:href="http://support.mozilla.org/kb/Options+window"/>
    </member>
-   <member><emphasis>Keyboard shortcuts</emphasis>: <link xlink:href="http://support.mozilla.org/kb/Keyboard+shortcuts"/>
+   <member><emphasis>Key combinations</emphasis>: <link xlink:href="http://support.mozilla.org/kb/Keyboard+shortcuts"/>
    </member>
   </simplelist>
  </sect1>

--- a/xml/apps_firefox.xml
+++ b/xml/apps_firefox.xml
@@ -673,8 +673,8 @@ The orange indicator was removed with Firefox 4 or so. There still is a
   can enable this support by adding
   <command>network.gio.supported-protocols=ftp:</command> via the
   <command>about:config</command> settings.
-  This will enable desktop support via the &gnome; Virtual File System (GVfs).
-  See the GVfs documentation for all supported protocols.</para>
+  This will enable desktop support via the &gnome; Virtual File System (GVFS).
+  See the GVFS documentation for all supported protocols.</para>
 </note>
 
   <para>

--- a/xml/apps_libreoffice.xml
+++ b/xml/apps_libreoffice.xml
@@ -337,7 +337,7 @@
       <productname>Writer</productname>) or the sum of values of selected cells
       (in <productname>Calc</productname>). However, it can also be
       used to change the zoom or language settings. Many elements open
-      additional menus or dialogs on left click, right-click, or double click.
+      additional menus or dialogs on left-click, right-click, or double-click.
      </para>
     </listitem>
    </varlistentry>

--- a/xml/apps_librevarious.xml
+++ b/xml/apps_librevarious.xml
@@ -173,6 +173,7 @@
        Open your presentation.
       </para>
       <tip>
+       <title>Applying master slides</title>
        <para>
        To apply a master slide to multiple slides but not all slides:
        Select the slides that you want a slide master applied to.
@@ -364,6 +365,7 @@
       </para>
       <informalfigure>
        <mediaobject>
+        <textobject><phrase>Field selection</phrase></textobject>
         <imageobject role="fo">
          <imagedata fileref="oo-wizard-base.png" width="100%" format="PNG"/>
         </imageobject>

--- a/xml/backup.xml
+++ b/xml/backup.xml
@@ -38,6 +38,7 @@ taroth 2013-02-19: reopended for SP3
 
 <informalfigure>
  <mediaobject>
+  <textobject><phrase>Backup application</phrase></textobject>
   <imageobject role="fo">
    <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
   </imageobject>
@@ -50,7 +51,7 @@ taroth 2013-02-19: reopended for SP3
 <sect1 xml:id="sec-gnome-backup-config">
  <title>Configuring backups</title>
  <para>
-  Before you can start to backup data, configure which files to back up, which
+  Before you can start to back up data, configure which files to back up, which
   ones to ignore and where to store the backup.
  </para>
  <procedure>

--- a/xml/gnome_accessibility.xml
+++ b/xml/gnome_accessibility.xml
@@ -123,6 +123,7 @@
     </para>
     <informalfigure >
      <mediaobject>
+      <textobject><phrase>On-screen keyboard</phrase></textobject>
       <imageobject role="fo">
        <imagedata fileref="gnome_onscreen_kbd.png" width="95%"
         format="PNG"></imagedata>

--- a/xml/gnome_custom.xml
+++ b/xml/gnome_custom.xml
@@ -141,14 +141,14 @@
       <guimenu>Language</guimenu>. Choose a language from the list. For the
       change to take effect, you will be prompted to <guimenu>Restart</guimenu>
       the desktop session. To do so, you must log out of your session and
-      log back in afterwards.</para>
+      log back in afterward.</para>
     </listitem>
     <listitem>
      <para>
       <guimenu>Formats</guimenu>: To change the formats for date, number,
       currency and related options, choose a country from the list. For the
       change to take effect, you must log out of your session and log back in
-      afterwards.
+      afterward.
      </para>
     </listitem>
    </itemizedlist>
@@ -207,7 +207,7 @@
   </figure>
   <para>
    This dialog shows the keyboard shortcuts that are configured for your system.
-   To edit a key combination, click the entry that you would like to change. To
+   To edit a key combination, click the entry that you want to change. To
    set a new key combination, press the respective keys. To disable a shortcut,
    press <keycap function="backspace"/> instead.
   </para>
@@ -564,7 +564,7 @@ commented out the screen. Texts taken from GNOME help.
 
    <para>
     To set up an additional monitor, connect the monitor to your computer. If
-    your system does not recognize it immediately, or you would like to adjust
+    your system does not recognize it immediately, or you want to adjust
     the settings, do the following:
    </para>
    <procedure>

--- a/xml/gnome_networking.xml
+++ b/xml/gnome_networking.xml
@@ -332,6 +332,7 @@
      </para>
      <informalfigure>
       <mediaobject>
+       <textobject><phrase>Sharing options</phrase></textobject>
        <imageobject role="fo">
         <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
        </imageobject>

--- a/xml/gnome_use.xml
+++ b/xml/gnome_use.xml
@@ -620,7 +620,7 @@
     </step>
     <step>
      <para>
-      Go to the location where the text should be inserted, click the right
+      Go to the location where the text should be inserted, right-click the
       mouse button and select <guimenu>Paste</guimenu> from the context menu.
      </para>
      <para>
@@ -686,6 +686,8 @@
 
   <informalfigure pgwide="0">
    <mediaobject>
+    <textobject><phrase><productname>Evolution</productname></phrase>
+    </textobject>
     <imageobject role="fo">
      <imagedata fileref="evolution.png" format="PNG" width="100%"/>
     </imageobject>
@@ -1085,7 +1087,7 @@
    <filename>~/Pictures</filename> folder in your home directory.
   </para>
   <para>
-   Use the following global keyboard shortcuts to quickly take a screenshot:
+   Use the following global key combinations to quickly take a screenshot:
   </para>
    <itemizedlist>
     <listitem>


### PR DESCRIPTION
Corrections from final checks for GNOME user guide (SLES/SLED/openSUSE)
- spellcheck
- linkcheck (no issues)
- stylecheck


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
