### PR TITLE
Security Guide: fix broken link to PCI-DSS

### DIFF
--- a/xml/security_pcidss.xml
+++ b/xml/security_pcidss.xml
@@ -24,6 +24,6 @@
   that are connected to payment processes, and to implement security-
   relevant actions to keep the data and the computing environment safe. For
   more information, see the &sle_pcidss_guide;
-  (<link xlink:href="https://documentation.suse.com/uvp/all/html/SLES-pci-dss/article-security-pcidss.html"/>)
+  (<link xlink:href="https://documentation.suse.com/compliance/pcidss/html/SLES-pci-dss/article-security-pcidss.html"/>)
  </para>
 </appendix>


### PR DESCRIPTION
### PR creator: Description

Publication page for the PCI-DSS Guide has moved recently. Adjust the link in the Security Guide accordingly.


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
