### PR TITLE
Care for syncing VM time after restore (bsc#1199991)

### DIFF
--- a/xml/libvirt_managing.xml
+++ b/xml/libvirt_managing.xml
@@ -501,6 +501,19 @@
   </warning>
 
   <important>
+   <title>Synchronize &vmguest;'s time after restoring it</title>
+   <para>
+    If you restore the &vmguest; after a long pause (hours) since
+    it was saved, its time synchronization service&mdash;for example,
+    &chronyd;&mdash;may refuse to synchronize its time. In this case,
+    manually synchronize &vmguest;'s time. For example, for &kvm; hosts,
+    you can use the &qemu; guest agent and instruct the guest with the
+    <command>guest-set-time</command>. Refer to <xref linkend="cha-qemu-ga"/>
+    for more details.
+   </para>
+  </important>
+
+  <important>
    <title>Only for &vmguest;s with disk types <literal>raw</literal>, <literal>qcow2</literal></title>
    <para>
     Saving and restoring &vmguest;s is only possible if the &vmguest; is using


### PR DESCRIPTION

### PR creator: Are there any relevant issues/feature requests?

https://bugzilla.suse.com/show_bug.cgi?id=1199991


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
