### PR TITLE
Cryptctl ha cluster

### DIFF
--- a/xml/security_cryptctl.xml
+++ b/xml/security_cryptctl.xml
@@ -709,7 +709,7 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
      </step>
      <step>
       <para>
-       Log in via SHH to <replaceable>Node2</replaceable> and join the cluster
+       Log in via SSH to <replaceable>Node2</replaceable> and join the cluster
        from there:
       </para>
       <screen>&prompt.root;<command>ssh <replaceable>Node2</replaceable></command>
@@ -793,7 +793,7 @@ filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
             cryptctl
           </entry>
           <entry>
-            Name of the resource group
+            Name of the resource group.
           </entry>
         </row>
         <row>
@@ -806,7 +806,7 @@ filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
           <entry>
           </entry>
           <entry>
-            The full path to the created certificate
+            The full path to the created certificate.
           </entry>
         </row>
         <row>
@@ -819,7 +819,7 @@ filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
           <entry>
           </entry>
           <entry>
-            The full path to the created certificate key
+            The full path to the created certificate key.
           </entry>
         </row>
         <row>
@@ -833,7 +833,7 @@ filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
            cryptctl-vip
           </entry>
           <entry>
-            The id of the virtual ip resource for the cryptctl server
+            The ID of the virtual IP resource for the cryptctl server.
           </entry>
         </row>
         <row>
@@ -846,7 +846,7 @@ filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
           <entry>
           </entry>
           <entry>
-            The IP address of the cryptctl server
+            The IP address of the cryptctl server.
           </entry>
         </row>
         <row>
@@ -857,10 +857,10 @@ filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
             no
           </entry>
           <entry>
-            Will be detected by virtual-ip resource agent.
+            Will be detected by the virtual-ip resource agent.
           </entry>
           <entry>
-            The network device the cryptctl server should be listening on. Is only required if the device can not be detected from the IP address.
+            The network device the cryptctl server should be listening on. Is only required if the device cannot be detected from the IP address.
           </entry>
         </row>
         <row>
@@ -871,10 +871,10 @@ filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
             no
           </entry>
           <entry>
-            Will be detected by virtual-ip resource agent.
+            Will be detected by the virtual-ip resource agent.
           </entry>
           <entry>
-            The numeric netmask of the IP address of the cryptctl server. Is only required if the netmask can not be detected from the IP address.
+            The numeric netmask of the IP address of the cryptctl server. Is only required if the netmask cannot be detected from the IP address.
           </entry>
         </row>
         <row>
@@ -885,10 +885,10 @@ filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
             no
           </entry>
           <entry>
-            Will be detected by virtual-ip resource agent.
+            Will be detected by the virtual-ip resource agent.
           </entry>
           <entry>
-            The broadcast address of the IP address of the cryptctl server. Is only required if this can not be detected from the IP address.
+            The broadcast address of the IP address of the cryptctl server. Is only required if this cannot be detected from the IP address.
           </entry>
         </row>
         <row>
@@ -902,7 +902,7 @@ filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
            cryptctl-filesystem
           </entry>
           <entry>
-            The id of the filesystem resource containing the disk encryption keys and records.
+            The ID of the filesystem resource containing the disk encryption keys and records.
           </entry>
         </row>
         <row>
@@ -915,7 +915,9 @@ filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
           <entry>
           </entry>
           <entry>
-            The device containing the filesystem. This can be a block device like /dev/sda .. or a NFS share path server:/path
+            The device containing the filesystem. This can be a block device
+            like <filename>/dev/sda<replaceable>...</replaceable></filename> or a NFS share path
+           <filename>server:path</filename>.
           </entry>
         </row>
         <row>
@@ -929,7 +931,9 @@ filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
             /var/lib/cryptctl/keydb
           </entry>
           <entry>
-            The directory where the device containing the filesystem. This can be a block device like /dev/sda .. or a NFS share path server:/path
+           The directory where the device containing the file system is located. This can be a block device
+           like <filename>/dev/sda<replaceable>...</replaceable></filename> or a NFS share path
+           <filename>server:path</filename>.
           </entry>
         </row>
         <row>
@@ -942,7 +946,7 @@ filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
           <entry>
           </entry>
           <entry>
-            The filesystem type. (nfs, xfs, ext4..)
+            The filesystem type. (for example, NFS, XFS, EXT4)
           </entry>
         </row>
         <row>
@@ -953,10 +957,10 @@ filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
             no
           </entry>
           <entry>
-            The default options of the selected filesystem.
+            The default options of the selected file system.
           </entry>
           <entry>
-            Mount options for the filesystem.
+            Mount options for the file system.
           </entry>
         </row>
       </tbody>

--- a/xml/security_cryptctl.xml
+++ b/xml/security_cryptctl.xml
@@ -725,8 +725,7 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
          cert-key-path=/etc/cryptctl/servertls/<replaceable>CertificatKeyFileName</replaceable> \
          virtual-ip:ip=<replaceable>CrypServerIP</replaceable> \
          filesystem:device=<replaceable>DevicePath</replaceable>
-         filesystem:fstype=<replaceable>FileSystemType</replaceable>
-         </command></screen>
+         filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
       </step>
       <step>
        <para>
