### PR TITLE
SEO fixes of broken links SLE15SP1

### DIFF
--- a/l10n/sles/zh-cn/xml/net_dhcp.xml
+++ b/l10n/sles/zh-cn/xml/net_dhcp.xml
@@ -465,7 +465,7 @@ fixed-address 192.168.2.100;
   <title>更多信息</title>
 
   <para>
-   有关 DHCP 的更多信息，请访问<emphasis>因特网系统联盟</emphasis>网站 (<link xlink:href="https://www.isc.org/blogs/category/dhcp/"/>)。也可在 <option>dhcpd</option>、<option>dhcpd.conf</option>、<option>dhcpd.leases</option> 和 <option>dhcp-options</option> 手册页中获得相关信息。
+   有关 DHCP 的更多信息，请访问<emphasis>因特网系统联盟</emphasis>网站 (<link xlink:href="https://www.isc.org/dhcp/"/>)。也可在 <option>dhcpd</option>、<option>dhcpd.conf</option>、<option>dhcpd.leases</option> 和 <option>dhcp-options</option> 手册页中获得相关信息。
   </para>
  </sect1>
 </chapter>

--- a/l10n/sles/zh-cn/xml/storage_filesystems.xml
+++ b/l10n/sles/zh-cn/xml/storage_filesystems.xml
@@ -1471,11 +1471,6 @@ Label: none uuid: 40123456-cb2c-4678-8b3d-d014d1c78c78
    </listitem>
    <listitem>
     <para>
-     XFS：高性能日记文件系统：<link xlink:href="http://oss.sgi.com/projects/xfs/"/>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
      OCFS2 Project（OCFS2 项目）：<link xlink:href="http://oss.oracle.com/projects/ocfs2/"/>
     </para>
    </listitem>

--- a/l10n/sles/zh-cn/xml/storage_nvmeof.xml
+++ b/l10n/sles/zh-cn/xml/storage_nvmeof.xml
@@ -255,10 +255,7 @@ Parameter traddr is now '10.0.0.1'.</screen>
    <para>
     要启用光纤通道端口作为 NVMe 目标，需要额外配置一个模块参数：<option>lpfc_enable_nvmet=<replaceable> COMMA_SEPARATED_WWPNS</replaceable></option>。请输入带有前置 <literal>0x</literal> 的 WWPN，例如 <option>lpfc_enable_nvmet=0x2000000055001122,0x2000000055003344</option>。系统只会为目标模式配置列出的 WWPN。可将光纤通道端口配置为目标<emphasis>或</emphasis>发起端。
    </para>
-   <para>
-    有关更多细节，请参见 <link xlink:href="https://docs.broadcom.com/docs/12379413"/>。
-   </para>
-  </sect2>
+   </sect2>
  </sect1>
  <sect1 xml:id="sec-nvmeof-more-information">
   <title>更多信息</title>

--- a/l10n/sles/zh-tw/xml/net_dhcp.xml
+++ b/l10n/sles/zh-tw/xml/net_dhcp.xml
@@ -465,7 +465,7 @@ fixed-address 192.168.2.100;
   <title>更多資訊</title>
 
   <para>
-   如需有關 DHCP 的詳細資訊，請參閱 <emphasis>Internet Systems Consortium</emphasis> 的網站 <link xlink:href="https://www.isc.org/blogs/category/dhcp/"/>。在 <option>dhcpd</option>、<option>dhcpd.conf</option>、<option>dhcpd.leases</option> 和 <option>dhcp-options</option> man 頁面中也可以找到資訊。
+   如需有關 DHCP 的詳細資訊，請參閱 <emphasis>Internet Systems Consortium</emphasis> 的網站 <link xlink:href="https://www.isc.org/dhcp/"/>。在 <option>dhcpd</option>、<option>dhcpd.conf</option>、<option>dhcpd.leases</option> 和 <option>dhcp-options</option> man 頁面中也可以找到資訊。
   </para>
  </sect1>
 </chapter>

--- a/l10n/sles/zh-tw/xml/storage_filesystems.xml
+++ b/l10n/sles/zh-tw/xml/storage_filesystems.xml
@@ -1471,11 +1471,6 @@ Label: none uuid: 40123456-cb2c-4678-8b3d-d014d1c78c78
    </listitem>
    <listitem>
     <para>
-     XFS︰高效能記錄檔案系統︰<link xlink:href="http://oss.sgi.com/projects/xfs/"/>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
      OCFS2 Project (OCFS2 專案)︰<link xlink:href="http://oss.oracle.com/projects/ocfs2/"/>
     </para>
    </listitem>

--- a/l10n/sles/zh-tw/xml/storage_nvmeof.xml
+++ b/l10n/sles/zh-tw/xml/storage_nvmeof.xml
@@ -255,10 +255,7 @@ Parameter traddr is now '10.0.0.1'.</screen>
    <para>
     若要啟用光纖通道連接埠做為 NVMe 目標，需要額外設定一個模組參數︰<option>lpfc_enable_nvmet=<replaceable> COMMA_SEPARATED_WWPNS</replaceable></option>。請輸入帶有前置 <literal>0x</literal> 的 WWPN，例如 <option>lpfc_enable_nvmet=0x2000000055001122,0x2000000055003344</option>。系統只會為目標模式設定列出的 WWPN。可將光纖通道連接埠設定為目標<emphasis>或</emphasis>啟動器。
    </para>
-   <para>
-    如需更多詳細資料，請參閱 <link xlink:href="https://docs.broadcom.com/docs/12379413"/>。
-   </para>
-  </sect2>
+ </sect2>
  </sect1>
  <sect1 xml:id="sec-nvmeof-more-information">
   <title>更多資訊</title>


### PR DESCRIPTION
Applied broken link fixes for SEO purposes.

Changes will be done for each version separately, so no backports needed.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
