### PR TITLE
New section on setting up Active Directory certificate auto-enrollment for SLES clients, using Samba

### DIFF
--- a/xml/security_ad_support.xml
+++ b/xml/security_ad_support.xml
@@ -1415,6 +1415,9 @@ Policy Type: Auto Enrollment Policy
     and private keys are installed in
     <filename>/var/lib/samba/private</filename>/certs.
    </para>
+   <para>
+    For more information, see <command>man samba-gpupdate</command>.
+   </para>
   </sect2>
  </sect1>
 </chapter>

--- a/xml/security_ad_support.xml
+++ b/xml/security_ad_support.xml
@@ -131,9 +131,9 @@
 
   <para>
    Many system components need to interact flawlessly to integrate
-   a Linux client into an existing Windows &ad; domain. The following sections
-   focus on the underlying processes of the key events in &ad; server and
-   client interaction.
+   a Linux client into an existing Windows &ad; domain. The following
+   sections focus on the underlying processes of the key events in &ad;
+   server and client interaction.
   </para>
 
   <para>
@@ -1302,5 +1302,119 @@
     </para>
    </step>
   </procedure>
+ </sect1>
+
+ <sect1 xml:id="sec-active-directory-certificate-auto-enrollment">
+  <title>&ad; certificate auto-enrollment</title>
+  <para>
+   Certificate auto-enrollment enables network devices to automatically
+   enroll certificates from Active Directory Certificate Services, including
+   &sles; devices, with no user intervention. This is managed by &ad;'s
+   Group Policy, using Samba's <command>samba-gpupdate</command> command.
+  </para>
+  <sect2 xml:id="sec-active-directory-auto-enrollment-server-configuration">
+   <title>Configuring certificate auto-enrollment on the server</title>
+   <para>
+    The Windows server roles "Certification Authority", "Certificate
+    Enrollment Policy Web Service", "Certificate Enrollment Web Service",
+    "Certification Authority Web Enrollment", and "Network Device Enrollment
+    Service" all must be installed and configured on the &ad; server.
+   </para>
+   <para>
+    Configure Group Policy auto-enrollment as described in this Microsoft
+    documentation: <link xlink:href="https://docs.microsoft.com/en-us/windows-server/networking/core-network-guide/cncg/server-certs/configure-server-certificate-autoenrollment#configure-server-certificate-auto-enrollment"/>.
+   </para>
+  </sect2>
+  <sect2 xml:id="sec-active-directory-auto-enrollment-client-configuration">
+   <title>Enable certificate auto-enrollment on the client</title>
+   <para>
+    Follow the steps in the following procedure to enable certificate on
+    your clients.
+   </para>
+   <procedure xml:id="pro-enable-certification-auto-enrollment-client">
+    <step>
+    <para>
+     Install the <package>samba-gpupdate</package> package. This will
+     automatically install the <package>certmonger</package>,
+     <package>cepces</package>, and <package>sscep</package> dependencies.
+     Samba uses <command>sscep</command> to download the Certificate
+     Authority root chain, then uses the
+     <systemitem class="daemon">certmonger</systemitem>
+     paired with <systemitem>cepces</systemitem> to monitor the host
+     certificate templates.
+     </para>
+    </step>
+    <step>
+     <para>
+      Join to an Active Directory domain (one where the CA has been
+      previously configured as explained in <xref linkend="sec-active-directory-auto-enrollment-server-configuration"/>).
+     </para>
+    </step>
+    <step>
+     <para>
+      On Winbind-joined machines, set the <filename>smb.conf</filename>
+      global parameter by adding the line
+      <literal>apply group policies = yes</literal>.
+     </para>
+    </step>
+    <step>
+    <para>
+     For SSSD-joined machines, install <package>samba-gpupdate</package>
+     from <link xlink:href="https://github.com/openSUSE/oddjob-gpupdate"/>.
+    </para>
+   </step>
+   <step>
+    <para>
+     Then verify that certificate auto-enrollment is correctly configured by
+     running the following command on the client:
+    </para>
+    <screen>&prompt.user;<command>/usr/sbin/samba-gpupdate --rsop</command>
+    </screen>
+    <para>
+    If you see output like the following example, it is correctly
+    configured:
+   </para>
+   <screen>Resultant Set of Policy
+Computer Policy
+GPO: Default Domain Policy
+==========================================================
+CSE: gp_cert_auto_enroll_ext
+-----------------------------------------------------------
+Policy Type: Auto Enrollment Policy
+-----------------------------------------------------------
+[ &lt;<replaceable>CA NAME</replaceable>> ] =
+[ CA Certificate ] =
+----BEGIN CERTIFICATE----
+&lt;<replaceable>CERTIFICATE</replaceable>>
+----END CERTIFICATE----
+[ Auto Enrollment Server ] = &lt;<replaceable>DNS NAME</replaceable>></screen>
+     </step>
+     <step>
+      <para>
+       Use the following command to display installed certificates:
+      </para>
+      <screen>&prompt.user;<command>getcert list</command>
+ Number of certificates and requests being tracked: 1.
+ Request ID 'Machine':
+ status: MONITORING
+ stuck: no
+ key pair storage: type=FILE,location='/var/lib/samba/private/certs/Machine.key'
+ certificate: type=FILE,location='/var/lib/samba/certs/Machine.crt'
+ CA: &lt;<replaceable>CA NAME</replaceable>>
+ issuer: CN=&lt;<replaceable>CA NAME</replaceable>>
+ subject: CN=&lt;<replaceable>HOSTNAME</replaceable>>
+ expires: 2017-08-15 17:37:02 UTC
+ dns: &lt;<replaceable>hostname</replaceable>>
+ key usage: digitalSignature,keyEncipherment
+ eku: id-kp-clientAuth,id-kp-serverAuth
+ certificate template/profile: Machine</screen>
+    </step>
+   </procedure>
+   <para>
+    Certificates are installed in <filename>/var/lib/samba/certs</filename>
+    and private keys are installed in
+    <filename>/var/lib/samba/private</filename>/certs.
+   </para>
+  </sect2>
  </sect1>
 </chapter>


### PR DESCRIPTION
### PR creator: Description
Add new section to the Active Directory chapter of the Security Guide that describes how to enable Active Directory certificate auto-enrollment


### PR creator: Are there any relevant issues/feature requests?

Jira SLE-20139

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
  - [ ] SLE 12 SP3

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
