### PR TITLE
Update usermod calls to include enough subuids/subgids

### DIFF
--- a/xml/art_admin_slemicro_podman.xml
+++ b/xml/art_admin_slemicro_podman.xml
@@ -148,8 +148,8 @@
    current user, run the following command:
   </para>
 <screen>
-&prompt.user;sudo usermod --add-subuids 200000-201000 \
-  --add-subgids 200000-201000 $USER
+&prompt.user;sudo usermod --add-subuids 100000-165535 \
+  --add-subgids 100000-165535 <replaceable>USER</replaceable>
 </screen>
   <para>
    Reboot the machine to enable the change. The command above defines a range
@@ -164,7 +164,7 @@
     <title>Limitations of rootless containers</title>
   <para>
    Running a container with Podman in rootless mode on &slema; may fail,
-   because the container might need access to directories or files that require &rootuser; privileges. 
+   because the container might need access to directories or files that require &rootuser; privileges.
   </para>
   <para>
     The <emphasis>toolbox</emphasis> container also requires &rootuser; privileges.

--- a/xml/containers-buildah-overview.xml
+++ b/xml/containers-buildah-overview.xml
@@ -102,7 +102,7 @@
    following command:
   </para>
 
-<screen>&prompt.user;sudo usermod --add-subuids 200000-201000 --add-subgids 200000-201000 $USER</screen>
+<screen>&prompt.user;sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 <replaceable>USER</replaceable></screen>
 
   <para>
    This command enables rootless mode for the current user. After running the

--- a/xml/containers-podman-overview.xml
+++ b/xml/containers-podman-overview.xml
@@ -67,7 +67,7 @@
   To run &podman; without root privileges, subuids and subgids must be assigned to the user running &podman;. If there is no entry in the <filename>/etc/subuid</filename> file, add an entry using the following command:
   </para>
 
-<screen>&prompt.user; sudo usermod --add-subuids 200000-201000 --add-subgids 200000-201000 $USER</screen>
+<screen>&prompt.user; sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 <replaceable>USER</replaceable></screen>
 
   <para>
    To enable the change, reboot the machine or stop the session of the current


### PR DESCRIPTION
### PR creator: Description

The currently present usermod calls do not add enough subuids & subgids for
containers with files owned by the nobody user (see for instance
https://bugzilla.suse.com/show_bug.cgi?id=1199178). This commit makes the
usermod calls consistent with the defaults of useradd


### PR creator: Are there any relevant issues/feature requests?

* [bsc#1199178](https://bugzilla.suse.com/show_bug.cgi?id=1199178)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4
  - [x] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
