### PR TITLE
SEO fixes of broken links SLE15SP3 ZH

### DIFF
--- a/l10n/sles/zh-cn/xml/xm_vs_xl_links.xml
+++ b/l10n/sles/zh-cn/xml/xm_vs_xl_links.xml
@@ -65,7 +65,7 @@
    <term>libvirt</term>
    <listitem>
     <para>
-     <link xlink:href="https://libvirt.org/virshcmdref.html">virsh</link> 命令。
+     <link xlink:href="https://libvirt.org/sources/virshcmdref/html/">virsh</link> 命令。
     </para>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
Applied broken link fixes for SEO purposes.

Changes will be done for each version separately, so no backports needed.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4