@@ -737,8 +736,7 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
          cert-key-path=/etc/cryptctl/servertls/<replaceable>CertificatKeyFileName</replaceable> \
          virtual-ip:ip=<replaceable>CrypServerIP</replaceable> \
          filesystem:device=<replaceable>DevicePath</replaceable>
-         filesystem:fstype=<replaceable>FileSystemType</replaceable>
-         </command></screen>
+         filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
       </step>
      </substeps>
     </step>

--- a/xml/security_cryptctl.xml
+++ b/xml/security_cryptctl.xml
@@ -605,10 +605,13 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
    </itemizedlist>
   </sect1>
  <sect1 xml:id="sec-configure-cryptctl-ha">
-  <title>Setup HA environment for cryptctl-server service</title>
+  <title>Setting up an HA environment for cryptctl-server service</title>
   <para>
-   It is strongly recommended to set up the cryptctl-server in a HA environment to avoid downtimes when the cryptctl-server need to be stopped due to maintenance work or the cryptctl-server suffers a damage.
-   In the following interactive setup creates an at last two node HA-Cluster for cryptctl-server configured using self-signed certificates.
+   To avoid downtimes when the cryptctl-server needs to be stopped for
+   maintenance of suffers a damage, it is strongly recommended to set up the
+   cryptctl-server in a HA environment. You need at least a two-node &ha; cluster for
+   this.
+   The following setup shows how to create a two-node HA cluster for cryptctl-server using self-signed certificates.
   </para>
   <para>
    Make sure the following preconditions are fulfilled:
@@ -616,12 +619,15 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
   <itemizedlist>
    <listitem>
     <para>
-     At least two servers with SLES and HA extensions installed are available. All servers must also have the cryptctl package installed. All servers can reach each other via ssh.
+     At least two servers which have &sles; and the &ha; extension installed
+     are available. All servers must also have the cryptctl package installed.
+     All servers can reach each other via SSH.
     </para>
    </listitem>
    <listitem>
     <para>
-     If you are set up new cluster you need an additional IP address for the web management console of the cluster (<replaceable>AdminIP</replaceable>).
+     If you set up a new cluster you need an additional IP address for the
+     &haweb; of the cluster (<replaceable>AdminIP</replaceable>).
     </para>
    </listitem>
    <listitem>
@@ -636,15 +642,16 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
    </listitem>
    <listitem>
     <para>
-     A HA-enabled block device or NFS share is available to store the keys.
+     An HA-enabled block device or NFS share is available to store the keys.
     </para>
     <para>
-     In our example we will use an NFS share: <filename>nfs-server.example.org/data/cryptctl-keys</filename> which will be mounted to the standard location <filename>/var/lib/cryptctl/keydb</filename>.
+     In our example we will use an NFS share:
+     <filename>nfs-server.example.org/data/cryptctl-keys</filename>. It will be mounted to the standard location <filename>/var/lib/cryptctl/keydb</filename>.
     </para>
    </listitem>
    <listitem>
     <para>
-     It is strongly recommended to use an sbd device.
+     It is strongly recommended to use an SBD device.
     </para>
    </listitem>
   </itemizedlist>

--- a/xml/security_cryptctl.xml
+++ b/xml/security_cryptctl.xml
@@ -730,7 +730,7 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
          cert-key-path=/etc/cryptctl/servertls/<replaceable>CertificatKeyFileName</replaceable> \
          virtual-ip:ip=<replaceable>CrypServerIP</replaceable> \
          filesystem:device=<replaceable>DevicePath</replaceable>
-         filesystem:type=<replaceable>FileSystemType</replaceable>
+         filesystem:fstype=<replaceable>FileSystemType</replaceable>
          </command></screen>
        </para>
       </step>
@@ -744,12 +744,216 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
          cert-key-path=/etc/cryptctl/servertls/<replaceable>CertificatKeyFileName</replaceable> \
          virtual-ip:ip=<replaceable>CrypServerIP</replaceable> \
          filesystem:device=<replaceable>DevicePath</replaceable>
-         filesystem:type=<replaceable>FileSystemType</replaceable>
+         filesystem:fstype=<replaceable>FileSystemType</replaceable>
          </command></screen>
        </para>
       </step>
      </substeps>
    </procedure>
