### PR TITLE
Fix techpreview label error

### DIFF
--- a/xml/containers-bci.xml
+++ b/xml/containers-bci.xml
@@ -113,23 +113,27 @@
     information is visible on the web on
     <link xlink:href="https://registry.suse.com">registry.suse.com</link>. In
     addition to that, it is also indicated via the
-    <literal>com.suse.techpreview</literal> label whether a container image
+    <literal>com.suse.supportlevel</literal> label whether a container image
     still has the tech preview status. You can use the skopeo and jq utilities
     to check the status of the desired &bcia; as follows:
    </para>
-<screen>skopeo inspect docker://registry.suse.com/bci/bci-micro:15.4 | jq '.Labels["com.suse.techpreview"]'
-1
-skopeo inspect docker://registry.suse.com/bci/bci-base:15.4 | jq '.Labels["com.suse.techpreview"]'
-null</screen>
+<screen>❯ skopeo inspect docker://registry.suse.com/bci/bci-micro:15.4 | jq '.Labels["com.suse.supportlevel"]'
+"techpreview"
+
+❯ skopeo inspect docker://registry.suse.com/bci/bci-base:15.4 | jq '.Labels["com.suse.supportlevel"]'
+"l3"
+</screen>
    <para>
-    In the example above, the <literal>com.suse.techpreview</literal> label is
-    set to 1 in the <literal>bci-micro</literal> container image, indicating
-    that the image still has the tech preview status. Unlike like the general
-    purpose &bcia;, the language stack &bcia; may not follow the lifecycle of
-    the &slea; distribution: they are supported as long as the respective
-    language stack receives support. In other words, new versions of &bcia;
-    (indicated by the OCI tags) may be released during the lifecycle of a
-    &slea; Service Pack, while older versions may become unsupported. Refer to
+    In the example above, the <literal>com.suse.supportlevel</literal> label is
+    set to <literal>techpreview</literal> in the <literal>bci-micro</literal> 
+    container image, indicating that the image still has the tech preview status. 
+    The <literal>bci-base</literal> container image on the other hand is fully l3
+    supported. Unlike like the general purpose &bcia;, the language stack &bcia;
+    may not follow the lifecycle of the &slea; distribution: they are supported 
+    as long as the respective language stack receives support. In other words,
+    new versions of &bcia; (indicated by the OCI tags) may be released during the
+    lifecycle of a &slea; Service Pack, while older versions may become 
+    unsupported. Refer to 
     <link xlink:href="https://suse.com/lifecycle">suse.com/lifecycle</link> to
     find out whether the container in question is still under support.
    </para>


### PR DESCRIPTION
### PR creator: Description

The `com.suse.techpreview` label does not exist anymore, it has been replaced with `com.suse.supportlevel`


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
