### PR TITLE
can use a one of the following => can use one of the following

### DIFF
--- a/xml/vt_cachemodes.xml
+++ b/xml/vt_cachemodes.xml
@@ -60,7 +60,7 @@
 
   <para>
    If you do not specify a cache mode, <literal>writeback</literal> is used by
-   default. Each guest disk can use a one of the following cache modes:
+   default. Each guest disk can use one of the following cache modes:
   </para>
 
   <variablelist>


### PR DESCRIPTION
Removed superfluous article in sentence.