+   <table xml:id="tab-parameters">
+    <title>List of all parameters to define the resource group with the cryptctl crm script.</title>
+    <tgroup cols="4">
+      <colspec colname="name"/>
+      <colspec colname="obligytory"/>
+      <colspec colname="default"/>
+      <colspec colname="description"/>
+      <thead>
+        <row>
+          <entry>
+            <para>Name</para>
+          </entry>
+          <entry>
+            <para>Mandatory</para>
+          </entry>
+          <entry>
+            <para>Default Value</para>
+          </entry>
+          <entry>
+            <para>Description</para>
+          </entry>
+        </row>
+      </thead>
+      <tbody>
+        <row>
+          <entry>
+            id
+          </entry>
+          <entry>
+            No
+          </entry>
+          <entry>
+            cryptctl
+          </entry>
+          <entry>
+            Name of the resource group
+          </entry>
+        </row>
+        <row>
+          <entry>
+            cert-path
+          </entry>
+          <entry>
+            yes
+          </entry>
+          <entry>
+          </entry>
+          <entry>
+            The full path to the created certificate
+          </entry>
+        </row>
+        <row>
+          <entry>
+            cert-key-path
+          </entry>
+          <entry>
+            yes
+          </entry>
+          <entry>
+          </entry>
+          <entry>
+            The full path to the created certificate key
+          </entry>
+        </row>
+        <row>
+          <entry>
+            virtual-ip:id
+          </entry>
+          <entry>
+            no
+          </entry>
+            cryptctl-vip
+          <entry>
+          </entry>
+          <entry>
+            The id of the virtual ip resource for the cryptctl server
+          </entry>
+        </row>
+        <row>
+          <entry>
+            virtual-ip:ip
+          </entry>
+          <entry>
+            yes
+          </entry>
+          <entry>
+          </entry>
+          <entry>
+            The IP address of the cryptctl server
+          </entry>
+        </row>
+        <row>
+          <entry>
+            virtual-ip:nic
+          </entry>
+          <entry>
+            no
+          </entry>
+          <entry>
+            Will be detected by virtual-ip resource agent.
+          </entry>
+          <entry>
+            The network device the cryptctl server should be listening on. Is only required if the device can not be detected from the IP address.
+          </entry>
+        </row>
+        <row>
+          <entry>
+            virtual-ip:cidr_netmask
+          </entry>
+          <entry>
+            no
+          </entry>
+          <entry>
+            Will be detected by virtual-ip resource agent.
+          </entry>
+          <entry>
+            The numeric netmask of the IP address of the cryptctl server. Is only required if the netmask can not be detected from the IP address.
+          </entry>
+        </row>
+        <row>
+          <entry>
+            virtual-ip:broadcast
+          </entry>
+          <entry>
+            no
+          </entry>
+          <entry>
+            Will be detected by virtual-ip resource agent.
+          </entry>
+          <entry>
+            The broadcast address of the IP address of the cryptctl server. Is only required if this can not be detected from the IP address.
+          </entry>
+        </row>
+        <row>
+          <entry>
+            filesystem:id
+          </entry>
+          <entry>
+            no
+          </entry>
+            cryptctl-filesystem
+          <entry>
+          </entry>
+          <entry>
+            The id of the filesystem resource containing the disk encryption keys and records.
+          </entry>
+        </row>
+        <row>
+          <entry>
+            filesystem:device
+          </entry>
+          <entry>
+            yes
+          </entry>
+          <entry>
+          </entry>
+          <entry>
+            The device containing the filesystem. This can be a block device like /dev/sda .. or a NFS share path server:/path
+          </entry>
+        </row>
+        <row>
+          <entry>
+            filesystem:directory
+          </entry>
+          <entry>
+            no
+          </entry>
+          <entry>
+            /var/lib/cryptctl/keydb
+          </entry>
+          <entry>
+            The directory where the device containing the filesystem. This can be a block device like /dev/sda .. or a NFS share path server:/path
+          </entry>
+        </row>
+        <row>
+          <entry>
+            filesystem:fstype
+          </entry>
+          <entry>
+            yes
+          </entry>
+          <entry>
+          </entry>
+          <entry>
+            The filesystem type. (nfs, xfs, ext4..)
+          </entry>
+        </row>
+        <row>
+          <entry>
+            filesystem:options
+          </entry>
+          <entry>
+            no
+          </entry>
+          <entry>
+            The default options of the selected filesystem.
+          </entry>
+          <entry>
+            Mount options for the filesystem.
+          </entry>
+        </row>
+      </tbody>
+    </tgroup>
+  </table>
  </sect1>
  <sect1 xml:id="sec-configure-cryptctl-more">
   <title>More information</title>

--- a/xml/security_cryptctl.xml
+++ b/xml/security_cryptctl.xml
@@ -604,6 +604,89 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
     </listitem>
    </itemizedlist>
   </sect1>
