### PR TITLE
Changed example in the _netdev section

### DIFF
--- a/xml/storage_uuids.xml
+++ b/xml/storage_uuids.xml
@@ -125,7 +125,7 @@ lrwxrwxrwx 1 10 Dec  5 07:48 e014e482-1c2d-4d09-84ec-61b3aefde77a -&gt; ../../sd
   </para>
 
 <screen>
-UUID=83df497d-bd6d-48a3-9275-37c0e3c8dc74  /root   ntfs  defaults,_netdev    0  0
+mars.example.org:/nfsexport  /shared   nfs  defaults,_netdev    0  0
   </screen>
  </sect1>
 </chapter>


### PR DESCRIPTION
I changed the mount of a local ntfs /root filesystem to the mount of a correctly specified remote system. This better reflects the exemplified usage.

### PR creator: Description

Describe the overall goals of this pull request.


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 GA
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4
  - [x] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
