### PR TITLE
SEO fixes of broken links SLE12SP4 JA

### DIFF
--- a/l10n/sles/ja-jp/xml/adm_support.xml
+++ b/l10n/sles/ja-jp/xml/adm_support.xml
@@ -1352,7 +1352,7 @@ setup-sca</screen>
    </listitem>
    <listitem>
     <para>
-     <link xlink:href="https://www.novell.com/communities/coolsolutions/cool_tools/create-your-own-supportconfig-plugin/"/>—「Create Your Own Supportconfig Plugin」
+     <link xlink:href="https://community.microfocus.com/collaboration/gw/groupwise/w/groupwise/34308/create-your-own-supportconfig-plugin/"/>—「Create Your Own Supportconfig Plugin」
     </para>
    </listitem>
    </itemizedlist>

--- a/l10n/sles/ja-jp/xml/net_nfs.xml
+++ b/l10n/sles/ja-jp/xml/net_nfs.xml
@@ -72,7 +72,7 @@
       NFSv4は、Kerberosによるセキュアなユーザ認証をサポートする新しいバージョン4の実装です。NFSv4で必要なポートは1つのみであるため、NFSv3よりもファイアウォール環境に適しています。
      </para>
      <para>
-      プロトコルは<link xlink:href="http://tools.ietf.org/html/rfc3530"/>で指定されています。
+      プロトコルは<link xlink:href="https://datatracker.ietf.org/doc/html/rfc3530"/>で指定されています。
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Applied broken link fixes for SEO purposes.

Changes will be done for each version separately, so no backports needed.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [x] SLE 12 SP4
  - [ ] SLE 12 SP3