### PR TITLE
Updated 'terminal console' to 'terminal'

### DIFF
--- a/xml/storage_fcoe.xml
+++ b/xml/storage_fcoe.xml
@@ -216,8 +216,8 @@
    </step>
    <step>
     <para>
-     On the <guimenu>Interfaces</guimenu> tab, view information about all of
-     the detected network adapters on the server, including information about
+     On the <guimenu>Interfaces</guimenu> tab, view information about all
+     detected network adapters on the server, including information about
      VLAN and FCoE configuration. You can also create an FCoE VLAN interface,
      change settings for an existing FCoE interface, or remove an FCoE
      interface.
@@ -402,7 +402,7 @@
    <procedure>
    <step>
    <para>
-   Open a terminal console.
+   Open a terminal.
    </para>
    </step>
    <step>
@@ -585,7 +585,7 @@
     <term><command>fcoeadm -i eth3</command></term>
     <listitem>
      <para>
-      Show information about all of the FCoE instances on interface
+      Show information about all FCoE instances on interface
       <literal>eth3</literal>. If no interface is specified, information for
       all interfaces that have FCoE instances created will be shown. The
       following example shows information on connection eth0.201:
@@ -615,8 +615,8 @@
     <term><command>fcoeadm -l eth3.101</command></term>
     <listitem>
      <para>
-      Show detailed information about all of the LUNs discovered on connection
-      eth3.101. If no connection is specified, information about all of the
+      Show detailed information about all LUNs discovered on connection
+      eth3.101. If no connection is specified, information about all
       LUNs discovered on all FCoE connections will be shown.
      </para>
     </listitem>
@@ -644,10 +644,10 @@
     <term><command>fcoeadm -t eth3</command></term>
     <listitem>
      <para>
-      Show information about all of the discovered targets from a given eth3
+      Show information about all discovered targets from a given eth3
       port having FCoE instances. After each discovered target, any associated
-      LUNs are listed. If no instance is specified, targets from all of the
-      ports that have FCoE instances are shown. The following example shows
+      LUNs are listed. If no instance is specified, targets from all ports
+      that have FCoE instances are shown. The following example shows
       information of targets from the eth0.201 connection:
      </para>
 <screen>&prompt.sudo;fcoeadm -t eth0.201

--- a/xml/storage_filesystems.xml
+++ b/xml/storage_filesystems.xml
@@ -482,7 +482,7 @@ Id Path      single   single    single   Unallocated
    <para>
     The Btrfs root file system subvolumes (for example,
     <filename>/var/log</filename>, <filename>/var/crash</filename>, or
-    <filename>/var/cache</filename>) can use all of the available disk space
+    <filename>/var/cache</filename>) can use all the available disk space
     during normal operation, and cause a system malfunction. To help avoid this
     situation, &productname; offers quota support for Btrfs subvolumes. If you
     set up the root file system from a &yast; proposal, you are ready to enable
@@ -1095,7 +1095,7 @@ ID 263 gen 39 top level 256 path @/opt
       decide where exactly (in file system blocks) the data should be stored.
       This decision is delayed until the last possible moment. Some short-lived
       temporary data might never make its way to disk, because it is obsolete
-      by the time XFS decides where actually to save it. In this way, XFS
+      by the time XFS decides where to save it. In this way, XFS
       increases write performance and reduces file system fragmentation.
       Because delayed allocation results in less frequent write events than in
       other file systems, it is likely that data loss after a crash during a
@@ -1322,7 +1322,7 @@ ID 263 gen 39 top level 256 path @/opt
        <para>
         opening or creating
         <filename>/etc/dracut.conf.d/filesystem.conf</filename> and adding the
-        following line (mind the leading white space):
+        following line (mind the leading blank space):
        </para>
 <screen>force_drivers+=" ext3 jbd"</screen>
       </step>
@@ -2161,7 +2161,7 @@ unblacklist: cramfs un-blacklisted by creating /etc/modprobe.d/60-blacklist_fs-c
   </para>
 
   <para>
-   Currently, all of our standard file systems have LFS (large file support),
+   Currently, all our standard file systems have LFS (large file support),
    which gives a maximum file size of 2<superscript>63</superscript> bytes in
    theory. <xref linkend="tab-filesystems-maxsize" xrefstyle="TableXRef"/>
    offers an overview of the current on-disk format limitations of Linux files
@@ -2543,7 +2543,7 @@ unblacklist: cramfs un-blacklisted by creating /etc/modprobe.d/60-blacklist_fs-c
   <sect2 xml:id="sec-filesystem-online-trim">
    <title>Online TRIM</title>
    <para>
-    Online TRIM of a device is performed each time data are written to the
+    Online TRIM of a device is performed each time data is written to the
     device.
    </para>
    <para>
