### PR TITLE
Replaced "Installation" with "Upgrade"

### DIFF
--- a/xml/ay_upgrade.xml
+++ b/xml/ay_upgrade.xml
@@ -132,7 +132,7 @@
      <para>Boot the system from the installation medium.</para>
     </step>
     <step>
-     <para>Select the <literal>Installation</literal> menu item.</para>
+     <para>Select the <literal>Upgrade</literal> menu item.</para>
     </step>
     <step>
      <para>On the command line, set <varname>autoupgrade=1</varname>.</para>
@@ -148,7 +148,7 @@
      <para>Boot the system from the installation media.</para>
     </step>
     <step>
-     <para>Select the <literal>Installation</literal> menu item.</para>
+     <para>Select the <literal>Upgrade</literal> menu item.</para>
     </step>
     <step>
       <para>On the command line, set <varname>netsetup=dhcp autoupgrade=1 autoyast=http://192.169.3.1/autoyast.xml</varname>.</para>


### PR DESCRIPTION
Replaced "Installation" with "Upgrade" for menu item to select when performing offline upgrade utilizing AutoYast within the AutoYast Guide for SLES 15 SP4. 
