### PR TITLE
Replace modules & extensions table

### DIFF
--- a/xml/art_modules.xml
+++ b/xml/art_modules.xml
@@ -117,873 +117,582 @@
    https://bugzilla.suse.com/1189275#c9 and
    https://jira.suse.com/browse/SLE-17270
   -->
-   <informaltable>
-    <tgroup cols="4">
-     <colspec colnum="1" colname="name" colwidth="30*"/>
-     <colspec colnum="2" colname="dependency" colwidth="25*"/>
-     <colspec colnum="3" colname="availability" colwidth="25*"/>
-     <colspec colnum="4" colname="support" colwidth="20*"/>
-     <thead>
-      <row>
-       <entry morerows="1">
-        <para>
-         Name
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Depends on
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Available for
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Support
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry namest="dependency" nameend="support">
-        <para>
-         Content
-        </para>
-       </entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry morerows="1">
-        <para>
-         <emphasis role="bold">Basesystem</emphasis>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         None
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Default on all products
-        </para>
-       </entry>
-       <entry>
-        <simplelist>
-         <member>
-          <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-         </member>
-         <member>
-          <emphasis role="bold">Extended:</emphasis> 3 yrs
-          LTSS<superscript>1</superscript>
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
-         </member>
-        </simplelist>
-       </entry>
-      </row>
-      <row>
-       <entry namest="dependency" nameend="support">
-        <para>
-         Adds a basic system on top of the Installer. It is
-         required by all other modules and extensions. The scope of an
-         installation that only contains the base system is comparable to the
-         <literal>minimal</literal> system installation pattern of previous
-         &productname; versions. This module is selected for installation by
-         default and should not be deselected.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry morerows="1">
-        <para>
-         <emphasis role="bold">Certifications</emphasis>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Basesystem
-        </para>
-       </entry>
-       <entry>
-        <para>
-         &slsa;, &sles4sapa;, &slert;, &slehpca;
-        </para>
-       </entry>
-       <entry>
-        <simplelist>
-         <member>
-          <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-         </member>
-         <member>
-          <emphasis role="bold">Extended:</emphasis> 3 yrs
-          LTSS<superscript>1</superscript>
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
-         </member>
-        </simplelist>
-       </entry>
-      </row>
-      <row>
-       <entry namest="dependency" nameend="support">
-        <para>
-         Contains the FIPS 140-2 certification packages.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry morerows="1">
-        <para>
-         <emphasis role="bold">Containers</emphasis>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Basesystem
-        </para>
-       </entry>
-       <entry>
-        <para>
-         &slsa;, &sles4sapa;, &slehpca;
-        </para>
-       </entry>
-       <entry>
-        <simplelist >
-         <member>
-          <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-         </member>
-         <member>
-          <emphasis role="bold">Extended:</emphasis> 3 yrs
-          LTSS<superscript>1</superscript>
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
-         </member>
-        </simplelist>
-       </entry>
-      </row>
-      <row>
-       <entry namest="dependency" nameend="support">
-        <para>
-         Contains packages relating to containers, including the container
-         engine and core container-related tools such as on-premise registry.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry morerows="1">
-        <para>
-         <emphasis role="bold">Desktop Applications</emphasis>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Basesystem
-        </para>
-       </entry>
-       <entry>
-        <para>
-         &slsa;, &sleda; (default), &slewea; (default), &sles4sapa;,
-         &slerta; (default), &slehpca;
-        </para>
-       </entry>
-       <entry>
-        <simplelist>
-         <member>
-          <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-         </member>
-         <member>
-          <emphasis role="bold">Extended:</emphasis> 3 yrs
-          LTSS<superscript>1</superscript>
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
-         </member>
-        </simplelist>
-       </entry>
-      </row>
-      <row>
-       <entry namest="dependency" nameend="support">
-        <para>
-         Adds a graphical user interface <phrase os="sled">(Wayland)</phrase>
-         and essential desktop applications to the system.
-         <phrase os="sled">This module is selected for installation by
-         default; deselecting it is not recommended.</phrase>
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry morerows="1">
-        <para>
-         <emphasis role="bold">Development Tools</emphasis>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Basesystem, Desktop Applications
-        </para>
-       </entry>
-       <entry>
-        <para>
-         &slsa;, &sles4sapa;, &sleda;, &slerta; (default), &slehpca;
-        </para>
-       </entry>
-       <entry>
-        <simplelist>
-         <member>
-          <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-         </member>
-         <member>
-          <emphasis role="bold">Extended:</emphasis> 3 yrs
-          LTSS<superscript>1</superscript>
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
-         </member>
-        </simplelist>
-       </entry>
-      </row>
-      <row>
-       <entry namest="dependency" nameend="support">
-        <para>
-         Contains compilers (including <package>gcc</package>) and libraries
-         required for compiling and debugging applications. Replaces the former
-         Software Development Kit (SDK).
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry morerows="1">
-        <para>
-         <emphasis role="bold">High Availability</emphasis>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Basesystem, Server Applications
-        </para>
-       </entry>
-       <entry>
-        <para>
-         &slsa;, &sles4sapa; (included), &slehpca;, &slert;
-        </para>
-       </entry>
-       <entry>
-        <simplelist>
-         <member>
-          <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-         </member>
-         <member>
-          <emphasis role="bold">Extended:</emphasis> 3 yrs
-          LTSS<superscript>1</superscript>
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
-         </member>
-        </simplelist>
-       </entry>
-      </row>
-      <row>
-       <entry namest="dependency" nameend="support">
-        <para>
-         Provides high-availability clustering technologies that can be deployed
-         in physical and/or virtual environments.
-        </para>
-        <para>
-         High Availability is included in the subscription for &sles4sapa; as a
-         module. It is also available as an extension for &slsa; and &slehpca;.
-         For more information about &sle; &hasi;, refer to <link
-          xlink:href="https://www.suse.com/products/highavailability"/>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry morerows="1">
-        <para>
-         <emphasis role="bold">High Performance Computing</emphasis>
-        </para>
-        <para>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Basesystem
-        </para>
-       </entry>
-       <entry>
-        <para>
-         &slehpca; (included)
-        </para>
-       </entry>
-       <entry>
-        <simplelist>
-         <member>
-          <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-         </member>
-         <member>
-          <emphasis role="bold">Extended:</emphasis> 1 yr
-          ESPOS<superscript>2</superscript>, 3 yrs
-          LTSS<superscript>1</superscript>
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
-         </member>
-        </simplelist>
-       </entry>
-      </row>
-      <row>
-       <entry namest="dependency" nameend="support">
-        <para>
-         Contains tools and libraries related to High Performance Computing
-         (HPC).
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry morerows="1">
-        <para>
-         <emphasis role="bold">Legacy</emphasis>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Basesystem, Server Applications
-        </para>
-       </entry>
-       <entry>
-        <para>
-         &slsa;, &sles4sapa;, &slehpca;
-        </para>
-       </entry>
-       <entry>
-        <para/>
-        <simplelist>
-         <member>
-          <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-         </member>
-         <member>
-          <emphasis role="bold">Extended:</emphasis> 3 yrs
-          LTSS<superscript>1</superscript>
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
-         </member>
-        </simplelist>
-       </entry>
-      </row>
-      <row>
-       <entry namest="dependency" nameend="support">
-        <para>
-         Helps you with migrating applications from earlier versions of
-         &productname; and other systems to &slsa; &productnumber;, by
-         providing packages which are discontinued on &sle;. Packages in this
-         module are selected based on the requirement for migration and the
-         level of complexity of configuration.
-        </para>
-        <para>
-         This module is recommended when migrating from a previous product
-         version.
-        </para>
-        <para>
-         Please note that this module has a different lifecycle than some of its
-         packages. Not all packages are supported for the complete lifecycle of
-         the module, but depend on migration requirements and upstream
-         lifecycles.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry morerows="1">
-        <para>
-         <emphasis role="bold">Live Patching</emphasis>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Basesystem
-        </para>
-       </entry>
-       <entry>
-        <para>
-         &slsa;, &sles4sapa;, &slehpca;
-         <!-- on x86-64, s390x, and ppc64le -->
-        </para>
-       </entry>
-       <entry>
-        <para/>
-        <simplelist>
-         <member>
-          <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-         </member>
-         <member>
-          <emphasis role="bold">Extended:</emphasis> 3 yrs
-          LTSS<superscript>1</superscript>
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
-         </member>
-        </simplelist>
-       </entry>
-      </row>
-      <row>
-       <entry namest="dependency" nameend="support">
-        <para>
-         Provides packages to update critical components in &sle; without
-         shutting down your system, which reduces planned downtime and increases
-         service availability.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry morerows="1">
-        <para>
-         <emphasis role="bold">NVIDIA Compute</emphasis>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Basesystem
-        </para>
-       </entry>
-       <entry>
-        <para>
-         &slsa; and &slehpca; on &x86-64; and &aarch64;
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Software in this module is provided by NVIDIA and is not supported by
-         &suse;
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry namest="dependency" nameend="support">
-        <para>
-         Contains the NVIDIA CUDA (Compute Unified Device Architecture) drivers.
-        </para>
-        <para>
-         The software in this module is provided by NVIDIA under the <link
-          xlink:href="http://docs.nvidia.com/cuda/eula/">CUDA End User License
-          Agreement</link> and is not supported by &suse;.
-        </para>
-        <important>
-         <title>Do not use <command>SUSEConnect</command> to add this module</title>
-         <para>
-          Do not try to add this module with the <command>SUSEConnect</command>
-          CLI tool. <command>SUSEConnect</command> is not capable of handling
-          third-party repositories.
-         </para>
-         <para>
-          During installation, select the module from the <guimenu>Extension and
-           Module Selection</guimenu> screen. Within an installed system, run
-          <command>yast registration</command>, select <guimenu>Select
-           Extensions</guimenu>, then <literal>NVIDIA Compute Module</literal>
-          and continue with <guimenu>Next</guimenu>. Verify and accept the
-          NVIDIA repository GPG key.
-         </para>
-        </important>
-        <important>
-         <title>Combining <literal>Workstation Extension</literal> and
-          <literal>NVIDIA Compute module</literal> is unsupported</title>
-         <para>
-          The <literal>Workstation Extension</literal> provides drivers for
-          NVIDIA graphics cards. These drivers share some packages with CUDA,
-          however versions may differ. It is therefore neither recommended
-          nor supported to enable both the <literal>NVIDIA Compute
-          Module</literal> and the <literal>Workstation Extension</literal> at
-          the same time.
-         </para>
-        </important>
-       </entry>
-      </row>
-      <row>
-       <entry morerows="1">
-        <para>
-         <emphasis role="bold">Public Cloud</emphasis>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Basesystem, Server Applications
-        </para>
-       </entry>
-       <entry>
-        <para>
-         &slsa;, &sles4sapa;, &slehpca;
-        </para>
-       </entry>
-       <entry>
-        <para/>
-        <simplelist>
-         <member>
-          <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-         </member>
-         <member>
-          <emphasis role="bold">Extended:</emphasis> 3 yrs
-          LTSS<superscript>1</superscript>
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
-         </member>
-        </simplelist>
-       </entry>
-      </row>
-      <row>
-       <entry namest="dependency" nameend="support">
-        <para>
-         Contains all tools required to create images for deploying
-         &productname; in cloud environments. For example: Amazon Web Services
-         (AWS), Microsoft Azure, Google Compute Platform, or &ostack;.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry morerows="1">
-        <para>
-         <emphasis role="bold">Python 3</emphasis>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Basesystem
-        </para>
-       </entry>
-       <entry>
-        <para>
-         &slsa;, &sles4sapa;, &slehpca;, &sleda;
-        </para>
-       </entry>
-       <entry>
-        <para/>
-        <simplelist>
-         <member>
-          <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-         </member>
-         <member>
-          <emphasis role="bold">Extended:</emphasis> None
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
-         </member>
-        </simplelist>
-       </entry>
-      </row>
-      <row>
-       <entry namest="dependency" nameend="support">
-        <para>
-         This module contains the most recent version of the selected Python 3 packages.
-        </para>
-        <para>
-         The module has a different lifecycle than &sle; itself. Packages in
-         this module are frequently updated to new upstream versions.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry morerows="1">
-        <para>
-         <emphasis role="bold">Real Time</emphasis>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Basesystem, Desktop Applications, Development Tools, Server Applications
-        </para>
-       </entry>
-       <entry>
-        <para>
-         &slerta; (included)
-        </para>
-       </entry>
-       <entry>
-        <para/>
-        <simplelist>
-         <member>
-          <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-         </member>
-         <member>
-          <emphasis role="bold">Extended:</emphasis> None
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
-         </member>
-        </simplelist>
-       </entry>
-      </row>
-      <row>
-       <entry namest="dependency" nameend="support">
-        <para>
-         Aims to reduce the latency and increase the predictability and
-         reliability of time-sensitive mission-critical applications.
-        </para>
-        <para>
-         Packages in this module are generally supported until a newer version
-         of the package is released or the package is dropped from the module.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry morerows="1">
-        <para>
-         <emphasis role="bold">SAP Applications</emphasis>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Basesystem
-        </para>
-       </entry>
-       <entry>
-        <para>
-         &sles4sapa; (included)
-        </para>
-       </entry>
-       <entry>
-        <simplelist>
-         <member>
-          <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-         </member>
-         <member>
-          <emphasis role="bold">Extended:</emphasis> 3 yrs
-          ESPOS<superscript>2</superscript>, 3 yrs
-          LTSS<superscript>1</superscript> for last SP
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
-         </member>
-        </simplelist>
-       </entry>
-      </row>
-      <row>
-       <entry namest="dependency" nameend="support">
-        <para>
-         Contains packages specific to &sles4sapa;.
-        </para>
-        <!-- see https://www.suse.com/de-de/support/policy-products/#sap -->
-        <para>
-         The module has a different lifecycle than &sle; itself. Subscriptions
-         for &sles4sap; include 1.5 years of General Support plus 3 years of
-         Extended Service Pack Overlap Support (ESPOS) for each service pack.
-         This eliminates the need for customers to purchase Long Term Service
-         Pack Support (LTSS) until the final service pack of a release.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry morerows="1">
-        <para>
-         <emphasis role="bold">Server Applications</emphasis>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Basesystem
-        </para>
-       </entry>
-       <entry>
-        <para>
-         SLES (default), &sles4sapa;, &slerta; (default), &slehpca;
-        </para>
-       </entry>
-       <entry>
-        <simplelist>
-         <member>
-          <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-         </member>
-         <member>
-          <emphasis role="bold">Extended:</emphasis> 3 yrs
-          LTSS<superscript>1</superscript>
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
-         </member>
-        </simplelist>
-       </entry>
-      </row>
-      <row>
-       <entry namest="dependency" nameend="support">
-        <para>
-         Adds server functionality by providing network services such as DHCP
-         server, name server, or Web server. <phrase os="sles">This module is
-         selected for installation by default; deselecting it is not
-         recommended.</phrase>
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry morerows="1">
-        <para>
-         <emphasis role="bold">&suse; Package Hub</emphasis>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Basesystem
-        </para>
-       </entry>
-       <entry>
-        <para>
-         All products
-        </para>
-       </entry>
-       <entry>
-        <simplelist>
-         <member>
-          <emphasis role="bold">Lifecycle:</emphasis> None
-         </member>
-         <member>
-          <emphasis role="bold">Extended:</emphasis> None
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> None
-         </member>
-        </simplelist>
-       </entry>
-      </row>
-      <row>
-       <entry namest="dependency" nameend="support">
-        <para>
-         Provides access to packages for &productname; maintained by the
-         &opensuse; community. These packages are delivered without L3 support
-         but do not interfere with the supportability of &productname;. For
-         more information, refer to <link
-          xlink:href="https://packagehub.suse.com/"/>.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry morerows="1">
-        <para>
-         <emphasis role="bold">Transactional Server</emphasis>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Basesystem
-        </para>
-       </entry>
-       <entry>
-        <para>
-         SLES
-        </para>
-       </entry>
-       <entry>
-        <simplelist>
-         <member>
-          <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-         </member>
-         <member>
-          <emphasis role="bold">Extended:</emphasis> 3 yrs
-          LTSS<superscript>1</superscript>
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
-         </member>
-        </simplelist>
-       </entry>
-      </row>
-      <row>
-       <entry namest="dependency" nameend="support">
-        <para>
-         Provides &sle; systems with a method of updating the operating system
-         and its packages in an entirely ‘atomic’ way. Updates are either
-         applied to the system all together in a single transaction, or not at
-         all. This happens without influencing the running system. If an update
-         fails, or if a successful update is deemed to be incompatible or
-         incorrect, you can discard it immediately and return to its previous
-         functioning state.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry morerows="1">
-        <para>
-         <emphasis role="bold">Web and Scripting</emphasis>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Basesystem, Server Applications
-        </para>
-       </entry>
-       <entry>
-        <para>
-         &slsa;, &sles4sapa;, &slehpca;
-        </para>
-       </entry>
-       <entry>
-        <simplelist>
-         <member>
-          <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-         </member>
-         <member>
-          <emphasis role="bold">Extended:</emphasis> 3 yrs
-          LTSS<superscript>1</superscript>
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> L3
-         </member>
-        </simplelist>
-       </entry>
-      </row>
-      <row>
-       <entry namest="dependency" nameend="support">
-        <para>
-         Contains packages intended for a running Web server.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry morerows="1">
-        <para>
-         <emphasis role="bold">Workstation Extension</emphasis>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Basesystem, Desktop Applications
-        </para>
-       </entry>
-       <entry>
-        <para>
-         &slsa;, &sleda; (default), &sles4sapa;
-        </para>
-       </entry>
-       <entry>
-        <simplelist>
-         <member>
-          <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-         </member>
-         <member>
-          <emphasis role="bold">Extended:</emphasis> no
-         </member>
-         <member>
-          <emphasis role="bold">Level:</emphasis> mixed L2/L3
-          (depending on package)
-         </member>
-        </simplelist>
-       </entry>
-      </row>
-      <row>
-       <entry namest="dependency" nameend="support">
-        <para>
-         Offers additional desktop applications and libraries. It is installed
-         by default on &sled;. Adding the Workstation Extension to a &sls;
-         installation allows you to seamlessly combine both products to create a
-         fully featured server workstation. For more information, refer to <link
-          xlink:href="https://www.suse.com/products/workstation-extension"/>.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
+   <variablelist>
+    <varlistentry>
+     <term>Basesystem</term>
+     <listitem>
+      <para>
+       Adds a basic system on top of the Installer. It is required by all other
+       modules and extensions. The scope of an installation that only contains
+       the base system is comparable to the <literal>minimal</literal> system
+       installation pattern of previous &productname; versions. This module is
+       selected for installation by default and should not be deselected.
+      </para>
+      <para>
+       <emphasis role="bold">Depends on</emphasis>: n.a.
+      </para>
+      <para>
+       <emphasis role="bold">Available for:</emphasis> Default on all products
+      </para>
+      <para>
+       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+      </para>
+      <para>
+       <emphasis role="bold">Extended Support:</emphasis> 3 yrs
+       LTSS<superscript>1</superscript>
+      </para>
+      <para>
+       <emphasis role="bold">Support level:</emphasis> L3
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>Certifications</term>
+     <listitem>
+      <para>
+       Contains the FIPS 140-2 certification packages.
+      </para>
+      <para>
+       <emphasis role="bold">Depends on</emphasis>: Basesystem
+      </para>
+      <para>
+       <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;,
+       &slert;, &slehpca;
+      </para>
+      <para>
+       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+      </para>
+      <para>
+       <emphasis role="bold">Extended support:</emphasis> 3 yrs
+       LTSS<superscript>1</superscript>
+      </para>
+      <para>
+       <emphasis role="bold">Support level:</emphasis> L3
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>Containers</term>
+     <listitem>
+      <para>
+       Contains packages relating to containers, including the container
+       engine and core container-related tools such as on-premise registry.
+      </para>
+      <para>
+       <emphasis role="bold">Depends on</emphasis>: Basesystem
+      </para>
+      <para>
+       <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;,
+       &slehpca;
+      </para>
+      <para>
+       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+      </para>
+      <para>
+       <emphasis role="bold">Extended support:</emphasis> 3 yrs
+       LTSS<superscript>1</superscript>
+      </para>
+      <para>
+       <emphasis role="bold">Support level:</emphasis> L3
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>Desktop Applications</term>
+     <listitem>
+      <para>
+       Adds a graphical user interface <phrase os="sled">(Wayland)</phrase>
+       and essential desktop applications to the system.
+       <phrase os="sled">This module is selected for installation by
+        default; deselecting it is not recommended.</phrase>
+      </para>
+      <para>
+       <emphasis role="bold">Depends on</emphasis>: Basesystem
+      </para>
+      <para>
+       <emphasis role="bold">Available for:</emphasis> &slsa;, &sleda;
+       (default), &slewea; (default), &sles4sapa;, &slerta; (default), &slehpca;
+      </para>
+      <para>
+       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+      </para>
+      <para>
+       <emphasis role="bold">Extended support:</emphasis> 3 yrs
+       LTSS<superscript>1</superscript>
+      </para>
+      <para>
+       <emphasis role="bold">Level:</emphasis> L3
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>Development Tools</term>
+     <listitem>
+      <para>
+       Contains compilers (including <package>gcc</package>) and libraries
+       required for compiling and debugging applications. Replaces the former
+       Software Development Kit (SDK).
+      </para>
+      <para>
+       <emphasis role="bold">Depends on</emphasis>: Basesystem, Desktop
+       Applications
+      </para>
+      <para>
+       <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;,
+       &sleda;, &slerta; (default), &slehpca;
+      </para>
+      <para>
+       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+      </para>
+      <para>
+       <emphasis role="bold">Extended support:</emphasis> 3 yrs
+       LTSS<superscript>1</superscript>
+      </para>
+      <para>
+       <emphasis role="bold">Level:</emphasis> L3
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>High Availability</term>
+     <listitem>
+      <para>
+       Provides high-availability clustering technologies that can be deployed
+       in physical and/or virtual environments.
+      </para>
+      <para>
+       High Availability is included in the subscription for &sles4sapa; as a
+       module. It is also available as an extension for &slsa; and &slehpca;.
+       For more information about &sle; &hasi;, refer to <link
+        xlink:href="https://www.suse.com/products/highavailability"/>.
+      </para>
+      <para>
+       <emphasis role="bold">Depends on</emphasis>: Basesystem, Server Applications
+      </para>
+      <para>
+       <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;
+       (included), &slehpca;, &slert;
+      </para>
+      <para>
+       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+      </para>
+      <para>
+       <emphasis role="bold">Extended support:</emphasis> 3 yrs
+       LTSS<superscript>1</superscript>
+      </para>
+      <para>
+       <emphasis role="bold">Level:</emphasis> L3
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>High Performance Computing</term>
+     <listitem>
+      <para>
+       Contains tools and libraries related to High Performance Computing
+       (HPC).
+      </para>
+      <para>
+       <emphasis role="bold">Depends on</emphasis>: Basesystem
+      </para>
+      <para>
+       <emphasis role="bold">Available for:</emphasis> &slehpca; (included)
+      </para>
+      <para>
+       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+      </para>
+      <para>
+       <emphasis role="bold">Extended support:</emphasis> 1 yr
+       ESPOS<superscript>2</superscript>, 3 yrs
+       LTSS<superscript>1</superscript>
+      </para>
+      <para>
+       <emphasis role="bold">Level:</emphasis> L3
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>Legacy</term>
+     <listitem>
+      <para>
+       Helps you with migrating applications from earlier versions of
+       &productname; and other systems to &slsa; &productnumber;, by
+       providing packages which are discontinued on &sle;. Packages in this
+       module are selected based on the requirement for migration and the
+       level of complexity of configuration.
+      </para>
+      <para>
+       This module is recommended when migrating from a previous product
+       version.
+      </para>
+      <para>
+       Please note that this module has a different lifecycle than some of its
+       packages. Not all packages are supported for the complete lifecycle of
+       the module, but depend on migration requirements and upstream
+       lifecycles.
+      </para>
+      <para>
+       <emphasis role="bold">Depends on</emphasis>: Basesystem, Server
+       Applications
+      </para>
+      <para>
+       <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;,
+       &slehpca;
+      </para>
+      <para>
+       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+      </para>
+      <para>
+       <emphasis role="bold">Extended support:</emphasis> 3 yrs
+       LTSS<superscript>1</superscript>
+      </para>
+      <para>
+       <emphasis role="bold">Level:</emphasis> L3
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>Live Patching</term>
+     <listitem>
+      <para>
+       Provides packages to update critical components in &sle; without
+       shutting down your system, which reduces planned downtime and increases
+       service availability.
+      </para>
+      <para>
+       <emphasis role="bold">Depends on</emphasis>: Basesystem
+      </para>
+      <para>
+       <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;,
+       &slehpca; <!-- on x86-64, s390x, and ppc64le -->
+      </para>
+      <para>
+       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+      </para>
+      <para>
+       <emphasis role="bold">Extended support:</emphasis> 3 yrs
+       LTSS<superscript>1</superscript>
+      </para>
+      <para>
+       <emphasis role="bold">Level:</emphasis> L3
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>NVIDIA Compute</term>
+     <listitem>
+      <para>
+       Contains the NVIDIA CUDA (Compute Unified Device Architecture) drivers.
+      </para>
+      <para>
+       The software in this module is provided by NVIDIA under the <link
+        xlink:href="http://docs.nvidia.com/cuda/eula/">CUDA End User License
+        Agreement</link> and is not supported by &suse;.
+      </para>
+      <important>
+       <title>Do not use <command>SUSEConnect</command> to add this module</title>
+       <para>
+        Do not try to add this module with the <command>SUSEConnect</command>
+        CLI tool. <command>SUSEConnect</command> is not capable of handling
+        third-party repositories.
+       </para>
+       <para>
+        During installation, select the module from the <guimenu>Extension and
+         Module Selection</guimenu> screen. Within an installed system, run
+        <command>yast registration</command>, select <guimenu>Select
+         Extensions</guimenu>, then <literal>NVIDIA Compute Module</literal>
+        and continue with <guimenu>Next</guimenu>. Verify and accept the
+        NVIDIA repository GPG key.
+       </para>
+      </important>
+      <important>
+       <title>Combining <literal>Workstation Extension</literal> and
+        <literal>NVIDIA Compute module</literal> is unsupported</title>
+       <para>
+        The <literal>Workstation Extension</literal> provides drivers for
+        NVIDIA graphics cards. These drivers share some packages with CUDA,
+        however versions may differ. It is therefore neither recommended
+        nor supported to enable both the <literal>NVIDIA Compute
+         Module</literal> and the <literal>Workstation Extension</literal> at
+        the same time.
+       </para>
+      </important>
+      <para>
+       <emphasis role="bold">Depends on</emphasis>: Basesystem
+      </para>
+      <para>
+       <emphasis role="bold">Available for:</emphasis> &slsa; and &slehpca;
+       on &x86-64; and &aarch64;
+      </para>
+      <para>
+       <emphasis role="bold">Support:</emphasis> Software in this module is
+       provided by NVIDIA and is not supported by &suse;
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>Public Cloud</term>
+     <listitem>
+      <para>
+       Contains all tools required to create images for deploying
+       &productname; in cloud environments. For example: Amazon Web Services
+       (AWS), Microsoft Azure, Google Compute Platform, or &ostack;.
+      </para>
+      <para>
+       <emphasis role="bold">Depends on</emphasis>: Basesystem, Server Applications
+      </para>
+      <para>
+       <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;, &slehpca;
+      </para>
+      <para>
+       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+      </para>
+      <para>
+       <emphasis role="bold">Extended support:</emphasis> 3 yrs
+       LTSS<superscript>1</superscript>
+      </para>
+      <para>
+       <emphasis role="bold">Level:</emphasis> L3
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>Python 3</term>
+     <listitem>
+      <para>
+       This module contains the most recent version of selected Python 3
+       packages.
+      </para>
+      <para>
+       The module has a different lifecycle than &sle; itself. Packages in
+       this module are frequently updated to new upstream versions.
+      </para>
+      <para>
+       <emphasis role="bold">Depends on</emphasis>: Basesystem
+      </para>
+      <para>
+       <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;,
+       &slehpca;, &sleda;
+      </para>
+      <para>
+       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+      </para>
+      <para>
+       <emphasis role="bold">Extended support:</emphasis> None
+       LTSS<superscript>1</superscript>
+      </para>
+      <para>
+       <emphasis role="bold">Level:</emphasis> L3
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>Real Time</term>
+     <listitem>
+      <para>
+       Aims to reduce the latency and increase the predictability and
+       reliability of time-sensitive mission-critical applications.
+      </para>
+      <para>
+       Packages in this module are generally supported until a newer version
+       of the package is released or the package is dropped from the module.
+      </para>
+      <para>
+       <emphasis role="bold">Depends on</emphasis>: Basesystem, Desktop
+       Applications, Development Tools, Server Applications
+      </para>
+      <para>
+       <emphasis role="bold">Available for:</emphasis> &slerta; (included)
+      </para>
+      <para>
+       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+      </para>
+      <para>
+       <emphasis role="bold">Extended support:</emphasis> None
+       LTSS<superscript>1</superscript>
+      </para>
+      <para>
+       <emphasis role="bold">Level:</emphasis> L3
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>SAP Applications</term>
+     <listitem>
+      <para>
+       Contains packages specific to &sles4sapa;.
+      </para>
+      <!-- see https://www.suse.com/de-de/support/policy-products/#sap -->
+      <para>
+       The module has a different lifecycle than &sle; itself. Subscriptions
+       for &sles4sap; include 1.5 years of General Support plus 3 years of
+       Extended Service Pack Overlap Support (ESPOS) for each service pack.
+       This eliminates the need for customers to purchase Long Term Service
+       Pack Support (LTSS) until the final service pack of a release.
+      </para>
+      <para>
+       <emphasis role="bold">Depends on</emphasis>: Basesystem
+      </para>
+      <para>
+       <emphasis role="bold">Available for:</emphasis> &sles4sapa; (included)
+      </para>
+      <para>
+       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+      </para>
+      <para>
+       <emphasis role="bold">Extended support:</emphasis> 3 yrs
+       ESPOS<superscript>2</superscript>, 3 yrs
+       LTSS<superscript>1</superscript> for last SP
+      </para>
+      <para>
+       <emphasis role="bold">Level:</emphasis> L3
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>Server Applications</term>
+     <listitem>
+      <para>
+       Adds server functionality by providing network services such as DHCP
+       server, name server, or Web server. <phrase os="sles">This module is
+        selected for installation by default; deselecting it is not
+        recommended.</phrase>
+      </para>
+      <para>
+       <emphasis role="bold">Depends on</emphasis>: Basesystem
+      </para>
+      <para>
+       <emphasis role="bold">Available for:</emphasis> &slsa; (default),
+       &sles4sapa;, &slerta; (default), &slehpca;
+      </para>
+      <para>
+       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+      </para>
+      <para>
+       <emphasis role="bold">Extended support:</emphasis> 3 yrs
+       LTSS<superscript>1</superscript>
+      </para>
+      <para>
+       <emphasis role="bold">Level:</emphasis> L3
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>&suse; Package Hub</term>
+     <listitem>
+      <para>
+       Provides access to packages for &productname; maintained by the
+       &opensuse; community. These packages are delivered without L3 support
+       but do not interfere with the supportability of &productname;. For
+       more information, refer to <link
+        xlink:href="https://packagehub.suse.com/"/>.
+      </para>
+      <para>
+       <emphasis role="bold">Depends on</emphasis>: Basesystem
+      </para>
+      <para>
+       <emphasis role="bold">Available for:</emphasis> All products
+      </para>
+      <para>
+       <emphasis role="bold">Lifecycle:</emphasis> None
+      </para>
+      <para>
+       <emphasis role="bold">Extended support:</emphasis> None
+       LTSS<superscript>1</superscript>
+      </para>
+      <para>
+       <emphasis role="bold">Level:</emphasis> None
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>Transactional Server</term>
+     <listitem>
+      <para>
+       Provides &sle; systems with a method of updating the operating system
+       and its packages in an entirely ‘atomic’ way. Updates are either
+       applied to the system all together in a single transaction, or not at
+       all. This happens without influencing the running system. If an update
+       fails, or if a successful update is deemed to be incompatible or
+       incorrect, you can discard it immediately and return to its previous
+       functioning state.
+      </para>
+      <para>
+       <emphasis role="bold">Depends on</emphasis>: Basesystem
+      </para>
+      <para>
+       <emphasis role="bold">Available for:</emphasis> &slsa;
+      </para>
+      <para>
+       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+      </para>
+      <para>
+       <emphasis role="bold">Extended support:</emphasis> 3 yrs
+       LTSS<superscript>1</superscript>
+      </para>
+      <para>
+       <emphasis role="bold">Level:</emphasis> L3
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>Web and Scripting</term>
+     <listitem>
+      <para>
+       Contains packages intended for a running Web server.
+      </para>
+      <para>
+       <emphasis role="bold">Depends on</emphasis>: Basesystem, Server
+       Applications
+      </para>
+      <para>
+       <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;,
+       &slehpca;
+      </para>
+      <para>
+       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+      </para>
+      <para>
+       <emphasis role="bold">Extended support:</emphasis> 3 yrs
+       LTSS<superscript>1</superscript>
+      </para>
+      <para>
+       <emphasis role="bold">Level:</emphasis> L3
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>Workstation Extension</term>
+     <listitem>
+      <para>
+       Offers additional desktop applications and libraries. It is installed
+       by default on &sled;. Adding the Workstation Extension to a &sls;
+       installation allows you to seamlessly combine both products to create a
+       fully featured server workstation. For more information, refer to <link
+        xlink:href="https://www.suse.com/products/workstation-extension"/>.
+      </para>
+      <para>
+       <emphasis role="bold">Depends on</emphasis>: Basesystem, Desktop
+       Applications
+      </para>
+      <para>
+       <emphasis role="bold">Available for:</emphasis> &slsa;, &sleda;
+       (default), &sles4sapa;
+      </para>
+      <para>
+       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+      </para>
+      <para>
+       <emphasis role="bold">Extended support:</emphasis> None
+       LTSS<superscript>1</superscript>
+      </para>
+      <para>
+       <emphasis role="bold">Level:</emphasis> mixed L2/L3
+       (depending on package)
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
    <simplelist>
     <member>
      <superscript>1</superscript> LTSS: <link xlink:href="https://www.suse.com/products/long-term-service-pack-support/">Long-Term Service Pack Support</link>