+ <sect1 xml:id="sec-configure-cryptctl-ha">
+  <title>Setup HA environment for cryptctl-server service</title>
+  <para>
+   It is strongly recommended to set up the cryptctl-server in a HA environment to avoid downtimes when the cryptctl-server need to be stopped due to maintenance work or the cryptctl-server suffers a damage.
+   In the following interactive setup creates an at last two node HA-Cluster for cryptctl-server configured using self-signed certificates.
+  </para>
+   <para>
+    Make sure the following preconditions are fulfilled:
+   </para>
+   <itemizedlist>
+    <listitem>
+     <para>
+      At least two servers with SLES and HA extensions installed are available. All servers must also have the cryptctl package installed. All servers can reach each other via ssh.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      A separate IP address is reserved for the cryptctl-server. If you are set up new cluster you need an additional IP address for the web management console of the cluster (<replaceable>AdminIP<replaceable>).
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      A separate dns-name is reserved for the cryptctl-server and is resolved to the above IP address.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      An HA-enabled block device or NFS share is available to store the keys.
+     </para>
+     <para>
+       In our example we will use an NFS share: <filename>nfs-server.example.org/data/cryptctl-keys</filename> which will be mounted to the standard location <filename>/var/lib/cryptctl/keydb</filename>.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      It is strongly recommended to use an sbd device.
+     </para>
+    </listitem>
+   </itemizedlist>
+   <para>
+      As <systemitem class="username">root</systemitem>, execute following steps on the same server. 
+   </para>
+   <procedure>
+    <step>
+      <para>
+       Setup an cryptctl-server as described in <xref linkend="sec-configure-cryptctl-server"/> with following parameters:
+      </para>
+      <substeps>
+        <step>
+          <para>
+            Do not use the hostname of the host to create the certificate but use the dedicated hostname for the cryptctl server.
+          </para>
+        </step>
+        <step>
+          <para>
+            Do not use the default IP address setting but use the dedicated IP address for the cryptctl server.
+          </para>
+        </step>
+        <step>
+          <para>
+            Do not configure an KMIP server.
+          </para>
+        </step>
+        <step>
+         <para>
+          When asked whether to start the <command>cryptctl</command> server, enter <literal>n</literal>.
+         </para>
+        </step>
+      </substeps>
+    </step>
+    <step>
+      <para>
+        Basic setup of the cluster.
+      </para>
+      <substeps>
+        <step>
+          <para>
+            <screen>&prompt.root;<command>crm cluster init -i <replaceable>NetDev</replaceable> -A <replaceable>AdminIP<replaceable> -n <replaceable>ClusterName</replaceable></command></screen>
+          </para>
+        </step>
+    </step>
+   </procedure>
+ </sect1>
  <sect1 xml:id="sec-configure-cryptctl-more">
   <title>More information</title>
   <para>

--- a/xml/security_cryptctl.xml
+++ b/xml/security_cryptctl.xml
@@ -608,7 +608,7 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
   <title>Setting up an HA environment for cryptctl-server service</title>
   <para>
    To avoid downtimes when the cryptctl-server needs to be stopped for
-   maintenance of suffers a damage, it is strongly recommended to set up the
+   maintenance or suffers a damage, it is strongly recommended to set up the
    cryptctl-server in a HA environment. You need at least a two-node &ha; cluster for
    this.
    The following setup shows how to create a two-node HA cluster for cryptctl-server using self-signed certificates.

--- a/xml/security_cryptctl.xml
+++ b/xml/security_cryptctl.xml
@@ -693,18 +693,14 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
        <para>
         If not already done you have to setup a basic cluster with at last two nodes. It is very important that Node1 must be the server where you have confiugred the cryptctl server.
        </para>
-       <para>
-        <screen>&prompt.root;<command>crm cluster init -i <replaceable>NetDev</replaceable> -A <replaceable>AdminIP<replaceable> -n <replaceable>ClusterName</replaceable></command></screen>
-       </para>
+        <screen>&prompt.root;<command>crm cluster init -i <replaceable>NetDev</replaceable> -A <replaceable>AdminIP</replaceable> -n <replaceable>ClusterName</replaceable></command></screen>
       </step>
       <step>
        <para>
         Join the cluster from other nodes.
        </para>
-       <para>
         <screen>&prompt.root;<command>ssh <replaceable>Node2</replaceable></command></screen>
         <screen>&prompt.root;<command>crm cluster join -y <replaceable>Node1</replaceable></command></screen>
-       </para>
       </step>
       <step>
        <para>
@@ -724,7 +720,6 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
        <para>
         You can setup all needed resource agents and copy all files to all nodes whit the cryptcl crm-shell-script in one step. It is scrictly recommended to verify the setup in first step.
        </para>
-       <para>
         <screen>&prompt.root;<command>crm script verify cryptctl  \
          cert-path=/etc/cryptctl/servertls/<replaceable>CertificatFileName</replaceable> \
          cert-key-path=/etc/cryptctl/servertls/<replaceable>CertificatKeyFileName</replaceable> \
@@ -732,13 +727,11 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
          filesystem:device=<replaceable>DevicePath</replaceable>
          filesystem:fstype=<replaceable>FileSystemType</replaceable>
          </command></screen>
-       </para>
       </step>
       <step>
        <para>
         If the check was succesfull you have to setup the cluster group by running the script:
        </para>
-       <para>
         <screen>&prompt.root;<command>crm script verify cryptctl  \
          cert-path=/etc/cryptctl/servertls/<replaceable>CertificatFileName</replaceable> \
          cert-key-path=/etc/cryptctl/servertls/<replaceable>CertificatKeyFileName</replaceable> \
@@ -746,9 +739,9 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
          filesystem:device=<replaceable>DevicePath</replaceable>
          filesystem:fstype=<replaceable>FileSystemType</replaceable>
          </command></screen>
-       </para>
       </step>
      </substeps>
+    </step>
    </procedure>
    <table xml:id="tab-parameters">
     <title>List of all parameters to define the resource group with the cryptctl crm script.</title>
@@ -821,8 +814,8 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
           <entry>
             no
           </entry>
-            cryptctl-vip
           <entry>
+           cryptctl-vip
           </entry>
           <entry>
             The id of the virtual ip resource for the cryptctl server
@@ -890,8 +883,8 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
           <entry>
             no
           </entry>
-            cryptctl-filesystem
           <entry>
