### PR TITLE
fix sudo usage

### DIFF
--- a/xml/storage_raid.xml
+++ b/xml/storage_raid.xml
@@ -419,7 +419,7 @@ lrwxrwxrwx 1 8 Dec  9 15:11 myRAID -&gt; ../md127</screen>
        the line <literal>CREATE names=yes</literal> to
        <filename>/etc/mdadm.conf</filename> by running the following command:
       </para>
-<screen>&prompt.sudo;echo "CREATE names=yes" &gt;&gt; /etc/mdadm.conf</screen>
+<screen>&prompt.user;echo "CREATE names=yes" | sudo tee -a  /etc/mdadm.conf</screen>
       <para>
        This will cause names like <literal>myRAID</literal> to be used as a
        <quote>real</quote> device name. The device will not only be accessible


### PR DESCRIPTION
### PR creator: Description

Fix this line using sudo that does't work  
```bash
sudo echo "CREATE names=yes" >> /etc/mdadm.conf
````

The command does not work because the redirection is performed by shell which does not have the permission to write to the file and not by sudo  
Using the following line fixes the issue
```bash
echo "CREATE names=yes" | sudo tee -a /etc/mdadm.conf
```



### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#SLE-...


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [X] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [X] SLE 15 SP4/openSUSE Leap 15.4
  - [X] SLE 15 SP3/openSUSE Leap 15.3
  - [X] SLE 15 SP2/openSUSE Leap 15.2
  - [X] SLE 15 SP1
  - [X] SLE 15 SP0
- SLE 12
  - [X] SLE 12 SP5
  - [X] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