--- a/xml/art_modules.xml
+++ b/xml/art_modules.xml
@@ -129,7 +129,7 @@
        selected for installation by default and should not be deselected.
       </para>
       <para>
-       <emphasis role="bold">Depends on</emphasis>: n.a.
+       <emphasis role="bold">Depends on:</emphasis> n.a.
       </para>
       <para>
        <emphasis role="bold">Available for:</emphasis> Default on all products
@@ -153,7 +153,7 @@
        Contains the FIPS 140-2 certification packages.
       </para>
       <para>
-       <emphasis role="bold">Depends on</emphasis>: Basesystem
+       <emphasis role="bold">Depends on:</emphasis> Basesystem
       </para>
       <para>
        <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;,
@@ -179,7 +179,7 @@
        engine and core container-related tools such as on-premise registry.
       </para>
       <para>
-       <emphasis role="bold">Depends on</emphasis>: Basesystem
+       <emphasis role="bold">Depends on:</emphasis> Basesystem
       </para>
       <para>
        <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;,
@@ -207,7 +207,7 @@
         default; deselecting it is not recommended.</phrase>
       </para>
       <para>
-       <emphasis role="bold">Depends on</emphasis>: Basesystem
+       <emphasis role="bold">Depends on:</emphasis> Basesystem
       </para>
       <para>
        <emphasis role="bold">Available for:</emphasis> &slsa;, &sleda;