@@ -2611,7 +2611,7 @@ unblacklist: cramfs un-blacklisted by creating /etc/modprobe.d/60-blacklist_fs-c
     <procedure>
      <step>
       <para>
-       Open a terminal console.
+       Open a terminal.
       </para>
      </step>
      <step>

--- a/xml/storage_fs-resizing.xml
+++ b/xml/storage_fs-resizing.xml
@@ -304,7 +304,7 @@
   <procedure>
    <step>
     <para>
-     Open a terminal console.
+     Open a terminal.
     </para>
    </step>
    <step>
@@ -369,7 +369,7 @@ sudo btrfs filesystem resize -<replaceable>SIZE</replaceable> /mnt</screen>
   <procedure>
    <step>
     <para>
-     Open a terminal console.
+     Open a terminal.
     </para>
    </step>
    <step>
@@ -413,7 +413,7 @@ sudo btrfs filesystem resize -<replaceable>SIZE</replaceable> /mnt</screen>
   <procedure>
    <step>
     <para>
-     Open a terminal console.
+     Open a terminal.
     </para>
    </step>
    <step>

--- a/xml/storage_iscsi.xml
+++ b/xml/storage_iscsi.xml
@@ -87,7 +87,7 @@
 
   <para>
    To install the iSCSI LIO Target Server, run the following command in a
-   terminal console:
+   terminal:
   </para>
 
 <screen>&prompt.sudo;zypper in yast2-iscsi-lio-server</screen>

--- a/xml/storage_isns.xml
+++ b/xml/storage_isns.xml
@@ -467,7 +467,7 @@
    iSNS must be started at the server where you install it. If you have not
    configured it to be started at boot time (see
    <xref linkend="sec-isns-install"/> for details), enter the following command
-   at a terminal console:
+   at a terminal:
   </para>
 
 <screen>&prompt.sudo;systemctl start isnsd</screen>

--- a/xml/storage_lvm-snapshots.xml
+++ b/xml/storage_lvm-snapshots.xml
@@ -136,7 +136,7 @@
   </para>
 
   <para>
-   Open a terminal console and enter
+   Open a terminal and enter
   </para>
 
 <screen>&prompt.sudo;lvcreate -s [-L <replaceable>&lt;size</replaceable>&gt;] -n <replaceable>SNAP_VOLUME</replaceable> <replaceable>SOURCE_VOLUME_PATH</replaceable></screen>
@@ -160,7 +160,7 @@
   <title>Monitoring a snapshot</title>
 
   <para>
-   Open a terminal console and enter
+   Open a terminal and enter
   </para>
 
 <screen>&prompt.sudo;lvdisplay <replaceable>SNAP_VOLUME</replaceable></screen>
@@ -194,7 +194,7 @@
   <title>Deleting Linux snapshots</title>
 
   <para>
-   Open a terminal console and enter
+   Open a terminal and enter
   </para>
 
 <screen>&prompt.sudo;lvremove <replaceable>SNAP_VOLUME_PATH</replaceable></screen>
@@ -383,7 +383,7 @@
   <procedure>
    <step>
     <para>
-     Open a terminal console and enter
+     Open a terminal and enter
     </para>
 <screen>&prompt.sudo;lvconvert --merge  [-b] [-i <replaceable>SECONDS</replaceable>] [<replaceable>SNAP_VOLUME_PATH</replaceable>[...<replaceable>snapN</replaceable>]|@<replaceable>VOLUME_TAG</replaceable>]</screen>
     <para>

--- a/xml/storage_lvm.xml
+++ b/xml/storage_lvm.xml
@@ -1474,7 +1474,7 @@ root's password:
    <procedure>
     <step>
      <para>
-      Open a terminal console.
+      Open a terminal.
      </para>
     </step>
     <step>
@@ -1487,7 +1487,7 @@ root's password:
     </step>
     <step>
      <para>
-      At the terminal console prompt, enter the following command to grow the
+      At the terminal prompt, enter the following command to grow the
       size of the logical volume:
      </para>
 <screen>&prompt.sudo;lvextend -L +<replaceable>SIZE</replaceable> /dev/<replaceable>VG_NAME</replaceable>/<replaceable>LV_NAME</replaceable></screen>
@@ -1524,7 +1524,7 @@ root's password:
    <procedure>
     <step>
      <para>
-      Open a terminal console.
+      Open a terminal.
      </para>
     </step>
     <step>
@@ -1543,7 +1543,7 @@ root's password:
     </step>
     <step>
      <para>
-      At the terminal console prompt, enter the following command to shrink the
+      At the terminal prompt, enter the following command to shrink the
       size of the logical volume to the size of the file system:
      </para>
 <screen>&prompt.sudo;lvreduce /dev/<replaceable>VG_NAME</replaceable>/<replaceable>LV_NAME</replaceable></screen>
