### PR TITLE
change customize LO

### DIFF
--- a/xml/apps_libreoffice.xml
+++ b/xml/apps_libreoffice.xml
@@ -783,21 +783,19 @@
    <title>Customizing toolbars</title>
    <step>
     <para>
-     In the customization dialog, click the tab <guimenu>Toolbars</guimenu>.
+     Click <menuchoice> <guimenu>Tools</guimenu> <guimenu>Customize</guimenu> 
+      <guimenu>Toolbars</guimenu></menuchoice>.
     </para>
    </step>
    <step>
     <para>
      In the right column in the <guimenu>Target</guimenu> drop-down box, select
-     the toolbar you want to customize. By default, it is set to
-     <guimenu>Standard</guimenu>.
+     the toolbar you want to customize.
     </para>
    </step>
    <step>
     <para>
-     Activate the check boxes next to the commands you want to appear on the
-     toolbar, and deactivate the check boxes next to the commands you do not
-     want to appear.
+    Select the commands you want to appear in the toolbar.
     </para>
    </step>
    <step>
@@ -815,8 +813,8 @@
   <procedure>
    <title>Customizing context menus</title>
    <para>
-    You can modify commands, rearrange the items of a context menu or even create
-    new commands.
+    You can modify commands, rearrange the items of a context menu, or even
+    create new commands.
    </para>
    <note>
     <para>
@@ -826,19 +824,19 @@
    </note>
    <step>
     <para>
-     Open a document and in the customization dialog, click the tab
+     Open a document. In the customization dialog, click the tab
      <guimenu>Context Menus</guimenu>.
     </para>
    </step>
    <step>
     <para>
-     In the left column select a <guimenu>Category</guimenu>. In the right column
-     select the <guimenu>Target</guimenu>.
+     In the left column, select a <guimenu>Category</guimenu>. In the right
+     column, select the <guimenu>Target</guimenu>.
     </para>
    </step>
    <step>
     <para>
-     To add a separator or submenu click <guimenu>Insert</guimenu>.
+     To add a separator or submenu, click <guimenu>Insert</guimenu>.
      To rename a command, select the command in the right column and click
      <guimenu>Modify</guimenu>.
     </para>

--- a/xml/apps_libreoffice.xml
+++ b/xml/apps_libreoffice.xml
@@ -13,7 +13,11 @@
   * SLE12 SP1 [beta 3]: 4.3.5.2.0+
   * SLE12 SP2 [beta 4]: 5.1.1.3
 -->
-<chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-lo-oview">
+<chapter xmlns="http://docbook.org/ns/docbook"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ version="5.0"
+ xml:id="cha-lo-oview">
  <title>&libo;: the office suite</title>
  <info>
   <abstract>
@@ -731,41 +735,6 @@
     the <guimenu>Customize</guimenu> dialog.
    </para>
   </note>
-
-  <procedure>
-   <title>Customizing toolbars</title>
-   <step>
-    <para>
-     In the customization dialog, click the tab <guimenu>Toolbars</guimenu>.
-    </para>
-   </step>
-   <step>
-    <para>
-     In the right column in the <guimenu>Target</guimenu> drop-down box, select
-     the toolbar you want to customize. By default, it is set to
-     <guimenu>Standard</guimenu>.
-    </para>
-   </step>
-   <step>
-    <para>
-     Activate the check boxes next to the commands you want to appear on the
-     toolbar, and deactivate the check boxes next to the commands you do not
-     want to appear.
-    </para>
-   </step>
-   <step>
-    <para>
-     To switch back to the original settings, click <guimenu>Defaults</guimenu>
-     and confirm with <guimenu>Yes</guimenu>.
-    </para>
-   </step>
-   <step>
-    <para>
-     To save the changes, click <guimenu>OK</guimenu>.
-    </para>
-   </step>
-  </procedure>
-
   <procedure>
    <title>Customizing menus</title>
    <para>
@@ -811,33 +780,30 @@
   </procedure>
 
   <procedure>
-   <title>Customizing key combinations</title>
-   <para>
-    You can reassign key combinations and assign new ones to frequently used
-    functions.
-   </para>
+   <title>Customizing toolbars</title>
    <step>
     <para>