@@ -234,7 +234,7 @@
        Software Development Kit (SDK).
       </para>
       <para>
-       <emphasis role="bold">Depends on</emphasis>: Basesystem, Desktop
+       <emphasis role="bold">Depends on:</emphasis> Basesystem, Desktop
        Applications
       </para>
       <para>
@@ -267,7 +267,7 @@
         xlink:href="https://www.suse.com/products/highavailability"/>.
       </para>
       <para>
-       <emphasis role="bold">Depends on</emphasis>: Basesystem, Server Applications
+       <emphasis role="bold">Depends on:</emphasis> Basesystem, Server Applications
       </para>
       <para>
        <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;
@@ -293,7 +293,7 @@
        (HPC).
       </para>
       <para>
-       <emphasis role="bold">Depends on</emphasis>: Basesystem
+       <emphasis role="bold">Depends on:</emphasis> Basesystem
       </para>
       <para>
        <emphasis role="bold">Available for:</emphasis> &slehpca; (included)
@@ -332,7 +332,7 @@
        lifecycles.
       </para>
       <para>
-       <emphasis role="bold">Depends on</emphasis>: Basesystem, Server
+       <emphasis role="bold">Depends on:</emphasis> Basesystem, Server
        Applications
       </para>
       <para>
@@ -360,7 +360,7 @@
        service availability.
       </para>
       <para>
-       <emphasis role="bold">Depends on</emphasis>: Basesystem
+       <emphasis role="bold">Depends on:</emphasis> Basesystem
       </para>
       <para>
        <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;,
@@ -418,7 +418,7 @@
        </para>
       </important>
       <para>
-       <emphasis role="bold">Depends on</emphasis>: Basesystem
+       <emphasis role="bold">Depends on:</emphasis> Basesystem
       </para>
       <para>
        <emphasis role="bold">Available for:</emphasis> &slsa; and &slehpca;
@@ -439,7 +439,7 @@
        (AWS), Microsoft Azure, Google Compute Platform, or &ostack;.
       </para>
       <para>
-       <emphasis role="bold">Depends on</emphasis>: Basesystem, Server Applications
+       <emphasis role="bold">Depends on:</emphasis> Basesystem, Server Applications
       </para>
       <para>
        <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;, &slehpca;
@@ -468,7 +468,7 @@
        this module are frequently updated to new upstream versions.
       </para>
       <para>
-       <emphasis role="bold">Depends on</emphasis>: Basesystem
+       <emphasis role="bold">Depends on:</emphasis> Basesystem
       </para>
       <para>
        <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;,
@@ -498,7 +498,7 @@
        of the package is released or the package is dropped from the module.
       </para>
       <para>
-       <emphasis role="bold">Depends on</emphasis>: Basesystem, Desktop
+       <emphasis role="bold">Depends on:</emphasis> Basesystem, Desktop
        Applications, Development Tools, Server Applications
       </para>
       <para>
@@ -531,7 +531,7 @@
        Pack Support (LTSS) until the final service pack of a release.
       </para>
       <para>
-       <emphasis role="bold">Depends on</emphasis>: Basesystem
+       <emphasis role="bold">Depends on:</emphasis> Basesystem
       </para>
       <para>
        <emphasis role="bold">Available for:</emphasis> &sles4sapa; (included)
@@ -559,7 +559,7 @@
         recommended.</phrase>
       </para>
       <para>
-       <emphasis role="bold">Depends on</emphasis>: Basesystem
+       <emphasis role="bold">Depends on:</emphasis> Basesystem
       </para>
       <para>
        <emphasis role="bold">Available for:</emphasis> &slsa; (default),
@@ -588,7 +588,7 @@
         xlink:href="https://packagehub.suse.com/"/>.
       </para>
       <para>
-       <emphasis role="bold">Depends on</emphasis>: Basesystem
+       <emphasis role="bold">Depends on:</emphasis> Basesystem
       </para>
       <para>
        <emphasis role="bold">Available for:</emphasis> All products
@@ -618,7 +618,7 @@
        functioning state.
       </para>
       <para>
-       <emphasis role="bold">Depends on</emphasis>: Basesystem
+       <emphasis role="bold">Depends on:</emphasis> Basesystem
       </para>
       <para>
        <emphasis role="bold">Available for:</emphasis> &slsa;
@@ -642,7 +642,7 @@
        Contains packages intended for a running Web server.
       </para>
       <para>
-       <emphasis role="bold">Depends on</emphasis>: Basesystem, Server
+       <emphasis role="bold">Depends on:</emphasis> Basesystem, Server
        Applications
       </para>
       <para>
@@ -672,7 +672,7 @@
         xlink:href="https://www.suse.com/products/workstation-extension"/>.
       </para>
       <para>
-       <emphasis role="bold">Depends on</emphasis>: Basesystem, Desktop
+       <emphasis role="bold">Depends on:</emphasis> Basesystem, Desktop
        Applications
       </para>
       <para>

--- a/xml/art_modules.xml
+++ b/xml/art_modules.xml
@@ -129,10 +129,10 @@
        selected for installation by default and should not be deselected.
       </para>
       <para>
-       <emphasis role="bold">Depends on:</emphasis> n.a.
+       <emphasis role="bold">Dependencies:</emphasis> n.a.
       </para>
       <para>
-       <emphasis role="bold">Available for:</emphasis> Default on all products
+       <emphasis role="bold">Availability:</emphasis> Default on all products
       </para>
       <para>
        <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
@@ -153,10 +153,10 @@
        Contains the FIPS 140-2 certification packages.
       </para>
       <para>
-       <emphasis role="bold">Depends on:</emphasis> Basesystem
+       <emphasis role="bold">Dependencies:</emphasis> Basesystem
       </para>
       <para>
-       <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;,
+       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
        &slert;, &slehpca;
       </para>
       <para>
@@ -179,10 +179,10 @@
        engine and core container-related tools such as on-premise registry.
       </para>
       <para>
-       <emphasis role="bold">Depends on:</emphasis> Basesystem
+       <emphasis role="bold">Dependencies:</emphasis> Basesystem
       </para>
       <para>
-       <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;,
+       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
        &slehpca;
       </para>
       <para>
@@ -207,10 +207,10 @@
         default; deselecting it is not recommended.</phrase>
       </para>
       <para>
-       <emphasis role="bold">Depends on:</emphasis> Basesystem
+       <emphasis role="bold">Dependencies:</emphasis> Basesystem
       </para>
       <para>
-       <emphasis role="bold">Available for:</emphasis> &slsa;, &sleda;
+       <emphasis role="bold">Availability:</emphasis> &slsa;, &sleda;
        (default), &slewea; (default), &sles4sapa;, &slerta; (default), &slehpca;
       </para>
       <para>
@@ -234,11 +234,11 @@
        Software Development Kit (SDK).
       </para>
       <para>
-       <emphasis role="bold">Depends on:</emphasis> Basesystem, Desktop
+       <emphasis role="bold">Dependencies:</emphasis> Basesystem, Desktop
        Applications
       </para>
       <para>
-       <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;,
+       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
        &sleda;, &slerta; (default), &slehpca;
       </para>
       <para>
@@ -267,10 +267,10 @@
         xlink:href="https://www.suse.com/products/highavailability"/>.
       </para>
       <para>
-       <emphasis role="bold">Depends on:</emphasis> Basesystem, Server Applications
+       <emphasis role="bold">Dependencies:</emphasis> Basesystem, Server Applications
       </para>
       <para>
-       <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;
+       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;
        (included), &slehpca;, &slert;
       </para>
       <para>
@@ -293,10 +293,10 @@
        (HPC).
       </para>
       <para>
-       <emphasis role="bold">Depends on:</emphasis> Basesystem
+       <emphasis role="bold">Dependencies:</emphasis> Basesystem
       </para>
       <para>
-       <emphasis role="bold">Available for:</emphasis> &slehpca; (included)
+       <emphasis role="bold">Availability:</emphasis> &slehpca; (included)
       </para>
       <para>
        <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
@@ -332,11 +332,11 @@
        lifecycles.
       </para>
       <para>
-       <emphasis role="bold">Depends on:</emphasis> Basesystem, Server
+       <emphasis role="bold">Dependencies:</emphasis> Basesystem, Server
        Applications
       </para>
       <para>
-       <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;,
+       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
        &slehpca;
       </para>
       <para>
@@ -360,10 +360,10 @@
        service availability.
       </para>
       <para>
-       <emphasis role="bold">Depends on:</emphasis> Basesystem
+       <emphasis role="bold">Dependencies:</emphasis> Basesystem
       </para>
       <para>
-       <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;,
+       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
        &slehpca; <!-- on x86-64, s390x, and ppc64le -->
       </para>
       <para>
@@ -418,10 +418,10 @@
        </para>
       </important>
       <para>
-       <emphasis role="bold">Depends on:</emphasis> Basesystem
+       <emphasis role="bold">Dependencies:</emphasis> Basesystem
       </para>
       <para>
-       <emphasis role="bold">Available for:</emphasis> &slsa; and &slehpca;
+       <emphasis role="bold">Availability:</emphasis> &slsa; and &slehpca;
        on &x86-64; and &aarch64;
       </para>
       <para>
@@ -439,10 +439,10 @@
        (AWS), Microsoft Azure, Google Compute Platform, or &ostack;.
       </para>
       <para>
-       <emphasis role="bold">Depends on:</emphasis> Basesystem, Server Applications
+       <emphasis role="bold">Dependencies:</emphasis> Basesystem, Server Applications
       </para>
       <para>
-       <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;, &slehpca;
+       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;, &slehpca;
       </para>
       <para>
        <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
@@ -468,10 +468,10 @@
        this module are frequently updated to new upstream versions.
       </para>
       <para>
-       <emphasis role="bold">Depends on:</emphasis> Basesystem
+       <emphasis role="bold">Dependencies:</emphasis> Basesystem
       </para>
       <para>
-       <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;,
+       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
        &slehpca;, &sleda;
       </para>
       <para>
@@ -498,11 +498,11 @@
        of the package is released or the package is dropped from the module.
       </para>
       <para>
-       <emphasis role="bold">Depends on:</emphasis> Basesystem, Desktop
+       <emphasis role="bold">Dependencies:</emphasis> Basesystem, Desktop
        Applications, Development Tools, Server Applications
       </para>
       <para>
-       <emphasis role="bold">Available for:</emphasis> &slerta; (included)
+       <emphasis role="bold">Availability:</emphasis> &slerta; (included)
       </para>
       <para>
        <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
@@ -531,10 +531,10 @@
        Pack Support (LTSS) until the final service pack of a release.
       </para>
       <para>
-       <emphasis role="bold">Depends on:</emphasis> Basesystem
+       <emphasis role="bold">Dependencies:</emphasis> Basesystem
       </para>
       <para>
-       <emphasis role="bold">Available for:</emphasis> &sles4sapa; (included)
+       <emphasis role="bold">Availability:</emphasis> &sles4sapa; (included)
       </para>
       <para>
        <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
@@ -559,10 +559,10 @@
         recommended.</phrase>
       </para>
       <para>
-       <emphasis role="bold">Depends on:</emphasis> Basesystem
+       <emphasis role="bold">Dependencies:</emphasis> Basesystem
       </para>
       <para>
-       <emphasis role="bold">Available for:</emphasis> &slsa; (default),
+       <emphasis role="bold">Availability:</emphasis> &slsa; (default),
        &sles4sapa;, &slerta; (default), &slehpca;
       </para>
       <para>
@@ -588,10 +588,10 @@
         xlink:href="https://packagehub.suse.com/"/>.
       </para>
       <para>
-       <emphasis role="bold">Depends on:</emphasis> Basesystem
+       <emphasis role="bold">Dependencies:</emphasis> Basesystem
       </para>
       <para>
