### PR TITLE
SEO fixes of broken links SLE12SP5 JA

### DIFF
--- a/l10n/sles/ja-jp/xml/adm_support.xml
+++ b/l10n/sles/ja-jp/xml/adm_support.xml
@@ -1328,7 +1328,7 @@ setup-sca</screen>
    </listitem>
    <listitem>
     <para>
-     <link xlink:href="https://www.novell.com/communities/coolsolutions/cool_tools/create-your-own-supportconfig-plugin/"/>—「Create Your Own Supportconfig Plugin」
+     <link xlink:href="https://community.microfocus.com/collaboration/gw/groupwise/w/groupwise/34308/create-your-own-supportconfig-plugin/"/>—「Create Your Own Supportconfig Plugin」
     </para>
    </listitem>
    <listitem>


### PR DESCRIPTION
Applied broken link fixes for SEO purposes.

Changes will be done for each version separately, so no backports needed.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [x] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