+           cryptctl-filesystem
           </entry>
           <entry>
             The id of the filesystem resource containing the disk encryption keys and records.

--- a/xml/security_cryptctl.xml
+++ b/xml/security_cryptctl.xml
@@ -917,7 +917,7 @@ filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
           <entry>
             The device containing the filesystem. This can be a block device
             like <filename>/dev/sda<replaceable>...</replaceable></filename> or a NFS share path
-           <filename>server:path</filename>.
+           <filename>server:/path</filename>.
           </entry>
         </row>
         <row>
@@ -933,7 +933,7 @@ filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
           <entry>
            The directory where the device containing the file system is located. This can be a block device
            like <filename>/dev/sda<replaceable>...</replaceable></filename> or a NFS share path
-           <filename>server:path</filename>.
+           <filename>server:/path</filename>.
           </entry>
         </row>
         <row>

--- a/xml/security_cryptctl.xml
+++ b/xml/security_cryptctl.xml
@@ -610,81 +610,145 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
    It is strongly recommended to set up the cryptctl-server in a HA environment to avoid downtimes when the cryptctl-server need to be stopped due to maintenance work or the cryptctl-server suffers a damage.
    In the following interactive setup creates an at last two node HA-Cluster for cryptctl-server configured using self-signed certificates.
   </para>
+  <para>
+   Make sure the following preconditions are fulfilled:
+  </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     At least two servers with SLES and HA extensions installed are available. All servers must also have the cryptctl package installed. All servers can reach each other via ssh.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     If you are set up new cluster you need an additional IP address for the web management console of the cluster (<replaceable>AdminIP</replaceable>).
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     A separate IP address (<replaceable>CrypServerIP</replaceable>) is reserved for the cryptctl-server.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     A separate dns-name (<replaceable>CrypServerHostName</replaceable>) is reserved for the cryptctl-server and is resolved to the above IP address.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     A HA-enabled block device or NFS share is available to store the keys.
+    </para>
+    <para>
+     In our example we will use an NFS share: <filename>nfs-server.example.org/data/cryptctl-keys</filename> which will be mounted to the standard location <filename>/var/lib/cryptctl/keydb</filename>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     It is strongly recommended to use an sbd device.
+    </para>
+   </listitem>
+  </itemizedlist>
    <para>
-    Make sure the following preconditions are fulfilled:
-   </para>
-   <itemizedlist>
-    <listitem>
-     <para>
-      At least two servers with SLES and HA extensions installed are available. All servers must also have the cryptctl package installed. All servers can reach each other via ssh.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      A separate IP address is reserved for the cryptctl-server. If you are set up new cluster you need an additional IP address for the web management console of the cluster (<replaceable>AdminIP<replaceable>).
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      A separate dns-name is reserved for the cryptctl-server and is resolved to the above IP address.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      An HA-enabled block device or NFS share is available to store the keys.
-     </para>
-     <para>
-       In our example we will use an NFS share: <filename>nfs-server.example.org/data/cryptctl-keys</filename> which will be mounted to the standard location <filename>/var/lib/cryptctl/keydb</filename>.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      It is strongly recommended to use an sbd device.
-     </para>
-    </listitem>
-   </itemizedlist>
-   <para>
-      As <systemitem class="username">root</systemitem>, execute following steps on the same server. 
+      Now it will describe step by step how to set up a cryptctl HA cluster.
    </para>
    <procedure>
     <step>
-      <para>
-       Setup an cryptctl-server as described in <xref linkend="sec-configure-cryptctl-server"/> with following parameters:
-      </para>
-      <substeps>
-        <step>
-          <para>
-            Do not use the hostname of the host to create the certificate but use the dedicated hostname for the cryptctl server.
-          </para>
-        </step>
-        <step>
-          <para>
-            Do not use the default IP address setting but use the dedicated IP address for the cryptctl server.
-          </para>
-        </step>
-        <step>
-          <para>
-            Do not configure an KMIP server.
-          </para>
-        </step>
-        <step>
-         <para>
-          When asked whether to start the <command>cryptctl</command> server, enter <literal>n</literal>.
-         </para>
-        </step>
-      </substeps>
+     <para>
+      You have to login on <replaceable>Node1</replaceable> as <systemitem class="username">root</systemitem>.
+     </para>
     </step>
     <step>
-      <para>
-        Basic setup of the cluster.
-      </para>
-      <substeps>
-        <step>
-          <para>
-            <screen>&prompt.root;<command>crm cluster init -i <replaceable>NetDev</replaceable> -A <replaceable>AdminIP<replaceable> -n <replaceable>ClusterName</replaceable></command></screen>
-          </para>
-        </step>
+     <para>
+      Setup an cryptctl-server as described in <xref linkend="sec-configure-cryptctl-server"/> with following parameters:
+     </para>
+     <substeps>
+      <step>
+        <para>
+         Do not use the hostname of the host to create the certificate but use the dedicated hostname <replaceable>CrypServerHostName</replaceable> of  the cryptctl server.
+        </para>
+      </step>
+      <step>
+       <para>
+        Do not use the default IP address setting but use the dedicated IP address <replaceable>CrypServerIP</replaceable> of the cryptctl server.
+       </para>
+      </step>
+      <step>
+       <para>
+        Do not configure an KMIP server.
+       </para>
+      </step>
+      <step>
+       <para>
+        When asked whether to start the <command>cryptctl</command> server, enter <literal>n</literal>.
+       </para>
+      </step>
+     </substeps>
     </step>