-       <emphasis role="bold">Available for:</emphasis> All products
+       <emphasis role="bold">Availability:</emphasis> All products
       </para>
       <para>
        <emphasis role="bold">Lifecycle:</emphasis> None
@@ -618,10 +618,10 @@
        functioning state.
       </para>
       <para>
-       <emphasis role="bold">Depends on:</emphasis> Basesystem
+       <emphasis role="bold">Dependencies:</emphasis> Basesystem
       </para>
       <para>
-       <emphasis role="bold">Available for:</emphasis> &slsa;
+       <emphasis role="bold">Availability:</emphasis> &slsa;
       </para>
       <para>
        <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
@@ -642,11 +642,11 @@
        Contains packages intended for a running Web server.
       </para>
       <para>
-       <emphasis role="bold">Depends on:</emphasis> Basesystem, Server
+       <emphasis role="bold">Dependencies:</emphasis> Basesystem, Server
        Applications
       </para>
       <para>
-       <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;,
+       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
        &slehpca;
       </para>
       <para>
@@ -672,11 +672,11 @@
         xlink:href="https://www.suse.com/products/workstation-extension"/>.
       </para>
       <para>
-       <emphasis role="bold">Depends on:</emphasis> Basesystem, Desktop
+       <emphasis role="bold">Dependencies:</emphasis> Basesystem, Desktop
        Applications
       </para>
       <para>
-       <emphasis role="bold">Available for:</emphasis> &slsa;, &sleda;
+       <emphasis role="bold">Availability:</emphasis> &slsa;, &sleda;
        (default), &sles4sapa;
       </para>
       <para>

--- a/xml/art_modules.xml
+++ b/xml/art_modules.xml
@@ -125,10 +125,7 @@
   <title>Modules and extensions for the &sle; product family</title>
   <para>
    The following modules and extensions are available within the &sle; product
-   family. Note that the availability depends on the product (refer to the
-   column <emphasis>Available for</emphasis>). For more information about
-   lifecycle, release frequency, and the overlay support period, see
-   <link xlink:href="https://www.suse.com/lifecycle"/>.
+   family:
   </para>
   <!--
    cwickert 2021-12-17: Information for the following table was taken from
@@ -139,7 +136,7 @@
    https://bugzilla.suse.com/1189275#c9 and
    https://jira.suse.com/browse/SLE-17270
   -->
-  <sect2>
+  <sect2 xml:id="art-modules-basesystem">
    <title>Basesystem</title>
    <para>
     This module adds a basic system on top of the Installer. It is required by
@@ -166,8 +163,7 @@
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">Extended Support:</emphasis> 3 yrs
-      LTSS<superscript>1</superscript>
+      <emphasis role="bold">Extended Support:</emphasis> 3 yrs LTSS
      </para>
     </listitem>
     <listitem>
@@ -177,7 +173,7 @@
     </listitem>
    </itemizedlist>
   </sect2>
-  <sect2>
+  <sect2 xml:base="art-modules-certifications">
    <title>Certifications</title>
    <para>
     This module contains the FIPS 140-2 certification packages.
@@ -201,8 +197,7 @@
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">Extended support:</emphasis> 3 yrs
-      LTSS<superscript>1</superscript>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs LTSS
      </para>
     </listitem>
     <listitem>
@@ -212,7 +207,7 @@
     </listitem>
    </itemizedlist>
   </sect2>
-  <sect2>
+  <sect2 xml:id="art-modules-containers">
    <title>Containers</title>
    <para>
     This module contains packages relating to containers, including the
@@ -238,8 +233,7 @@
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">Extended support:</emphasis> 3 yrs
-      LTSS<superscript>1</superscript>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs LTSS
      </para>
     </listitem>
     <listitem>
@@ -249,12 +243,12 @@
     </listitem>
    </itemizedlist>
   </sect2>
-  <sect2>
+  <sect2 xml:id="art-modules-desktop-applications">
    <title>Desktop Applications</title>
    <para>
-    Adds a graphical user interface <phrase os="sled">(Wayland)</phrase>
-    and essential desktop applications to the system.
-    <phrase os="sled">This module is selected for installation by
+    This module adds a graphical user interface <phrase
+     os="sled">(Wayland)</phrase> and essential desktop applications to the
+    system. <phrase os="sled">This module is selected for installation by
      default; deselecting it is not recommended.</phrase>
    </para>
    <itemizedlist>
@@ -276,8 +270,7 @@
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">Extended support:</emphasis> 3 yrs
-      LTSS<superscript>1</superscript>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs LTSS
      </para>
     </listitem>
     <listitem>
@@ -287,12 +280,12 @@
     </listitem>
    </itemizedlist>
   </sect2>
-  <sect2>
+  <sect2 xml:id="art-modules-development">
    <title>Development Tools</title>
    <para>
-    Contains compilers (including <package>gcc</package>) and libraries
-    required for compiling and debugging applications. Replaces the former
-    Software Development Kit (SDK).
+    This module contains compilers (including <package>gcc</package>) and
+    libraries required for compiling and debugging applications. Replaces the
+    former Software Development Kit (SDK).
    </para>
    <para>
     <emphasis role="bold">Dependencies:</emphasis> Basesystem, Desktop
@@ -312,8 +305,7 @@
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">Extended support:</emphasis> 3 yrs
-      LTSS<superscript>1</superscript>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs LTSS
      </para>
     </listitem>
     <listitem>
@@ -323,11 +315,11 @@
     </listitem>
    </itemizedlist>
   </sect2>
-  <sect2>
+  <sect2 xml:id="art-modules-high-availability">
    <title>High Availability</title>
    <para>
-    Provides high-availability clustering technologies that can be deployed
-    in physical and/or virtual environments.
+    This extension provides high-availability clustering technologies that can
+    be deployed in physical and/or virtual environments.
    </para>
    <para>
     High Availability is included in the subscription for &sles4sapa; as a
@@ -354,8 +346,7 @@
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">Extended support:</emphasis> 3 yrs
-      LTSS<superscript>1</superscript>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs LTSS
      </para>
     </listitem>
     <listitem>
@@ -365,11 +356,11 @@
     </listitem>
    </itemizedlist>
   </sect2>
-  <sect2>
+  <sect2 xml:id="art-modules-high-performance-computing">
    <title>High Performance Computing</title>
    <para>
-    Contains tools and libraries related to High Performance Computing
-    (HPC).
+    This extension contains tools and libraries related to High Performance
+    Computing (HPC).
    </para>
    <itemizedlist>
     <listitem>
@@ -389,9 +380,8 @@
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">Extended support:</emphasis> 1 yr
-      ESPOS<superscript>2</superscript>, 3 yrs
-      LTSS<superscript>1</superscript>
+      <emphasis role="bold">Extended support:</emphasis> 1 year ESPOS, 3 yrs
+      LTSS
      </para>
     </listitem>
     <listitem>
@@ -401,10 +391,10 @@
     </listitem>
    </itemizedlist>
   </sect2>
-  <sect2>
+  <sect2 xml:id="art-modules-legacy">
    <title>Legacy</title>
    <para>
-    Helps you with migrating applications from earlier versions of
+    This module helps you with migrating applications from earlier versions of
     &productname; and other systems to &slsa; &productnumber;, by
     providing packages which are discontinued on &sle;. Packages in this
     module are selected based on the requirement for migration and the
@@ -440,8 +430,7 @@
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">Extended support:</emphasis> 3 yrs
-      LTSS<superscript>1</superscript>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs LTSS
      </para>
     </listitem>
     <listitem>
@@ -451,12 +440,12 @@
     </listitem>
    </itemizedlist>
   </sect2>
-  <sect2>
+  <sect2 xml:id="art-modules-live-patching">
    <title>Live Patching</title>
    <para>
-    Provides packages to update critical components in &sle; without
-    shutting down your system, which reduces planned downtime and increases
-    service availability.
+    This extension provides packages to update critical components in &sle;
+    without shutting down your system, which reduces planned downtime and
+    increases service availability.
    </para>
    <itemizedlist>
     <listitem>
@@ -477,8 +466,7 @@
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">Extended support:</emphasis> 3 yrs
-      LTSS<superscript>1</superscript>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs LTSS
      </para>
     </listitem>
     <listitem>
@@ -488,13 +476,11 @@
     </listitem>
    </itemizedlist>
   </sect2>
-  <sect2>
+  <sect2 xml:id="art-modules-nvidia-compute">
    <title>NVIDIA Compute</title>
    <para>
-    Contains the NVIDIA CUDA (Compute Unified Device Architecture) drivers.
-   </para>
-   <para>
-    The software in this module is provided by NVIDIA under the <link
+    This module contains the NVIDIA CUDA (Compute Unified Device Architecture)
+    drivers. The software in this module is provided by NVIDIA under the <link
      xlink:href="http://docs.nvidia.com/cuda/eula/">CUDA End User License
      Agreement</link> and is not supported by &suse;.
    </para>
@@ -546,10 +532,10 @@
     </listitem>
    </itemizedlist>
   </sect2>
-  <sect2>
+  <sect2 xml:id="art-modules-public-cloud">
    <title>Public Cloud</title>
    <para>
-    Contains all tools required to create images for deploying
+    This module Contains all tools required to create images for deploying
     &productname; in cloud environments. For example: Amazon Web Services
     (AWS), Microsoft Azure, Google Compute Platform, or &ostack;.
    </para>
@@ -571,8 +557,7 @@
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">Extended support:</emphasis> 3 yrs
-      LTSS<superscript>1</superscript>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs LTSS
      </para>
     </listitem>
     <listitem>
@@ -582,15 +567,12 @@
     </listitem>
    </itemizedlist>
   </sect2>
-  <sect2>
+  <sect2 xml:id="art-modules-python-3">
    <title>Python 3</title>
    <para>
-    This module contains the most recent version of selected Python 3
-    packages.
-   </para>
-   <para>
-    The module has a different lifecycle than &sle; itself. Packages in
-    this module are frequently updated to new upstream versions.
+    This module contains the most recent version of selected Python 3 packages.
+    It has a different lifecycle than &sle; itself. Packages in this module are
+    frequently updated to new upstream versions.
    </para>
    <itemizedlist>
     <listitem>
@@ -612,7 +594,6 @@
     <listitem>
      <para>
       <emphasis role="bold">Extended support:</emphasis> None
-      LTSS<superscript>1</superscript>
      </para>
     </listitem>
     <listitem>
@@ -622,11 +603,11 @@
     </listitem>
    </itemizedlist>
   </sect2>
-  <sect2>
+  <sect2 xml:id="art-modules-real-time">
    <title>Real Time</title>
    <para>
-    Aims to reduce the latency and increase the predictability and
-    reliability of time-sensitive mission-critical applications.
+    This extension aims to reduce the latency and increase the predictability
+    and reliability of time-sensitive mission-critical applications.
    </para>
    <para>
     Packages in this module are generally supported until a newer version
@@ -661,18 +642,16 @@
     </listitem>
    </itemizedlist>
   </sect2>
-  <sect2>
+  <sect2 xml:id="art-modules-sap-applications">
    <title>SAP Applications</title>
-   <para>
-    Contains packages specific to &sles4sapa;.
-   </para>
    <!-- see https://www.suse.com/de-de/support/policy-products/#sap -->
    <para>
-    The module has a different lifecycle than &sle; itself. Subscriptions
-    for &sles4sap; include 1.5 years of General Support plus 3 years of
-    Extended Service Pack Overlap Support (ESPOS) for each service pack.
-    This eliminates the need for customers to purchase Long Term Service
-    Pack Support (LTSS) until the final service pack of a release.
+    This module contains packages specific to &sles4sapa;. It has a different
+    lifecycle than &sle; itself. Subscriptions for &sles4sap; include 1.5 years
+    of General Support plus 3 years of Extended Service Pack Overlap Support
+    (ESPOS) for each service pack. This eliminates the need for customers to
+    purchase Long Term Service Pack Support (LTSS) until the final service pack
+    of a release.
    </para>
    <itemizedlist>
     <listitem>
@@ -692,9 +671,8 @@
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">Extended support:</emphasis> 3 yrs
-      ESPOS<superscript>2</superscript>, 3 yrs
-      LTSS<superscript>1</superscript> for last SP
+      <emphasis role="bold">Extended support:</emphasis> 3 years ESPOS, 3 years
+      LTSS for last SP
      </para>
     </listitem>
     <listitem>
@@ -704,11 +682,11 @@
     </listitem>
    </itemizedlist>
   </sect2>
-  <sect2>
+  <sect2 xml:id="art-modules-server-applications">
    <title>Server Applications</title>
    <para>
-    Adds server functionality by providing network services such as DHCP
-    server, name server, or Web server. <phrase os="sles">This module is
+    This module adds server functionality by providing network services such as
+    DHCP server, name server, or Web server. <phrase os="sles">This module is
      selected for installation by default; deselecting it is not
      recommended.</phrase>
    </para>
@@ -731,8 +709,7 @@
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">Extended support:</emphasis> 3 yrs
-      LTSS<superscript>1</superscript>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs LTSS
      </para>
     </listitem>
     <listitem>
@@ -742,14 +719,13 @@
     </listitem>
    </itemizedlist>
   </sect2>
-  <sect2>
+  <sect2 xml:id="art-modules-suse-package-hub">
    <title>&suse; Package Hub</title>
    <para>
-    The <literal>&suse; Package Hub</literal> Provides access to packages for
-    &productname; maintained by the &opensuse; community. These packages are delivered without L3 support
-    but do not interfere with the supportability of &productname;. For
-    more information, refer to <link
-     xlink:href="https://packagehub.suse.com/"/>.
+    This module provides access to packages for &productname; maintained by the
+    &opensuse; community. These packages are delivered without L3 support but do
+    not interfere with the supportability of &productname;. For more
+    information, refer to <link xlink:href="https://packagehub.suse.com/"/>.
    </para>
    <itemizedlist>
     <listitem>
@@ -770,7 +746,6 @@
     <listitem>
      <para>
       <emphasis role="bold">Extended support:</emphasis> None
-      LTSS<superscript>1</superscript>
      </para>
     </listitem>
     <listitem>
@@ -780,16 +755,15 @@
     </listitem>
    </itemizedlist>
   </sect2>
-  <sect2>
+  <sect2 xml:id="art-modules-transactional-server">
    <title>Transactional Server</title>
    <para>
-    The <literal>Transactional Server</literal> module provides &sle; systems
-    with a method of updating the operating system and its packages in an
-    entirely ‘atomic’ way. Updates are either applied to the system all together
-    in a single transaction, or not at all. This happens without influencing the
-    running system. If an update fails, or if a successful update is deemed to
-    be incompatible or incorrect, you can discard it immediately and return to
-    its previous functioning state.
+    This module provides &sle; systems with a method of updating the operating
+    system and its packages in an entirely ‘atomic’ way. Updates are either
+    applied to the system all together in a single transaction, or not at all.
+    This happens without influencing the running system. If an update fails, or
+    if a successful update is deemed to be incompatible or incorrect, you can
+    discard it immediately and return to its previous functioning state.
    </para>
    <itemizedlist>
     <listitem>
@@ -809,8 +783,7 @@
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">Extended support:</emphasis> 3 yrs
-      LTSS<superscript>1</superscript>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs LTSS
      </para>
     </listitem>
     <listitem>
@@ -820,11 +793,10 @@
     </listitem>
    </itemizedlist>
   </sect2>
-  <sect2>
+  <sect2 xml:id="art-modules-web-scripting">
    <title>Web and Scripting</title>
    <para>
-    The <literal>Web and Scripting</literal> module contains packages intended
-    for a running Web server.
+    This module contains packages intended for a running Web server.
    </para>
    <itemizedlist>
     <listitem>
@@ -846,8 +818,7 @@
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">Extended support:</emphasis> 3 yrs
-      LTSS<superscript>1</superscript>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs LTSS
      </para>
     </listitem>
     <listitem>
@@ -857,14 +828,13 @@
     </listitem>
    </itemizedlist>
   </sect2>
