### PR TITLE
add new coredump core size value, infinity, in Tuning Guide

### DIFF
--- a/xml/tuning_systemd_coredump.xml
+++ b/xml/tuning_systemd_coredump.xml
@@ -4,8 +4,8 @@
   <!ENTITY % entities SYSTEM "generic-entities.ent">
     %entities;
 ]>
-<chapter xmlns="http://docbook.org/ns/docbook" 
-         xmlns:xi="http://www.w3.org/2001/XInclude" 
+<chapter xmlns="http://docbook.org/ns/docbook"
+         xmlns:xi="http://www.w3.org/2001/XInclude"
          xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0"
          xml:id="cha-tuning-systemd-coredump">
  <title>Using &systemdcd; to debug application crashes</title>
@@ -46,8 +46,14 @@
 </screen>
 
   <para>
+   Size units are B, K, M, G, T, P, and E. <literal>ExternalSizeMax</literal> also supports a value of <literal>infinity</literal>.
+   <!-- see https://github.com/systemd/systemd/pull/21371/files,
+   c schroder 2022-09-15 -->
+  </para>
+
+  <para>
    The following example shows how to use Vim for simple testing, by creating a
-   segfault to generate journal entries and a core dump. 
+   segfault to generate journal entries and a core dump.
   </para>
 
   <procedure xml:id="pro-test-coredump">
@@ -73,8 +79,8 @@
      Get the PID and generate a segfault:
     </para>
 <screen>&prompt.user;ps ax | grep vim
-2345 pts/3    S+     0:00 vim testfile               
-                 
+2345 pts/3    S+     0:00 vim testfile
+
 &prompt.root;kill -s SIGSEGV 2345</screen>
 <para>
     Vim will emit error messages:
@@ -109,7 +115,7 @@ Control Group: /user.slice/user-1000.slice/session-1.scope
     Hostname: linux-uoch
     Coredump: /var/lib/systemd/coredump/core.vim.0.b5c251b86ab34674a2222cef102
     Message: Process 2345 (vim) of user 0 dumped core.
-                
+
          Stack trace of thread 2345:
          #0  0x00007f21dd87e2a7 kill (libc.so.6)
          #1  0x000000000050cb35 may_core_dump (vim)
@@ -117,7 +123,7 @@ Control Group: /user.slice/user-1000.slice/session-1.scope
          #3  0x00007f21dd92ea33 __select (libc.so.6)
          #4  0x000000000050b4e3 RealWaitForChar (vim)
          #5  0x000000000050b86b mch_inchar (vim)
-[...]                                             
+[...]
 </screen>
    </step>
   </procedure>


### PR DESCRIPTION
### PR creator: Description

Add new "infinity" coredump core size value for coredump.conf


### PR creator: Are there any relevant issues/feature requests?
Jira SLE-23932


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 SP0
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
