### PR TITLE
SEO fix broken links

### DIFF
--- a/l10n/sled/de-de/xml/apps_gimp.xml
+++ b/l10n/sled/de-de/xml/apps_gimp.xml
@@ -777,7 +777,7 @@
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     Es gibt verschiedene Mailinglisten zu GIMP. Sie finden diese unter <link xlink:href="http://www.gimp.org/mail_lists.html"/>. Die GIMP-Benutzerliste ist der beste Ort für Benutzerfragen. 
+     Es gibt verschiedene Mailinglisten zu GIMP. Sie finden diese unter <link xlink:href="https://www.gimp.org/discuss.html#mailing-lists"/>. Die GIMP-Benutzerliste ist der beste Ort für Benutzerfragen. 
     </para>
    </listitem>
    <listitem>

--- a/l10n/sled/ja-jp/xml/apps_gimp.xml
+++ b/l10n/sled/ja-jp/xml/apps_gimp.xml
@@ -777,7 +777,7 @@
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     GIMPに関しては、さまざまなメーリングリストが存在します。こうしたメーリングリストは、<link xlink:href="http://www.gimp.org/mail_lists.html"/>で検索できます。GIMPユーザリストは、ユーザが質問するうえで最適な場所です。
+     GIMPに関しては、さまざまなメーリングリストが存在します。こうしたメーリングリストは、<link xlink:href="https://www.gimp.org/discuss.html#mailing-lists"/>で検索できます。GIMPユーザリストは、ユーザが質問するうえで最適な場所です。
     </para>
    </listitem>
    <listitem>

--- a/l10n/sled/pt-br/xml/apps_gimp.xml
+++ b/l10n/sled/pt-br/xml/apps_gimp.xml
@@ -762,7 +762,7 @@
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     Há várias listas de discussão sobre o GIMP. Elas estão em <link xlink:href="http://www.gimp.org/mail_lists.html"/>. A lista Usuário do GIMP é a mais adequada para fazer perguntas aos usuários.
+     Há várias listas de discussão sobre o GIMP. Elas estão em <link xlink:href="https://www.gimp.org/discuss.html#mailing-lists"/>. A lista Usuário do GIMP é a mais adequada para fazer perguntas aos usuários.
     </para>
    </listitem>
    <listitem>

--- a/l10n/sled/zh-cn/xml/apps_gimp.xml
+++ b/l10n/sled/zh-cn/xml/apps_gimp.xml
@@ -777,7 +777,7 @@
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     有关 GIMP 的邮件列表有多个。您可以在 <link xlink:href="http://www.gimp.org/mail_lists.html"/> 上找到这些列表。“GIMP 用户”列表最适合用来提出用户遇到的问题。
+     有关 GIMP 的邮件列表有多个。您可以在 <link xlink:href="https://www.gimp.org/discuss.html#mailing-lists"/> 上找到这些列表。“GIMP 用户”列表最适合用来提出用户遇到的问题。
     </para>
    </listitem>
    <listitem>

--- a/l10n/sled/zh-tw/xml/apps_gimp.xml
+++ b/l10n/sled/zh-tw/xml/apps_gimp.xml
@@ -777,7 +777,7 @@
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     有關 GIMP 的通信論壇有多個。它們都可以在 <link xlink:href="http://www.gimp.org/mail_lists.html"/> 中找到。GIMP 使用者論壇是使用者詢問問題的最佳場所。
+     有關 GIMP 的通信論壇有多個。它們都可以在 <link xlink:href="https://www.gimp.org/discuss.html#mailing-lists"/> 中找到。GIMP 使用者論壇是使用者詢問問題的最佳場所。
     </para>
    </listitem>
    <listitem>

--- a/l10n/sles/de-de/xml/apps_gimp.xml
+++ b/l10n/sles/de-de/xml/apps_gimp.xml
@@ -777,7 +777,7 @@
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     Es gibt verschiedene Mailinglisten zu GIMP. Sie finden diese unter <link xlink:href="http://www.gimp.org/mail_lists.html"/>. Die GIMP-Benutzerliste ist der beste Ort für Benutzerfragen. 
+     Es gibt verschiedene Mailinglisten zu GIMP. Sie finden diese unter <link xlink:href="https://www.gimp.org/discuss.html#mailing-lists"/>. Die GIMP-Benutzerliste ist der beste Ort für Benutzerfragen. 
     </para>
    </listitem>
    <listitem>