-  <sect2>
+  <sect2 xml:id="art-modules-workstation">
    <title>Workstation Extension</title>
    <para>
-    The <literal>Workstation Extension</literal> offers additional desktop
-    applications and libraries. It is installed by default on &sled;. Adding the
-    Workstation Extension to a &sls; installation allows you to seamlessly
-    combine both products to create a fully featured server workstation. For
-    more information, refer to <link
+    This extension offers additional desktop applications and libraries. It is
+    installed by default on &sled;. Adding the Workstation Extension to a &sls;
+    installation allows you to seamlessly combine both products to create a
+    fully featured server workstation. For more information, refer to <link
      xlink:href="https://www.suse.com/products/workstation-extension"/>.
    </para>
    <itemizedlist>

--- a/xml/art_modules.xml
+++ b/xml/art_modules.xml
@@ -966,7 +966,7 @@
  </sect1>
 
  <sect1 xml:id="sec-modules-install">
-  <title>Installing and managing</title>
+  <title>Installing and managing modules and extensions</title>
   <para>
    Modules and extensions can be installed when initially setting up
    the system and on an existing &productname; installation.

--- a/xml/art_modules.xml
+++ b/xml/art_modules.xml
@@ -88,6 +88,37 @@
     </listitem>
    </varlistentry>
   </variablelist>
+  <sect2 xml:id="art-modules-support">
+   <title>Support</title>
+   <para>
+    L3 support is generally provided for packages except for <literal>&suse;
+     Package Hub</literal> and third-party modules. To check the support level
+    for a package, run
+    <command>zypper info <replaceable>PACKAGE</replaceable></command>.
+   </para>
+   <para>
+    <literal>Long-Term Service Pack Support </literal>(LTSS) is available for
+    most modules and extensions. For more information, refer to <link
+     xlink:href="https://www.suse.com/products/long-term-service-pack-support/">Long-Term
+     Service Pack Support</link>.
+   </para>
+   <para>
+    Some modules and extensions also include <literal>Extended Service Pack
+     Overlay Support</literal> (ESPOS). For more information, refer to <link
+     xlink:href="https://www.suse.com/support/policy-products/#hpc">Extended
+     Service Pack Overlay Support</link>.
+   </para>
+   <para>
+    Fore more information on support and lifecycles, refer to the
+    <link xlink:href="https://www.suse.com/support/policy/">SUSE Technical
+     Support Policy</link> and the
+    <link xlink:href="https://www.suse.com/support/policy-products/">Product
+     Lifecycle Support Policies</link>.  For a complete list of lifecycle dates
+    by product, refer to the
+    <link xlink:href="https://www.suse.com/lifecycle/">Product Support
+     Lifecycle</link> page.
+   </para>
+  </sect2>
  </sect1>
 
  <sect1 xml:id="sec-modules-list">
@@ -99,15 +130,6 @@
    lifecycle, release frequency, and the overlay support period, see
    <link xlink:href="https://www.suse.com/lifecycle"/>.
   </para>
-  <note>
-   <title>L3 support</title>
-   <para>
-    L3 support is generally provided for packages in modules. However, this
-    excludes <literal>Package Hub</literal> and third-party modules. To check
-    the support level for a package, run
-    <command>zypper info <replaceable>PACKAGE</replaceable></command>.
-   </para>
-  </note>
   <!--
    cwickert 2021-12-17: Information for the following table was taken from
    https://confluence.suse.com/x/GQHiHw#id-[SLE15SP3]PRDallinone-ModuleLTSS
@@ -117,590 +139,763 @@
    https://bugzilla.suse.com/1189275#c9 and
    https://jira.suse.com/browse/SLE-17270
   -->
-  <variablelist>
-   <varlistentry>
-    <term>Basesystem</term>
+  <sect2>
+   <title>Basesystem</title>
+   <para>
+    This module adds a basic system on top of the Installer. It is required by
+    all other modules and extensions. The scope of an installation that only
+    contains the base system is comparable to the <literal>minimal</literal>
+    system installation pattern of previous &productname; versions. This module
+    is selected for installation by default and should not be deselected.
+   </para>
+   <itemizedlist>
     <listitem>
-     <para>
-      Adds a basic system on top of the Installer. It is required by all other
-      modules and extensions. The scope of an installation that only contains
-      the base system is comparable to the <literal>minimal</literal> system
-      installation pattern of previous &productname; versions. This module is
-      selected for installation by default and should not be deselected.
-     </para>
      <para>
       <emphasis role="bold">Dependencies:</emphasis> n.a.
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Availability:</emphasis> Default on all products
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Extended Support:</emphasis> 3 yrs
       LTSS<superscript>1</superscript>
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Support level:</emphasis> L3
      </para>
     </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>Certifications</term>
+   </itemizedlist>
+  </sect2>
+  <sect2>
+   <title>Certifications</title>
+   <para>
+    This module contains the FIPS 140-2 certification packages.
+   </para>
+   <itemizedlist>
     <listitem>
      <para>
-      Contains the FIPS 140-2 certification packages.
+      <emphasis role="bold">Depends on</emphasis>: Basesystem
      </para>
+    </listitem>
+    <listitem>
      <para>
-      <emphasis role="bold">Dependencies:</emphasis> Basesystem
-     </para>
-     <para>
-      <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
+      <emphasis role="bold">Available for:</emphasis> &slsa;, &sles4sapa;,
       &slert;, &slehpca;
-     </para>
+     </para>  
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-     </para>
+     </para>  
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Extended support:</emphasis> 3 yrs
       LTSS<superscript>1</superscript>
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Support level:</emphasis> L3
      </para>
     </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>Containers</term>
+   </itemizedlist>
+  </sect2>
+  <sect2>
+   <title>Containers</title>
+   <para>
+    This module contains packages relating to containers, including the
+    container engine and core container-related tools such as on-premise
+    registry.
+   </para>
+   <itemizedlist>
     <listitem>
-     <para>
-      Contains packages relating to containers, including the container
-      engine and core container-related tools such as on-premise registry.
-     </para>
      <para>
       <emphasis role="bold">Dependencies:</emphasis> Basesystem
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
       &slehpca;
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Extended support:</emphasis> 3 yrs
       LTSS<superscript>1</superscript>
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Support level:</emphasis> L3
      </para>
     </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>Desktop Applications</term>
+   </itemizedlist>
+  </sect2>
+  <sect2>
+   <title>Desktop Applications</title>
+   <para>
+    Adds a graphical user interface <phrase os="sled">(Wayland)</phrase>
+    and essential desktop applications to the system.
+    <phrase os="sled">This module is selected for installation by
+     default; deselecting it is not recommended.</phrase>
+   </para>
+   <itemizedlist>
     <listitem>
-     <para>
-      Adds a graphical user interface <phrase os="sled">(Wayland)</phrase>
-      and essential desktop applications to the system.
-      <phrase os="sled">This module is selected for installation by
-       default; deselecting it is not recommended.</phrase>
-     </para>
      <para>
       <emphasis role="bold">Dependencies:</emphasis> Basesystem
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Availability:</emphasis> &slsa;, &sleda;
       (default), &slewea; (default), &sles4sapa;, &slerta; (default), &slehpca;
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Extended support:</emphasis> 3 yrs
       LTSS<superscript>1</superscript>
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Level:</emphasis> L3
      </para>
     </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>Development Tools</term>
+   </itemizedlist>
+  </sect2>
+  <sect2>
+   <title>Development Tools</title>
+   <para>
+    Contains compilers (including <package>gcc</package>) and libraries
+    required for compiling and debugging applications. Replaces the former
+    Software Development Kit (SDK).
+   </para>
+   <para>
+    <emphasis role="bold">Dependencies:</emphasis> Basesystem, Desktop
+    Applications
+   </para>
+   <itemizedlist>
     <listitem>
-     <para>
-      Contains compilers (including <package>gcc</package>) and libraries
-      required for compiling and debugging applications. Replaces the former
-      Software Development Kit (SDK).
-     </para>
-     <para>
-      <emphasis role="bold">Dependencies:</emphasis> Basesystem, Desktop
-      Applications
-     </para>
      <para>
       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
       &sleda;, &slerta; (default), &slehpca;
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Extended support:</emphasis> 3 yrs
       LTSS<superscript>1</superscript>
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Level:</emphasis> L3
      </para>
     </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>High Availability</term>
+   </itemizedlist>
+  </sect2>
+  <sect2>
+   <title>High Availability</title>
+   <para>
+    Provides high-availability clustering technologies that can be deployed
+    in physical and/or virtual environments.
+   </para>
+   <para>
+    High Availability is included in the subscription for &sles4sapa; as a
+    module. It is also available as an extension for &slsa; and &slehpca;.
+    For more information about &sle; &hasi;, refer to <link
+     xlink:href="https://www.suse.com/products/highavailability"/>.
+   </para>
+   <itemizedlist>
     <listitem>
-     <para>
-      Provides high-availability clustering technologies that can be deployed
-      in physical and/or virtual environments.
-     </para>
-     <para>
-      High Availability is included in the subscription for &sles4sapa; as a
-      module. It is also available as an extension for &slsa; and &slehpca;.
-      For more information about &sle; &hasi;, refer to <link
-       xlink:href="https://www.suse.com/products/highavailability"/>.
-     </para>
      <para>
       <emphasis role="bold">Dependencies:</emphasis> Basesystem, Server Applications
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;
       (included), &slehpca;, &slert;
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Extended support:</emphasis> 3 yrs
       LTSS<superscript>1</superscript>
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Level:</emphasis> L3
      </para>
     </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>High Performance Computing</term>
+   </itemizedlist>
+  </sect2>
+  <sect2>
+   <title>High Performance Computing</title>
+   <para>
+    Contains tools and libraries related to High Performance Computing
+    (HPC).
+   </para>
+   <itemizedlist>
     <listitem>
-     <para>
-      Contains tools and libraries related to High Performance Computing
-      (HPC).
-     </para>
      <para>
       <emphasis role="bold">Dependencies:</emphasis> Basesystem
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Availability:</emphasis> &slehpca; (included)
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Extended support:</emphasis> 1 yr
       ESPOS<superscript>2</superscript>, 3 yrs
       LTSS<superscript>1</superscript>
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Level:</emphasis> L3
      </para>
     </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>Legacy</term>
+   </itemizedlist>
+  </sect2>
+  <sect2>
+   <title>Legacy</title>
+   <para>
+    Helps you with migrating applications from earlier versions of
+    &productname; and other systems to &slsa; &productnumber;, by
+    providing packages which are discontinued on &sle;. Packages in this
+    module are selected based on the requirement for migration and the
+    level of complexity of configuration.
+   </para>
+   <para>
+    This module is recommended when migrating from a previous product
+    version.
+   </para>
+   <para>
+    Please note that this module has a different lifecycle than some of its
+    packages. Not all packages are supported for the complete lifecycle of
+    the module, but depend on migration requirements and upstream
+    lifecycles.
+   </para>
+   <itemizedlist>
     <listitem>
-     <para>
-      Helps you with migrating applications from earlier versions of
-      &productname; and other systems to &slsa; &productnumber;, by
-      providing packages which are discontinued on &sle;. Packages in this
-      module are selected based on the requirement for migration and the
-      level of complexity of configuration.
-     </para>
-     <para>
-      This module is recommended when migrating from a previous product
-      version.
-     </para>
-     <para>
-      Please note that this module has a different lifecycle than some of its
-      packages. Not all packages are supported for the complete lifecycle of
-      the module, but depend on migration requirements and upstream
-      lifecycles.
-     </para>
      <para>
       <emphasis role="bold">Dependencies:</emphasis> Basesystem, Server
       Applications
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
       &slehpca;
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Extended support:</emphasis> 3 yrs
       LTSS<superscript>1</superscript>
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Level:</emphasis> L3
      </para>
     </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>Live Patching</term>
+   </itemizedlist>
+  </sect2>
+  <sect2>
+   <title>Live Patching</title>
+   <para>
+    Provides packages to update critical components in &sle; without
+    shutting down your system, which reduces planned downtime and increases
+    service availability.
+   </para>
+   <itemizedlist>
     <listitem>
-     <para>
-      Provides packages to update critical components in &sle; without
-      shutting down your system, which reduces planned downtime and increases
-      service availability.
-     </para>
      <para>
       <emphasis role="bold">Dependencies:</emphasis> Basesystem
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
       &slehpca; <!-- on x86-64, s390x, and ppc64le -->
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Extended support:</emphasis> 3 yrs
       LTSS<superscript>1</superscript>
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Level:</emphasis> L3
      </para>
     </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>NVIDIA Compute</term>
+   </itemizedlist>
+  </sect2>
+  <sect2>
+   <title>NVIDIA Compute</title>
+   <para>
+    Contains the NVIDIA CUDA (Compute Unified Device Architecture) drivers.
+   </para>
+   <para>
+    The software in this module is provided by NVIDIA under the <link
+     xlink:href="http://docs.nvidia.com/cuda/eula/">CUDA End User License
+     Agreement</link> and is not supported by &suse;.
+   </para>
+   <important>
+    <title>Do not use <command>SUSEConnect</command> to add this module</title>
+    <para>
+     Do not try to add this module with the <command>SUSEConnect</command>
+     CLI tool. <command>SUSEConnect</command> is not capable of handling
+     third-party repositories.
+    </para>
+    <para>
+     During installation, select the module from the <guimenu>Extension and
+      Module Selection</guimenu> screen. Within an installed system, run
+     <command>yast registration</command>, select <guimenu>Select
+      Extensions</guimenu>, then <literal>NVIDIA Compute Module</literal>
+     and continue with <guimenu>Next</guimenu>. Verify and accept the
+     NVIDIA repository GPG key.
+    </para>
+   </important>
+   <important>
+    <title>Combining <literal>Workstation Extension</literal> and
+     <literal>NVIDIA Compute module</literal> is unsupported</title>
+    <para>
+     The <literal>Workstation Extension</literal> provides drivers for
+     NVIDIA graphics cards. These drivers share some packages with CUDA,
+     however versions may differ. It is therefore neither recommended
+     nor supported to enable both the <literal>NVIDIA Compute
+      Module</literal> and the <literal>Workstation Extension</literal> at
+     the same time.
+    </para>
+   </important>
+   <itemizedlist>
     <listitem>
-     <para>
-      Contains the NVIDIA CUDA (Compute Unified Device Architecture) drivers.
-     </para>
-     <para>
-      The software in this module is provided by NVIDIA under the <link
-       xlink:href="http://docs.nvidia.com/cuda/eula/">CUDA End User License
-       Agreement</link> and is not supported by &suse;.
-     </para>
-     <important>
-      <title>Do not use <command>SUSEConnect</command> to add this module</title>
-      <para>
-       Do not try to add this module with the <command>SUSEConnect</command>
-       CLI tool. <command>SUSEConnect</command> is not capable of handling
-       third-party repositories.
-      </para>
-      <para>
-       During installation, select the module from the <guimenu>Extension and
-        Module Selection</guimenu> screen. Within an installed system, run
-       <command>yast registration</command>, select <guimenu>Select
-        Extensions</guimenu>, then <literal>NVIDIA Compute Module</literal>
-       and continue with <guimenu>Next</guimenu>. Verify and accept the
-       NVIDIA repository GPG key.
-      </para>
-     </important>
-     <important>
-      <title>Combining <literal>Workstation Extension</literal> and
-       <literal>NVIDIA Compute module</literal> is unsupported</title>
-      <para>
-       The <literal>Workstation Extension</literal> provides drivers for
-       NVIDIA graphics cards. These drivers share some packages with CUDA,
-       however versions may differ. It is therefore neither recommended
-       nor supported to enable both the <literal>NVIDIA Compute
-        Module</literal> and the <literal>Workstation Extension</literal> at
-       the same time.
-      </para>
-     </important>
      <para>
       <emphasis role="bold">Dependencies:</emphasis> Basesystem
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Availability:</emphasis> &slsa; and &slehpca;
       on &x86-64; and &aarch64;
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Support:</emphasis> Software in this module is
       provided by NVIDIA and is not supported by &suse;
      </para>
     </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>Public Cloud</term>
