### PR TITLE
AutoYaST network closing tags

### DIFF
--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -186,7 +186,7 @@
       <literal>none</literal>, the latter of which will disable the network
       service.
      </para>
-<screen>&lt;backend&gt;network_manager&lt;backend&gt;</screen>
+<screen>&lt;backend&gt;network_manager&lt;/backend&gt;</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -200,7 +200,7 @@
       <literal>false</literal>. The value is <literal>true</literal> by
       default.
      </para>
-<screen>&lt;keep_install_network config:type="boolean"&gt;false&lt;keep_install_network&gt;</screen>
+<screen>&lt;keep_install_network config:type="boolean"&gt;false&lt;/keep_install_network&gt;</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -212,7 +212,7 @@
      <para>
       Deprecated. Use <literal>backend</literal> instead.
      </para>
-<screen>&lt;managed config:type="boolean"&gt;true&lt;managed&gt;</screen>
+<screen>&lt;managed config:type="boolean"&gt;true&lt;/managed&gt;</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -221,7 +221,7 @@
      <para>
       Forces &ay; to restart the network just after writing the configuration.
      </para>
-<screen>&lt;start_immediately config:type="boolean"&gt;true&lt;start_immediately&gt;</screen>
+<screen>&lt;start_immediately config:type="boolean"&gt;true&lt;/start_immediately&gt;</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -232,7 +232,7 @@
       installation process. Otherwise, &ay; relies on the configuration set by
       <command>linuxrc</command>.
      </para>
-<screen>&lt;setup_before_proposal config:type="boolean"&gt;true&lt;setup_before_proposal&gt;</screen>
+<screen>&lt;setup_before_proposal config:type="boolean"&gt;true&lt;/setup_before_proposal&gt;</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -244,7 +244,7 @@
       is controlled by this element. If it is set to <literal>0</literal>, the
       installation is stopped.
      </para>
-<screen>&lt;strict_IP_check_timeout config:type="integer"&gt;5&lt;strict_IP_check_timeout&gt;</screen>
+<screen>&lt;strict_IP_check_timeout config:type="integer"&gt;5&lt;/strict_IP_check_timeout&gt;</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -255,7 +255,7 @@
       installed (for example, Xen, QEMU or KVM). You can disable this behavior by
       setting this element to <literal>false</literal>.
      </para>
-<screen>&lt;virt_bridge_proposal config:type="boolean"&gt;false&gt;virt_bridge_proposal&gt;</screen>
+<screen>&lt;virt_bridge_proposal config:type="boolean"&gt;false&gt;/virt_bridge_proposal&gt;</screen>
     </listitem>
    </varlistentry>
   </variablelist>


### PR DESCRIPTION
Signed-off-by: Georg Pfuetzenreuter <georg.pfuetzenreuter@suse.com>

### PR creator: Description

Minor touch-up of some XML closing tags to clarify proper usage.


### PR creator: Are there any relevant issues/feature requests?

* n/a


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
