### PR TITLE
add chapter to Security Guide on using OpenSSH certificate auth

### DIFF
--- a/xml/security_ssh.xml
+++ b/xml/security_ssh.xml
@@ -860,13 +860,14 @@ Have a lot of fun...</screen>
   <sect1 xml:id="sec-ssh-certificate-auth">
   <title>OpenSSH certificate authentication</title>
   <para>
-   OpenSSH introduced certificate authentication in OpenSSH 5.4. Hosts and
-   users authenticate to each other with digitally-signed encryption
-   certificates instead of encryption keys. Certificate authentication
-   provides central management for server and user certificates,
-   eliminating the need to manually copy user public keys to multiple hosts.
-   It increases security by giving more control to administrators, and less
-   to users.
+   OpenSSH introduced certificate authentication in OpenSSH 5.4.
+   Certificate authentication is similar to public key authentication,
+   except hosts and users authenticate to each other with digitally-signed
+   encryption certificates instead of encryption keys. Certificate
+   authentication provides central management for server and user
+   certificates, eliminating the need to manually copy user public keys to
+   multiple hosts. It increases security by giving more control to
+   administrators, and less to users.
   </para>
   <para>
    Certificates consist of a public encryption key, a user-defined identity
@@ -907,7 +908,7 @@ Have a lot of fun...</screen>
    Set up a secure trusted server to host your certificate authority,
    for signing host and user keys. Create a new key pair for signing
    keys. The private key signs user and host keys, and the public key is
-   copied to all users.
+   copied to all users who are allowed access to the server.
   </para>
   </listitem>
   <listitem>
@@ -944,10 +945,7 @@ Have a lot of fun...</screen>
     Users and server admins create and protect their own OpenSSH keys. It is
     safe to freely share public keys. It is safe to transfer the new
     certificates by insecure methods, such as email, because they require
-    their private keys to validate. You should keep copies of all the public
-    keys you receive, in case you need to re-issue certificates. (See
-    <xref linkend="sec-ssh-certificate-create-signing-keys"/> to learn about
-    keeping your CA organized.)
+    their private keys to validate.
    </para>
    <para>
    Note that SSH certificates follow the OpenPGP standard, rather than
@@ -980,9 +978,13 @@ Have a lot of fun...</screen>
     CAs for hosts and clients on separate machines. If you prefer
     using a single machine, give each CA its own directory.
     The examples in this section use <filename>/ca-ssh-hosts</filename>
-    and <filename>/ca-ssh-users</filename>. Keep copies of users' and host's
-    public keys in their own subdirectories, for easier tracking and
-    avoiding key name collisions.
+    and <filename>/ca-ssh-users</filename>. The example machine is
+    <replaceable>ca.example.com</replaceable>.
+   </para>
+   <para>
+    If your security policy requires
+    keeping copies of users' and host's public keys, store them in their own
+    subdirectories, for easier tracking and avoiding key name collisions.
    </para>
    <important>
     <title>RSA signing keys deprecated</title>
@@ -1134,8 +1136,7 @@ valid from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
    </para>
    <screen>&prompt.sudo;<command>systemctl restart sshd.service</command></screen>
    <para>
-    If the server has more than one host key, create and configure
-    host certificates for all of them. See
+    See
     <xref linkend="sec-ssh-certificate-user-config"/> to learn how to
     configure clients to accept host certificates.
    </para>
@@ -1146,7 +1147,7 @@ valid from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
    <para>
     The following example shows how to configure clients to trust your CA
     rather than individual keys. The example grants access to a single
-    server. This entry must be on a single unbroken line in your users'
+    server. This entry must be on a single unbroken  line in your users'
     <filename>~/.ssh/known_hosts</filename> files. Move the original
     <filename>~/.ssh/known_hosts</filename> file, and create a new
     file that contains only the CA configuration. Or, create a global
@@ -1155,26 +1156,57 @@ valid from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
    </para>
    <screen>@cert-authority db,db.example.com ssh-ed25519
  AAAAC3NzaC1lZDI1NTE5AAAAIH1pF6DN4BdsfUKWuyiGt/leCvuZ/fPu
- YxY7+4V68Fz0 db-server host cert</screen>
+ YxY7+4V68Fz0 signing key for user certificates
+   </screen>
     <para>
      List each server the user is allowed to access in a comma-delimited
      list, for example
-     <literal>db,db.example.com,db2,db2.example.com</literal>. You may also
-     grant access to whole domains with wildcards, for example
+     <literal><replaceable>&wsII;,&wsIIname;,&wsIII;,&wsIIIname;</replaceable></literal>. You may also
+     grant access to all servers in domains with wildcards, for example
      <literal>*.example.com,*.example2.com</literal>.
     </para>
     <para>
-     Try connecting to a server. You should be prompted for the password
+     Try connecting to the server. You should be prompted for the password
      of the remote account, without being prompted to verify the host
      certificate.
+    </para>
+  </sect2>
+
+  <sect2 xml:id="sec-ssh-certificate-user-certs">
+   <title>Creating user certificates</title>
+   <para>
+    Sign the user's public key:
+   </para>
+   <screen>&prompt.sudo;<command>ssh-keygen <replaceable>/ca-ssh-hosts/ca-user-sign-key -I "suzanne's cert" -n &exampleuserIII_plain; -V +52w user-key.pub</replaceable></command>
+ Signed user key .ssh/ed25519key-cert.pub: id "suzanne's cert" serial 0
+ for suzanne valid from 2022-09-14T12:57:00 to 2023-09-13T12:58:21
+</screen>
+   <para>
+    The principal on user certificates is always the username. Store the
+    user's certificate in <filename>~/.ssh</filename> on the user's machine.
+   </para>
+   <para>
+    User certificates replace the <filename>~/.ssh/authorized_keys</filename> files. Remove this file from a user account on the remote
+    machine, then try opening an SSH session to that account. You should be
+    able to log  in without being prompted for a password. (Remember, the
+    server should have a
+    <literal>TrustedUserCAKeys /etc/ssh/<replaceable>ca-user-sign-key.pub</replaceable></literal>
+    line in its
+    <filename>/etc/ssh/sshd_config</filename> file, so that the server
+    knows to trust your certificate authority.)
+   </para>
+   <para>
+    Additionally, look for <literal>Accepted publickey for
+     <replaceable>&exampleuserIII_plain;</replaceable></literal> messages in
+    your log files.
     </para>
   </sect2>
 
   <sect2 xml:id="sec-ssh-certificate-revoke-host-keys">
    <title>Revoking host keys</title>
    <para>
-    When you need to revoke a host certificate because the server has been
-    compromised or retired, add the name of the certificate's corresponding
+    When you need to revoke a certificate because a server has been
+    compromised or retired, add the certificate's corresponding
     public key to a file on every client, for example
     <filename>/etc/ssh/revoked-host-key</filename>:
    </para>
@@ -1187,17 +1219,12 @@ valid from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
     aC1lZDI1NTE5AAAAQI+mbJsQjt/9bLiURse8DF3yTa6Yk3HpoE2uf9FW/
     KeLsw2wPeDv0d6jv49Wgr5T3xHYPf+VPJQW35ntFiHTlQg= root@db
    </screen>
-  </sect2>
-
-  <sect2 xml:id="sec-ssh-certificate-user-certs">
-   <title></title>
    <para>
+    This file must be named in <filename>/etc/ssh/sshd_config</filename>:
    </para>
+   <screen>RevokedKeys /etc/ssh/revoked_keys</screen>
   </sect2>
-
  </sect1>
-
-
 
  <sect1 xml:id="sec-ssh-gnome-keyring">
   <title>Automated public key logins with gnome-keyring</title>

--- a/xml/security_ssh.xml
+++ b/xml/security_ssh.xml
@@ -905,7 +905,9 @@ Have a lot of fun...</screen>
   <listitem>
   <para>
    Set up a secure trusted server to host your certificate authority,
-   for signing host and user keys.
+   for signing host and user keys. Create a new key pair for signing
+   keys. The private key signs user and host keys, and the public key is
+   copied to all users.
   </para>
   </listitem>
   <listitem>
@@ -1121,8 +1123,8 @@ valid from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
         Extensions: (none)
     </screen>
    <para>
-    Add the new host certificate to
-    <filename>/etc/ssh/sshd_config</filename> on its server, to make it
+    Add the full path of the new host certificate to
+    <filename>/etc/ssh/sshd_config</filename>, to make it
     available to clients:
    </para>
    <screen>HostCertificate <replaceable>/etc/ssh/ssh_host_ed25519_key-cert.pub</replaceable></screen>
@@ -1132,31 +1134,70 @@ valid from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
    </para>
    <screen>&prompt.sudo;<command>systemctl restart sshd.service</command></screen>
    <para>
-    See <xref linkend="sec-ssh-certificate-test-client"/> to learn how to
+    If the server has more than one host key, create and configure
+    host certificates for all of them. See
+    <xref linkend="sec-ssh-certificate-user-config"/> to learn how to
     configure clients to accept host certificates.
    </para>
   </sect2>
 