+   </itemizedlist>
+  </sect2>
+  <sect2>
+   <title>Public Cloud</title>
+   <para>
+    Contains all tools required to create images for deploying
+    &productname; in cloud environments. For example: Amazon Web Services
+    (AWS), Microsoft Azure, Google Compute Platform, or &ostack;.
+   </para>
+   <itemizedlist>
     <listitem>
-     <para>
-      Contains all tools required to create images for deploying
-      &productname; in cloud environments. For example: Amazon Web Services
-      (AWS), Microsoft Azure, Google Compute Platform, or &ostack;.
-     </para>
      <para>
       <emphasis role="bold">Dependencies:</emphasis> Basesystem, Server Applications
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;, &slehpca;
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Extended support:</emphasis> 3 yrs
       LTSS<superscript>1</superscript>
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Level:</emphasis> L3
      </para>
     </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>Python 3</term>
+   </itemizedlist>
+  </sect2>
+  <sect2>
+   <title>Python 3</title>
+   <para>
+    This module contains the most recent version of selected Python 3
+    packages.
+   </para>
+   <para>
+    The module has a different lifecycle than &sle; itself. Packages in
+    this module are frequently updated to new upstream versions.
+   </para>
+   <itemizedlist>
     <listitem>
-     <para>
-      This module contains the most recent version of selected Python 3
-      packages.
-     </para>
-     <para>
-      The module has a different lifecycle than &sle; itself. Packages in
-      this module are frequently updated to new upstream versions.
-     </para>
      <para>
       <emphasis role="bold">Dependencies:</emphasis> Basesystem
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
       &slehpca;, &sleda;
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Extended support:</emphasis> None
       LTSS<superscript>1</superscript>
      </para>
-     <para>
-      <emphasis role="bold">Level:</emphasis> L3
-     </para>
     </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>Real Time</term>
     <listitem>
      <para>
-      Aims to reduce the latency and increase the predictability and
-      reliability of time-sensitive mission-critical applications.
+     <emphasis role="bold">Level:</emphasis> L3
      </para>
-     <para>
-      Packages in this module are generally supported until a newer version
-      of the package is released or the package is dropped from the module.
-     </para>
+    </listitem>
+   </itemizedlist>
+  </sect2>
+  <sect2>
+   <title>Real Time</title>
+   <para>
+    Aims to reduce the latency and increase the predictability and
+    reliability of time-sensitive mission-critical applications.
+   </para>
+   <para>
+    Packages in this module are generally supported until a newer version
+    of the package is released or the package is dropped from the module.
+   </para>
+   <itemizedlist>
+    <listitem>
      <para>
       <emphasis role="bold">Dependencies:</emphasis> Basesystem, Desktop
       Applications, Development Tools, Server Applications
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Availability:</emphasis> &slerta; (included)
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Extended support:</emphasis> None
-      LTSS<superscript>1</superscript>
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Level:</emphasis> L3
      </para>
     </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>SAP Applications</term>
+   </itemizedlist>
+  </sect2>
+  <sect2>
+   <title>SAP Applications</title>
+   <para>
+    Contains packages specific to &sles4sapa;.
+   </para>
+   <!-- see https://www.suse.com/de-de/support/policy-products/#sap -->
+   <para>
+    The module has a different lifecycle than &sle; itself. Subscriptions
+    for &sles4sap; include 1.5 years of General Support plus 3 years of
+    Extended Service Pack Overlap Support (ESPOS) for each service pack.
+    This eliminates the need for customers to purchase Long Term Service
+    Pack Support (LTSS) until the final service pack of a release.
+   </para>
+   <itemizedlist>
     <listitem>
-     <para>
-      Contains packages specific to &sles4sapa;.
-     </para>
-     <!-- see https://www.suse.com/de-de/support/policy-products/#sap -->
-     <para>
-      The module has a different lifecycle than &sle; itself. Subscriptions
-      for &sles4sap; include 1.5 years of General Support plus 3 years of
-      Extended Service Pack Overlap Support (ESPOS) for each service pack.
-      This eliminates the need for customers to purchase Long Term Service
-      Pack Support (LTSS) until the final service pack of a release.
-     </para>
      <para>
       <emphasis role="bold">Dependencies:</emphasis> Basesystem
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Availability:</emphasis> &sles4sapa; (included)
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Extended support:</emphasis> 3 yrs
       ESPOS<superscript>2</superscript>, 3 yrs
       LTSS<superscript>1</superscript> for last SP
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Level:</emphasis> L3
      </para>
     </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>Server Applications</term>
+   </itemizedlist>
+  </sect2>
+  <sect2>
+   <title>Server Applications</title>
+   <para>
+    Adds server functionality by providing network services such as DHCP
+    server, name server, or Web server. <phrase os="sles">This module is
+     selected for installation by default; deselecting it is not
+     recommended.</phrase>
+   </para>
+   <itemizedlist>
     <listitem>
-     <para>
-      Adds server functionality by providing network services such as DHCP
-      server, name server, or Web server. <phrase os="sles">This module is
-       selected for installation by default; deselecting it is not
-       recommended.</phrase>
-     </para>
      <para>
       <emphasis role="bold">Dependencies:</emphasis> Basesystem
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Availability:</emphasis> &slsa; (default),
       &sles4sapa;, &slerta; (default), &slehpca;
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Extended support:</emphasis> 3 yrs
       LTSS<superscript>1</superscript>
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Level:</emphasis> L3
      </para>
     </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>&suse; Package Hub</term>
+   </itemizedlist>
+  </sect2>
+  <sect2>
+   <title>&suse; Package Hub</title>
+   <para>
+    The <literal>&suse; Package Hub</literal> Provides access to packages for
+    &productname; maintained by the &opensuse; community. These packages are delivered without L3 support
+    but do not interfere with the supportability of &productname;. For
+    more information, refer to <link
+     xlink:href="https://packagehub.suse.com/"/>.
+   </para>
+   <itemizedlist>
     <listitem>
-     <para>
-      Provides access to packages for &productname; maintained by the
-      &opensuse; community. These packages are delivered without L3 support
-      but do not interfere with the supportability of &productname;. For
-      more information, refer to <link
-       xlink:href="https://packagehub.suse.com/"/>.
-     </para>
      <para>
       <emphasis role="bold">Dependencies:</emphasis> Basesystem
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Availability:</emphasis> All products
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Lifecycle:</emphasis> None
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Extended support:</emphasis> None
       LTSS<superscript>1</superscript>
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Level:</emphasis> None
      </para>
     </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>Transactional Server</term>
+   </itemizedlist>
+  </sect2>
+  <sect2>
+   <title>Transactional Server</title>
+   <para>
+    The <literal>Transactional Server</literal> module provides &sle; systems
+    with a method of updating the operating system and its packages in an
+    entirely ‘atomic’ way. Updates are either applied to the system all together
+    in a single transaction, or not at all. This happens without influencing the
+    running system. If an update fails, or if a successful update is deemed to
+    be incompatible or incorrect, you can discard it immediately and return to
+    its previous functioning state.
+   </para>
+   <itemizedlist>
     <listitem>
-     <para>
-      Provides &sle; systems with a method of updating the operating system
-      and its packages in an entirely ‘atomic’ way. Updates are either
-      applied to the system all together in a single transaction, or not at
-      all. This happens without influencing the running system. If an update
-      fails, or if a successful update is deemed to be incompatible or
-      incorrect, you can discard it immediately and return to its previous
-      functioning state.
-     </para>
      <para>
       <emphasis role="bold">Dependencies:</emphasis> Basesystem
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Availability:</emphasis> &slsa;
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Extended support:</emphasis> 3 yrs
       LTSS<superscript>1</superscript>
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Level:</emphasis> L3
      </para>
     </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>Web and Scripting</term>
+   </itemizedlist>
+  </sect2>
+  <sect2>
+   <title>Web and Scripting</title>
+   <para>
+    The <literal>Web and Scripting</literal> module contains packages intended
+    for a running Web server.
+   </para>
+   <itemizedlist>
     <listitem>
-     <para>
-      Contains packages intended for a running Web server.
-     </para>
      <para>
       <emphasis role="bold">Dependencies:</emphasis> Basesystem, Server
       Applications
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
       &slehpca;
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Extended support:</emphasis> 3 yrs
       LTSS<superscript>1</superscript>
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Level:</emphasis> L3
      </para>
     </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>Workstation Extension</term>
+   </itemizedlist>
+  </sect2>
+  <sect2>
+   <title>Workstation Extension</title>
+   <para>
+    The <literal>Workstation Extension</literal> offers additional desktop
+    applications and libraries. It is installed by default on &sled;. Adding the
+    Workstation Extension to a &sls; installation allows you to seamlessly
+    combine both products to create a fully featured server workstation. For
+    more information, refer to <link
+     xlink:href="https://www.suse.com/products/workstation-extension"/>.
+   </para>
+   <itemizedlist>
     <listitem>
      <para>
-      Offers additional desktop applications and libraries. It is installed
-      by default on &sled;. Adding the Workstation Extension to a &sls;
-      installation allows you to seamlessly combine both products to create a
-      fully featured server workstation. For more information, refer to <link
-       xlink:href="https://www.suse.com/products/workstation-extension"/>.
-     </para>
-     <para>
       <emphasis role="bold">Dependencies:</emphasis> Basesystem, Desktop
-      Applications
      </para>
+    </listitem>
+    <listitem>
      <para>
-      <emphasis role="bold">Availability:</emphasis> &slsa;, &sleda;
-      (default), &sles4sapa;
+      <emphasis role="bold">Availability:</emphasis> &slsa;, &sleda; (default),
+      &sles4sapa;
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
      </para>
+    </listitem>
+    <listitem>
      <para>
       <emphasis role="bold">Extended support:</emphasis> None
-      LTSS<superscript>1</superscript>
-     </para>
-     <para>
-      <emphasis role="bold">Level:</emphasis> mixed L2/L3
-      (depending on package)
      </para>
     </listitem>
-   </varlistentry>
-  </variablelist>
-  <simplelist>
-   <member>
-    <superscript>1</superscript> LTSS: <link xlink:href="https://www.suse.com/products/long-term-service-pack-support/">Long-Term Service Pack Support</link>
-   </member>
-   <member>
-    <superscript>2</superscript> ESPOS: <link xlink:href="https://www.suse.com/support/policy-products/#hpc">Extended Service Pack Overlay Support</link>
-   </member>
-  </simplelist>
+    <listitem>
+     <para>
+      <emphasis role="bold">Level:</emphasis> mixed L2/L3 (depending on package)
+     </para>
+    </listitem>
+   </itemizedlist>
+  </sect2>
  </sect1>
 
  <sect1 xml:id="sec-modules-install">

--- a/xml/art_modules.xml
+++ b/xml/art_modules.xml
@@ -136,6 +136,103 @@
    https://bugzilla.suse.com/1189275#c9 and
    https://jira.suse.com/browse/SLE-17270
   -->
+  <itemizedlist>
+   <listitem>
+    <para>
+     <xref xrefstyle="select:title" linkend="art-modules-basesystem"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <xref xrefstyle="select:title" linkend="art-modules-containers"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <xref xrefstyle="select:title" linkend="art-modules-desktop-applications"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <xref xrefstyle="select:title" linkend="art-modules-development"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <xref xrefstyle="select:title" linkend="art-modules-high-availability"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <xref xrefstyle="select:title" linkend="art-modules-high-performance-computing"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <xref xrefstyle="select:title" linkend="art-modules-legacy"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <xref xrefstyle="select:title" linkend="art-modules-live-patching"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <xref xrefstyle="select:title" linkend="art-modules-nvidia-compute"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <xref xrefstyle="select:title" linkend="art-modules-public-cloud"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <xref xrefstyle="select:title" linkend="art-modules-python-3"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <xref xrefstyle="select:title" linkend="art-modules-real-time"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <xref xrefstyle="select:title" linkend="art-modules-sap-applications"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <xref xrefstyle="select:title" linkend="art-modules-server-applications"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <xref xrefstyle="select:title" linkend="art-modules-suse-package-hub"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <xref xrefstyle="select:title" linkend="art-modules-transactional-server"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <xref xrefstyle="select:title" linkend="art-modules-web-scripting"/>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <xref xrefstyle="select:title" linkend="art-modules-workstation"/>
+    </para>
+   </listitem>
+  </itemizedlist>
+  <para>
+   Please note that the availability depends on the product. Not all modules and
+   extensions are available for all products. Some modules are included in one
+   product but also available as extension for another.
+  </para>
   <sect2 xml:id="art-modules-basesystem">
    <title>Basesystem</title>
    <para>

--- a/xml/art_modules.xml
+++ b/xml/art_modules.xml
@@ -92,22 +92,22 @@
 
  <sect1 xml:id="sec-modules-list">
   <title>Modules and extensions for the &sle; product family</title>
+  <para>
+   The following modules and extensions are available within the &sle; product
+   family. Note that the availability depends on the product (refer to the
+   column <emphasis>Available for</emphasis>). For more information about
+   lifecycle, release frequency, and the overlay support period, see
+   <link xlink:href="https://www.suse.com/lifecycle"/>.
+  </para>
+  <note>
+   <title>L3 support</title>
    <para>
-    The following modules and extensions are available within the &sle; product
-    family. Note that the availability depends on the product (refer to the
-    column <emphasis>Available for</emphasis>). For more information about
-    lifecycle, release frequency, and the overlay support period, see
-    <link xlink:href="https://www.suse.com/lifecycle"/>.
+    L3 support is generally provided for packages in modules. However, this
+    excludes <literal>Package Hub</literal> and third-party modules. To check
+    the support level for a package, run
+    <command>zypper info <replaceable>PACKAGE</replaceable></command>.
    </para>
-   <note>
-    <title>L3 support</title>
-    <para>
-     L3 support is generally provided for packages in modules. However, this
-     excludes <literal>Package Hub</literal> and third-party modules. To check
-     the support level for a package, run
-     <command>zypper info <replaceable>PACKAGE</replaceable></command>.
-    </para>
-   </note>
+  </note>
   <!--
    cwickert 2021-12-17: Information for the following table was taken from
    https://confluence.suse.com/x/GQHiHw#id-[SLE15SP3]PRDallinone-ModuleLTSS
@@ -117,590 +117,590 @@
    https://bugzilla.suse.com/1189275#c9 and
    https://jira.suse.com/browse/SLE-17270
   -->
