### PR TITLE
SEO fixes of broken links SLE12SP5 EN

### DIFF
--- a/xml/apps_gimp.xml
+++ b/xml/apps_gimp.xml
@@ -1197,7 +1197,7 @@
    <listitem>
     <para>
      There are several mailing lists about GIMP. You will find them at
-     <link xlink:href="https://www.gimp.org/mail_lists.html"/>. The GIMP User
+     <link xlink:href="https://www.gimp.org/discuss.html"/>. The GIMP User
      list is the most appropriate place to ask user questions.
     </para>
    </listitem>


### PR DESCRIPTION
Applied broken link fixes for SEO purposes.

Changes will be done for each version separately, so no backports needed.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [x] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