-  <!-- zone files, retain cert copies, user creates key pair & submits pub
-  key to be signed -->
-
-  <sect2 xml:id="sec-ssh-certificate-test-client">
-   <title>User configuration</title>
+  <sect2 xml:id="sec-ssh-certificate-user-config">
+   <title>CA configuration for users</title>
    <para>
-    The following example shows the client configuration for your CA for a
-    single domain. The example domain is named with a wildcard, which
-    permits users to access all servers in the domain. This entry must be on
-    a single unbroken line in your users'
-    <filename>~/.ssh/known_hosts</filename> files:
+    The following example shows how to configure clients to trust your CA
+    rather than individual keys. The example grants access to a single
+    server. This entry must be on a single unbroken line in your users'
+    <filename>~/.ssh/known_hosts</filename> files. Move the original
+    <filename>~/.ssh/known_hosts</filename> file, and create a new
+    file that contains only the CA configuration. Or, create a global
+    configuration in <filename>/etc/ssh/ssh_known_hosts</filename>, which
+    has the advantage of being un-editable by unprivileged users:
    </para>
-   <screen>@cert-authority *.example.com ssh-ed25519
+   <screen>@cert-authority db,db.example.com ssh-ed25519
  AAAAC3NzaC1lZDI1NTE5AAAAIH1pF6DN4BdsfUKWuyiGt/leCvuZ/fPu
  YxY7+4V68Fz0 db-server host cert</screen>
     <para>
-
+     List each server the user is allowed to access in a comma-delimited
+     list, for example
+     <literal>db,db.example.com,db2,db2.example.com</literal>. You may also
+     grant access to whole domains with wildcards, for example
+     <literal>*.example.com,*.example2.com</literal>.
+    </para>
+    <para>
+     Try connecting to a server. You should be prompted for the password
+     of the remote account, without being prompted to verify the host
+     certificate.
     </para>
   </sect2>
+
+  <sect2 xml:id="sec-ssh-certificate-revoke-host-keys">
+   <title>Revoking host keys</title>
+   <para>
+    When you need to revoke a host certificate because the server has been
+    compromised or retired, add the name of the certificate's corresponding
+    public key to a file on every client, for example
+    <filename>/etc/ssh/revoked-host-key</filename>:
+   </para>
+   <screen>ssh-ed25519-cert-v01@openssh.com
+    AAAAIHNzaC1lZDI1NTE5LWNlcnQtdjAxQG9wZW5zc2guY29tAAAAIK6hyvFAhFI+0hkKehF/
+    506fD1VdcW29ykfFJn1CPK9lAAAAIAawaXbbEFiQOAe5LGclrCHSLWbEeUauK5+CAuhTJyz0
+    AAAAAAAAAAAAAAACAAAAE2RiLXNlcnZlciBob3N0IGNlcnQAAAAeAAAABXZlbnVzAAAAEXZl
+    bnVzLmV4YW1wbGUuY29tAAAAAGMabhQAAAAAYz9YgQAAAAAAAAAAAAAAAAAAADMAAAALc3No
+    LWVkMjU1MTkAAAAgfWkXoM3gF2x9Qpa7KIa3+V4K+5n98+5jFjv7hXrwXPQAAABTAAAAC3Nz
+    aC1lZDI1NTE5AAAAQI+mbJsQjt/9bLiURse8DF3yTa6Yk3HpoE2uf9FW/
+    KeLsw2wPeDv0d6jv49Wgr5T3xHYPf+VPJQW35ntFiHTlQg= root@db
+   </screen>
+  </sect2>
+
+  <sect2 xml:id="sec-ssh-certificate-user-certs">
+   <title></title>
+   <para>
+   </para>
+  </sect2>
+
  </sect1>
+
+
 
  <sect1 xml:id="sec-ssh-gnome-keyring">
   <title>Automated public key logins with gnome-keyring</title>

--- a/xml/security_ssh.xml
+++ b/xml/security_ssh.xml
@@ -757,7 +757,7 @@ Deprecating obsolete hostkey: ED25519
 SHA256:V28d3VpHgjsCoV04RBCZpLo5c0kEslCZDVdIUnCvqPI
 Deprecating obsolete hostkey:
 RSA SHA256:+NR4DVdbsUNsqJPIhISzx+eqD4x/awCCwijZ4a9eP8I
-Accept updated hostkeys? (yes/no):<literal>yes</literal></screen>
+Accept updated hostkeys? (yes/no):yes</screen>
     <para>
       You may set <literal>UpdateHostKeys ask</literal> to
       <literal>UpdateHostKeys yes</literal> to apply the changes

--- a/xml/security_ssh.xml
+++ b/xml/security_ssh.xml
@@ -157,7 +157,7 @@ Host key verification failed.</screen>
        authentication in GNOME sessions.
       </para>
       <para>
-       See <xref linkend="sec-ssh-ssh-agent"/> to learn how to use
+       See <xref linkend="sec-ssh-authentic-agent"/> to learn how to use
        <literal>ssh-agent</literal> for automated public key
        authentication in console sessions.
       </para>
@@ -374,7 +374,6 @@ MaxAuthTries <replaceable>4</replaceable>
   <command>scp</command> (<xref linkend="sec-ssh-copy"/>), and
   <command>sftp</command> (<xref linkend="sec-ssh-sftp"/>).
   </para>
-
   <procedure xml:id="pro-ssh-restrict-logins">
    <title>Configuring remote login restrictions</title>
    <para>
@@ -857,34 +856,259 @@ Have a lot of fun...</screen>
   </para>
   <para>
    For console sessions, use <literal>ssh-agent</literal>
-   (<xref linkend="sec-ssh-ssh-agent"/>).
+   (<xref linkend="sec-ssh-authentic-agent"/>).
   </para>
  </sect1>
 
- <sect1 xml:id="sec-ssh-keyrings">
-  <title>Automatic public key logins</title>
+  <sect1 xml:id="sec-ssh-certificate-auth">
+  <title>OpenSSH certificate authentication</title>
   <para>
-   When you run a lot of SSH sessions, continually re-entering passphrases
-   is a bit of a chore, especially if you have proper strong passphrases.
-   There are two solutions for this: <package>gnome-keyring</package> and
-   <literal>ssh-agent</literal>, which remember your keys and passphrases,
-   and load them for you.
+   OpenSSH introduced certificate authentication in OpenSSH 5.4. Servers and
+   users authenticate to each other with digitally-signed encryption
+   certificates instead of encryption keys, and it enables central
+   management for server and user certificates.
   </para>
   <para>
-   <package>gnome-keyring</package> is launched automatically by the
-   GNOME desktop environment. When you are running a system without
-   GNOME and boot to the console, use <literal>ssh-agent</literal>.
+   Certificates consist of a public encryption key, a user-defined identity
+   string, zero or more user names or host names, and other options.
+   Certificates are signed by a Certificate Authority (CA) signing key.
+   Users and servers trust the CA key, and verify its signature on a
+   certificate, rather than trusting user and server host encryption keys.
+  </para>
+  <para>
+   Traditional OpenSSH public key authentication requires copying user
+   public keys to every SSH server they need access to, and relying on
+   users to verify new SSH server host keys before accepting them. This is
+   error-prone and complicated to manage. Another weakness is OpenSSH keys
+   never expire.
+  </para>
+  <para>
+   Setting up an OpenSSH certificate authority involves the following steps:
+  </para>
+ <itemizedlist>
+  <listitem>
+  <para>
+   Set up a secure trusted server to host your certificate authority,
+   and for creating and signing new server and user keys.
+  </para>
+  </listitem>
+  <listitem>
+  <para>
+   Create, sign, and distribute host keys.
+  </para>
+  </listitem>
+  <listitem>
+  <para>
+   Create, sign, and distribute user keys.
+  </para>
+  </listitem>
+  <listitem>
+  <para>
+   Revoke certificates as needed, for example when you suspect a certificate
+   has been compromised, a user has left your organization, or a server has
+   been retired.
+  </para>
+  </listitem>
+ </itemizedlist>
+   <para>
+   Note that SSH certificates follow the OpenPGP standard, rather than
+   SSL/TLS, and that the certificate format is OpenPGP, not X509.
   </para>
 
