### PR TITLE
SEO fixes of broken links SLE15SP1 DE

### DIFF
--- a/l10n/sles/de-de/xml/net_nfs.xml
+++ b/l10n/sles/de-de/xml/net_nfs.xml
@@ -72,7 +72,7 @@
       NFSv4 ist die neue Implementationsversion 4, die die sichere Benutzerauthentifizierung über Kerberos unterstützt. Für NFSv4 ist nur ein einzelner Port erforderlich; diese Version eignet sich daher besser für Umgebungen hinter einer Firewall als NFSv3.
      </para>
      <para>
-      Das Protokoll wird als <link xlink:href="http://tools.ietf.org/html/rfc3530"/> angegeben.
+      Das Protokoll wird als <link xlink:href="https://datatracker.ietf.org/doc/html/rfc3530"/> angegeben.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
Applied broken link fixes for SEO purposes.

Changes will be done for each version separately, so no backports needed.


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
