### PR TITLE
SEO fixes of broken links SLE12SP3_JA

### DIFF
--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -414,15 +414,6 @@ system_u:object_r:var_t var</screen>
    package <package>selinux-policy-minimum</package>. The examples in
    this chapter refer to this policy if not stated otherwise.
   </para>
-<!-- fs 2018-09-27: Packages no longer exist
-  <tip>
-   <para>
-    To install a different policy, you need to download it from
-    <link xlink:href="https://build.opensuse.org/package/binaries/security:SELinux/selinux-policy?repository=SLE_12"/>
-    and install:</para>
-<screen>sudo zypper in selinux-policy-targeted-<replaceable>VERSION_NUMBER</replaceable>.noarch.rpm</screen>
-  </tip>
--->
   <para>
    After installing the policy, you are ready to start file system labeling.
    Run


### PR DESCRIPTION
Applied broken link fixes for SEO purposes.

Changes will be done for each version separately, so no backports needed.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP4/openSUSE Leap 15.4 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [x] SLE 12 SP3