-  <sect2 xml:id="sec-ssh-gnome-keyring">
-   <title>Automatic public key logins in GNOME with gnome-keyring</title>
+ <sect2 xml:id="sec-ssh-certificate-create-signing-keys">
+  <title>Setting up a new certificate authority</title>
+  <para>
+   This section describes how to set up a new certificate
+   authority (CA). It is a best practice to carefully consider
+   how you want to organize your CA, to keep it manageable and
+   efficient.
+  </para>
+  <important>
+   <title>Protect your certificate authority</title>
+   <para>
+    It is extremely important to protect the machine that hosts
+    your certificate authority. Your CA is literally the key to
+    your entire network. Anyone who gains access to your CA can
+    create their own certificates and freely access your network
+    resources, or even compromise your servers and the CA itself.
+    A common practice is to use a dedicated machine that is started only
+    when you need to sign keys.
+   </para>
+  </important>
+   <para>
+    It is a best practice to create one signing key for servers,
+    and another signing key for clients. If you have a large number of
+    certificates to manage, it can be helpful to create your
+    CAs for hosts and clients on separate machines. If you prefer
+    using a single machine, give each CA its own directory.
+    Do not use <filename>/etc</filename> or <filename>/root</filename>.
+    <filename>/etc</filename> is for local configuration files, and
+    <filename>/root</filename> is the home directory for the root user. The
+    examples in this section use <filename>/ca-ssh-host</filename>
+    and <filename>/ca-ssh-client</filename>.
+   </para>
+   <para>
+    The following examples create two signing keys, one for signing server
+    host keys, and one for user keys. Give them strong passphrases:
+  </para>
+  <screen>&prompt.sudo;<command>sudo ssh-keygen -f <replaceable>/ca-ssh-server/ca-server-sign-key</replaceable></command>
+Generating public/private rsa key pair.
+Enter passphrase (empty for no passphrase):
+Enter same passphrase again:
+Your identification has been saved in
+ /ca-ssh-server/ca-server-sign-key
+Your public key has been saved in
+ /ca-ssh-server/ca-server-sign-key.pub
+The key fingerprint is:
+SHA256:uwAbTRaQ9hHaIsxUmILxcpERvR6bFPJ6f root@caserver
+The key's randomart image is:
++---[RSA 3072]----+
+|o.=Oo+E+         |
+|o==.*o*.o        |
+|..*=oB+*         |
+| o .B=o .        |
+|   +o=. S        |
+|  . =+o  .       |
+|   ....o.        |
+|      ....       |
+|       ..        |
++----[SHA256]-----+
+</screen>
+
+<screen>&prompt.sudo;<command>ssh-keygen -f <replaceable>/ca-ssh-user/ca-user-sign-key</replaceable></command>
+Generating public/private rsa key pair.
+Enter passphrase (empty for no passphrase):
+Enter same passphrase again:
+Your identification has been saved in
+ /ca-ssh-user/ca-user-sign-key
+Your public key has been saved in
+ /ca-ssh-user/ca-user-sign-key.pub
+The key fingerprint is:
+SHA256:Fm0ApNggXVOD7rlP+IH+Z0XdglrQe9d06ov+ root@caserver
+The key's randomart image is:
++---[RSA 3072]----+
+|....o+=...       |
+| ..+.o ..o.     o|
+|  ..o   ..o+ . +.|
+|    .    o= + + .|
+|   . .  S+ . +   |
+|    oo .. .   .  |
+|    o.o  .   o...|
+|   ..o .o   +oo..|
+|    .o+o   .+E+. |
++----[SHA256]-----+
+
+ </screen>
+
+<para>
+   Sign the CA server's public host key to create the server's own server
+   host certificate:
+  </para>
+  <screen>&prompt.sudo;<command>ssh-keygen -s <replaceable>/ca-ssh-host/ca-host-sign-key</replaceable></command> \
+   <command>-n <replaceable>root,&wsII;,&wsIIname;</replaceable> -I <replaceable>"ca-server host cert"</replaceable></command> \
+   <command>-h -V +1h <replaceable>/etc/ssh/ssh_host_ed25519_key.pub</replaceable></command>
+Enter passphrase:
+Signed host key /etc/ssh/ssh_host_ed25519_key-cert.pub: id
+"ca-server host cert" serial 0 for root,venus,venus.example.com
+valid from 2022-08-08T14:20:00 to 2022-08-08T15:21:19
+    </screen>
+      <para>
+       If you have multiple server host keys, sign all of them.
+      </para>
+    <itemizedlist>
+     <listitem>
+      <para>
+       <option>-s</option> is your private signing key.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       <option>-n</option> is your list of principals. By default,
+       certificates are valid for all users and hosts. Principals are a
+       comma-delimited list of user or host names, limiting access to hosts
+       from the specified users or hosts. See TODO for more information.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       <option>-I</option> is the identity string. This is any
+       comment or description you want. The string is logged, to help you
+       quickly find relevant log entries.
+      </para>
+     </listitem>
+     <listitem>
+      <para>
+       <option>-h</option> creates a host certificate.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <option>-V</option> sets the expiration date for the certificate. In
+      the example, the certificate expires in one hour. Short expirations
+      are useful for testing. (See the "-V validity_interval" section of
+      <command>man 1 ssh-keygen</command> for allowed time formats.)
+     </para>
+    </listitem>
+   </itemizedlist>
+   <para>
+    Verify that your new certicate is built the way you want:
+   </para>
+   <screen>&prompt.user;<command>ssh-keygen -Lf /etc/ssh/ssh_host_ed25519_key-cert.pub</command>
+ /etc/ssh/ssh_host_ed25519_key-cert.pub:
+        Type: ssh-ed25519-cert-v01@openssh.com host certificate
+        Public key: ED25519-CERT SHA256:/U7C+qABXYyuvueUuhFKzzVINq3d7IULRLwBstvVC+Q
+        Signing CA: RSA SHA256:uwAbTRaQ9hHaIsxUmILxcpERvR6bFPJ6
+         (using rsa-sha2-512)
+        Key ID: "ca-server host cert"
+        Serial: 0
+        Valid: from 2022-08-08T14:20:00 to 2022-08-08T15:21:19
+        Principals:
+                root
+                venus
+                venus.example.com
+        Critical Options: (none)
+        Extensions: (none)
+    </screen>
+
+       <!--principals, extensions, revocation, ~/.ssh/config TODO -->
+
+   <!-- user certs -->
+   <para>
+    Add the new host certificate to <filename>/etc/ssh/sshd_config</filename>,
+    to make it available to clients:
+   </para>
+   <screen>HostCertificate <replaceable>/etc/ssh/ssh_host_ed25519_key-cert.pub</replaceable></screen>
+   <para>
+    Restart <systemitem class="daemon">sshd</systemitem> to load your
+    changes:
+   </para>
+   <screen>&prompt.user;<command>sudo systemctl restart sshd.service</command></screen>
+  </sect2>
+
+  <sect2 xml:id="sec-ssh-certificate-test-client">
+   <title>Configuring a client</title>
+   <para>
+    On your test client, edit all <filename>known_hosts</filename> files.
+    Each user can have their own <filename>~/.ssh/known_hosts</filename>,
+    and check for a global <filename>known_hosts</filename> file in
+    <filename>/etc/ssh</filename>. Delete all existing entries, and replace
+    them
+   </para>
+
+
+
+  </sect2>
+ </sect1>
+
+ <sect1 xml:id="sec-ssh-gnome-keyring">
+  <title>Automated public key logins with gnome-keyring</title>
   <para>
    The <package>gnome-keyring</package> package is installed and enabled
    by default when the GNOME desktop environment is installed.
    <literal>gnome-keyring</literal> is integrated with your
    system login, automatically unlocking your secrets storage at login.
    When you change your login password, <literal>gnome-keyring</literal>
-   updates itself with your new password.
+   automatically updates itself with your new password.
   </para>
   <para>
    <literal>gnome-keyring</literal> automatically loads all key pairs in
@@ -897,26 +1121,25 @@ Have a lot of fun...</screen>
   <para>
    List all loaded keys:
   </para>
-  <screen>&prompt.user;<command>ssh-add -l</command></screen>
+  <screen>&prompt.user;<command>ssh-add -L</command></screen>
   <para>
    When you start up your system and then open an SSH session, you will be
    prompted for your private key passphrase.
   </para>
    <para>
-    <literal>gnome-keyring</literal> will remember the passphrase for the
-    rest of your session. You will not have to re-enter the passphrase until
-    after a system restart.
+    <literal>gnome-keyring</literal> will remember the passphrase for the rest of your
+    session. You will not have to re-enter the passphrase until after a system
+    restart.
    </para>
- </sect2>
+ </sect1>
 
-  <sect2 xml:id="sec-ssh-ssh-agent">
-   <title>Automated public key logins in the console with ssh-agent</title>
+  <sect1 xml:id="sec-ssh-authentic-agent">
+   <title>Automated public key logins with ssh-agent</title>
    <para>
     The <package>openssh</package> package
     provides the <command>ssh-agent</command> utility, which retains your
     private keys and passphrases, and automatically applies your passphrases
-    for you during the current session. Use <command>ssh-agent</command>
-    when you boot to the console and do not use GNOME.
+    for you during the current session.
    </para>
    <para>
     Configure <command>ssh-agent</command> to start automatically and load
@@ -930,16 +1153,57 @@ ssh-add</screen>
     loads all the keys in your <filename>~/.ssh</filename> folder.
     When you open an SSH session that requires public key authentication,
     you will be prompted for the passphrase. After the passphrase has been
-    provided the first time, you will not have to enter it again, until
-    after you restart your system.
+    provided once, you will not have to enter it again, until after you
+    restart your system.
    </para>
    <para>
     You may configure <filename>~./profile</filename> to load only
     specific keys, like the following example that loads
     <filename>id_rsa</filename> and <filename>id_ed25519</filename>:
    </para>