--- a/l10n/sles/ja-jp/xml/apps_gimp.xml
+++ b/l10n/sles/ja-jp/xml/apps_gimp.xml
@@ -777,7 +777,7 @@
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     GIMPに関しては、さまざまなメーリングリストが存在します。こうしたメーリングリストは、<link xlink:href="http://www.gimp.org/mail_lists.html"/>で検索できます。GIMPユーザリストは、ユーザが質問するうえで最適な場所です。
+     GIMPに関しては、さまざまなメーリングリストが存在します。こうしたメーリングリストは、<link xlink:href="https://www.gimp.org/discuss.html#mailing-lists"/>で検索できます。GIMPユーザリストは、ユーザが質問するうえで最適な場所です。
     </para>
    </listitem>
    <listitem>

--- a/l10n/sles/pt-br/xml/apps_gimp.xml
+++ b/l10n/sles/pt-br/xml/apps_gimp.xml
@@ -762,7 +762,7 @@
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     Há várias listas de discussão sobre o GIMP. Elas estão em <link xlink:href="http://www.gimp.org/mail_lists.html"/>. A lista Usuário do GIMP é a mais adequada para fazer perguntas aos usuários.
+     Há várias listas de discussão sobre o GIMP. Elas estão em <link xlink:href="https://www.gimp.org/discuss.html#mailing-lists"/>. A lista Usuário do GIMP é a mais adequada para fazer perguntas aos usuários.
     </para>
    </listitem>
    <listitem>

--- a/l10n/sles/zh-cn/xml/apps_gimp.xml
+++ b/l10n/sles/zh-cn/xml/apps_gimp.xml
@@ -777,7 +777,7 @@
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     有关 GIMP 的邮件列表有多个。您可以在 <link xlink:href="http://www.gimp.org/mail_lists.html"/> 上找到这些列表。“GIMP 用户”列表最适合用来提出用户遇到的问题。
+     有关 GIMP 的邮件列表有多个。您可以在 <link xlink:href="https://www.gimp.org/discuss.html#mailing-lists"/> 上找到这些列表。“GIMP 用户”列表最适合用来提出用户遇到的问题。
     </para>
    </listitem>
    <listitem>

--- a/l10n/sles/zh-cn/xml/storage_nvmeof.xml
+++ b/l10n/sles/zh-cn/xml/storage_nvmeof.xml
@@ -278,9 +278,6 @@ Parameter traddr is now '10.0.0.1'.</screen>
    <listitem>
     <para><link xlink:href="https://storpool.com/blog/demystifying-what-is-nvmeof"/></para>
    </listitem>
-   <listitem>
-    <para><link xlink:href="https://medium.com/@metebalci/a-quick-tour-of-nvm-express-nvme-3da2246ce4ef"/></para>
-   </listitem>
   </itemizedlist>
  </sect1>
 </chapter>

--- a/l10n/sles/zh-tw/xml/apps_gimp.xml
+++ b/l10n/sles/zh-tw/xml/apps_gimp.xml
@@ -777,7 +777,7 @@
   <itemizedlist mark="bullet" spacing="normal">
    <listitem>
     <para>
-     有關 GIMP 的通信論壇有多個。它們都可以在 <link xlink:href="http://www.gimp.org/mail_lists.html"/> 中找到。GIMP 使用者論壇是使用者詢問問題的最佳場所。
+     有關 GIMP 的通信論壇有多個。它們都可以在 <link xlink:href="https://www.gimp.org/discuss.html#mailing-lists"/> 中找到。GIMP 使用者論壇是使用者詢問問題的最佳場所。
     </para>
    </listitem>
    <listitem>

--- a/l10n/sles/zh-tw/xml/storage_nvmeof.xml
+++ b/l10n/sles/zh-tw/xml/storage_nvmeof.xml
@@ -278,9 +278,6 @@ Parameter traddr is now '10.0.0.1'.</screen>
    <listitem>
     <para><link xlink:href="https://storpool.com/blog/demystifying-what-is-nvmeof"/></para>
    </listitem>
-   <listitem>
-    <para><link xlink:href="https://medium.com/@metebalci/a-quick-tour-of-nvm-express-nvme-3da2246ce4ef"/></para>
-   </listitem>
   </itemizedlist>
  </sect1>
 </chapter>

--- a/xml/libvirt_networking.xml
+++ b/xml/libvirt_networking.xml
@@ -718,7 +718,6 @@ Networking (help keyword 'network'):
      http://wiki.libvirt.org/page/VirtualNetworking#Creating_a_virtual_network
      http://libvirt.org/formatnetwork.html
      http://libvirt.org/sources/virshcmdref/html/sect-net-create.html
-     http://libvirt.org/sources/virshcmdref/html/
      -->
     <para>
      To create a new <emphasis>running</emphasis> virtual network, run


### PR DESCRIPTION
### PR creator: Description

SEO fix broken links for SLE 15 SP2 for all languages.
Fixes will be done for each branch separately.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