-   <variablelist>
-    <varlistentry>
-     <term>Basesystem</term>
-     <listitem>
-      <para>
-       Adds a basic system on top of the Installer. It is required by all other
-       modules and extensions. The scope of an installation that only contains
-       the base system is comparable to the <literal>minimal</literal> system
-       installation pattern of previous &productname; versions. This module is
-       selected for installation by default and should not be deselected.
-      </para>
-      <para>
-       <emphasis role="bold">Dependencies:</emphasis> n.a.
-      </para>
-      <para>
-       <emphasis role="bold">Availability:</emphasis> Default on all products
-      </para>
-      <para>
-       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-      </para>
-      <para>
-       <emphasis role="bold">Extended Support:</emphasis> 3 yrs
-       LTSS<superscript>1</superscript>
-      </para>
-      <para>
-       <emphasis role="bold">Support level:</emphasis> L3
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>Certifications</term>
-     <listitem>
-      <para>
-       Contains the FIPS 140-2 certification packages.
-      </para>
-      <para>
-       <emphasis role="bold">Dependencies:</emphasis> Basesystem
-      </para>
-      <para>
-       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
-       &slert;, &slehpca;
-      </para>
-      <para>
-       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-      </para>
-      <para>
-       <emphasis role="bold">Extended support:</emphasis> 3 yrs
-       LTSS<superscript>1</superscript>
-      </para>
-      <para>
-       <emphasis role="bold">Support level:</emphasis> L3
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>Containers</term>
-     <listitem>
-      <para>
-       Contains packages relating to containers, including the container
-       engine and core container-related tools such as on-premise registry.
-      </para>
-      <para>
-       <emphasis role="bold">Dependencies:</emphasis> Basesystem
-      </para>
-      <para>
-       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
-       &slehpca;
-      </para>
-      <para>
-       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-      </para>
-      <para>
-       <emphasis role="bold">Extended support:</emphasis> 3 yrs
-       LTSS<superscript>1</superscript>
-      </para>
-      <para>
-       <emphasis role="bold">Support level:</emphasis> L3
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>Desktop Applications</term>
-     <listitem>
-      <para>
-       Adds a graphical user interface <phrase os="sled">(Wayland)</phrase>
-       and essential desktop applications to the system.
-       <phrase os="sled">This module is selected for installation by
-        default; deselecting it is not recommended.</phrase>
-      </para>
-      <para>
-       <emphasis role="bold">Dependencies:</emphasis> Basesystem
-      </para>
-      <para>
-       <emphasis role="bold">Availability:</emphasis> &slsa;, &sleda;
-       (default), &slewea; (default), &sles4sapa;, &slerta; (default), &slehpca;
-      </para>
-      <para>
-       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-      </para>
-      <para>
-       <emphasis role="bold">Extended support:</emphasis> 3 yrs
-       LTSS<superscript>1</superscript>
-      </para>
-      <para>
-       <emphasis role="bold">Level:</emphasis> L3
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>Development Tools</term>
-     <listitem>
-      <para>
-       Contains compilers (including <package>gcc</package>) and libraries
-       required for compiling and debugging applications. Replaces the former
-       Software Development Kit (SDK).
-      </para>
-      <para>
-       <emphasis role="bold">Dependencies:</emphasis> Basesystem, Desktop
-       Applications
-      </para>
-      <para>
-       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
-       &sleda;, &slerta; (default), &slehpca;
-      </para>
-      <para>
-       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-      </para>
-      <para>
-       <emphasis role="bold">Extended support:</emphasis> 3 yrs
-       LTSS<superscript>1</superscript>
-      </para>
-      <para>
-       <emphasis role="bold">Level:</emphasis> L3
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>High Availability</term>
-     <listitem>
-      <para>
-       Provides high-availability clustering technologies that can be deployed
-       in physical and/or virtual environments.
-      </para>
-      <para>
-       High Availability is included in the subscription for &sles4sapa; as a
-       module. It is also available as an extension for &slsa; and &slehpca;.
-       For more information about &sle; &hasi;, refer to <link
-        xlink:href="https://www.suse.com/products/highavailability"/>.
-      </para>
-      <para>
-       <emphasis role="bold">Dependencies:</emphasis> Basesystem, Server Applications
-      </para>
-      <para>
-       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;
-       (included), &slehpca;, &slert;
-      </para>
-      <para>
-       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-      </para>
-      <para>
-       <emphasis role="bold">Extended support:</emphasis> 3 yrs
-       LTSS<superscript>1</superscript>
-      </para>
-      <para>
-       <emphasis role="bold">Level:</emphasis> L3
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>High Performance Computing</term>
-     <listitem>
-      <para>
-       Contains tools and libraries related to High Performance Computing
-       (HPC).
-      </para>
-      <para>
-       <emphasis role="bold">Dependencies:</emphasis> Basesystem
-      </para>
-      <para>
-       <emphasis role="bold">Availability:</emphasis> &slehpca; (included)
-      </para>
-      <para>
-       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-      </para>
-      <para>
-       <emphasis role="bold">Extended support:</emphasis> 1 yr
-       ESPOS<superscript>2</superscript>, 3 yrs
-       LTSS<superscript>1</superscript>
-      </para>
-      <para>
-       <emphasis role="bold">Level:</emphasis> L3
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>Legacy</term>
-     <listitem>
-      <para>
-       Helps you with migrating applications from earlier versions of
-       &productname; and other systems to &slsa; &productnumber;, by
-       providing packages which are discontinued on &sle;. Packages in this
-       module are selected based on the requirement for migration and the
-       level of complexity of configuration.
-      </para>
-      <para>
-       This module is recommended when migrating from a previous product
-       version.
-      </para>
-      <para>
-       Please note that this module has a different lifecycle than some of its
-       packages. Not all packages are supported for the complete lifecycle of
-       the module, but depend on migration requirements and upstream
-       lifecycles.
-      </para>
-      <para>
-       <emphasis role="bold">Dependencies:</emphasis> Basesystem, Server
-       Applications
-      </para>
-      <para>
-       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
-       &slehpca;
-      </para>
-      <para>
-       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-      </para>
-      <para>
-       <emphasis role="bold">Extended support:</emphasis> 3 yrs
-       LTSS<superscript>1</superscript>
-      </para>
-      <para>
-       <emphasis role="bold">Level:</emphasis> L3
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>Live Patching</term>
-     <listitem>
-      <para>
-       Provides packages to update critical components in &sle; without
-       shutting down your system, which reduces planned downtime and increases
-       service availability.
-      </para>
-      <para>
-       <emphasis role="bold">Dependencies:</emphasis> Basesystem
-      </para>
-      <para>
-       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
-       &slehpca; <!-- on x86-64, s390x, and ppc64le -->
-      </para>
-      <para>
-       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-      </para>
-      <para>
-       <emphasis role="bold">Extended support:</emphasis> 3 yrs
-       LTSS<superscript>1</superscript>
-      </para>
-      <para>
-       <emphasis role="bold">Level:</emphasis> L3
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>NVIDIA Compute</term>
-     <listitem>
-      <para>
-       Contains the NVIDIA CUDA (Compute Unified Device Architecture) drivers.
-      </para>
-      <para>
-       The software in this module is provided by NVIDIA under the <link
-        xlink:href="http://docs.nvidia.com/cuda/eula/">CUDA End User License
-        Agreement</link> and is not supported by &suse;.
-      </para>
-      <important>
-       <title>Do not use <command>SUSEConnect</command> to add this module</title>
-       <para>
-        Do not try to add this module with the <command>SUSEConnect</command>
-        CLI tool. <command>SUSEConnect</command> is not capable of handling
-        third-party repositories.
-       </para>
-       <para>
-        During installation, select the module from the <guimenu>Extension and
-         Module Selection</guimenu> screen. Within an installed system, run
-        <command>yast registration</command>, select <guimenu>Select
-         Extensions</guimenu>, then <literal>NVIDIA Compute Module</literal>
-        and continue with <guimenu>Next</guimenu>. Verify and accept the
-        NVIDIA repository GPG key.
-       </para>
-      </important>
-      <important>
-       <title>Combining <literal>Workstation Extension</literal> and
-        <literal>NVIDIA Compute module</literal> is unsupported</title>
-       <para>
-        The <literal>Workstation Extension</literal> provides drivers for
-        NVIDIA graphics cards. These drivers share some packages with CUDA,
-        however versions may differ. It is therefore neither recommended
-        nor supported to enable both the <literal>NVIDIA Compute
-         Module</literal> and the <literal>Workstation Extension</literal> at
-        the same time.
-       </para>
-      </important>
-      <para>
-       <emphasis role="bold">Dependencies:</emphasis> Basesystem
-      </para>
-      <para>
-       <emphasis role="bold">Availability:</emphasis> &slsa; and &slehpca;
-       on &x86-64; and &aarch64;
-      </para>
-      <para>
-       <emphasis role="bold">Support:</emphasis> Software in this module is
-       provided by NVIDIA and is not supported by &suse;
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>Public Cloud</term>
-     <listitem>
-      <para>
-       Contains all tools required to create images for deploying
-       &productname; in cloud environments. For example: Amazon Web Services
-       (AWS), Microsoft Azure, Google Compute Platform, or &ostack;.
-      </para>
-      <para>
-       <emphasis role="bold">Dependencies:</emphasis> Basesystem, Server Applications
-      </para>
-      <para>
-       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;, &slehpca;
-      </para>
-      <para>
-       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-      </para>
-      <para>
-       <emphasis role="bold">Extended support:</emphasis> 3 yrs
-       LTSS<superscript>1</superscript>
-      </para>
-      <para>
-       <emphasis role="bold">Level:</emphasis> L3
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>Python 3</term>
-     <listitem>
-      <para>
-       This module contains the most recent version of selected Python 3
-       packages.
-      </para>
-      <para>
-       The module has a different lifecycle than &sle; itself. Packages in
-       this module are frequently updated to new upstream versions.
-      </para>
-      <para>
-       <emphasis role="bold">Dependencies:</emphasis> Basesystem
-      </para>
-      <para>
-       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
-       &slehpca;, &sleda;
-      </para>
-      <para>
-       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-      </para>
-      <para>
-       <emphasis role="bold">Extended support:</emphasis> None
-       LTSS<superscript>1</superscript>
-      </para>
-      <para>
-       <emphasis role="bold">Level:</emphasis> L3
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>Real Time</term>
-     <listitem>
-      <para>
-       Aims to reduce the latency and increase the predictability and
-       reliability of time-sensitive mission-critical applications.
-      </para>
-      <para>
-       Packages in this module are generally supported until a newer version
-       of the package is released or the package is dropped from the module.
-      </para>
-      <para>
-       <emphasis role="bold">Dependencies:</emphasis> Basesystem, Desktop
-       Applications, Development Tools, Server Applications
-      </para>
-      <para>
-       <emphasis role="bold">Availability:</emphasis> &slerta; (included)
-      </para>
-      <para>
-       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-      </para>
-      <para>
-       <emphasis role="bold">Extended support:</emphasis> None
-       LTSS<superscript>1</superscript>
-      </para>
-      <para>
-       <emphasis role="bold">Level:</emphasis> L3
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>SAP Applications</term>
-     <listitem>
-      <para>
-       Contains packages specific to &sles4sapa;.
-      </para>
-      <!-- see https://www.suse.com/de-de/support/policy-products/#sap -->
-      <para>
-       The module has a different lifecycle than &sle; itself. Subscriptions
-       for &sles4sap; include 1.5 years of General Support plus 3 years of
-       Extended Service Pack Overlap Support (ESPOS) for each service pack.
-       This eliminates the need for customers to purchase Long Term Service
-       Pack Support (LTSS) until the final service pack of a release.
-      </para>
-      <para>
-       <emphasis role="bold">Dependencies:</emphasis> Basesystem
-      </para>
-      <para>
-       <emphasis role="bold">Availability:</emphasis> &sles4sapa; (included)
-      </para>
-      <para>
-       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-      </para>
-      <para>
-       <emphasis role="bold">Extended support:</emphasis> 3 yrs
-       ESPOS<superscript>2</superscript>, 3 yrs
-       LTSS<superscript>1</superscript> for last SP
-      </para>
-      <para>
-       <emphasis role="bold">Level:</emphasis> L3
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>Server Applications</term>
-     <listitem>
-      <para>
-       Adds server functionality by providing network services such as DHCP
-       server, name server, or Web server. <phrase os="sles">This module is
-        selected for installation by default; deselecting it is not
-        recommended.</phrase>
-      </para>
-      <para>
-       <emphasis role="bold">Dependencies:</emphasis> Basesystem
-      </para>
-      <para>
-       <emphasis role="bold">Availability:</emphasis> &slsa; (default),
-       &sles4sapa;, &slerta; (default), &slehpca;
-      </para>
-      <para>
-       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-      </para>
-      <para>
-       <emphasis role="bold">Extended support:</emphasis> 3 yrs
-       LTSS<superscript>1</superscript>
-      </para>
-      <para>
-       <emphasis role="bold">Level:</emphasis> L3
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>&suse; Package Hub</term>
-     <listitem>
-      <para>
-       Provides access to packages for &productname; maintained by the
-       &opensuse; community. These packages are delivered without L3 support
-       but do not interfere with the supportability of &productname;. For
-       more information, refer to <link
-        xlink:href="https://packagehub.suse.com/"/>.
-      </para>
-      <para>
-       <emphasis role="bold">Dependencies:</emphasis> Basesystem
-      </para>
-      <para>
-       <emphasis role="bold">Availability:</emphasis> All products
-      </para>
-      <para>
-       <emphasis role="bold">Lifecycle:</emphasis> None
-      </para>
-      <para>
-       <emphasis role="bold">Extended support:</emphasis> None
-       LTSS<superscript>1</superscript>
-      </para>
-      <para>
-       <emphasis role="bold">Level:</emphasis> None
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>Transactional Server</term>
-     <listitem>
-      <para>
-       Provides &sle; systems with a method of updating the operating system
-       and its packages in an entirely ‘atomic’ way. Updates are either
-       applied to the system all together in a single transaction, or not at
-       all. This happens without influencing the running system. If an update
-       fails, or if a successful update is deemed to be incompatible or
-       incorrect, you can discard it immediately and return to its previous
-       functioning state.
-      </para>
-      <para>
-       <emphasis role="bold">Dependencies:</emphasis> Basesystem
-      </para>
-      <para>
-       <emphasis role="bold">Availability:</emphasis> &slsa;
-      </para>
-      <para>
-       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-      </para>
-      <para>
-       <emphasis role="bold">Extended support:</emphasis> 3 yrs
-       LTSS<superscript>1</superscript>
-      </para>
-      <para>
-       <emphasis role="bold">Level:</emphasis> L3
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>Web and Scripting</term>
-     <listitem>
-      <para>
-       Contains packages intended for a running Web server.
-      </para>
-      <para>
-       <emphasis role="bold">Dependencies:</emphasis> Basesystem, Server
-       Applications
-      </para>
-      <para>
-       <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
-       &slehpca;
-      </para>
-      <para>
-       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-      </para>
-      <para>
-       <emphasis role="bold">Extended support:</emphasis> 3 yrs
-       LTSS<superscript>1</superscript>
-      </para>
-      <para>
-       <emphasis role="bold">Level:</emphasis> L3
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>Workstation Extension</term>
-     <listitem>
-      <para>
-       Offers additional desktop applications and libraries. It is installed
-       by default on &sled;. Adding the Workstation Extension to a &sls;
-       installation allows you to seamlessly combine both products to create a
-       fully featured server workstation. For more information, refer to <link
-        xlink:href="https://www.suse.com/products/workstation-extension"/>.
-      </para>
-      <para>
-       <emphasis role="bold">Dependencies:</emphasis> Basesystem, Desktop
-       Applications
-      </para>
-      <para>
-       <emphasis role="bold">Availability:</emphasis> &slsa;, &sleda;
-       (default), &sles4sapa;
-      </para>
-      <para>
-       <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
-      </para>
-      <para>
-       <emphasis role="bold">Extended support:</emphasis> None
-       LTSS<superscript>1</superscript>
-      </para>
-      <para>
-       <emphasis role="bold">Level:</emphasis> mixed L2/L3
-       (depending on package)
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-   <simplelist>
-    <member>
-     <superscript>1</superscript> LTSS: <link xlink:href="https://www.suse.com/products/long-term-service-pack-support/">Long-Term Service Pack Support</link>
-    </member>
-    <member>
-     <superscript>2</superscript> ESPOS: <link xlink:href="https://www.suse.com/support/policy-products/#hpc">Extended Service Pack Overlay Support</link>
-    </member>
-   </simplelist>
+  <variablelist>
+   <varlistentry>
+    <term>Basesystem</term>
+    <listitem>
+     <para>
+      Adds a basic system on top of the Installer. It is required by all other
+      modules and extensions. The scope of an installation that only contains
+      the base system is comparable to the <literal>minimal</literal> system
+      installation pattern of previous &productname; versions. This module is
+      selected for installation by default and should not be deselected.
+     </para>
+     <para>
+      <emphasis role="bold">Dependencies:</emphasis> n.a.
+     </para>
+     <para>
+      <emphasis role="bold">Availability:</emphasis> Default on all products
+     </para>
+     <para>
+      <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+     </para>
+     <para>
+      <emphasis role="bold">Extended Support:</emphasis> 3 yrs
+      LTSS<superscript>1</superscript>
+     </para>
+     <para>
+      <emphasis role="bold">Support level:</emphasis> L3
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Certifications</term>
+    <listitem>
+     <para>
+      Contains the FIPS 140-2 certification packages.
+     </para>
+     <para>
+      <emphasis role="bold">Dependencies:</emphasis> Basesystem
+     </para>
+     <para>
+      <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
+      &slert;, &slehpca;
+     </para>
+     <para>
+      <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+     </para>
+     <para>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs
+      LTSS<superscript>1</superscript>
+     </para>
+     <para>
+      <emphasis role="bold">Support level:</emphasis> L3
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Containers</term>
+    <listitem>
+     <para>
+      Contains packages relating to containers, including the container
+      engine and core container-related tools such as on-premise registry.
+     </para>
+     <para>
+      <emphasis role="bold">Dependencies:</emphasis> Basesystem
+     </para>
+     <para>
+      <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
+      &slehpca;
+     </para>
+     <para>
+      <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+     </para>
+     <para>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs
+      LTSS<superscript>1</superscript>
+     </para>
+     <para>
+      <emphasis role="bold">Support level:</emphasis> L3
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Desktop Applications</term>
+    <listitem>
+     <para>
+      Adds a graphical user interface <phrase os="sled">(Wayland)</phrase>
+      and essential desktop applications to the system.
+      <phrase os="sled">This module is selected for installation by
+       default; deselecting it is not recommended.</phrase>
+     </para>
+     <para>
+      <emphasis role="bold">Dependencies:</emphasis> Basesystem
+     </para>
+     <para>
+      <emphasis role="bold">Availability:</emphasis> &slsa;, &sleda;
+      (default), &slewea; (default), &sles4sapa;, &slerta; (default), &slehpca;
+     </para>
+     <para>
+      <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+     </para>
+     <para>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs
+      LTSS<superscript>1</superscript>
+     </para>
+     <para>
+      <emphasis role="bold">Level:</emphasis> L3
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Development Tools</term>
+    <listitem>
+     <para>
+      Contains compilers (including <package>gcc</package>) and libraries
+      required for compiling and debugging applications. Replaces the former
+      Software Development Kit (SDK).
+     </para>
+     <para>
+      <emphasis role="bold">Dependencies:</emphasis> Basesystem, Desktop
+      Applications
+     </para>
+     <para>
+      <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
+      &sleda;, &slerta; (default), &slehpca;
+     </para>
+     <para>
+      <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+     </para>
+     <para>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs
+      LTSS<superscript>1</superscript>
+     </para>
+     <para>
+      <emphasis role="bold">Level:</emphasis> L3
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>High Availability</term>
+    <listitem>
+     <para>
+      Provides high-availability clustering technologies that can be deployed
+      in physical and/or virtual environments.
+     </para>
+     <para>
+      High Availability is included in the subscription for &sles4sapa; as a
+      module. It is also available as an extension for &slsa; and &slehpca;.
+      For more information about &sle; &hasi;, refer to <link
+       xlink:href="https://www.suse.com/products/highavailability"/>.
+     </para>
+     <para>
+      <emphasis role="bold">Dependencies:</emphasis> Basesystem, Server Applications
+     </para>
+     <para>
+      <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;
+      (included), &slehpca;, &slert;
+     </para>
+     <para>
+      <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+     </para>
+     <para>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs
+      LTSS<superscript>1</superscript>
+     </para>
+     <para>
+      <emphasis role="bold">Level:</emphasis> L3
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>High Performance Computing</term>
+    <listitem>
+     <para>
+      Contains tools and libraries related to High Performance Computing
+      (HPC).
+     </para>
+     <para>
+      <emphasis role="bold">Dependencies:</emphasis> Basesystem
+     </para>
+     <para>
+      <emphasis role="bold">Availability:</emphasis> &slehpca; (included)
+     </para>
+     <para>
+      <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+     </para>
+     <para>
+      <emphasis role="bold">Extended support:</emphasis> 1 yr
+      ESPOS<superscript>2</superscript>, 3 yrs
+      LTSS<superscript>1</superscript>
+     </para>
+     <para>
+      <emphasis role="bold">Level:</emphasis> L3
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Legacy</term>
+    <listitem>
+     <para>
+      Helps you with migrating applications from earlier versions of
+      &productname; and other systems to &slsa; &productnumber;, by
+      providing packages which are discontinued on &sle;. Packages in this
+      module are selected based on the requirement for migration and the
+      level of complexity of configuration.
+     </para>
+     <para>
+      This module is recommended when migrating from a previous product
+      version.
+     </para>
+     <para>
+      Please note that this module has a different lifecycle than some of its
+      packages. Not all packages are supported for the complete lifecycle of
+      the module, but depend on migration requirements and upstream
+      lifecycles.
+     </para>
+     <para>
+      <emphasis role="bold">Dependencies:</emphasis> Basesystem, Server
+      Applications
+     </para>
+     <para>
+      <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
+      &slehpca;
+     </para>
+     <para>
+      <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+     </para>
+     <para>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs
+      LTSS<superscript>1</superscript>
+     </para>
+     <para>
+      <emphasis role="bold">Level:</emphasis> L3
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Live Patching</term>
+    <listitem>
+     <para>
+      Provides packages to update critical components in &sle; without
+      shutting down your system, which reduces planned downtime and increases
+      service availability.
+     </para>
+     <para>
+      <emphasis role="bold">Dependencies:</emphasis> Basesystem
+     </para>
+     <para>
+      <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
+      &slehpca; <!-- on x86-64, s390x, and ppc64le -->
+     </para>
+     <para>
+      <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+     </para>
+     <para>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs
+      LTSS<superscript>1</superscript>
+     </para>
+     <para>
+      <emphasis role="bold">Level:</emphasis> L3
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>NVIDIA Compute</term>
+    <listitem>
+     <para>
+      Contains the NVIDIA CUDA (Compute Unified Device Architecture) drivers.
+     </para>
+     <para>
+      The software in this module is provided by NVIDIA under the <link
+       xlink:href="http://docs.nvidia.com/cuda/eula/">CUDA End User License
+       Agreement</link> and is not supported by &suse;.
+     </para>
+     <important>
+      <title>Do not use <command>SUSEConnect</command> to add this module</title>
+      <para>
+       Do not try to add this module with the <command>SUSEConnect</command>
+       CLI tool. <command>SUSEConnect</command> is not capable of handling
+       third-party repositories.
+      </para>
+      <para>
+       During installation, select the module from the <guimenu>Extension and
+        Module Selection</guimenu> screen. Within an installed system, run
+       <command>yast registration</command>, select <guimenu>Select
+        Extensions</guimenu>, then <literal>NVIDIA Compute Module</literal>
+       and continue with <guimenu>Next</guimenu>. Verify and accept the
+       NVIDIA repository GPG key.
+      </para>
+     </important>
+     <important>
+      <title>Combining <literal>Workstation Extension</literal> and
+       <literal>NVIDIA Compute module</literal> is unsupported</title>
+      <para>
+       The <literal>Workstation Extension</literal> provides drivers for
+       NVIDIA graphics cards. These drivers share some packages with CUDA,
+       however versions may differ. It is therefore neither recommended
+       nor supported to enable both the <literal>NVIDIA Compute
+        Module</literal> and the <literal>Workstation Extension</literal> at
+       the same time.
+      </para>
+     </important>
+     <para>
+      <emphasis role="bold">Dependencies:</emphasis> Basesystem
+     </para>
+     <para>
+      <emphasis role="bold">Availability:</emphasis> &slsa; and &slehpca;
+      on &x86-64; and &aarch64;
+     </para>
+     <para>
+      <emphasis role="bold">Support:</emphasis> Software in this module is
+      provided by NVIDIA and is not supported by &suse;
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Public Cloud</term>
+    <listitem>
+     <para>
+      Contains all tools required to create images for deploying
+      &productname; in cloud environments. For example: Amazon Web Services
+      (AWS), Microsoft Azure, Google Compute Platform, or &ostack;.
+     </para>
+     <para>
+      <emphasis role="bold">Dependencies:</emphasis> Basesystem, Server Applications
+     </para>
+     <para>
+      <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;, &slehpca;
+     </para>
+     <para>
+      <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+     </para>
+     <para>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs
+      LTSS<superscript>1</superscript>
+     </para>
+     <para>
+      <emphasis role="bold">Level:</emphasis> L3
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Python 3</term>
+    <listitem>
+     <para>
+      This module contains the most recent version of selected Python 3
+      packages.
+     </para>
+     <para>
+      The module has a different lifecycle than &sle; itself. Packages in
+      this module are frequently updated to new upstream versions.
+     </para>
+     <para>
+      <emphasis role="bold">Dependencies:</emphasis> Basesystem
+     </para>
+     <para>
+      <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
+      &slehpca;, &sleda;
+     </para>
+     <para>
+      <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+     </para>
+     <para>
+      <emphasis role="bold">Extended support:</emphasis> None
+      LTSS<superscript>1</superscript>
+     </para>
+     <para>
+      <emphasis role="bold">Level:</emphasis> L3
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Real Time</term>
+    <listitem>
+     <para>
+      Aims to reduce the latency and increase the predictability and
+      reliability of time-sensitive mission-critical applications.
+     </para>
+     <para>
+      Packages in this module are generally supported until a newer version
+      of the package is released or the package is dropped from the module.
+     </para>
+     <para>
+      <emphasis role="bold">Dependencies:</emphasis> Basesystem, Desktop
+      Applications, Development Tools, Server Applications
+     </para>
+     <para>
+      <emphasis role="bold">Availability:</emphasis> &slerta; (included)
+     </para>
+     <para>
+      <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+     </para>
+     <para>
+      <emphasis role="bold">Extended support:</emphasis> None
+      LTSS<superscript>1</superscript>
+     </para>
+     <para>
+      <emphasis role="bold">Level:</emphasis> L3
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>SAP Applications</term>
+    <listitem>
+     <para>
+      Contains packages specific to &sles4sapa;.
+     </para>
+     <!-- see https://www.suse.com/de-de/support/policy-products/#sap -->
+     <para>
+      The module has a different lifecycle than &sle; itself. Subscriptions
+      for &sles4sap; include 1.5 years of General Support plus 3 years of
+      Extended Service Pack Overlap Support (ESPOS) for each service pack.
+      This eliminates the need for customers to purchase Long Term Service
+      Pack Support (LTSS) until the final service pack of a release.
+     </para>
+     <para>
+      <emphasis role="bold">Dependencies:</emphasis> Basesystem
+     </para>
+     <para>
+      <emphasis role="bold">Availability:</emphasis> &sles4sapa; (included)
+     </para>
+     <para>
+      <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+     </para>
+     <para>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs
+      ESPOS<superscript>2</superscript>, 3 yrs
+      LTSS<superscript>1</superscript> for last SP
+     </para>
+     <para>
+      <emphasis role="bold">Level:</emphasis> L3
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Server Applications</term>
+    <listitem>
+     <para>
+      Adds server functionality by providing network services such as DHCP
+      server, name server, or Web server. <phrase os="sles">This module is
+       selected for installation by default; deselecting it is not
+       recommended.</phrase>
+     </para>
+     <para>
+      <emphasis role="bold">Dependencies:</emphasis> Basesystem
+     </para>
+     <para>
+      <emphasis role="bold">Availability:</emphasis> &slsa; (default),
+      &sles4sapa;, &slerta; (default), &slehpca;
+     </para>
+     <para>
+      <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+     </para>
+     <para>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs
+      LTSS<superscript>1</superscript>
+     </para>
+     <para>
+      <emphasis role="bold">Level:</emphasis> L3
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>&suse; Package Hub</term>
+    <listitem>
+     <para>
+      Provides access to packages for &productname; maintained by the
+      &opensuse; community. These packages are delivered without L3 support
+      but do not interfere with the supportability of &productname;. For
+      more information, refer to <link
+       xlink:href="https://packagehub.suse.com/"/>.
+     </para>
+     <para>
+      <emphasis role="bold">Dependencies:</emphasis> Basesystem
+     </para>
+     <para>
+      <emphasis role="bold">Availability:</emphasis> All products
+     </para>
+     <para>
+      <emphasis role="bold">Lifecycle:</emphasis> None
+     </para>
+     <para>
+      <emphasis role="bold">Extended support:</emphasis> None
+      LTSS<superscript>1</superscript>
+     </para>
+     <para>
+      <emphasis role="bold">Level:</emphasis> None
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Transactional Server</term>
+    <listitem>
+     <para>
+      Provides &sle; systems with a method of updating the operating system
+      and its packages in an entirely ‘atomic’ way. Updates are either
+      applied to the system all together in a single transaction, or not at
+      all. This happens without influencing the running system. If an update
+      fails, or if a successful update is deemed to be incompatible or
+      incorrect, you can discard it immediately and return to its previous
+      functioning state.
+     </para>
+     <para>
+      <emphasis role="bold">Dependencies:</emphasis> Basesystem
+     </para>
+     <para>
+      <emphasis role="bold">Availability:</emphasis> &slsa;
+     </para>
+     <para>
+      <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+     </para>
+     <para>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs
+      LTSS<superscript>1</superscript>
+     </para>
+     <para>
+      <emphasis role="bold">Level:</emphasis> L3
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Web and Scripting</term>
+    <listitem>
+     <para>
+      Contains packages intended for a running Web server.
+     </para>
+     <para>
+      <emphasis role="bold">Dependencies:</emphasis> Basesystem, Server
+      Applications
+     </para>
+     <para>
+      <emphasis role="bold">Availability:</emphasis> &slsa;, &sles4sapa;,
+      &slehpca;
+     </para>
+     <para>
+      <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+     </para>
+     <para>
+      <emphasis role="bold">Extended support:</emphasis> 3 yrs
+      LTSS<superscript>1</superscript>
+     </para>
+     <para>
+      <emphasis role="bold">Level:</emphasis> L3
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>Workstation Extension</term>
+    <listitem>
+     <para>
+      Offers additional desktop applications and libraries. It is installed
+      by default on &sled;. Adding the Workstation Extension to a &sls;
+      installation allows you to seamlessly combine both products to create a
+      fully featured server workstation. For more information, refer to <link
+       xlink:href="https://www.suse.com/products/workstation-extension"/>.
+     </para>
+     <para>
+      <emphasis role="bold">Dependencies:</emphasis> Basesystem, Desktop
+      Applications
+     </para>
+     <para>
+      <emphasis role="bold">Availability:</emphasis> &slsa;, &sleda;
+      (default), &sles4sapa;
+     </para>
+     <para>
+      <emphasis role="bold">Lifecycle:</emphasis> 10 yrs
+     </para>
+     <para>
+      <emphasis role="bold">Extended support:</emphasis> None
+      LTSS<superscript>1</superscript>
+     </para>
+     <para>
+      <emphasis role="bold">Level:</emphasis> mixed L2/L3
+      (depending on package)
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+  <simplelist>
+   <member>
+    <superscript>1</superscript> LTSS: <link xlink:href="https://www.suse.com/products/long-term-service-pack-support/">Long-Term Service Pack Support</link>
+   </member>
+   <member>
+    <superscript>2</superscript> ESPOS: <link xlink:href="https://www.suse.com/support/policy-products/#hpc">Extended Service Pack Overlay Support</link>
+   </member>
+  </simplelist>
  </sect1>
 
  <sect1 xml:id="sec-modules-install">


### PR DESCRIPTION
### PR creator: Description

The giant modules and extensions table does not work on small screens, especially not with modules like the NVIDIA Cuda module since it has `<important>`s .

In order to get rid of the table, I first tried a `<variablelist>` but then settled for `<sect2>`s and an `<itemizedlist>`. Looks great and works on small screens.

Additionally, I added a 'Support' section that contains the content of the former footnotes (since we cannot have a `<para>` after a `<sect2>`) and some additional information.

Everything is validated, spell- and linkchecked, so I see no reasons to not merge it, even if it is late in the cycle.

### PR creator: Which product versions do the changes apply to?

- SLE 15/openSUSE Leap 15.x
  - [x ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*

Backports are optional.

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
