### PR TITLE
New AutoYaST schema for SLES 15 SP4 and SLE Micro

### DIFF
--- a/xml/ay_create_control_file.xml
+++ b/xml/ay_create_control_file.xml
@@ -179,10 +179,16 @@
 
 <screen>jing /usr/share/YaST2/schema/autoyast/rng/profile.rng &lt;control file&gt;</screen>
 
-  <para>
+  <para os="sles;sled;osuse">
    <literal>/usr/share/YaST2/schema/autoyast/rng/profile.rng</literal> is
-   provided by the package <literal>yast2-schema</literal>. This file describes
-   the syntax and classes of an &ay; profile.
+   provided by the package <literal>yast2-schema-default</literal>. This
+   file describes the syntax and classes of an &ay; profile.
+  </para>
+
+  <para os="slemicro">
+   <literal>/usr/share/YaST2/schema/autoyast/rng/profile.rng</literal> is
+   provided by the package <literal>yast2-schema-micro</literal>. This file
+   describes the syntax and classes of an &ay; profile.
   </para>
 
   <note os="osuse;sles;sled">


### PR DESCRIPTION
resolves Jira SLE-21343

### PR creator: Description

yast2-schema is replaced by two new schema.
yast2-schema-default is for SLES.
yast2-schema-micro is for SLE Micro.

The AY Guide is is profiled accordingly.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
