### PR TITLE
SEO fixes of broken links SLE15SP1

### DIFF
--- a/xml/security_preface.xml
+++ b/xml/security_preface.xml
@@ -402,7 +402,7 @@
    </listitem>
    <listitem>
     <para><link
-    xlink:href="https://www.bsi.bund.de/DE/Service/Aktuell/Cert_Bund_Meldungen/cert_bund_meldungen_node.html"
+    xlink:href="https://www.bsi.bund.de/DE/Service-Navi/Abonnements/Warnmeldungen/warnmeldungen_node.html"
     />, <emphasis>German Federal Office for Information
     Security</emphasis> vulnerability feed</para>
    </listitem>

--- a/xml/security_preface.xml
+++ b/xml/security_preface.xml
@@ -350,7 +350,7 @@
    &suse; provides a feed of security advisories. It is available at
    <link xlink:href="https://www.suse.com/en-us/support/update/" />.
    There is also a list of security updates by CVE number available at
-   <link xlink:href="https://www.suse.com/en-us/security/cve/" />.
+   <link xlink:href="https://www.suse.com/security/cve/" />.
   </para>
   <note os="sles;sled">
    <title>Backports and Version Numbers</title>

--- a/xml/storage_nvmeof.xml
+++ b/xml/storage_nvmeof.xml
@@ -436,9 +436,6 @@ Parameter traddr is now '10.0.0.3'.</screen>
    <listitem>
     <para><link xlink:href="https://storpool.com/blog/demystifying-what-is-nvmeof"/></para>
    </listitem>
-   <listitem>
-    <para><link xlink:href="https://medium.com/@metebalci/a-quick-tour-of-nvm-express-nvme-3da2246ce4ef"/></para>
-   </listitem>
-  </itemizedlist>
+   </itemizedlist>
  </sect1>
 </chapter>

--- a/xml/vt_best_practices.xml
+++ b/xml/vt_best_practices.xml
@@ -4199,12 +4199,6 @@ ln -sf /dev/xvda1 /dev/hda1
    </listitem>
    <listitem>
     <para>
-     <link xlink:href="http://wiki.mikejung.biz/KVM_/_Xen">&kvm; / &xen;
-     tweaks</link>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
      <link
        xlink:href="http://events.linuxfoundation.org/sites/events/files/slides/CloudOpen2013_Khoa_Huynh_v3.pdf">Dr.
      Khoa Huynh, IBM Linux Technology Center</link>

--- a/xml/xm_vs_xl_links.xml
+++ b/xml/xm_vs_xl_links.xml
@@ -79,7 +79,7 @@
    <term>libvirt</term>
    <listitem>
     <para>
-     <link xlink:href="https://libvirt.org/virshcmdref.html">virsh</link>
+     <link xlink:href="https://libvirt.org/manpages/virsh.html">virsh</link>
      command.
     </para>
    </listitem>


### PR DESCRIPTION
PR creator: Description
Applied broken link fixes for SEO purposes.

Changes will be done for each version separately, so no backports needed.

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
