### PR TITLE
Booting Xen from snapshot fails (bsc#1196834)

### DIFF
--- a/xml/snapper.xml
+++ b/xml/snapper.xml
@@ -1122,7 +1122,7 @@ single | 4 |     |         |                       |
     </mediaobject>
    </figure>
    <warning>
-    <title>Booting &xen; from a Btrfs snapshot currently does not work</title>
+    <title>Booting &xen; from a Btrfs snapshot using &uefisecboot; currently fails</title>
     <para>
      Refer to <link
       xlink:href="https://www.suse.com/support/kb/doc/?id=000020602"/> for more

--- a/xml/snapper.xml
+++ b/xml/snapper.xml
@@ -1121,6 +1121,14 @@ single | 4 |     |         |                       |
      </imageobject>
     </mediaobject>
    </figure>
+   <warning>
+    <title>Booting &xen; from a Btrfs snapshot currently fails</title>
+    <para>
+     Refer to <link
+      xlink:href="https://www.suse.com/support/kb/doc/?id=000020602"/> for more
+     details.
+    </para>
+   </warning>
    <para>
     Each snapshot entry in the boot loader follows a naming scheme which makes
     it possible to identify it easily:

--- a/xml/snapper.xml
+++ b/xml/snapper.xml
@@ -1122,7 +1122,7 @@ single | 4 |     |         |                       |
     </mediaobject>
    </figure>
    <warning>
-    <title>Booting &xen; from a Btrfs snapshot currently fails</title>
+    <title>Booting &xen; from a Btrfs snapshot currently does not work</title>
     <para>
      Refer to <link
       xlink:href="https://www.suse.com/support/kb/doc/?id=000020602"/> for more

--- a/xml/snapper.xml
+++ b/xml/snapper.xml
@@ -1122,7 +1122,7 @@ single | 4 |     |         |                       |
     </mediaobject>
    </figure>
    <warning>
-    <title>Booting &xen; from a Btrfs snapshot using &uefisecboot; currently fails</title>
+    <title>Booting &xen; from a Btrfs snapshot using UEFI currently fails</title>
     <para>
      Refer to <link
       xlink:href="https://www.suse.com/support/kb/doc/?id=000020602"/> for more


### PR DESCRIPTION
### PR creator: Description

Currently, booting Xen kernel from a Btrfs snapshot fails. This update referres to a relevant support article.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1196834


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4
  - [x] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
