### PR TITLE
Removed unnecessary 'Xenstrore in tmpfs' section from Virt BP

### DIFF
--- a/xml/art_virtualization-best-practices.xml
+++ b/xml/art_virtualization-best-practices.xml
@@ -454,20 +454,6 @@ always madvise [never]</screen>
       <filename>/etc/xen/xl.conf</filename>.
      </para>
     </sect4>
-    <sect4 xml:id="sec-vt-best-mem-xen-tmpfs">
-     <title>xenstore in <systemitem>tmpfs</systemitem></title>
-     <para>
-      When using &xen;, we recommend placing the xenstore database on
-      <systemitem>tmpfs</systemitem>. Xenstore is used as a control plane by
-      the xm/xend and xl/libxl toolstacks and the front-end and back-end
-      drivers servicing domain I/O devices. The load on xenstore increases
-      linearly as the number of running domains increase. If you anticipate
-      hosting many &vmguest; on a &xen; host, move the xenstore database onto
-      tmpfs to improve overall performance of the control plane. Mount the
-      <filename>/var/lib/xenstored</filename> directory on tmpfs:
-     </para>
-<screen>&prompt.user;&sudo; mount -t tmpfs tmpfs /var/lib/xenstored/</screen>
-    </sect4>
    </sect3>
    <sect3 xml:id="sec-vt-best-perf-ksm">
     <title>KSM and page sharing</title>


### PR DESCRIPTION
### PR creator: Description

According to https://bugzilla.suse.com/show_bug.cgi?id=1195441, this section is unneeded.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1195441



### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
