### PR TITLE
Removed GlusterFS mentions (bsc#1200243)

### DIFF
--- a/xml/libvirt_host.xml
+++ b/xml/libvirt_host.xml
@@ -1103,14 +1103,6 @@ Network vnet_isolated has been undefined</screen>
         </para>
        </listitem>
       </varlistentry>
-<!-- <varlistentry>
-      <term>GlusterFS device (<guimenu>gluster</guimenu>)</term>
-      <listitem>
-       <para>
-        ...
-       </para>
-      </listitem>
-     </varlistentry> -->
       <varlistentry>
        <term>iSCSI target (iscsi)</term>
        <listitem>
@@ -1176,8 +1168,7 @@ Syncing disks.</screen>
          Specify a network directory to be used in the same way as a file
          system directory pool (a directory for hosting image files). The only
          difference to using a file system directory is that &libvirt; takes
-         care of mounting the directory. Supported protocols are NFS and
-         GlusterFS.
+         care of mounting the directory. The supported protocol is NFS.
         </para>
        </listitem>
       </varlistentry>


### PR DESCRIPTION
### PR creator: Description

GlusterFS is not supported by SUSE.


### PR creator: Are there any relevant issues/feature requests?

fixes https://bugzilla.suse.com/show_bug.cgi?id=1200243


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 GA
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
