### PR TITLE
Preparing a stand-alone version of the Container Guide

### DIFF
--- a/DC-SLE-container-guide
+++ b/DC-SLE-container-guide
@@ -1,0 +1,15 @@
+## ---------------------------- 
+## Doc Config File for SLES
+## Container Guide
+## ----------------------------
+##
+## Basics
+MAIN="book_container.xml"
+
+## Profiling
+PROFOS="sles"
+PROFARCH="x86_64;zseries;power;aarch64"
+
+## stylesheet location
+STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
+FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"

--- a/xml/containers-basics.xml
+++ b/xml/containers-basics.xml
@@ -12,8 +12,7 @@
   </dm:docmanager>
  </info>
  <para>
-  The Linux kernel's namespaces and kernel control groups features (see <xref
-  linkend="cha-tuning-cgroups"/>) enable the container isolation from the rest
+  The Linux kernel's namespaces and kernel control groups features (see <link xlink:href="&dsc-sles;-15/html/SLES-all/cha-tuning-cgroups.html"/>) enable the container isolation from the rest
   of the host system and other containers. Linux containers offer a lightweight
   virtualization method to run multiple isolated environments simultaneously on
   a single host. Unlike &xen; and &kvm;, where a full guest operating system is
@@ -52,7 +51,7 @@
   <title>Limitations of containers</title>
   <listitem>
    <para>
-    Containers run on the host system's kernel, so the containers will have to use the specific 
+    Containers run on the host system's kernel, so the containers will have to use the specific
     kernel version provided by the host.
    </para>
   </listitem>

--- a/xml/containers-docker-installation.xml
+++ b/xml/containers-docker-installation.xml
@@ -264,8 +264,7 @@
     <filename>/var/lib/docker</filename> from snapshots, the file system will
     likely run out of disk space soon after you start deploying containers. In
     addition, a rollback to a previous snapshot will also reset the &docker;
-    database and images. For more information, see
-    <xref linkend="sec-snapper-setup-customizing-new-subvolume"/>.
+    database and images. For more information, see <link xlink:href="&dsc-sles;-15/html/SLES-all/cha-snapper.html#sec-snapper-setup-customizing-new-subvolume"/>.
    </para>
   </important>
  </sect1>


### PR DESCRIPTION
Preparing the Container Guide for a stand-alone build, so it can be published in a separate category on d.s.c. Long term plan (SLE 15 SP5) is to move it out of the set to doc-unversioned (caution: will break existing localized builds). Therefore this change should not be mereged into any maintenance branch.

* created a new DC-file for a stand-alone version of the guide
* replaced internal xfres with external links




