### PR TITLE
AY guide: Behaviour of ! in user_password depends on encrypted setting.

### DIFF
--- a/xml/ay_users_groups.xml
+++ b/xml/ay_users_groups.xml
@@ -246,13 +246,18 @@
      </para>
 <screen>&lt;user_password&gt;some-password&lt;/user_password&gt;</screen>
      <para>
-      Optional. If you enter an exclamation mark (<literal>!</literal>), a
-      random password will be generated. A user's password can be written in
+      Optional. A user's password can be written in
       plain text (not recommended) or in encrypted form. To create an encrypted
       password, use <command>mkpasswd</command>. Enter the password as written
       in <filename>/etc/shadow</filename> (second column). To enable or disable
       the use of encrypted passwords in the profile, see the
       <literal>encrypted</literal> parameter.
+      With encrypted passwords disabled, if you enter an exclamation
+      mark (<literal>!</literal>), a random password will be generated.
+      With encrypted passwords enabled, the value is copied to the password field
+      of <filename>/etc/shadow</filename>.
+      If you enter an exclamation mark (<literal>!</literal>) in this case,
+      you get an account with locked password that cannot login on console.
      </para>
     </listitem>
    </varlistentry>


### PR DESCRIPTION
### PR creator: Description

The current description of the user_password setting in autoyast guide claims that a exclamation mark will generate a random password. This is only true if and only if encrypted value is set to false.
If you set an exclamation mark as value in user_password and encrypted is true, you get a account with locked password.
This is a nice feature and should be clarified in the documentation.

Since this is my first PR to sle-doc, feel free to correct me, e.g if I marked the wrong checkboxed below and I only used main as target branch.
I tested this with SLES12 SP5, SLES15 SP3 and SLES15 SP4.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 SP0
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4
  - [x] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
