### PR TITLE
update sle 15 sp3 and up, kdump and kevec work in Secure Boot mode

### DIFF
--- a/xml/uefi.xml
+++ b/xml/uefi.xml
@@ -264,7 +264,7 @@ Microsoft certificate for this. -->
 
   <sect2 xml:id="sec-uefi-secboot-mok">
    <title>MOK (Machine Owner Key)</title>
-   
+
    <para>
    To replace specific kernels, drivers, or other components that are part of
    the boot process, you need to use Machine Owner Keys (MOKs). The
@@ -286,7 +286,7 @@ Microsoft certificate for this. -->
    Enrolling a key from disk is usually done when the shim fails to
    load <systemitem>grub2</systemitem> and falls back to loading
    MokManager. As <systemitem>MokNew</systemitem> does not exist yet,
-   you have the option of locating the key on the UEFI partition. 
+   you have the option of locating the key on the UEFI partition.
    </para>
   </sect2>
 
@@ -586,6 +586,12 @@ MOK
       UEFI booting from USB devices is supported.
      </para>
     </listitem>
+     <listitem>
+     <para>
+      Since @sles;&nbsp;15 SP3, Kexec and Kdump are enabled to work in
+      Secure Boot mode.
+     </para>
+    </listitem>
    </itemizedlist>
    <para>
     When booting in Secure Boot mode, the following limitations apply:
@@ -601,11 +607,6 @@ MOK
     <listitem>
      <para>
       Boot loader, kernel, and kernel modules must be signed.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      Kexec and Kdump are disabled.
      </para>
     </listitem>
     <listitem>


### PR DESCRIPTION
### PR creator: Description

Describe the overall goals of this pull request.


### PR creator: Are there any relevant issues/feature requests?
* bsc# 1200086
* jsc# DOCTEAM-651


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?
1200086
The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