+    <step>
+     <para>
+      Basic setup of the cluster.
+     </para>
+     <substeps>
+      <step>
+       <para>
+        If not already done you have to setup a basic cluster with at last two nodes. It is very important that Node1 must be the server where you have confiugred the cryptctl server.
+       </para>
+       <para>
+        <screen>&prompt.root;<command>crm cluster init -i <replaceable>NetDev</replaceable> -A <replaceable>AdminIP<replaceable> -n <replaceable>ClusterName</replaceable></command></screen>
+       </para>
+      </step>
+      <step>
+       <para>
+        Join the cluster from other nodes.
+       </para>
+       <para>
+        <screen>&prompt.root;<command>ssh <replaceable>Node2</replaceable></command></screen>
+        <screen>&prompt.root;<command>crm cluster join -y <replaceable>Node1</replaceable></command></screen>
+       </para>
+      </step>
+      <step>
+       <para>
+        For more information, also see the documentation of the SUSE Linux Enterprise High Availability Extension<link xlink:href="https://DOCU-TEAM-PLEASE-ENTER THE RIGHT URL"/>.
+       </para>
+      </step>
+     </substeps>
+    </step>
+    <step>
+     <para>
+      Setup the resource group for the cryptctl server
+     </para>
+    </step>
+    <step>
+     <substeps>
+      <step>
+       <para>
+        You can setup all needed resource agents and copy all files to all nodes whit the cryptcl crm-shell-script in one step. It is scrictly recommended to verify the setup in first step.
+       </para>
+       <para>
+        <screen>&prompt.root;<command>crm script verify cryptctl  \
+         cert-path=/etc/cryptctl/servertls/<replaceable>CertificatFileName</replaceable> \
+         cert-key-path=/etc/cryptctl/servertls/<replaceable>CertificatKeyFileName</replaceable> \
+         virtual-ip:ip=<replaceable>CrypServerIP</replaceable> \
+         filesystem:device=<replaceable>DevicePath</replaceable>
+         filesystem:type=<replaceable>FileSystemType</replaceable>
+         </command></screen>
+       </para>
+      </step>
+      <step>
+       <para>
+        If the check was succesfull you have to setup the cluster group by running the script:
+       </para>
+       <para>
+        <screen>&prompt.root;<command>crm script verify cryptctl  \
+         cert-path=/etc/cryptctl/servertls/<replaceable>CertificatFileName</replaceable> \
+         cert-key-path=/etc/cryptctl/servertls/<replaceable>CertificatKeyFileName</replaceable> \
+         virtual-ip:ip=<replaceable>CrypServerIP</replaceable> \
+         filesystem:device=<replaceable>DevicePath</replaceable>
+         filesystem:type=<replaceable>FileSystemType</replaceable>
+         </command></screen>
+       </para>
+      </step>
+     </substeps>
    </procedure>
  </sect1>
  <sect1 xml:id="sec-configure-cryptctl-more">

--- a/xml/security_cryptctl.xml
+++ b/xml/security_cryptctl.xml
@@ -609,7 +609,7 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
   <para>
    To avoid downtimes when the cryptctl-server needs to be stopped for
    maintenance or suffers a damage, it is strongly recommended to set up the
-   cryptctl-server in a HA environment. You need at least a two-node &ha; cluster for
+   cryptctl-server in an HA environment. You need at least a two-node &ha; cluster for
    this.
    The following setup shows how to create a two-node HA cluster for cryptctl-server using self-signed certificates.
   </para>
@@ -626,7 +626,7 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
    </listitem>
    <listitem>
     <para>
-     If you set up a new cluster you need an additional IP address for the
+     If you set up a new cluster, you need an additional IP address for the
      &haweb; of the cluster (<replaceable>AdminIP</replaceable>).
     </para>
    </listitem>
@@ -645,7 +645,7 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
      An HA-enabled block device or NFS share is available to store the keys.
     </para>
     <para>
-     In our example we will use an NFS share:
+     In our example, we will use an NFS share:
      <filename>nfs-server.example.org/data/cryptctl-keys</filename>. It will be mounted to the standard location <filename>/var/lib/cryptctl/keydb</filename>.
     </para>
    </listitem>
@@ -665,13 +665,13 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
    </step>
    <step>
     <para>
-     Set up an cryptctl-server as described in <xref
+     Set up a cryptctl-server as described in <xref
       linkend="sec-configure-cryptctl-server"/>. Use the following parameters:
     </para>
     <substeps>
      <step>
       <para>
-       To create the certificate use the dedicated hostname
+       To create the certificate, use the dedicated hostname
        <replaceable>CrypServerHostName</replaceable> of the cryptctl server.
        Do <emphasis>not</emphasis> use the host name of the host.
       </para>
@@ -684,7 +684,7 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
      </step>
      <step>
       <para>
-       Do not configure an KMIP server.
+       Do not configure a KMIP server.
       </para>
      </step>
      <step>