-   <screen>ssh-add id_rsa id_ed25519</screen>
-  </sect2>
+   <screen>&prompt.user;ssh-add <replaceable>id_rsa id_ed25519</replaceable></screen>
+
+   <sect2 xml:id="sec-ssh-authentic-agent-x">
+    <title>Using <command>ssh-agent</command> in an X session</title>
+    <para>
+     On &productname;, <command>ssh-agent</command> is automatically
+     started by the &gnome; display manager. To also invoke
+     <command>ssh-add</command> to add your keys to the agent at the
+     beginning of an X session, do the following:
+    </para>
+    <procedure>
+     <step>
+      <para>
+       Log in as the desired user and check whether the file
+       <filename>~/.xinitrc</filename> exists.
+      </para>
+     </step>
+     <step>
+      <para>
+       If it does not exist, use an existing template or copy it from
+       <filename>/etc/skel</filename>:
+      </para>
+<screen>if [ -f ~/.xinitrc.template ]; then mv ~/.xinitrc.template ~/.xinitrc; \
+else cp /etc/skel/.xinitrc.template ~/.xinitrc; fi</screen>
+     </step>
+     <step>
+      <para>
+       If you have copied the template, search for the following lines and
+       uncomment them. If <filename>~/.xinitrc</filename> already existed,
+       add the following lines (without comment signs).
+      </para>
+<screen># if test -S "$SSH_AUTH_SOCK" -a -x "$SSH_ASKPASS"; then
+#       ssh-add &lt; /dev/null
+# fi</screen>
+     </step>
+     <step>
+      <para>
+       When starting a new X session, you will be prompted for your SSH
+       passphrase.
+      </para>
+     </step>
+    </procedure>
+   </sect2>
  </sect1>
 
  <sect1 xml:id="sec-ssh-change-passphrase">

--- a/xml/security_ssh.xml
+++ b/xml/security_ssh.xml
@@ -856,6 +856,7 @@ Have a lot of fun...</screen>
 
   <sect1 xml:id="sec-ssh-certificate-auth">
   <title>OpenSSH certificate authentication</title>
+
   <para>
    OpenSSH introduced certificate authentication in OpenSSH 5.4. Hosts and
    users authenticate to each other with digitally-signed encryption

--- a/xml/security_ssh.xml
+++ b/xml/security_ssh.xml
@@ -48,7 +48,7 @@
    custom configurations, such as limiting who can have access, and which
    authentication methods are allowed.
   </para>
-  <para>
+   <para>
    Authentication and encryption are provided by encryption key pairs. Each
    key pair has a public key and a private key. Public keys encrypt, and
    private keys decrypt. Public keys are meant to be freely shared, while
@@ -489,8 +489,8 @@ MaxAuthTries <replaceable>4</replaceable>
      SSH keys serve two purposes: authenticating servers to clients, and
      authenticating clients to servers (see
      <xref linkend="sec-ssh-public-key-auth"/>). Server host keys are stored
-     in <filename>/etc/ssh</filename>. Client keys are users' personal keys,
-     and are stored in <filename>/home/<replaceable>user</replaceable>/.ssh</filename>.
+     in <filename>/etc/ssh</filename>. Users' personal keys are stored in
+     <filename>/home/<replaceable>user</replaceable>/.ssh</filename>.
     </para>
     <para>
      <filename>/home/<replaceable>user</replaceable>/.ssh</filename> is
@@ -500,24 +500,20 @@ MaxAuthTries <replaceable>4</replaceable>
      Host keys must not have passphrases.
    </para>
    <para>
-     In most cases, private client keys should have strong passphrases.
+     In most cases, private user keys should have strong passphrases.
    </para>
-   <important>
-    <title>Protect SSH keys</title>
-    <para>Be sure to maintain secure backups of all keys, hosts and clients.
-    </para>
-   </important>
 
    <sect2 xml:id="sec-create-ssh-key-client">
-     <title>Creating client SSH key pairs</title>
+     <title>Creating user SSH key pairs</title>
       <para>
-       The following procedure shows how to create client encryption keys.
+       The following procedure shows how to create user OpenSSH encryption
+       keys.
       </para>
      <procedure xml:id="pro-create-ssh-client-keys">
      <title>Creating default and customized keys</title>
     <step>
      <para>
