### PR TITLE
New location for list of keyboard layouts

### DIFF
--- a/xml/ay_country_settings.xml
+++ b/xml/ay_country_settings.xml
@@ -115,7 +115,7 @@
     <para>
      Keymap-code values or keymap-alias values are valid. A list of available
      entries can be found in
-     <literal>/usr/share/YaST2/data/keyboards.rb</literal>. For example,
+     <literal>/usr/share/YaST2/lib/y2keyboard/keyboards.rb</literal>. For example,
      <literal>english-us, us, english-uk, uk.</literal>
     </para>
    </listitem>


### PR DESCRIPTION
Just fixing the path of file containing a list of entries available for setting up a keyboard layout.

### PR creator: Description

Accordingly to documentation, file used to be in:
/usr/share/YaST2/data/keyboards.rb

Checked that in openSUSE 15.3 it is in:
/usr/share/YaST2/lib/y2keyboard/keyboards.rb

### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
