### PR TITLE
SEO fixes for de in SLE15 SP1

### DIFF
--- a/l10n/sles/de-de/xml/net_dhcp.xml
+++ b/l10n/sles/de-de/xml/net_dhcp.xml
@@ -465,7 +465,7 @@ fixed-address 192.168.2.100;
   <title>Weiterführende Informationen</title>
 
   <para>
-   Weitere Informationen zu DHCP finden Sie auf der Website des <emphasis>Internet Systems Consortium</emphasis> (<link xlink:href="https://www.isc.org/blogs/category/dhcp/"/>). Weitere Informationen finden Sie zudem auf den man-Seiten <option>dhcpd</option>, <option>dhcpd.conf</option>, <option>dhcpd.leases</option> und <option>dhcp-options</option>.
+   Weitere Informationen zu DHCP finden Sie auf der Website des <emphasis>Internet Systems Consortium</emphasis> (<link xlink:href="https://www.isc.org/dhcp/"/>). Weitere Informationen finden Sie zudem auf den man-Seiten <option>dhcpd</option>, <option>dhcpd.conf</option>, <option>dhcpd.leases</option> und <option>dhcp-options</option>.
   </para>
  </sect1>
 </chapter>


### PR DESCRIPTION
### PR creator: Description

SEO fixes in de translations for SLE15SP1. No backports, no cherry-picking.


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [x ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
