### PR TITLE
Use suse2022-ns stylesheets for SLE (SLES, SLED, SLE Micro)

### DIFF
--- a/DC-SLE-Micro-administration
+++ b/DC-SLE-Micro-administration
@@ -12,5 +12,5 @@ PROFOS="slemicro"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLE-Micro-all
+++ b/DC-SLE-Micro-all
@@ -11,5 +11,5 @@ PROFOS="slemicro"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLE-Micro-autoyast
+++ b/DC-SLE-Micro-autoyast
@@ -12,5 +12,5 @@ PROFOS="slemicro"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLE-Micro-deployment
+++ b/DC-SLE-Micro-deployment
@@ -12,5 +12,5 @@ PROFOS="slemicro"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLE-Micro-podman
+++ b/DC-SLE-Micro-podman
@@ -12,5 +12,5 @@ PROFOS="slemicro"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLE-Micro-security
+++ b/DC-SLE-Micro-security
@@ -12,5 +12,5 @@ PROFOS="slemicro"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLE-Micro-upgrade
+++ b/DC-SLE-Micro-upgrade
@@ -12,5 +12,5 @@ PROFOS="slemicro"
 PROFARCH="x86_64;zseries;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-administration
+++ b/DC-SLED-administration
@@ -12,5 +12,5 @@ PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-all
+++ b/DC-SLED-all
@@ -11,5 +11,5 @@ PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-deployment
+++ b/DC-SLED-deployment
@@ -12,5 +12,5 @@ PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-gnome-user
+++ b/DC-SLED-gnome-user
@@ -12,5 +12,5 @@ PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-html
+++ b/DC-SLED-html
@@ -11,5 +11,5 @@ PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-installation
+++ b/DC-SLED-installation
@@ -12,7 +12,7 @@ PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 # Setting the TOC depth to sect 3

--- a/DC-SLED-modules
+++ b/DC-SLED-modules
@@ -12,7 +12,7 @@ PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 # Setting the TOC depth to sect 2

--- a/DC-SLED-security
+++ b/DC-SLED-security
@@ -12,5 +12,5 @@ PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-tuning
+++ b/DC-SLED-tuning
@@ -12,5 +12,5 @@ PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLED-upgrade
+++ b/DC-SLED-upgrade
@@ -12,5 +12,5 @@ PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-administration
+++ b/DC-SLES-administration
@@ -12,5 +12,5 @@ PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-all
+++ b/DC-SLES-all
@@ -11,5 +11,5 @@ PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-amd-sev
+++ b/DC-SLES-amd-sev
@@ -13,5 +13,5 @@ PROFARCH="x86_64;zseries;power;aarch64"
 
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-autoyast
+++ b/DC-SLES-autoyast
@@ -12,5 +12,5 @@ PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-container
+++ b/DC-SLES-container
@@ -12,5 +12,5 @@ PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-deployment
+++ b/DC-SLES-deployment
@@ -12,5 +12,5 @@ PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-gnome-user
+++ b/DC-SLES-gnome-user
@@ -12,5 +12,5 @@ PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-html
+++ b/DC-SLES-html
@@ -11,5 +11,5 @@ PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-installation
+++ b/DC-SLES-installation
@@ -12,7 +12,7 @@ PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 # Setting the TOC depth to sect 2

--- a/DC-SLES-minimal-vm
+++ b/DC-SLES-minimal-vm
@@ -12,7 +12,7 @@ PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 # Setting the TOC depth to sect 2

--- a/DC-SLES-modules
+++ b/DC-SLES-modules
@@ -12,7 +12,7 @@ PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 # Setting the TOC depth to sect 2

--- a/DC-SLES-nvidia-vgpu
+++ b/DC-SLES-nvidia-vgpu
@@ -12,5 +12,5 @@ PROFARCH="x86_64;zseries;power;aarch64"
 
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-raspberry-pi
+++ b/DC-SLES-raspberry-pi
@@ -12,7 +12,7 @@ PROFOS="sles"
 PROFARCH="aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 # Setting the TOC depth to sect 2

--- a/DC-SLES-rmt
+++ b/DC-SLES-rmt
@@ -12,4 +12,4 @@ PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLES-security
+++ b/DC-SLES-security
@@ -12,5 +12,5 @@ PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-storage
+++ b/DC-SLES-storage
@@ -12,5 +12,5 @@ PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-tuning
+++ b/DC-SLES-tuning
@@ -12,5 +12,5 @@ PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-upgrade
+++ b/DC-SLES-upgrade
@@ -12,5 +12,5 @@ PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/DC-SLES-virtualization
+++ b/DC-SLES-virtualization
@@ -12,7 +12,7 @@ PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 ### Sort the glossary

--- a/DC-SLES-virtualization-best-practices
+++ b/DC-SLES-virtualization-best-practices
@@ -12,7 +12,7 @@ PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
 
 ## stylesheet location
-STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 ### Sort the glossary


### PR DESCRIPTION
### PR creator: Description

We want to switch to the new 3-column layout. This PR uses the new stylesheets.


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP4/~openSUSE Leap 15.4~ *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/~openSUSE Leap 15.3~
  - [x] SLE 15 SP2/~openSUSE Leap 15.2~
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4
  - [x] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

Needs to be cherry-picked to the respective, supported branches.