### PR TITLE
Remove empty replaceable that broke all subsequent styling.

### DIFF
--- a/xml/storage_lvm.xml
+++ b/xml/storage_lvm.xml
@@ -1498,7 +1498,7 @@ root's password:
       with the Linux path to the logical volume, such as
       <filename>/dev/LOCAL/DATA</filename>. For example:
      </para>
-<screen>&prompt.sudo;lvextend -L +10GB /dev/vg1/v1<replaceable/></screen>
+<screen>&prompt.sudo;lvextend -L +10GB /dev/vg1/v1</screen>
     </step>
     <step>
      <para>


### PR DESCRIPTION
### PR creator: Description

Empty <replaceable> triggered all styling to break. Removed it to make things look pretty again.


### PR creator: Are there any relevant issues/feature requests?


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 SP0
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