@@ -1609,7 +1609,7 @@ sudo lvreduce /dev/LOCAL/DATA</screen>
    <procedure>
     <step>
      <para>
-      Open a terminal console.
+      Open a terminal.
      </para>
     </step>
     <step>
@@ -2039,14 +2039,14 @@ sudo lvreduce /dev/LOCAL/DATA</screen>
      <step>
       <para>
        Add the <literal>@database</literal> tag to the metadata of volume group
-       <filename>vg1</filename>. In a terminal console, enter
+       <filename>vg1</filename>. In a terminal, enter
       </para>
 <screen>&prompt.sudo;vgchange --addtag @database vg1</screen>
      </step>
      <step>
       <para>
        Add the <literal>@fileserver</literal> tag to the metadata of volume
-       group <filename>vg2</filename>. In a terminal console, enter
+       group <filename>vg2</filename>. In a terminal, enter
       </para>
 <screen>&prompt.sudo;vgchange --addtag @fileserver vg2</screen>
      </step>
@@ -2085,7 +2085,7 @@ activation {
       <para>
        If the file server host goes down, <filename>vg2</filename> can be
        brought up on <filename>fsb1</filename> by entering the following
-       commands in a terminal console on any node:
+       commands in a terminal on any node:
       </para>
 <screen>&prompt.sudo;vgchange --addtag @fileserverbackup vg2
 &prompt.sudo;vgchange -ay vg2</screen>
@@ -2102,14 +2102,14 @@ activation {
      <step>
       <para>
        Add the <literal>@database</literal> tag to the metadata of volume group
-       <filename>vg1</filename>. In a terminal console, enter
+       <filename>vg1</filename>. In a terminal, enter
       </para>
 <screen>&prompt.sudo;vgchange --addtag @database vg1</screen>
      </step>
      <step>
       <para>
        Add the <literal>@fileserver</literal> tag to the metadata of volume
-       group <filename>vg2</filename>. In a terminal console, enter
+       group <filename>vg2</filename>. In a terminal, enter
       </para>
 <screen>&prompt.sudo;vgchange --addtag @fileserver vg2</screen>
      </step>
@@ -2188,7 +2188,7 @@ activation {
        </step>
        <step>
         <para>
-         In a terminal console, enter one of the following commands:
+         In a terminal, enter one of the following commands:
         </para>
 <screen>&prompt.sudo;vgchange -ay vg2
 &prompt.sudo;vgchange -ay @fileserver</screen>

--- a/xml/storage_mdadm-resize.xml
+++ b/xml/storage_mdadm-resize.xml
@@ -237,7 +237,7 @@
    <procedure>
     <step>
      <para>
-      Open a terminal console.
+      Open a terminal.
      </para>
     </step>
     <step>
@@ -338,7 +338,7 @@
    <procedure>
     <step>
      <para>
-      Open a terminal console.
+      Open a terminal.
      </para>
     </step>
     <step>
@@ -532,7 +532,7 @@
    <procedure>
     <step>
      <para>
-      Open a terminal console.
+      Open a terminal.
      </para>
     </step>
     <step>
@@ -615,7 +615,7 @@
    <procedure>
     <step>
      <para>
-      Open a terminal console.
+      Open a terminal.
      </para>
     </step>
     <step>

--- a/xml/storage_multipath.xml
+++ b/xml/storage_multipath.xml
@@ -3321,7 +3321,7 @@ size=64G features='3 queue_if_no_path pg_init_retries 50'<co xml:id="mp-co-top-f
    <procedure>
     <step>
      <para>
-      Enter the following command at a terminal console prompt:
+      Enter the following command at a terminal prompt:
      </para>
 <screen>&prompt.sudo;multipathd disablequeueing map <replaceable>MAPNAME</replaceable></screen>
      <para>

--- a/xml/storage_raid10.xml
+++ b/xml/storage_raid10.xml
@@ -243,7 +243,7 @@
    <procedure>
     <step>
      <para>
-      Open a terminal console.
+      Open a terminal.
      </para>
     </step>
     <step>
@@ -410,7 +410,7 @@ ARRAY /dev/md2 UUID=<replaceable>UUID</replaceable></screen>
    <procedure>
     <step>
      <para>
-      Open a terminal console.
+      Open a terminal.
      </para>
     </step>
     <step>
@@ -1053,7 +1053,7 @@ ARRAY /dev/md2 UUID=<replaceable>UUID</replaceable></screen>
    <procedure>
     <step>
      <para>
-      Open a terminal console.
+      Open a terminal.
      </para>
     </step>
     <step>


### PR DESCRIPTION
### PR creator: Description

Updated 'terminal console' to 'terminal' in all instances of the Storage Guide per [issue #178](https://github.com/SUSE/doc-styleguide/issues/178)

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
