### PR TITLE
Deployment -> SUSEConnect timer

### DIFF
--- a/xml/deployment_register.xml
+++ b/xml/deployment_register.xml
@@ -584,4 +584,60 @@ https://www.suse.com/products/server/features/modules.html</screen>
 
   </sect2>
  </sect1>
+ <sect1 xml:id="sec-register-sle-suseconnect-timer">
+  <title>&suseconnect; keep-alive timer</title>
+  <para>
+   From version 0.3.33, the &suseconnect; package ships with two &systemd; units:
+  </para>
+
+  <itemizedlist>
+   <listitem>
+    <para>
+     <filename>suseconnect-keepalive.service</filename>: a one-shot service
+     which runs the command <command>&suseconnect; --keep-alive</command>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <filename>suseconnect-keepalive.timer</filename>: a timer which runs the
+     service <filename>suseconnect-keepalive.service</filename> on a daily
+     basis.
+    </para>
+   </listitem>
+  </itemizedlist>
+
+  <para>
+   These units are responsible for keeping the system information up-to-date
+   with the &scc; or registration server, and to provide accurate data about
+   subscription usage.
+  </para>
+  <para>
+   The command <command>&suseconnect; --keep-alive</command> updates the last
+   time a system has been seen and its hardware information with the
+   registration service.
+  </para>
+
+  <note>
+   <title>The timer is enabled automatically</title>
+   <para>
+    When the &suseconnect; package is installed or updated, and its version
+    is equal to or greater than the one described above, the keep-alive timer
+    will be enabled automatically.
+   </para>
+  </note>
+
+  <tip>
+   <title>Disabling the &suseconnect; keep-alive timer</title>
+   <para>
+    If you prefer to not have the &suseconnect; keep-alive timer running on your
+    system, you can disable it with <command>systemctl</command>:
+   </para>
+   <screen>&prompt.sudo;systemctl disable --now suse-connect-keepalive.timer</screen>
+   <para>
+    Once the timer is disabled, subsequent updates to the &suseconnect; package
+    will not reenable it.
+   </para>
+  </tip>
+
+ </sect1>
 </chapter>


### PR DESCRIPTION
### PR creator: Description

Updates the Deployment guide with new information regarding the SUSEConnect keep-alive timer.

https://github.com/SUSE/connect/blob/master/package/SUSEConnect.changes

### PR creator: Are there any relevant issues/feature requests?

No.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
