### PR TITLE
fix bsc#1201583: mcelog is x86_64 only

### DIFF
--- a/xml/utilities.xml
+++ b/xml/utilities.xml
@@ -2574,6 +2574,10 @@ Ctrl-c - Quit   TAB - Tuning
 
   <sect2 xml:id="sec-util-hardware-mcelog">
    <title>MCELog: machine check exceptions (MCE)</title>
+   <note>
+    <title>Availability</title>
+    <para>This tool is only available on &x86-64; systems.</para>
+   </note>
    <para>
     The <systemitem class="resource">mcelog</systemitem> package logs and
     parses/translates Machine Check Exceptions (MCE) on hardware errors, including


### PR DESCRIPTION
### PR creator: Description

Tuning Guide, Utilities Chapter: Add note that mcelog tool is only available for x86-64.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1201583


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
