### PR TITLE
Fixed suffix to .ulp (bsc#1200859)

### DIFF
--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -122,7 +122,7 @@
      Live patches are applied using the <systemitem>ulp trigger</systemitem>
      command, for example:
     </para>
-<screen>ulp trigger -p <replaceable>PID</replaceable> <replaceable>LIVEPATCH</replaceable>.so</screen>
+<screen>ulp trigger -p <replaceable>PID</replaceable> <replaceable>LIVEPATCH</replaceable>.ulp</screen>
     <para>
      In this example, <literal>PID</literal> is the PID of the running process
      that uses the library to be patched and <literal>LIVEPATCH.ulp</literal>


### PR DESCRIPTION
### PR creator: Description

Just updated the file suffix to *.ulp


### PR creator: Are there any relevant issues/feature requests?

* bsc#1200859



### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 SP0
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
