### PR TITLE
guest do not => guest does not

### DIFF
--- a/xml/vt_cachemodes.xml
+++ b/xml/vt_cachemodes.xml
@@ -83,7 +83,7 @@
      <para>
       Writes are reported as completed only when the data has been committed to
       the storage device. The guest's virtual storage adapter is informed that
-      there is no <emphasis>writeback</emphasis> cache, so the guest do not
+      there is no <emphasis>writeback</emphasis> cache, so the guest does not
       need to send flush commands to manage data integrity.
      </para>
     </listitem>


### PR DESCRIPTION
Corrected grammar: third person does, not do.