### PR TITLE
grep -v"domain" --> grep -v "domain"

### DIFF
--- a/xml/tuning_taskscheduler.xml
+++ b/xml/tuning_taskscheduler.xml
@@ -480,7 +480,7 @@ pid 16244's current scheduling priority: 0
     To get a list of all scheduler related <command>sysctl</command>
     variables, enter
    </para>
-<screen>&prompt.root;<command>sysctl</command> <option>-A</option> | <command>grep</command> <replaceable>"sched"</replaceable> | <command>grep</command> <option>-v</option><replaceable>"domain"</replaceable></screen>
+<screen>&prompt.root;<command>sysctl</command> <option>-A</option> | <command>grep</command> <replaceable>"sched"</replaceable> | <command>grep</command> <option>-v</option> <replaceable>"domain"</replaceable></screen>
 <screen>&prompt.root;sysctl -A | grep "sched" | grep -v "domain"
 kernel.sched_cfs_bandwidth_slice_us = 5000
 kernel.sched_child_runs_first = 0


### PR DESCRIPTION
Added missing space between argument and value.