### PR TITLE
Remove 'backend' element from AY Guide SP3

### DIFF
--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -177,18 +177,6 @@
    configuration is applied:
   </para>
   <variablelist>
-   <varlistentry os="slemicro">
-    <term>backend</term>
-    <listitem>
-     <para>
-      Selects the network backend to be used. Supported values are
-      <literal>wicked</literal>, <literal>network_manager</literal> or
-      <literal>none</literal>, the latter of which will disable the network
-      service.
-     </para>
-<screen>&lt;backend&gt;network_manager&lt;/backend&gt;</screen>
-    </listitem>
-   </varlistentry>
    <varlistentry>
     <term>keep_install_network</term>
     <listitem>


### PR DESCRIPTION
This element applies only to SLE 15 SP4 and up

### PR creator: Description

Profile 'backend' element for SLE Micro; applies only to SLES 15SP4 and up.
Also corrections to XML tags 

Jira #DOCTEAM-525
Bugzilla #1200722



### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
