### PR TITLE
correction to xml tag: closing </para> in the wrong place

### DIFF
--- a/xml/security_polkit.xml
+++ b/xml/security_polkit.xml
@@ -481,8 +481,8 @@ polkit.addRule(function(action, subject) {
 <screen><replaceable>&lt;action-id&gt;</replaceable>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<replaceable>&lt;auth_any&gt;</replaceable>:<replaceable>&lt;auth_inactive&gt;</replaceable>:<replaceable>&lt;auth_active&gt;</replaceable></screen>
      <para>
       Alternatively, if all three categories will receive the same value, you can also specify only a single value:
-<screen><replaceable>&lt;action-id&gt;</replaceable>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<replaceable>&lt;auth_all&gt;</replaceable></screen>
      </para>
+<screen><replaceable>&lt;action-id&gt;</replaceable>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<replaceable>&lt;auth_all&gt;</replaceable></screen>
      <para>
       For example:
      </para>


### PR DESCRIPTION
### PR creator: Description

This corrects an XML tag error in https://github.com/SUSE/doc-sle/pull/1313

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
