### PR TITLE
No need to add the vfio-pci in a loadabale list (bsc#1200003)

### DIFF
--- a/xml/gpu_passthru.xml
+++ b/xml/gpu_passthru.xml
@@ -209,21 +209,6 @@ Welcome to SUSE Linux Enterprise Server 15  (x86_64) - Kernel \r (\l).
      </step>
     </procedure>
    </sect3>
-   <sect3 xml:id="gpu-passthru-load-vfio-modules">
-    <title>Adding the driver to the list of auto-loaded modules</title>
-    <para>
-     Create the file <filename>/etc/modules-load.d/vfio-pci.conf</filename> and
-     add the following content:
-    </para>
-<screen>
-pci_stub
-vfio
-vfio_iommu_type1
-vfio_pci
-kvm
-kvm_intel
-</screen>
-   </sect3>
    <sect3 xml:id="gpu-passthru-load-vfio-manual">
     <title>Loading the driver manually</title>
     <para>

--- a/xml/gpu_passthru.xml
+++ b/xml/gpu_passthru.xml
@@ -209,6 +209,20 @@ Welcome to SUSE Linux Enterprise Server 15  (x86_64) - Kernel \r (\l).
      </step>
     </procedure>
    </sect3>
+   <sect3 xml:id="gpu-passthru-load-vfio-modules">
+    <title>Adding the driver to the list of auto-loaded modules</title>
+    <para>
+     Create the file <filename>/etc/modules-load.d/vfio-pci.conf</filename> and
+     add the following content:
+    </para>
+<screen>
+vfio
+vfio_iommu_type1
+vfio_pci
+kvm
+kvm_intel
+</screen>
+   </sect3>
    <sect3 xml:id="gpu-passthru-load-vfio-manual">
     <title>Loading the driver manually</title>
     <para>


### PR DESCRIPTION
### PR creator: Description

The related modules are already in the kernel.

### PR creator: Are there any relevant issues/feature requests?

* bsc#1200003



### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