@@ -733,8 +733,8 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
      <step>
       <para>
        You can set up all needed resource agents and copy all files to all
-       nodes whit the cryptcl crm-shell-script in one step. It is strictly
-       recommended to verify the setup in first step:
+       nodes with the cryptcl crm-shell-script in one step. It is strictly
+       recommended to verify the setup in the first step:
       </para>
       <screen>&prompt.root;<command>crm script verify cryptctl  \
 cert-path=/etc/cryptctl/servertls/<replaceable>CertificatFileName</replaceable> \
@@ -745,7 +745,7 @@ filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
      </step>
      <step>
       <para>
-       If the check was successful set up the cluster group by running the
+       If the check was successful, set up the cluster group by running the
        script as follows:
       </para>
       <screen>&prompt.root;<command>crm script verify cryptctl  \
@@ -787,7 +787,7 @@ filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
             id
           </entry>
           <entry>
-            No
+            no
           </entry>
           <entry>
             cryptctl
@@ -916,7 +916,7 @@ filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
           </entry>
           <entry>
             The device containing the filesystem. This can be a block device
-            like <filename>/dev/sda<replaceable>...</replaceable></filename> or a NFS share path
+            like <filename>/dev/sda<replaceable>...</replaceable></filename> or an NFS share path
            <filename>server:/path</filename>.
           </entry>
         </row>
@@ -932,7 +932,7 @@ filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
           </entry>
           <entry>
            The directory where the device containing the file system is located. This can be a block device
-           like <filename>/dev/sda<replaceable>...</replaceable></filename> or a NFS share path
+           like <filename>/dev/sda<replaceable>...</replaceable></filename> or an NFS share path
            <filename>server:/path</filename>.
           </entry>
         </row>
@@ -946,7 +946,7 @@ filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
           <entry>
           </entry>
           <entry>
-            The filesystem type. (for example, NFS, XFS, EXT4)
+            The filesystem type (for example, NFS, XFS, EXT4).
           </entry>
         </row>
         <row>

--- a/xml/security_cryptctl.xml
+++ b/xml/security_cryptctl.xml
@@ -655,98 +655,108 @@ Used By      When                 UUID  Max.Users  Num.Users  Mount Point
     </para>
    </listitem>
   </itemizedlist>
-   <para>
-      Now it will describe step by step how to set up a cryptctl HA cluster.
-   </para>
-   <procedure>
-    <step>
-     <para>
-      You have to login on <replaceable>Node1</replaceable> as <systemitem class="username">root</systemitem>.
-     </para>
-    </step>
-    <step>
-     <para>
-      Setup an cryptctl-server as described in <xref linkend="sec-configure-cryptctl-server"/> with following parameters:
-     </para>
-     <substeps>
-      <step>
-        <para>
-         Do not use the hostname of the host to create the certificate but use the dedicated hostname <replaceable>CrypServerHostName</replaceable> of  the cryptctl server.
-        </para>
-      </step>
-      <step>
+
+  <procedure>
+   <title>Setting up a cryptctl two-node HA cluster</title>
+   <step>
+    <para>
+     Log in to <replaceable>Node1</replaceable> as <systemitem class="username">root</systemitem>.
+    </para>
+   </step>
+   <step>
+    <para>
+     Set up an cryptctl-server as described in <xref
+      linkend="sec-configure-cryptctl-server"/>. Use the following parameters:
+    </para>
+    <substeps>
+     <step>
+      <para>
+       To create the certificate use the dedicated hostname
+       <replaceable>CrypServerHostName</replaceable> of the cryptctl server.
+       Do <emphasis>not</emphasis> use the host name of the host.
+      </para>
+     </step>
+     <step>
+      <para>
+       Use the dedicated IP address <replaceable>CrypServerIP</replaceable> of
+       the cryptctl server. Do <emphasis>not</emphasis> use the default IP address setting.
+      </para>
+     </step>
+     <step>
+      <para>
+       Do not configure an KMIP server.
+      </para>
+     </step>
+     <step>
+      <para>
+       When asked whether to start the <command>cryptctl</command> server, enter <literal>n</literal>.
+      </para>
+     </step>
+    </substeps>
+   </step>
+   <step>
+    <para>
+     Set up a two-node HA cluster:
+    </para>
+    <substeps>
+     <step>
+      <important>
        <para>