-     Click <menuchoice> <guimenu>Tools</guimenu> <guimenu>Customize</guimenu>
-     <guimenu>Keyboard</guimenu> </menuchoice>.
+     In the customization dialog, click the tab <guimenu>Toolbars</guimenu>.
     </para>
    </step>
    <step>
     <para>
-     In the <guimenu>Shortcut Keys</guimenu> box, select the key or key
-     combination you want to assign a command to.
+     In the right column in the <guimenu>Target</guimenu> drop-down box, select
+     the toolbar you want to customize. By default, it is set to
+     <guimenu>Standard</guimenu>.
     </para>
    </step>
    <step>
     <para>
-     Select a <guimenu>Category</guimenu> and <guimenu>Function</guimenu> at
-     the bottom of the dialog.
+     Activate the check boxes next to the commands you want to appear on the
+     toolbar, and deactivate the check boxes next to the commands you do not
+     want to appear.
     </para>
    </step>
    <step>
     <para>
-     Click <guimenu>Modify</guimenu> to assign the function to the key or
-     <guimenu>Delete</guimenu> to remove an existing assignment.
+     To switch back to the original settings, click <guimenu>Defaults</guimenu>
+     and confirm with <guimenu>Yes</guimenu>.
     </para>
    </step>
    <step>
@@ -846,7 +812,49 @@
     </para>
    </step>
   </procedure>
-
+  <procedure>
+   <title>Customizing context menus</title>
+   <para>
+    You can modify commands, rearrange the items of a context menu or even create
+    new commands.
+   </para>
+   <note>
+    <para>
+     The <guimenu>Context Menus</guimenu> tab is only available in an open
+     document.
+    </para>
+   </note>
+   <step>
+    <para>
+     Open a document and in the customization dialog, click the tab
+     <guimenu>Context Menus</guimenu>.
+    </para>
+   </step>
+   <step>
+    <para>
+     In the left column select a <guimenu>Category</guimenu>. In the right column
+     select the <guimenu>Target</guimenu>.
+    </para>
+   </step>
+   <step>
+    <para>
+     To add a separator or submenu click <guimenu>Insert</guimenu>.
+     To rename a command, select the command in the right column and click
+     <guimenu>Modify</guimenu>.
+    </para>
+   </step>
+   <step>
+    <para>
+     To switch back to the original settings, click <guimenu>Defaults</guimenu>
+     and confirm with <guimenu>Yes</guimenu>.
+    </para>
+   </step>
+   <step>
+    <para>
+     To save the changes, click <guimenu>OK</guimenu>.
+    </para>
+   </step>
+  </procedure>
   <procedure>
    <title>Customizing events</title>
    <para>
@@ -877,6 +885,51 @@
     </para>
    </step>
   </procedure>
+
+
+  <procedure>
+   <title>Customizing key combinations</title>
+   <para>
+    You can reassign key combinations and assign new ones to frequently used
+    functions.
+   </para>
+   <note>
+    <para>
+     The <guimenu>Keyboard</guimenu> tab is only available in an open document.
+    </para>
+   </note>
+    
+   <step>
+    <para>
+     Open a document and click <menuchoice> <guimenu>Tools</guimenu>
+      <guimenu>Customize</guimenu> <guimenu>Keyboard</guimenu> </menuchoice>.
+    </para>
+   </step>
+   <step>
+    <para>
+     In the <guimenu>Shortcut Keys</guimenu> box, select the key or key
+     combination you want to assign a command to.
+    </para>
+   </step>
+   <step>
+    <para>
+     Select a <guimenu>Category</guimenu> and <guimenu>Function</guimenu> at
+     the bottom of the dialog.
+    </para>
+   </step>
+   <step>
+    <para>
+     Click <guimenu>Modify</guimenu> to assign the function to the key or
+     <guimenu>Delete</guimenu> to remove an existing assignment.
+    </para>
+   </step>
+   <step>
+    <para>
+     To save the changes, click <guimenu>OK</guimenu>.
+    </para>
+   </step>
+  </procedure>
+
  </sect1>
  <sect1 xml:id="sec-lo-oview-global">
   <title>Changing the global settings</title>


### PR DESCRIPTION
### PR creator: Description

The new Libre Office version 7.3 will be released soon for SLE 15 SP4/SP3 and SLE 12 SP5. 
The order and description of how to customize LO has changed.


### PR creator: Are there any relevant issues/feature requests?

* jsc#SLE-24442


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [x] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
