### PR TITLE
Added 'systems purge' subcommand (bsc#1202752)

### DIFF
--- a/xml/rmt_rmt-cli.xml
+++ b/xml/rmt_rmt-cli.xml
@@ -327,6 +327,39 @@
      </para>
     </listitem>
    </varlistentry>
+   <varlistentry>
+    <term><command>rmt-cli systems purge</command></term>
+    <listitem>
+     <para>
+      This command lists and optionally deletes inactive systems.
+      It has the following options:
+     </para>
+     <itemizedlist>
+      <listitem>
+       <para>
+        <option>--before <replaceable>DATE</replaceable></option> - lists systems that have been
+        inactive since <replaceable>DATE</replaceable> till now. Default is the last 3 months.
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        <option>--no-confirmation</option> - allows the administrator to delete matching systems
+        without confirmation.
+       </para>
+      </listitem>
+     </itemizedlist>
+<screen>&prompt.root;rmt-cli systems purge --before 2021-06-16
++------------+----------+---------------------+---------------------+----------+
+| Login      | Hostname | Registration time   | Last seen           | Products |
++------------+----------+---------------------+---------------------+----------+
+| SCC_c5b0.. | 6e485e48b| 2021-06-11 13:38:07 | 2021-06-11 13:52:01 | SLES/15..|
+| SCC_5fcf.. | node52   | 2021-06-15 13:29:24 | 2021-06-15 13:31:25 | SLES/15..|
++------------+----------+---------------------+---------------------+----------+
+Do you want to delete these systems? (y/n) y
+Purged systems that have not contacted this RMT since 2021-06-16.
+</screen>
+    </listitem>
+   </varlistentry>
   </variablelist>
  </sect2>
 

--- a/xml/rmt_rmt-cli.xml
+++ b/xml/rmt_rmt-cli.xml
@@ -337,14 +337,15 @@
      <itemizedlist>
       <listitem>
        <para>
-        <option>--before <replaceable>DATE</replaceable></option> - lists systems that have been
-        inactive since <replaceable>DATE</replaceable> until now. Default is the last 3 months.
+        <option>--before <replaceable>DATE</replaceable></option>&mdash;lists 
+        systems that have been inactive since <replaceable>DATE</replaceable>
+        until now. Default is the last 3 months.
        </para>
       </listitem>
       <listitem>
        <para>
-        <option>--no-confirmation</option> - allows the administrator to delete matching systems
-        without confirmation.
+        <option>--no-confirmation</option>&mdash;allows the administrator to
+        delete matching systems without confirmation.
        </para>
       </listitem>
      </itemizedlist>

--- a/xml/rmt_rmt-cli.xml
+++ b/xml/rmt_rmt-cli.xml
@@ -338,7 +338,7 @@
       <listitem>
        <para>
         <option>--before <replaceable>DATE</replaceable></option> - lists systems that have been
-        inactive since <replaceable>DATE</replaceable> till now. Default is the last 3 months.
+        inactive since <replaceable>DATE</replaceable> until now. Default is the last 3 months.
        </para>
       </listitem>
       <listitem>


### PR DESCRIPTION
### PR creator: Description

`rmt-cli` take the new `systems purge` subcommand. This update reflects that


### PR creator: Are there any relevant issues/feature requests?

* bsc#1202752


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
