### PR TITLE
Update qemu_host_installation.xml

### DIFF
--- a/xml/qemu_host_installation.xml
+++ b/xml/qemu_host_installation.xml
@@ -114,10 +114,10 @@
     <para>
      After all the required packages are installed (and new network setup
      activated), try to load the &kvm; kernel module relevant for your CPU
-     type&mdash;<systemitem>kvm-intel</systemitem> or
-     <systemitem>kvm-amd</systemitem>:
+     type&mdash;<systemitem>kvm_intel</systemitem> or
+     <systemitem>kvm_amd</systemitem>:
     </para>
-<screen>&prompt.root;modprobe kvm-intel</screen>
+<screen>&prompt.root;modprobe kvm_intel</screen>
     <para>
      Check if the module is loaded into memory:
     </para>


### PR DESCRIPTION
Changed kvm-intel and kvm-amd to kvm_intel and kvm_amd

### PR creator: Description

Correct the names of the two KVM modules (Intel and AMD).


### PR creator: Are there any relevant issues/feature requests?

None.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