-        Do not use the default IP address setting but use the dedicated IP address <replaceable>CrypServerIP</replaceable> of the cryptctl server.
-       </para>
-      </step>
-      <step>
-       <para>
-        Do not configure an KMIP server.
-       </para>
-      </step>
-      <step>
-       <para>
-        When asked whether to start the <command>cryptctl</command> server, enter <literal>n</literal>.
-       </para>
-      </step>
-     </substeps>
-    </step>
-    <step>
-     <para>
-      Basic setup of the cluster.
-     </para>
-     <substeps>
-      <step>
-       <para>
-        If not already done you have to setup a basic cluster with at last two nodes. It is very important that Node1 must be the server where you have confiugred the cryptctl server.
-       </para>
-        <screen>&prompt.root;<command>crm cluster init -i <replaceable>NetDev</replaceable> -A <replaceable>AdminIP</replaceable> -n <replaceable>ClusterName</replaceable></command></screen>
-      </step>
-      <step>
-       <para>
-        Join the cluster from other nodes.
-       </para>
-        <screen>&prompt.root;<command>ssh <replaceable>Node2</replaceable></command></screen>
-        <screen>&prompt.root;<command>crm cluster join -y <replaceable>Node1</replaceable></command></screen>
-      </step>
-      <step>
-       <para>
-        For more information, also see the documentation of the SUSE Linux Enterprise High Availability Extension<link xlink:href="https://DOCU-TEAM-PLEASE-ENTER THE RIGHT URL"/>.
-       </para>
-      </step>
-     </substeps>
-    </step>
-    <step>
-     <para>
-      Setup the resource group for the cryptctl server
-     </para>
-    </step>
-    <step>
-     <substeps>
-      <step>
-       <para>
-        You can setup all needed resource agents and copy all files to all nodes whit the cryptcl crm-shell-script in one step. It is scrictly recommended to verify the setup in first step.
-       </para>
-        <screen>&prompt.root;<command>crm script verify cryptctl  \
-         cert-path=/etc/cryptctl/servertls/<replaceable>CertificatFileName</replaceable> \
-         cert-key-path=/etc/cryptctl/servertls/<replaceable>CertificatKeyFileName</replaceable> \
-         virtual-ip:ip=<replaceable>CrypServerIP</replaceable> \
-         filesystem:device=<replaceable>DevicePath</replaceable>
-         filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
-      </step>
-      <step>
-       <para>
-        If the check was succesfull you have to setup the cluster group by running the script:
-       </para>
-        <screen>&prompt.root;<command>crm script verify cryptctl  \
-         cert-path=/etc/cryptctl/servertls/<replaceable>CertificatFileName</replaceable> \
-         cert-key-path=/etc/cryptctl/servertls/<replaceable>CertificatKeyFileName</replaceable> \
-         virtual-ip:ip=<replaceable>CrypServerIP</replaceable> \
-         filesystem:device=<replaceable>DevicePath</replaceable>
-         filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
-      </step>
-     </substeps>
-    </step>
+        <replaceable>Node1</replaceable> must be the server where you have configured the cryptctl server.</para>
+      </important>
+      <para>On the machine where you have configured the cryptctl server, set up the first node as follows:</para>
+      <screen>&prompt.root;<command>crm cluster init -i <replaceable>NetDev</replaceable> -A <replaceable>AdminIP</replaceable> -n <replaceable>ClusterName</replaceable></command></screen>
+     </step>
+     <step>
+      <para>
+       Log in via SHH to <replaceable>Node2</replaceable> and join the cluster
+       from there:
+      </para>
+      <screen>&prompt.root;<command>ssh <replaceable>Node2</replaceable></command>
+&prompt.root;<command>crm cluster join -y <replaceable>Node1</replaceable></command></screen>
+     </step>
+     <step>
+      <para>
+       For more information, also see the <link
+        xlink:href="https://documentation.suse.com/sle-ha/html/SLE-HA-all/article-installation.html">&haquick;</link>.
+      </para>
+     </step>
+    </substeps>
+   </step>
+   <step>
+    <para>
+     Set up the resource group for the cryptctl server:
+    </para>
+   </step>
+   <step>
+    <substeps>
+     <step>
+      <para>
+       You can set up all needed resource agents and copy all files to all
+       nodes whit the cryptcl crm-shell-script in one step. It is strictly
+       recommended to verify the setup in first step:
+      </para>
+      <screen>&prompt.root;<command>crm script verify cryptctl  \
+cert-path=/etc/cryptctl/servertls/<replaceable>CertificatFileName</replaceable> \
+cert-key-path=/etc/cryptctl/servertls/<replaceable>CertificatKeyFileName</replaceable> \
+virtual-ip:ip=<replaceable>CrypServerIP</replaceable> \
+filesystem:device=<replaceable>DevicePath</replaceable>
+filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
+     </step>
+     <step>
+      <para>
+       If the check was successful set up the cluster group by running the
+       script as follows:
+      </para>
+      <screen>&prompt.root;<command>crm script verify cryptctl  \
+cert-path=/etc/cryptctl/servertls/<replaceable>CertificatFileName</replaceable> \
+cert-key-path=/etc/cryptctl/servertls/<replaceable>CertificatKeyFileName</replaceable> \
+virtual-ip:ip=<replaceable>CrypServerIP</replaceable> \
+filesystem:device=<replaceable>DevicePath</replaceable>
+filesystem:fstype=<replaceable>FileSystemType</replaceable></command></screen>
+     </step>
+    </substeps>
+   </step>
    </procedure>
    <table xml:id="tab-parameters">
     <title>List of all parameters to define the resource group with the cryptctl crm script.</title>


### PR DESCRIPTION
### 
There is a JIRA request to make HA envinroment for cryptcl: https://jira.suse.com/browse/PED-1326
An crmsh-script was written to make a cluster setup easy.
This document enhancement describes the usage of this script and how to setup a HA environment for cryptctl.

### Feature requests?

* jsc#PED-1326


### Which product versions do the changes apply to?

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4