### PR TITLE
AutoYaST: document packages/patterns installation using regexps

### DIFF
--- a/xml/ay_software.xml
+++ b/xml/ay_software.xml
@@ -214,6 +214,24 @@
         </listitem>
       </varlistentry>
     </variablelist>
+
+    <para>
+     It is possible to specify package and pattern names using regular expressions. In that case,
+     &ay; will select all packages or patterns that match the expression. Beware that such
+     expressions must be enclosed within slashes. In
+     <xref linkend="ay-packages-selection-using-a-regexp"/>, all packages whose name starts with
+     <literal>nginx</literal> will be selected (e.g., <literal>nginx</literal> and
+     <literal>nginx-macros</literal>). 
+    </para>
+
+    <example xml:id="ay-packages-selection-using-a-regexp">
+     <title>Packages selection using a regular expression</title>
+<screen>&lt;software&gt;
+  &lt;packages config:type="list"&gt;
+    &lt;package&gt;/nginx.*/&lt;/package&gt;
+  &lt;/packages&gt;
+&lt;/software&gt;</screen>
+    </example>
    </sect2>
 
    <sect2 xml:id="Software-Selections-images" os="osuse">


### PR DESCRIPTION
### PR creator: Description

Describe how to use regular expressions to install packages and patterns in AutoYaST. It is a relatively unknown feature that has been there [since 2009](https://github.com/yast/yast-autoinstallation/commit/d7dbe6322f709f4f372e1e119a2ec89d0ef1ccfe) but, AFAIK, it was never documented.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [X] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [X] SLE 15 SP4/openSUSE Leap 15.4
  - [X] SLE 15 SP3/openSUSE Leap 15.3
  - [X] SLE 15 SP2/openSUSE Leap 15.2
  - [X] SLE 15 SP1
  - [X] SLE 15 SP0
- SLE 12
  - [X] SLE 12 SP5
  - [X] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
