### PR TITLE
SEO fixes of broken links SLE15SP0 EN

### DIFF
--- a/l10n/sles/zh-cn/xml/net_nfs.xml
+++ b/l10n/sles/zh-cn/xml/net_nfs.xml
@@ -72,7 +72,7 @@
       NFSv4 是新的版本 4 实施，支持通过 kerberos 进行安全用户身份验证。NFSv4 只需要一个端口，因此，它比 NFSv3 更适合用于防火墙后的环境。
      </para>
      <para>
-      协议指定为 <link xlink:href="https://datatracker.ietf.org/doc/html/rfc3530/"/>。
+      协议指定为 <link xlink:href="http://tools.ietf.org/html/rfc3530"/>。
      </para>
     </listitem>
    </varlistentry>

--- a/xml/apps_gimp.xml
+++ b/xml/apps_gimp.xml
@@ -1113,7 +1113,7 @@
    <listitem>
     <para>
      There are several mailing lists about GIMP. You will find them at
-     <link xlink:href="https://www.gimp.org/mail_lists.html"/>. The GIMP User
+     <link xlink:href="https://www.gimp.org/discuss.html#mailing-lists/"/>. The GIMP User
      list is the most appropriate place to ask user questions.
     </para>
    </listitem>

--- a/xml/apps_gimp.xml
+++ b/xml/apps_gimp.xml
@@ -1113,7 +1113,7 @@
    <listitem>
     <para>
      There are several mailing lists about GIMP. You will find them at
-     <link xlink:href="https://www.gimp.org/discuss.html#mailing-lists/"/>. The GIMP User
+     <link xlink:href="https://www.gimp.org/discuss.html#mailing-lists"/>. The GIMP User
      list is the most appropriate place to ask user questions.
     </para>
    </listitem>

--- a/xml/apps_gimp.xml
+++ b/xml/apps_gimp.xml
@@ -1113,7 +1113,7 @@
    <listitem>
     <para>
      There are several mailing lists about GIMP. You will find them at
-     <link xlink:href="https://www.gimp.org/discuss.html#mailing-lists"/>. The GIMP User
+     <link xlink:href="https://www.gimp.org/discuss.html"/>. The GIMP User
      list is the most appropriate place to ask user questions.
     </para>
    </listitem>


### PR DESCRIPTION
Applied broken link fixes for SEO purposes.

Changes will be done for each version separately, so no backports needed.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [x] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

