### PR TITLE
"less errors" => "fewer errors"

### DIFF
--- a/xml/tuning_tracing.xml
+++ b/xml/tuning_tracing.xml
@@ -301,7 +301,7 @@ clock_gettime(1, 0x7fff4b5c34c0, 0xffffffffff600180, -1, 0) = 0
 
   <para>
    Valgrind is a set of tools to debug and profile your programs so that
-   they can run both faster and with less errors. Valgrind can detect problems
+   they can run both faster and with fewer errors. Valgrind can detect problems
    related to memory management and threading, or can also serve as a
    framework for building new debugging tools. It is well known that this
    tool can incur high overhead, causing, for example, higher runtimes or


### PR DESCRIPTION
Corrected grammar. Countable nouns (more/fewer) vs uncountable (more/less)