-      To generate a client key pair with the default parameters (RSA, 3072
+      To generate a user key pair with the default parameters (RSA, 3072
       bits), use the <command>ssh-keygen</command> command with no options.
       Protect your private key with a strong passphrase:
      </para>
@@ -556,7 +552,7 @@ The key's randomart image is:
     </step>
     <step>
       <para>
-       You may create as many client keys as you want, for accessing
+       You may create as many user keys as you want, for accessing
        different servers. Each key pair must have a unique name, and  optionally, a comment. These help you remember what each
        key pair is for. Create an RSA key pair with a custom name and a
        comment:
@@ -607,8 +603,8 @@ total 608
       types for which host keys do not exist, with the default key file
       path, an empty passphrase, default bit size for the key type, and an
       empty comment. The following example creates a complete new
-      set of keys by first deleting the existing keys, then creating a new
-      set:
+      set of host keys by first deleting the existing keys, then creating a
+      new set:
     </para>
     <screen>&prompt.sudo;<command>rm /etc/ssh/ssh_host*</command>
 &prompt.sudo;<command>ssh-keygen -A</command></screen>
@@ -629,9 +625,8 @@ total 608
     <para>
      When you want to rotate host keys
      (see <xref linkend="sec-ssh-sshdserver-rotation"/>), you must create
-     the new keys
-     individually, because they must exist at the same time as your
-     old host keys. Your clients will authenticate with the old keys,
+     the new keys individually, because they must exist at the same time as
+     your old host keys. Your users will authenticate with the old keys,
      and then receive the list of new keys. They need unique names,
      to not conflict with the old keys. The following example creates new
      RSA and Ed25519 host keys, labeled with the year and month they were
@@ -655,7 +650,7 @@ total 608
     compromised, or it is time to upgrade to stronger keys. Before OpenSSH
     6.8, if <literal>StrictHostKeyChecking</literal>
     was set to <literal>yes</literal> in <filename>ssh_config</filename>
-    on client machines, clients would see a warning that the host key had
+    on user machines, users would see a warning that the host key had
     changed, and were not allowed to connect. Then the users would have to
     manually delete the server's public key from their
     <filename>known_hosts</filename> file, reconnect, and manually accept the
@@ -667,8 +662,8 @@ total 608
      keys without service interruptions. When clients connect, the server
      sends them a list of new keys. Then the next time they log in they are
      asked if they wish to accept the changes. Give users a few days to
-     connect and receive the new keys, and then remove the old keys. The
-     <filename>known_hosts</filename> files on the clients are automatically
+     connect and receive the new keys, and then you can remove the old keys.
+     The users' <filename>known_hosts</filename> files are automatically
      updated, with new keys added and the old keys removed.
    </para>
     <para>
@@ -746,7 +741,7 @@ HostKey /etc/ssh/ssh_host_ed25519_2022-01</screen>
     <screen>&prompt.root;<command>systemctl restart sshd.service</command>
     </screen>
     <para>
-      The <filename>/etc/ssh/ssh_config</filename> file on the clients must
+      The <filename>/etc/ssh/ssh_config</filename> file on user machines must
       include the following settings:
     </para>
     <screen>UpdateHostKeys ask
@@ -762,7 +757,7 @@ Deprecating obsolete hostkey: ED25519
 SHA256:V28d3VpHgjsCoV04RBCZpLo5c0kEslCZDVdIUnCvqPI
 Deprecating obsolete hostkey:
 RSA SHA256:+NR4DVdbsUNsqJPIhISzx+eqD4x/awCCwijZ4a9eP8I
-Accept updated hostkeys? (yes/no):</screen>
+Accept updated hostkeys? (yes/no):<literal>yes</literal></screen>
     <para>
       You may set <literal>UpdateHostKeys ask</literal> to
       <literal>UpdateHostKeys yes</literal> to apply the changes
@@ -831,9 +826,8 @@ Have a lot of fun...</screen>
    authentication access on the remote machine already, you cannot copy your
    new public key with <command>ssh-copy-id</command>, and must use other
    means, such as manually copying it from a USB stick to the
-   <filename>~/.ssh/authorized_keys</filename> file of your remote
-   user account. Public keys are plain text, so you can copy them
-   like any text file.
+   <filename>~/.ssh/authorized_keys</filename> file of the remote
+   user account.
   </para>
  </sect1>
 
@@ -863,7 +857,7 @@ Have a lot of fun...</screen>
   <sect1 xml:id="sec-ssh-certificate-auth">
   <title>OpenSSH certificate authentication</title>
   <para>
-   OpenSSH introduced certificate authentication in OpenSSH 5.4. Servers and
+   OpenSSH introduced certificate authentication in OpenSSH 5.4. Hosts and
    users authenticate to each other with digitally-signed encryption
    certificates instead of encryption keys, and it enables central
    management for server and user certificates.
@@ -880,7 +874,8 @@ Have a lot of fun...</screen>
    public keys to every SSH server they need access to, and relying on
    users to verify new SSH server host keys before accepting them. This is
    error-prone and complicated to manage. Another weakness is OpenSSH keys
-   never expire.
+   never expire. When you want to revoke a particular public key, you have to
+   hunt down and remove all of its copies.
   </para>
   <para>
    Setting up an OpenSSH certificate authority involves the following steps:
@@ -894,19 +889,22 @@ Have a lot of fun...</screen>
   </listitem>
   <listitem>
   <para>
-   Create, sign, and distribute host keys.
+   Create and sign host public keys, then distribute and configure the new
+   host certificates.
   </para>
   </listitem>
   <listitem>
   <para>
-   Create, sign, and distribute user keys.
+   Create and sign user keys, then distribute and configure the new
+   user certificates.
   </para>
   </listitem>
   <listitem>
   <para>
    Revoke certificates as needed, for example when you suspect a certificate
    has been compromised, a user has left your organization, or a server has
-   been retired.
+   been retired. Revoking a certificate is simpler than hunting down all
+   of the relevant public key copies, and updating configuration files.
   </para>
   </listitem>
  </itemizedlist>
@@ -919,9 +917,8 @@ Have a lot of fun...</screen>
   <title>Setting up a new certificate authority</title>
   <para>
    This section describes how to set up a new certificate
-   authority (CA). It is a best practice to carefully consider
-   how you want to organize your CA, to keep it manageable and
-   efficient.
+   authority (CA). Give careful consideration to organizing
+   your CA, to keep it manageable and efficient.
   </para>
   <important>
    <title>Protect your certificate authority</title>
@@ -941,17 +938,17 @@ Have a lot of fun...</screen>
     certificates to manage, it can be helpful to create your
     CAs for hosts and clients on separate machines. If you prefer
     using a single machine, give each CA its own directory.
-    Do not use <filename>/etc</filename> or <filename>/root</filename>.
-    <filename>/etc</filename> is for local configuration files, and
-    <filename>/root</filename> is the home directory for the root user. The
-    examples in this section use <filename>/ca-ssh-host</filename>
+    Do not use <filename>/etc</filename> or <filename>/root</filename>
+    for your CA. <filename>/etc</filename> is for local configuration files,
+    and <filename>/root</filename> is the home directory for the root user.
+    The examples in this section use <filename>/ca-ssh-host</filename>
     and <filename>/ca-ssh-client</filename>.
    </para>
    <para>
     The following examples create two signing keys, one for signing server
     host keys, and one for user keys. Give them strong passphrases:
   </para>
-  <screen>&prompt.sudo;<command>sudo ssh-keygen -f <replaceable>/ca-ssh-server/ca-server-sign-key</replaceable></command>
+  <screen>&prompt.sudo;<command>ssh-keygen -f <replaceable>/ca-ssh-hosts/ca-server-sign-key</replaceable></command>
 Generating public/private rsa key pair.
 Enter passphrase (empty for no passphrase):
 Enter same passphrase again:
@@ -997,23 +994,25 @@ The key's randomart image is:
 |   ..o .o   +oo..|
 |    .o+o   .+E+. |
 +----[SHA256]-----+
-
  </screen>
-
+ <para>
+  Add the name of user signing key to <filename>/etc/ssh/sshd_config</filename>:
+ </para>
+ <screen>TrustedUserCAKeys /ca-ssh-user/ca-user-sign-key.pub</screen>
 <para>
-   Sign the CA server's public host key to create the server's own server
-   host certificate:
+   The following example signs the CA server's public host key to create the
+   CA server's own host certificate:
   </para>
   <screen>&prompt.sudo;<command>ssh-keygen -s <replaceable>/ca-ssh-host/ca-host-sign-key</replaceable></command> \
    <command>-n <replaceable>root,&wsII;,&wsIIname;</replaceable> -I <replaceable>"ca-server host cert"</replaceable></command> \
-   <command>-h -V +1h <replaceable>/etc/ssh/ssh_host_ed25519_key.pub</replaceable></command>
+   <command>-h -V +4w <replaceable>/etc/ssh/ssh_host_ed25519_key.pub</replaceable></command>
 Enter passphrase:
 Signed host key /etc/ssh/ssh_host_ed25519_key-cert.pub: id
 "ca-server host cert" serial 0 for root,venus,venus.example.com
-valid from 2022-08-08T14:20:00 to 2022-08-08T15:21:19
+valid from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
     </screen>
       <para>
-       If you have multiple server host keys, sign all of them.
+       If you have more than one server host key, sign all of them.
       </para>
     <itemizedlist>
      <listitem>
@@ -1025,8 +1024,12 @@ valid from 2022-08-08T14:20:00 to 2022-08-08T15:21:19
       <para>
        <option>-n</option> is your list of principals. By default,
        certificates are valid for all users and hosts. Principals are a
-       comma-delimited list of user or host names, limiting access to hosts
-       from the specified users or hosts. See TODO for more information.
+       comma-delimited list of user or host names, limiting access to the
+       specified users or hosts. This is especially important to consider
+       for the root user, because root signs all keys, and automatically has
+       access to everything. You may want to restrict access to root users
+       from specific hosts, rather than allowing universal access to every
+       root user in your organization.
       </para>
      </listitem>
      <listitem>
@@ -1044,14 +1047,16 @@ valid from 2022-08-08T14:20:00 to 2022-08-08T15:21:19
     <listitem>
      <para>
       <option>-V</option> sets the expiration date for the certificate. In
-      the example, the certificate expires in one hour. Short expirations
-      are useful for testing. (See the "-V validity_interval" section of
-      <command>man 1 ssh-keygen</command> for allowed time formats.)
+      the example, the certificate expires in four weeks. Short expirations
+      are useful for testing, so there are no testing certificates
+      that are still valid after you are finished with them. (See the "-V
+      validity_interval" section of <command>man 1 ssh-keygen</command> for
+      allowed time formats.)
      </para>
     </listitem>
    </itemizedlist>
    <para>
-    Verify that your new certicate is built the way you want:
+    Verify that your new certificate is built the way you want:
    </para>
    <screen>&prompt.user;<command>ssh-keygen -Lf /etc/ssh/ssh_host_ed25519_key-cert.pub</command>
  /etc/ssh/ssh_host_ed25519_key-cert.pub:
@@ -1061,7 +1066,7 @@ valid from 2022-08-08T14:20:00 to 2022-08-08T15:21:19
          (using rsa-sha2-512)
         Key ID: "ca-server host cert"
         Serial: 0
-        Valid: from 2022-08-08T14:20:00 to 2022-08-08T15:21:19
+        Valid: from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
         Principals:
                 root
                 venus
@@ -1069,34 +1074,36 @@ valid from 2022-08-08T14:20:00 to 2022-08-08T15:21:19
         Critical Options: (none)
         Extensions: (none)
     </screen>
-
-       <!--principals, extensions, revocation, ~/.ssh/config TODO -->
-
-   <!-- user certs -->
    <para>
-    Add the new host certificate to <filename>/etc/ssh/sshd_config</filename>,
-    to make it available to clients:
+    Add the new host certificate to
+    <filename>/etc/ssh/sshd_config</filename> on the server, to make it
+    available to clients:
    </para>
    <screen>HostCertificate <replaceable>/etc/ssh/ssh_host_ed25519_key-cert.pub</replaceable></screen>
    <para>
     Restart <systemitem class="daemon">sshd</systemitem> to load your
     changes:
    </para>
-   <screen>&prompt.user;<command>sudo systemctl restart sshd.service</command></screen>
+   <screen>&prompt.sudo;<command>systemctl restart sshd.service</command></screen>
+   <para>
+    See <xref linkend="sec-ssh-certificate-test-client"/> to learn how to
+    configure clients to accept host certificates.
+   </para>
   </sect2>
 
   <sect2 xml:id="sec-ssh-certificate-test-client">
    <title>Configuring a client</title>
    <para>
-    On your test client, edit all <filename>known_hosts</filename> files.
-    Each user can have their own <filename>~/.ssh/known_hosts</filename>,
-    and check for a global <filename>known_hosts</filename> file in
-    <filename>/etc/ssh</filename>. Delete all existing entries, and replace
-    them
+    Rather than maintaining <filename>known_hosts</filename> files (which are
+    difficult to audit and maintain) on your client machines, replace the
+    entire contents of <filename>known_hosts</filename> with a directive to
+    your CA:
    </para>
-
-
-
+   <screen>@&wsIIname; cert-authority ssh-ed25519 AAAB4...</screen>
+   <para>
+    Check for both <filename>~/.ssh/known_hosts</filename> files, and the
+    global <filename>/etc/ssh/known_hosts</filename>.
+   </para>
   </sect2>
  </sect1>
 

--- a/xml/security_ssh.xml
+++ b/xml/security_ssh.xml
@@ -464,17 +464,20 @@ MaxAuthTries <replaceable>4</replaceable>
   </sect1>
 
    <sect1 xml:id="sec-ssh-authentic-gen-key">
-   <title>Managing client and host encryption keys</title>
+   <title>Managing user and host encryption keys</title>
    <para>
      There are several key types to choose from: DSA, RSA, ECDSA, ECDSA-SK,
      Ed25519, and Ed25519-SK. DSA was deprecated several years ago, and was
      disabled in OpenSSH 7.0 and should not be used. RSA is the most
-     universal as it is older, and more widely used.
+     universal as it is older, and more widely used. (As of OpenSSH
+     8.2, RSA is deprecated for host keys. Use ECDSA or Ed25519 for host
+     keys.)
    </para>
    <para>
      Ed25519 and ECDSA are stronger and faster. Ed25519 is
      considered to be the strongest. If you must support older clients
-     that do not support Ed25519, create both Ed25519 and RSA host keys.
+     that do not support Ed25519 or ECDSA, create host keys in all three
+     formats.
    </para>
    <note>
      <title>Older clients are unsafe</title>
@@ -856,27 +859,32 @@ Have a lot of fun...</screen>
 
   <sect1 xml:id="sec-ssh-certificate-auth">
   <title>OpenSSH certificate authentication</title>
-
   <para>
    OpenSSH introduced certificate authentication in OpenSSH 5.4. Hosts and
    users authenticate to each other with digitally-signed encryption
-   certificates instead of encryption keys, and it enables central
-   management for server and user certificates.
+   certificates instead of encryption keys. Certificate authentication
+   provides central management for server and user certificates,
+   eliminating the need to copy user public keys to multiple hosts. It also
+   eliminates relying on users to verify host keys, or to maintain their
+   <filename>known_hosts</filename> files.
   </para>
   <para>
    Certificates consist of a public encryption key, a user-defined identity
    string, zero or more user names or host names, and other options.
    Certificates are signed by a Certificate Authority (CA) signing key.
-   Users and servers trust the CA key, and verify its signature on a
-   certificate, rather than trusting user and server host encryption keys.
+   Users and hosts trust the CA key, and verify its signature on a
+   certificate, rather than trusting individual user and
+   host encryption keys.
   </para>
   <para>
    Traditional OpenSSH public key authentication requires copying user
-   public keys to every SSH server they need access to, and relying on
-   users to verify new SSH server host keys before accepting them. This is
-   error-prone and complicated to manage. Another weakness is OpenSSH keys
-   never expire. When you want to revoke a particular public key, you have to
-   hunt down and remove all of its copies.
+   public keys to every SSH server they need access to (to the appropriate
+   <filename>~/.ssh/authorized_keys</filename> files), and relying on
+   users to verify new SSH server host keys before accepting them (stored
+   in <filename>~/.ssh/known_hosts</filename>). This is
+   error-prone and complicated to manage. Another disadvantage is OpenSSH
+   keys never expire. When you want to revoke a particular public key, you
+   have to find and remove all of its copies.
   </para>
   <para>
    Setting up an OpenSSH certificate authority involves the following steps:
@@ -885,30 +893,47 @@ Have a lot of fun...</screen>
   <listitem>
   <para>
    Set up a secure trusted server to host your certificate authority,
-   and for creating and signing new server and user keys.
+   for signing host and user keys.
   </para>
   </listitem>
   <listitem>
   <para>
-   Create and sign host public keys, then distribute and configure the new
-   host certificates.
+   Receive and sign host public keys, then return the new host certificates
+   to their respective hosts. Host certificates go in
+   <filename>/etc/ssh</filename>, just like host keys.
   </para>
   </listitem>
   <listitem>
   <para>
-   Create and sign user keys, then distribute and configure the new
-   user certificates.
+   Receive and sign user keys, then return the new user certificates to
+   their owners.
   </para>
+  </listitem>
+  <listitem>
+   <para>
+    Add a clause to each user's <filename>~/.ssh/known_hosts</filename> that
+    directs SSH to trust your certificate authority.
+   </para>
   </listitem>
   <listitem>
   <para>
    Revoke certificates as needed, for example when you suspect a certificate
    has been compromised, a user has left your organization, or a server has
-   been retired. Revoking a certificate is simpler than hunting down all
-   of the relevant public key copies, and updating configuration files.
+   been retired. Revoking a certificate is considerably simpler than finding
+   and removing all relevant public key copies.
   </para>
   </listitem>
  </itemizedlist>
+   <para>
+    Users and server admins create and protect their own OpenSSH keys. It is
+    safe to freely share public keys, because that is what they are for. It
+    is safe to transfer the new certificates by insecure methods, such as
+    email, because they require their private keys to validate.
+    You should keep copies of all the public keys you receive, in case you
+    need to re-issue certificates. (See
+    <xref linkend="sec-ssh-certificate-create-signing-keys"/> to learn about
+    keeping your CA organized.)
+   </para>
    <para>
    Note that SSH certificates follow the OpenPGP standard, rather than
    SSL/TLS, and that the certificate format is OpenPGP, not X509.
@@ -939,65 +964,51 @@ Have a lot of fun...</screen>
     certificates to manage, it can be helpful to create your
     CAs for hosts and clients on separate machines. If you prefer
     using a single machine, give each CA its own directory.
-    Do not use <filename>/etc</filename> or <filename>/root</filename>
-    for your CA. <filename>/etc</filename> is for local configuration files,
-    and <filename>/root</filename> is the home directory for the root user.
     The examples in this section use <filename>/ca-ssh-host</filename>
-    and <filename>/ca-ssh-client</filename>.
+    and <filename>/ca-ssh-client</filename>. Copies of user's and host's
+    original public keys are kept in subdirectories, and each user
+    and host get their own folders.
    </para>
+   <important>
+    <title>RSA signing keys deprecated</title>
+    <para>
+     OpenSSH 8.2, released February 2020, deprecates RSA signing keys.
+     Use Ed25519 or ECDSA.
+    </para>
+   </important>
    <para>
-    The following examples create two signing keys, one for signing server
+    The following examples create two signing keys, one for signing
     host keys, and one for user keys. Give them strong passphrases:
   </para>
-  <screen>&prompt.sudo;<command>ssh-keygen -f <replaceable>/ca-ssh-hosts/ca-server-sign-key</replaceable></command>
-Generating public/private rsa key pair.
+  <screen>&prompt.sudo;<command>ssh-keygen -t ed25519 -f <replaceable>/ca-ssh-hosts/ca-host-sign-key -C "signing key for host certificates"</replaceable></command>
+Generating public/private ed25519 key pair.
 Enter passphrase (empty for no passphrase):
 Enter same passphrase again:
-Your identification has been saved in
- /ca-ssh-server/ca-server-sign-key
-Your public key has been saved in
- /ca-ssh-server/ca-server-sign-key.pub
+Your identification has been saved in ca-host-sign-key
+Your public key has been saved in ca-host-sign-key.pub
 The key fingerprint is:
-SHA256:uwAbTRaQ9hHaIsxUmILxcpERvR6bFPJ6f root@caserver
+SHA256:STuQ7HgDrPcEa7ybNIW0n6kPbj28X5HN8GgwllBbAt0
+ signing key for host certificates
 The key's randomart image is:
-+---[RSA 3072]----+
-|o.=Oo+E+         |
-|o==.*o*.o        |
-|..*=oB+*         |
-| o .B=o .        |
-|   +o=. S        |
-|  . =+o  .       |
-|   ....o.        |
-|      ....       |
-|       ..        |
++--[ED25519 256]--+
+|      o+o..      |
+|   . . o.=E      |
+|    = + B .      |
+|   + O + = B     |
+|  . O * S = +    |
+|   o B + o .     |
+|    =o=   .      |
+|   o.*+  .       |
+|   .=.o+.        |
 +----[SHA256]-----+
 </screen>
 
-<screen>&prompt.sudo;<command>ssh-keygen -f <replaceable>/ca-ssh-user/ca-user-sign-key</replaceable></command>
-Generating public/private rsa key pair.
-Enter passphrase (empty for no passphrase):
-Enter same passphrase again:
-Your identification has been saved in
- /ca-ssh-user/ca-user-sign-key
-Your public key has been saved in
- /ca-ssh-user/ca-user-sign-key.pub
-The key fingerprint is:
-SHA256:Fm0ApNggXVOD7rlP+IH+Z0XdglrQe9d06ov+ root@caserver
-The key's randomart image is:
-+---[RSA 3072]----+
-|....o+=...       |
-| ..+.o ..o.     o|
-|  ..o   ..o+ . +.|
-|    .    o= + + .|
-|   . .  S+ . +   |
-|    oo .. .   .  |
-|    o.o  .   o...|
-|   ..o .o   +oo..|
-|    .o+o   .+E+. |
-+----[SHA256]-----+
+  <screen>&prompt.sudo;<command>ssh-keygen -t ed25519 -f <replaceable>/ca-ssh-users/ca-user-sign-key -C "signing key for user certificates"</replaceable></command>
+
  </screen>
  <para>
-  Add the name of user signing key to <filename>/etc/ssh/sshd_config</filename>:
+  Add the full path to the user signing key to
+  <filename>/etc/ssh/sshd_config</filename>:
  </para>
  <screen>TrustedUserCAKeys /ca-ssh-user/ca-user-sign-key.pub</screen>
 <para>
@@ -1005,7 +1016,7 @@ The key's randomart image is:
    CA server's own host certificate:
   </para>
   <screen>&prompt.sudo;<command>ssh-keygen -s <replaceable>/ca-ssh-host/ca-host-sign-key</replaceable></command> \
-   <command>-n <replaceable>root,&wsII;,&wsIIname;</replaceable> -I <replaceable>"ca-server host cert"</replaceable></command> \
+   <command>-n <replaceable>&wsII;,&wsIIname;</replaceable> -I <replaceable>"ca-server host cert"</replaceable></command> \
    <command>-h -V +4w <replaceable>/etc/ssh/ssh_host_ed25519_key.pub</replaceable></command>
 Enter passphrase:
 Signed host key /etc/ssh/ssh_host_ed25519_key-cert.pub: id
@@ -1013,7 +1024,7 @@ Signed host key /etc/ssh/ssh_host_ed25519_key-cert.pub: id
 valid from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
     </screen>
       <para>
-       If you have more than one server host key, sign all of them.
+       If you have more than one host key on a server, sign all of them.
       </para>
     <itemizedlist>
      <listitem>
@@ -1025,12 +1036,8 @@ valid from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
       <para>
        <option>-n</option> is your list of principals. By default,
        certificates are valid for all users and hosts. Principals are a
-       comma-delimited list of user or host names, limiting access to the
-       specified users or hosts. This is especially important to consider
-       for the root user, because root signs all keys, and automatically has
-       access to everything. You may want to restrict access to root users
-       from specific hosts, rather than allowing universal access to every
-       root user in your organization.
+       comma-delimited list of user or host names, limiting SSH access to
+       connection requests from the specified users or hosts.
       </para>
      </listitem>
      <listitem>
@@ -1049,10 +1056,9 @@ valid from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
      <para>
       <option>-V</option> sets the expiration date for the certificate. In
       the example, the certificate expires in four weeks. Short expirations
-      are useful for testing, so there are no testing certificates
-      that are still valid after you are finished with them. (See the "-V
-      validity_interval" section of <command>man 1 ssh-keygen</command> for
-      allowed time formats.)
+      are useful for testing, in case you forget to delete them. (See
+      the "-V validity_interval" section of
+      <command>man 1 ssh-keygen</command> for allowed time formats.)
      </para>
     </listitem>
    </itemizedlist>
@@ -1069,7 +1075,6 @@ valid from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
         Serial: 0
         Valid: from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
         Principals:
-                root
                 venus
                 venus.example.com
         Critical Options: (none)
@@ -1092,19 +1097,27 @@ valid from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
    </para>
   </sect2>
 
+  <!-- zone files, retain cert copies, user creates key pair & submits pub
+  key to be signed -->
+
   <sect2 xml:id="sec-ssh-certificate-test-client">
-   <title>Configuring a client</title>
+   <title>User configuration</title>
    <para>
-    Rather than maintaining <filename>known_hosts</filename> files (which are
-    difficult to audit and maintain) on your client machines, replace the
-    entire contents of <filename>known_hosts</filename> with a directive to
-    your CA:
+    Ideally, you could replace the entire contents of your users'
+    <filename>known_hosts</filename> files with a directive to your CA
+    signing key. However, there may be hosts that are not managed by
+    your CA in this file that the user needs to connect to. Cleaning up
+    unwanted entries from <filename>known_hosts</filename> is a chore that
+    nobody like to do. However you decide to manage this, the following
+    example shows how to configure the CA for single domain. The example
+    domain is named with a wildcard, allowing users to access all servers
+    in the domain. This entry must be on a single unbroken line:
    </para>
-   <screen>@&wsIIname; cert-authority ssh-ed25519 AAAB4...</screen>
-   <para>
-    Check for both <filename>~/.ssh/known_hosts</filename> files, and the
-    global <filename>/etc/ssh/known_hosts</filename>.
-   </para>
+   <screen>@cert-authority &wsIIname; ssh-ed25519
+ AAAAC3NzaC1lZDI1NTE5AAAAIH1pF6DN4BdsfUKWuyiGt/leCvuZ/fPu
+ YxY7+4V68Fz0 signing key for host certificates</screen>
+    <para>
+    </para>
   </sect2>
  </sect1>
 

--- a/xml/security_ssh.xml
+++ b/xml/security_ssh.xml
@@ -22,7 +22,7 @@
     between two hosts, including authentication, to protect against
     eavesdropping and connection hijacking. This chapter covers basic
     operations, plus host key rotation and certificate authentication, which
-    are especially useful for managing larger SSH deployments.
+    are useful for managing larger SSH deployments.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -85,13 +85,13 @@
     accurate match than a visual comparison.
    </para>
    <para>
-    You can't rely on all users to use correct verification methods. If the
+    You can't rely on users to use correct verification methods. If the
     fingerprints do not match, the user can still type
     <literal>yes</literal>, or copy the fingerprint in the message, and
-    complete the connection. <!-- A stronger alternative is to use
+    complete the connection. A stronger alternative is to use
     certificate authentication, which provides a global authentication
     mechansism, and does not require perfect behavior from users
-    (see TODO)-->
+    (see <xref linkend="sec-ssh-certificate-auth"/>).
    </para>
   </note>
    <para>
@@ -864,17 +864,17 @@ Have a lot of fun...</screen>
    users authenticate to each other with digitally-signed encryption
    certificates instead of encryption keys. Certificate authentication
    provides central management for server and user certificates,
-   eliminating the need to copy user public keys to multiple hosts. It also
-   eliminates relying on users to verify host keys, or to maintain their
-   <filename>known_hosts</filename> files.
+   eliminating the need to manually copy user public keys to multiple hosts.
+   It increases security by giving more control to administrators, and less
+   to users.
   </para>
   <para>
    Certificates consist of a public encryption key, a user-defined identity
    string, zero or more user names or host names, and other options.
-   Certificates are signed by a Certificate Authority (CA) signing key.
-   Users and hosts trust the CA key, and verify its signature on a
-   certificate, rather than trusting individual user and
-   host encryption keys.
+   User and host public keys are signed by a Certificate Authority (CA)
+   private signing key to create an encryption certificate. Users and hosts
+   trust the public CA key, rather than trusting individual user and host
+   public encryption keys.
   </para>
   <para>
    Traditional OpenSSH public key authentication requires copying user
@@ -883,8 +883,20 @@ Have a lot of fun...</screen>
    users to verify new SSH server host keys before accepting them (stored
    in <filename>~/.ssh/known_hosts</filename>). This is
    error-prone and complicated to manage. Another disadvantage is OpenSSH
-   keys never expire. When you want to revoke a particular public key, you
-   have to find and remove all of its copies.
+   keys never expire. When you need to revoke a particular public key, you
+   have to find and remove all of its copies on your network.
+  </para>
+  <para>
+   Automating the whole process (for example, with Ansible) is virtually a
+   necessity. Large organizations, such as Meta
+   (see <link xlink:href="https://engineering.fb.com/2016/09/12/security/scalable-and-secure-access-with-ssh/"/>),
+   automate the process completely, so they can revoke and replace
+   certificates, and even certificate authorities, as often as they want
+   without disrupting operations.
+  </para>
+  <para>
+   A prerequisite is the ability to open SSH sessions to all hosts on your
+   network, and perform tasks like editing configuration files and restarting <systemitem class="daemon">sshd</systemitem>.
   </para>
   <para>
    Setting up an OpenSSH certificate authority involves the following steps:
@@ -898,21 +910,23 @@ Have a lot of fun...</screen>
   </listitem>
   <listitem>
   <para>
-   Receive and sign host public keys, then return the new host certificates
-   to their respective hosts. Host certificates go in
+   Receive and sign host public keys, then distribute the new host
+   certificates to their respective hosts. Host certificates go in
    <filename>/etc/ssh</filename>, just like host keys.
   </para>
   </listitem>
   <listitem>
   <para>
-   Receive and sign user keys, then return the new user certificates to
-   their owners.
+   Receive and sign user public keys, then distribute the new user
+   certificates to their owners. User certificates go in
+   <filename>~/.ssh</filename>, just like user keys.
   </para>
   </listitem>
   <listitem>
    <para>
-    Add a clause to each user's <filename>~/.ssh/known_hosts</filename> that
-    directs SSH to trust your certificate authority.
+     Edit configuration files on servers and users' machines, and stop and
+     start <systemitem class="daemon">sshd</systemitem> on hosts as
+     necessary.
    </para>
   </listitem>
   <listitem>
@@ -926,17 +940,16 @@ Have a lot of fun...</screen>
  </itemizedlist>
    <para>
     Users and server admins create and protect their own OpenSSH keys. It is
-    safe to freely share public keys, because that is what they are for. It
-    is safe to transfer the new certificates by insecure methods, such as
-    email, because they require their private keys to validate.
-    You should keep copies of all the public keys you receive, in case you
-    need to re-issue certificates. (See
+    safe to freely share public keys. It is safe to transfer the new
+    certificates by insecure methods, such as email, because they require
+    their private keys to validate. You should keep copies of all the public
+    keys you receive, in case you need to re-issue certificates. (See
     <xref linkend="sec-ssh-certificate-create-signing-keys"/> to learn about
     keeping your CA organized.)
    </para>
    <para>
    Note that SSH certificates follow the OpenPGP standard, rather than
-   SSL/TLS, and that the certificate format is OpenPGP, not X509.
+   SSL/TLS, and that the certificate format is OpenPGP, not X.509.
   </para>
 
  <sect2 xml:id="sec-ssh-certificate-create-signing-keys">
@@ -964,10 +977,10 @@ Have a lot of fun...</screen>
     certificates to manage, it can be helpful to create your
     CAs for hosts and clients on separate machines. If you prefer
     using a single machine, give each CA its own directory.
-    The examples in this section use <filename>/ca-ssh-host</filename>
-    and <filename>/ca-ssh-client</filename>. Copies of user's and host's
-    original public keys are kept in subdirectories, and each user
-    and host get their own folders.
+    The examples in this section use <filename>/ca-ssh-hosts</filename>
+    and <filename>/ca-ssh-users</filename>. Keep copies of users' and host's
+    public keys in their own subdirectories, for easier tracking and
+    avoiding key name collisions.
    </para>
    <important>
     <title>RSA signing keys deprecated</title>
@@ -1004,27 +1017,55 @@ The key's randomart image is:
 </screen>
 
   <screen>&prompt.sudo;<command>ssh-keygen -t ed25519 -f <replaceable>/ca-ssh-users/ca-user-sign-key -C "signing key for user certificates"</replaceable></command>
-
+Generating public/private ed25519 key pair.
+Enter passphrase (empty for no passphrase):
+Enter same passphrase again:
+Your identification has been saved in ca-user-sign-key
+Your public key has been saved in ca-user-sign-key.pub
+The key fingerprint is:
+SHA256:taYj8tTnjkzgfHRvQ6HTj8a37PY6rwv96V1x+GHRjIk signing key for user certificates
+The key's randomart image is:
++--[ED25519 256]--+
+|                 |
+|             . +.|
+|          . E o.o|
+|         . + . ..|
+|      . S * o .+.|
+|     o + + = +..+|
+|    . = * . O + o|
+|     + = = o =oo+|
+|      . o.o  oOX=|
++----[SHA256]-----+
  </screen>
  <para>
-  Add the full path to the user signing key to
-  <filename>/etc/ssh/sshd_config</filename>:
+  Copy your public user signing key (be sure you are copying the PUBLIC
+  key) to <filename>/etc/ssh</filename> on all hosts running SSH servers.
+  Then enter the full path of the public user signing key to
+  <filename>/etc/ssh/sshd_config</filename> on the hosts:
  </para>
- <screen>TrustedUserCAKeys /ca-ssh-user/ca-user-sign-key.pub</screen>
-<para>
-   The following example signs the CA server's public host key to create the
-   CA server's own host certificate:
+ <screen>TrustedUserCAKeys <replaceable>/etc/ssh/ca-user-sign-key.pub</replaceable>
+</screen>
+ <para>
+  Then restart <systemitem class="daemon">sshd</systemitem>.
+ </para>
+</sect2>
+
+ <sect2 xml:id="sec-ssh-certificate-create-host-certs">
+  <title>Creating host certificates</title>
+  <para>
+   The following example signs a host public key to create a host
+   certificate for a database server:
   </para>
-  <screen>&prompt.sudo;<command>ssh-keygen -s <replaceable>/ca-ssh-host/ca-host-sign-key</replaceable></command> \
-   <command>-n <replaceable>&wsII;,&wsIIname;</replaceable> -I <replaceable>"ca-server host cert"</replaceable></command> \
+  <screen>&prompt.sudo;<command>ssh-keygen -s <replaceable>/ca-ssh-hosts/ca-host-sign-key</replaceable></command> \
+   <command>-n <replaceable>&wsII;,&wsIIname;</replaceable> -I <replaceable>"db-server host cert"</replaceable></command> \
    <command>-h -V +4w <replaceable>/etc/ssh/ssh_host_ed25519_key.pub</replaceable></command>
 Enter passphrase:
 Signed host key /etc/ssh/ssh_host_ed25519_key-cert.pub: id
-"ca-server host cert" serial 0 for root,venus,venus.example.com
+"db-server host cert" serial 0 for venus,venus.example.com
 valid from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
     </screen>
       <para>
-       If you have more than one host key on a server, sign all of them.
+       If there is more than one host key on a server, sign all of them.
       </para>
     <itemizedlist>
      <listitem>
@@ -1034,10 +1075,9 @@ valid from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
      </listitem>
      <listitem>
       <para>
-       <option>-n</option> is your list of principals. By default,
-       certificates are valid for all users and hosts. Principals are a
-       comma-delimited list of user or host names, limiting SSH access to
-       connection requests from the specified users or hosts.
+       <option>-n</option> is your list of principals. For host
+       certificates, the principals are the machine's host name
+       and fully-qualified domain name.
       </para>
      </listitem>
      <listitem>
@@ -1055,8 +1095,7 @@ valid from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
     <listitem>
      <para>
       <option>-V</option> sets the expiration date for the certificate. In
-      the example, the certificate expires in four weeks. Short expirations
-      are useful for testing, in case you forget to delete them. (See
+      the example, the certificate expires in four weeks. (See
       the "-V validity_interval" section of
       <command>man 1 ssh-keygen</command> for allowed time formats.)
      </para>
@@ -1068,10 +1107,11 @@ valid from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
    <screen>&prompt.user;<command>ssh-keygen -Lf /etc/ssh/ssh_host_ed25519_key-cert.pub</command>
  /etc/ssh/ssh_host_ed25519_key-cert.pub:
         Type: ssh-ed25519-cert-v01@openssh.com host certificate
-        Public key: ED25519-CERT SHA256:/U7C+qABXYyuvueUuhFKzzVINq3d7IULRLwBstvVC+Q
-        Signing CA: RSA SHA256:uwAbTRaQ9hHaIsxUmILxcpERvR6bFPJ6
-         (using rsa-sha2-512)
-        Key ID: "ca-server host cert"
+        Public key: ED25519-CERT SHA256:/
+         U7C+qABXYyuvueUuhFKzzVINq3d7IULRLwBstvVC+Q
+        Signing CA: ED25519 SHA256:
+         STuQ7HgDrPcEa7ybNIW0n6kPbj28X5HN8GgwllBbAt0 (using ssh-ed25519)
+        Key ID: "db-server host cert"
         Serial: 0
         Valid: from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
         Principals:
@@ -1082,7 +1122,7 @@ valid from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
     </screen>
    <para>
     Add the new host certificate to
-    <filename>/etc/ssh/sshd_config</filename> on the server, to make it
+    <filename>/etc/ssh/sshd_config</filename> on its server, to make it
     available to clients:
    </para>
    <screen>HostCertificate <replaceable>/etc/ssh/ssh_host_ed25519_key-cert.pub</replaceable></screen>
@@ -1103,20 +1143,17 @@ valid from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
   <sect2 xml:id="sec-ssh-certificate-test-client">
    <title>User configuration</title>
    <para>
-    Ideally, you could replace the entire contents of your users'
-    <filename>known_hosts</filename> files with a directive to your CA
-    signing key. However, there may be hosts that are not managed by
-    your CA in this file that the user needs to connect to. Cleaning up
-    unwanted entries from <filename>known_hosts</filename> is a chore that
-    nobody like to do. However you decide to manage this, the following
-    example shows how to configure the CA for single domain. The example
-    domain is named with a wildcard, allowing users to access all servers
-    in the domain. This entry must be on a single unbroken line:
+    The following example shows the client configuration for your CA for a
+    single domain. The example domain is named with a wildcard, which
+    permits users to access all servers in the domain. This entry must be on
+    a single unbroken line in your users'
+    <filename>~/.ssh/known_hosts</filename> files:
    </para>
-   <screen>@cert-authority &wsIIname; ssh-ed25519
+   <screen>@cert-authority *.example.com ssh-ed25519
  AAAAC3NzaC1lZDI1NTE5AAAAIH1pF6DN4BdsfUKWuyiGt/leCvuZ/fPu
- YxY7+4V68Fz0 signing key for host certificates</screen>
+ YxY7+4V68Fz0 db-server host cert</screen>
     <para>
+
     </para>
   </sect2>
  </sect1>


### PR DESCRIPTION
### PR creator: Description

Certificate auth in OpenSSH is good for large scale deployments, and giving admins more control

### PR creator: Are there any relevant issues/feature requests?

Jira DOCTEAM-615

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
