### PR TITLE
SEO fixes of broken links SLE15SP2 ZH

### DIFF
--- a/l10n/sles/zh-cn/xml/security_preface.xml
+++ b/l10n/sles/zh-cn/xml/security_preface.xml
@@ -194,7 +194,7 @@
    漏洞通常在中心数据库（例如，由美国政府维护的<emphasis>国家漏洞数据库</emphasis>）中公告。您可以订阅这些信息源，及时了解最新发现的漏洞。在某些情况下，可以在软件更新推出之前对 bug 造成的问题加以缓解。漏洞会分配到一个<emphasis>公共漏洞和暴露</emphasis> (<emphasis>CVE</emphasis>) 编号和一个<emphasis>公共漏洞评分系统</emphasis> (<emphasis>CVSS</emphasis>) 分数。该分数有助于识别漏洞的严重性。
   </para>
   <para>
-   SUSE 会提供安全建议源。可通过 <link xlink:href="https://www.suse.com/en-us/support/update/"/> 获得。<link xlink:href="https://www.suse.com/en-us/security/cve/"/> 上还按 CVE 编号列出了安全更新。
+   SUSE 会提供安全建议源。可通过 <link xlink:href="https://www.suse.com/en-us/support/update/"/> 获得。<link xlink:href="https://www.suse.com/security/cve/"/> 上还按 CVE 编号列出了安全更新。
   </para>
   <note os="sles;sled">
    <title>向后移植和版本号</title>
@@ -231,7 +231,7 @@
     </para>
    </listitem>
    <listitem>
-    <para><link xlink:href="https://www.bsi.bund.de/DE/Service/Aktuell/Cert_Bund_Meldungen/cert_bund_meldungen_node.html"/>，<emphasis>德国联邦信息安全局</emphasis>漏洞信息源</para>
+    <para><link xlink:href="https://www.bsi.bund.de/DE/Themen/Unternehmen-und-Organisationen/Cyber-Sicherheitslage/Reaktion/CERT-Bund/CERT-Bund-Reports/cert-bund-reports_node.html"/>，<emphasis>德国联邦信息安全局</emphasis>漏洞信息源</para>
    </listitem>
    <listitem>
     <para>


### PR DESCRIPTION
Applied broken link fixes for SEO purposes.

Changes will be done for each version separately, so no backports needed.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
