### PR TITLE
SEO fixes of broken links SLE15SP0 JA

### DIFF
--- a/l10n/sles/ja-jp/xml/net_dhcp.xml
+++ b/l10n/sles/ja-jp/xml/net_dhcp.xml
@@ -440,7 +440,7 @@ fixed-address 192.168.2.100;
   <title>その他の情報</title>
 
   <para>
-   DHCPの詳細については、<emphasis>Internet Systems Consortium</emphasis>のWebサイト(<link xlink:href="http://www.isc.org/products/DHCP/"/>)を参照してください。また、<option>dhcpd</option>、<option>dhcpd.conf</option>、<option>dhcpd.leases</option>、および<option>dhcp-options</option>のマニュアルページにも詳細が記載されています。
+   DHCPの詳細については、<emphasis>Internet Systems Consortium</emphasis>のWebサイト(<link xlink:href="https://www.isc.org/dhcp/"/>)を参照してください。また、<option>dhcpd</option>、<option>dhcpd.conf</option>、<option>dhcpd.leases</option>、および<option>dhcp-options</option>のマニュアルページにも詳細が記載されています。
   </para>
  </sect1>
 </chapter>

--- a/l10n/sles/ja-jp/xml/net_nfs.xml
+++ b/l10n/sles/ja-jp/xml/net_nfs.xml
@@ -72,7 +72,7 @@
       NFSv4は、Kerberosによるセキュアなユーザ認証をサポートする新しいバージョン4の実装です。NFSv4で必要なポートは1つのみであるため、NFSv3よりもファイアウォール環境に適しています。
      </para>
      <para>
-      プロトコルは<link xlink:href="http://tools.ietf.org/html/rfc3530"/>で指定されています。
+      プロトコルは<link xlink:href="https://datatracker.ietf.org/doc/html/rfc3530"/>で指定されています。
      </para>
     </listitem>
    </varlistentry>

--- a/l10n/sles/ja-jp/xml/storage_filesystems.xml
+++ b/l10n/sles/ja-jp/xml/storage_filesystems.xml
@@ -1445,11 +1445,6 @@ Label: none uuid: 40123456-cb2c-4678-8b3d-d014d1c78c78
    </listitem>
    <listitem>
     <para>
-     XFS: 高パフォーマンスジャーナリングファイルシステム: <link xlink:href="http://oss.sgi.com/projects/xfs/"/>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
      OCFS2プロジェクト: <link xlink:href="http://oss.oracle.com/projects/ocfs2/"/>
     </para>
    </listitem>

--- a/l10n/sles/ja-jp/xml/storage_nvmeof.xml
+++ b/l10n/sles/ja-jp/xml/storage_nvmeof.xml
@@ -253,10 +253,7 @@ Parameter traddr is now '10.0.0.1'.</screen>
    <para>
     ファイバチャネルポートをNVMeターゲットとして有効にするには、追加のモジュールパラメータを設定する必要があります。たとえば、<option>lpfc_enable_nvmet=<replaceable> COMMA_SEPARATED_WWPNS</replaceable></option>と指定します。先行する<literal>0x</literal>とともにWWPNを入力します。たとえば、<option>lpfc_enable_nvmet=0x2000000055001122,0x2000000055003344</option>と指定します。一覧表示されているWWPNのみがターゲットモードに設定されます。ファイバチャネルポートは、ターゲットまたはイニシエータとして設定できます。
    </para>
-   <para>
-    詳細については、<link xlink:href="https://docs.broadcom.com/docs/12379413"/>も参照してください。
-   </para>
-  </sect2>
+   </sect2>
  </sect1>
  <sect1 xml:id="sec-nvmeof-more-information">
   <title>詳細情報</title>
@@ -276,9 +273,6 @@ Parameter traddr is now '10.0.0.1'.</screen>
    <listitem>
     <para><link xlink:href="https://storpool.com/blog/demystifying-what-is-nvmeof"/></para>
    </listitem>
-   <listitem>
-    <para><link xlink:href="https://medium.com/@metebalci/a-quick-tour-of-nvm-express-nvme-3da2246ce4ef"/></para>
-   </listitem>
-  </itemizedlist>
+   </itemizedlist>
  </sect1>
 </chapter>


### PR DESCRIPTION
Applied broken link fixes for SEO purposes.

Changes will be done for each version separately, so no backports needed.
### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [x] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3
