### PR TITLE
Remove format attribute from <imagedata/>

### DIFF
--- a/xml/adm_support.xml
+++ b/xml/adm_support.xml
@@ -186,10 +186,10 @@ CPU Load Average:         7 (3%) with 2 CPUs
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_support_main.png" width="70%" format="PNG"/>
+        <imagedata fileref="yast2_support_main.png" width="70%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_support_main.png" width="60%" format="PNG"/>
+        <imagedata fileref="yast2_support_main.png" width="60%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -239,10 +239,10 @@ CPU Load Average:         7 (3%) with 2 CPUs
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_support_conf.png" width="90%" format="PNG"/>
+        <imagedata fileref="yast2_support_conf.png" width="90%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_support_conf.png" width="80%" format="PNG"/>
+        <imagedata fileref="yast2_support_conf.png" width="80%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -887,10 +887,10 @@ Creating Tar Ball
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_support_conf_upload.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_support_conf_upload.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_support_conf_upload.png" width="60%" format="PNG"/>
+       <imagedata fileref="yast2_support_conf_upload.png" width="60%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/xml/apache2_yast_i.xml
+++ b/xml/apache2_yast_i.xml
@@ -86,10 +86,10 @@
     <title>HTTP server wizard: default host</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_apache_wizard3.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_apache_wizard3.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_apache_wizard3.png" format="PNG"/>
+      <imagedata fileref="yast2_apache_wizard3.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -257,10 +257,10 @@
     <title>HTTP server wizard: summary</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_apache_wizard5.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_apache_wizard5.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_apache_wizard5.png" format="PNG"/>
+      <imagedata fileref="yast2_apache_wizard5.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -306,10 +306,10 @@
     <title>HTTP server configuration: listen ports and addresses</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_apache_config_listen.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_apache_config_listen.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_apache_config_listen.png" format="PNG"/>
+      <imagedata fileref="yast2_apache_config_listen.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -326,10 +326,10 @@
     <title>HTTP server configuration: server modules</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_apache_config_modules.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_apache_config_modules.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_apache_config_modules.png" format="PNG"/>
+      <imagedata fileref="yast2_apache_config_modules.png"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/xml/apparmor_changehat.xml
+++ b/xml/apparmor_changehat.xml
@@ -286,10 +286,10 @@
      <title>Adminer login page</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata format="PNG" fileref="aa_changehat_adminer.png" width="75%"/>
+       <imagedata fileref="aa_changehat_adminer.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="aa_changehat_adminer.png" width="40%" format="PNG"/>
+       <imagedata fileref="aa_changehat_adminer.png" width="40%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -589,10 +589,10 @@ apparmor module is loaded.
      <textobject role="description"><phrase>&aa; profile dialog</phrase>
      </textobject>
      <imageobject role="fo">
-      <imagedata format="PNG" fileref="hats_in_profiles.png" width="75%"/>
+      <imagedata fileref="hats_in_profiles.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="hats_in_profiles.png" width="75%" format="PNG"/>
+      <imagedata fileref="hats_in_profiles.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>
@@ -608,10 +608,10 @@ apparmor module is loaded.
        <textobject role="description"><phrase>Enter hat name</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata format="PNG" fileref="hat_createhat.png" width="50%"/>
+        <imagedata fileref="hat_createhat.png" width="50%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="hat_createhat.png" width="35%" format="PNG"/>
+        <imagedata fileref="hat_createhat.png" width="35%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/xml/apparmor_managing.xml
+++ b/xml/apparmor_managing.xml
@@ -146,10 +146,10 @@
 	  notification window</phrase>
       </textobject>
       <imageobject role="fo">
-       <imagedata format="PNG" fileref="eventnotif.png" width="75%"/>
+       <imagedata fileref="eventnotif.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="eventnotif.png" width="75%" format="PNG"/>
+       <imagedata fileref="eventnotif.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -393,10 +393,10 @@
       <textobject role="description"><phrase>Reports window</phrase>
       </textobject>
       <imageobject role="fo">
-       <imagedata format="PNG" fileref="report1.png" width="75%"/>
+       <imagedata fileref="report1.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="report1.png" width="75%" format="PNG"/>
+       <imagedata fileref="report1.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -502,10 +502,10 @@
        <textobject role="description"><phrase>Security Event Report</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata format="PNG" fileref="reports_viewarch_pg1.png" width="75%"/>
+        <imagedata fileref="reports_viewarch_pg1.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="reports_viewarch_pg1.png" width="75%" format="PNG"/>
+        <imagedata fileref="reports_viewarch_pg1.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -552,10 +552,10 @@
        <textobject role="description"><phrase>Report Configuration</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata format="PNG" fileref="report_config.png" width="75%"/>
+        <imagedata fileref="report_config.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="report_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="report_config.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -720,10 +720,10 @@
       <textobject role="description"><phrase>Application audit report</phrase>
       </textobject>
       <imageobject role="fo">
-       <imagedata format="PNG" fileref="reports_run_appaudit.png" width="75%"/>
+       <imagedata fileref="reports_run_appaudit.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="reports_run_appaudit.png" width="75%" format="PNG"/>
+       <imagedata fileref="reports_run_appaudit.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -836,10 +836,10 @@
       <textobject role="description"><phrase>Security incident report</phrase>
       </textobject>
       <imageobject role="fo">
-       <imagedata format="PNG" fileref="reports_run_sir.png" width="75%"/>
+       <imagedata fileref="reports_run_sir.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="reports_run_sir.png" width="75%" format="PNG"/>
+       <imagedata fileref="reports_run_sir.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -956,11 +956,11 @@
 	 summary</phrase>
       </textobject>
       <imageobject role="fo">
-       <imagedata format="PNG" fileref="reports_run_execsummary.png" width="75%"/>
+       <imagedata fileref="reports_run_execsummary.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
        <imagedata fileref="reports_run_execsummary.png" width="75%"
-	 format="PNG"/>
+	/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -1069,10 +1069,10 @@
        <textobject role="description"><phrase>Report Configuration</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata format="PNG" fileref="report_config.png" width="75%"/>
+        <imagedata fileref="report_config.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="report_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="report_config.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -1262,10 +1262,10 @@
        <textobject role="description"><phrase>Add scheduled SIR</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata format="PNG" fileref="reports_add_pg1.png" width="75%"/>
+        <imagedata fileref="reports_add_pg1.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="reports_add_pg1.png" width="75%" format="PNG"/>
+        <imagedata fileref="reports_add_pg1.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -1363,10 +1363,10 @@
        <textobject role="description"><phrase>Add scheduled SIR, page 2</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata format="PNG" fileref="reports_add_pg2.png" width="75%"/>
+        <imagedata fileref="reports_add_pg2.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="reports_add_pg2.png" width="50%" format="PNG"/>
+        <imagedata fileref="reports_add_pg2.png" width="50%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -1496,10 +1496,10 @@
        <textobject role="description"><phrase>Edit scheduled SIR</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata format="PNG" fileref="reports_edit_pg1.png" width="75%"/>
+        <imagedata fileref="reports_edit_pg1.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="reports_edit_pg1.png" width="75%" format="PNG"/>
+        <imagedata fileref="reports_edit_pg1.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -1589,10 +1589,10 @@
        <textobject role="description"><phrase>Edit scheduled reports, page two</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata format="PNG" fileref="reports_edit_pg2.png" width="75%"/>
+        <imagedata fileref="reports_edit_pg2.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="reports_edit_pg2.png" width="50%" format="PNG"/>
+        <imagedata fileref="reports_edit_pg2.png" width="50%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/xml/apparmor_profiles_man.xml
+++ b/xml/apparmor_profiles_man.xml
@@ -1821,10 +1821,10 @@ New Mode: r
      <title><command>aa-notify Message in GNOME</command></title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata format="PNG" fileref="aa-notify.png" width="75%"/>
+       <imagedata fileref="aa-notify.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="aa-notify.png" width="40%" format="PNG"/>
+       <imagedata fileref="aa-notify.png" width="40%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/xml/apparmor_profiles_yast.xml
+++ b/xml/apparmor_profiles_yast.xml
@@ -120,10 +120,10 @@
       <textobject role="description"><phrase>Choose the profile to edit</phrase>
       </textobject>
       <imageobject role="fo">
-       <imagedata format="PNG" fileref="edit_1.png" width="75%"/>
+       <imagedata fileref="edit_1.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata format="PNG" fileref="edit_1.png"/>
+       <imagedata fileref="edit_1.png"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -143,10 +143,10 @@
       <textobject role="description"><phrase>&aa; profile dialog</phrase>
       </textobject>
       <imageobject role="fo">
-       <imagedata format="PNG" fileref="edit_2.png" width="75%"/>
+       <imagedata fileref="edit_2.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata format="PNG" fileref="edit_2.png"/>
+       <imagedata fileref="edit_2.png"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -216,10 +216,10 @@
         <textobject role="description"><phrase>Select a file to add</phrase>
         </textobject>
         <imageobject role="fo">
-         <imagedata format="PNG" fileref="add_2_addentry_file.png" width="60%"/>
+         <imagedata fileref="add_2_addentry_file.png" width="60%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="add_2_addentry_file.png" width="35%" format="PNG"/>
+         <imagedata fileref="add_2_addentry_file.png" width="35%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -245,10 +245,10 @@
 	  add</phrase>
         </textobject>
         <imageobject role="fo">
-         <imagedata format="PNG" fileref="add_2_addentry_file.png" width="60%"/>
+         <imagedata fileref="add_2_addentry_file.png" width="60%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="add_2_addentry_file.png" width="35%" format="PNG"/>
+         <imagedata fileref="add_2_addentry_file.png" width="35%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -267,10 +267,10 @@
         <textobject role="description"><phrase>Select capabilities</phrase>
         </textobject>
         <imageobject role="fo">
-         <imagedata format="PNG" fileref="add_2_addentry_network.png" width="50%"/>
+         <imagedata fileref="add_2_addentry_network.png" width="50%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata format="PNG" fileref="add_2_addentry_network.png" width="35%"/>
+         <imagedata fileref="add_2_addentry_network.png" width="35%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -291,10 +291,10 @@
         <textobject role="description"><phrase>Select capabilities</phrase>
         </textobject>
         <imageobject role="fo">
-         <imagedata format="PNG" fileref="add_2_addentry_capability.png" width="75%"/>
+         <imagedata fileref="add_2_addentry_capability.png" width="75%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata format="PNG" fileref="add_2_addentry_capability.png"/>
+         <imagedata fileref="add_2_addentry_capability.png"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -324,10 +324,10 @@
        <mediaobject>
         <textobject><phrase>enter subprofile name in popup window</phrase></textobject>
         <imageobject role="fo">
-         <imagedata fileref="add_2_addentry_hat.png" width="50%" format="PNG"/>
+         <imagedata fileref="add_2_addentry_hat.png" width="50%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="add_2_addentry_hat.png" format="PNG" width="60%"/>
+         <imagedata fileref="add_2_addentry_hat.png" width="60%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -412,10 +412,10 @@
 	panel</phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata format="PNG" fileref="sd_controlpanel_1.png" width="75%"/>
+     <imagedata fileref="sd_controlpanel_1.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata format="PNG" fileref="sd_controlpanel_1.png"/>
+     <imagedata fileref="sd_controlpanel_1.png"/>
     </imageobject>
    </mediaobject>
   </informalfigure>

--- a/xml/apparmor_support.xml
+++ b/xml/apparmor_support.xml
@@ -615,10 +615,10 @@ Profile /etc/apparmor.d/usr.sbin.squid failed to load
      <textobject><phrase>error message with hint for correcting the error</phrase>
       </textobject>
      <imageobject role="fo">
-      <imagedata fileref="aa_syncheck.png" width="60%" format="PNG"/>
+      <imagedata fileref="aa_syncheck.png" width="60%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="aa_syncheck.png" width="60%" format="PNG"/>
+      <imagedata fileref="aa_syncheck.png" width="60%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/xml/apps_ekiga.xml
+++ b/xml/apps_ekiga.xml
@@ -206,10 +206,10 @@
    <title><productname>Ekiga</productname> user interface</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="ekiga_main.png" width="45%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="45%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ekiga_main.png" width="55%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="55%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/apps_evolution.xml
+++ b/xml/apps_evolution.xml
@@ -898,10 +898,10 @@
    <title><productname>Evolution</productname> window</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" width="100%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" width="86%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="86%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/apps_gimp.xml
+++ b/xml/apps_gimp.xml
@@ -194,10 +194,10 @@
     <title>The toolbox</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="gimp-toolbox.png" width="35%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="35%"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="gimp-toolbox.png" width="30%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="30%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -795,10 +795,10 @@
        <title>The basic color selector dialog</title>
        <mediaobject>
         <imageobject role="html">
-         <imagedata fileref="gimp-color.png" width="70%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="70%"/>
         </imageobject>
         <imageobject role="fo">
-         <imagedata fileref="gimp-color.png" width="80%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="80%"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -1038,10 +1038,10 @@
    <title>The print dialog</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="gimp-print.png" width="75%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="75%"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="gimp-print.png" width="70%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/apps_libreoffice.xml
+++ b/xml/apps_libreoffice.xml
@@ -720,10 +720,10 @@
    <title>Customization dialog in <guimenu>Writer</guimenu></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -943,10 +943,10 @@
    <title>The options window</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_options.png" width="95%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_options.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/apps_librevarious.xml
+++ b/xml/apps_librevarious.xml
@@ -367,10 +367,10 @@
        <mediaobject>
         <textobject><phrase>Field selection</phrase></textobject>
         <imageobject role="fo">
-         <imagedata fileref="oo-wizard-base.png" width="90%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="90%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="oo-wizard-base.png" width="85%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="85%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>

--- a/xml/apps_librewriter.xml
+++ b/xml/apps_librewriter.xml
@@ -89,10 +89,10 @@
    <title>A &libo; wizard</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo-wizard.png" width="100%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo-wizard.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -301,10 +301,10 @@
     <title>Styles panel</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo-stylist.png" width="40%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="40%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo-stylist.png" width="50%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -782,10 +782,10 @@
     <title>Navigator tool in <guimenu>Writer</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo_navigator.png" width="55%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo_navigator.png" width="45%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="45%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/xml/apps_totem.xml
+++ b/xml/apps_totem.xml
@@ -83,10 +83,10 @@
    <title><guimenu>&gnome; Videos</guimenu> start-up window</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -369,10 +369,10 @@
     <title><guimenu>&gnome; Videos</guimenu> general preferences</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -419,10 +419,10 @@
     <title><guimenu>&gnome; Videos</guimenu> display preferences</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -461,10 +461,10 @@
     <title><guimenu>&gnome; Videos</guimenu> audio preferences</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/xml/art_modules.xml
+++ b/xml/art_modules.xml
@@ -1173,10 +1173,10 @@
         <phrase><guimenu>Add-On Product</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_addon_new.png" width="90%" format="PNG"/>
+        <imagedata fileref="yast2_addon_new.png" width="90%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_addon_new.png" width="80%" format="PNG"/>
+        <imagedata fileref="yast2_addon_new.png" width="80%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -1260,15 +1260,15 @@
        </textobject>
        <imageobject role="fo">
         <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png"
-         width="90%" format="png"/>
+         width="90%"/>
         <imagedata os="sled" fileref="yast2_addon_installed_sled.png"
-         width="90%" format="png"/>
+         width="90%"/>
        </imageobject>
        <imageobject role="html">
         <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png"
-         width="80%" format="png"/>
+         width="80%"/>
         <imagedata os="sled" fileref="yast2_addon_installed_sled.png"
-         width="80%" format="png"/>
+         width="80%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/xml/art_raspberry-pi.xml
+++ b/xml/art_raspberry-pi.xml
@@ -62,11 +62,11 @@
     <mediaobject>
      <imageobject role="fo">
       <imagedata fileref="rpi-3b-overview-2.png" width="80%"
-              format="PNG"/>
+             />
      </imageobject>
      <imageobject role="html">
       <imagedata fileref="rpi-3b-overview-2.png" width="80%"
-              format="PNG"/>
+             />
      </imageobject>
      <textobject><phrase>Overview of the &rpi3; Model&nbsp;B connectors &copy; Efa /
               English Wikipedia / CC BY-SA 3.0</phrase>
@@ -77,11 +77,11 @@
     <title>Photo of the &rpi3; model&nbsp;B connectors, &copy; Evan-Amos / own work / public domain</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="rpi-3b-photo.png" width="80%" format="PNG"
+      <imagedata fileref="rpi-3b-photo.png" width="80%"
             />
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="rpi-3b-photo.png" width="80%" format="PNG"
+      <imagedata fileref="rpi-3b-photo.png" width="80%"
             />
      </imageobject>
      <textobject><phrase>Photo of the &rpi3; Model&nbsp;B connectors &copy; Evan-Amos

--- a/xml/art_virtualization-best-practices.xml
+++ b/xml/art_virtualization-best-practices.xml
@@ -110,7 +110,7 @@
        <entry>
        <mediaobject>
        <imageobject>
-       <imagedata fileref="thumbup_green.png" width="25%" format="PNG"/>
+       <imagedata fileref="thumbup_green.png" width="25%"/>
        </imageobject>
        </mediaobject>
        </entry>
@@ -123,7 +123,7 @@
        <entry>
        <mediaobject>
        <imageobject>
-       <imagedata fileref="thumbdown_red.png" width="25%" format="PNG"/>
+       <imagedata fileref="thumbdown_red.png" width="25%"/>
        </imageobject>
        </mediaobject>
        </entry>
@@ -2155,10 +2155,10 @@ lazy refcounts: true</screen>
     <title>Understanding image overlay</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="qemu-img-overlay.png" width="95%" format="PNG"/>
+      <imagedata fileref="qemu-img-overlay.png" width="95%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="qemu-img-overlay.png" width="95%" format="PNG"/>
+      <imagedata fileref="qemu-img-overlay.png" width="95%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/xml/audit_components.xml
+++ b/xml/audit_components.xml
@@ -227,10 +227,10 @@
    <title>Introducing the components of Linux audit</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="audit_components.png" width="75%" format="PNG"/>
+     <imagedata fileref="audit_components.png" width="75%"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="audit_components.png" width="75%" format="PNG"/>
+     <imagedata fileref="audit_components.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -2269,10 +2269,10 @@ Syscall Report
    <title>Flow graph&mdash;program versus system call relationship</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="audit_mkgraph.png" width="75%" format="PNG"/>
+     <imagedata fileref="audit_mkgraph.png" width="75%"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="audit_mkgraph.png" width="100%" format="PNG"/>
+     <imagedata fileref="audit_mkgraph.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -2311,10 +2311,10 @@ total  type
    <title>Bar chart&mdash;common event types</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="audit_mkbar.png" width="75%" format="PNG"/>
+     <imagedata fileref="audit_mkbar.png" width="75%"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="audit_mkbar.png" width="100%" format="PNG"/>
+     <imagedata fileref="audit_mkbar.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -1411,10 +1411,10 @@
     <title>Keeping partitions</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="partitioning-keep1.png" format="PNG"/>
+      <imagedata fileref="partitioning-keep1.png"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="partitioning-keep1.png" width="75%" format="PNG"/>
+      <imagedata fileref="partitioning-keep1.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/xml/ay_rules_classes.xml
+++ b/xml/ay_rules_classes.xml
@@ -95,10 +95,10 @@ autoyast=http://10.10.0.1/profile/rules/rules.xml</screen>
    <title>Rules</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="autoyast_rules.png" format="PNG"/>
+     <imagedata fileref="autoyast_rules.png"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="autoyast_rules.png" width="75%" format="PNG"/>
+     <imagedata fileref="autoyast_rules.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/backup.xml
+++ b/xml/backup.xml
@@ -40,10 +40,10 @@ taroth 2013-02-19: reopended for SP3
  <mediaobject>
   <textobject><phrase>Backup application</phrase></textobject>
   <imageobject role="fo">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
   <imageobject role="html">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
  </mediaobject>
 </informalfigure>

--- a/xml/chrony.xml
+++ b/xml/chrony.xml
@@ -80,10 +80,10 @@
    <title>NTP configuration window</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="ntp_client.png" width="70%" format="PNG"/>
+     <imagedata fileref="ntp_client.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ntp_client.png" width="70%" format="PNG"/>
+     <imagedata fileref="ntp_client.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -154,10 +154,10 @@
     <title>Adding a time server</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="ntp_client_serveradd.png" width="70%" format="PNG"/>
+      <imagedata fileref="ntp_client_serveradd.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="ntp_client_serveradd.png" width="70%" format="PNG"/>
+      <imagedata fileref="ntp_client_serveradd.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/xml/deployment_expert_partitioner_lvm.xml
+++ b/xml/deployment_expert_partitioner_lvm.xml
@@ -121,10 +121,10 @@
    <title>Creating a volume group</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -149,10 +149,10 @@
    <title>Logical volume management</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/deployment_expert_partitioner_overview.xml
+++ b/xml/deployment_expert_partitioner_overview.xml
@@ -39,10 +39,10 @@
   <title>The &yast; partitioner</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -369,10 +369,10 @@
         <title>Btrfs subvolumes in &yast; partitioner</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
         </mediaobject>
        </figure>

--- a/xml/deployment_expert_partitioner_raid.xml
+++ b/xml/deployment_expert_partitioner_raid.xml
@@ -101,10 +101,10 @@
    <title>RAID partitions</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/deployment_register.xml
+++ b/xml/deployment_register.xml
@@ -122,15 +122,15 @@
        </textobject>
        <imageobject role="fo">
         <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="75%"
-                   format="png"/>
+                  />
         <imagedata os="sled" fileref="yast2_register_sled.png"
-                   width="75%" format="png"/>
+                   width="75%"/>
        </imageobject>
        <imageobject role="html">
         <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="100%"
-                   format="png"/>
+                  />
         <imagedata os="sled" fileref="yast2_register_sled.png" width="100%"
-                   format="png"/>
+                  />
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -167,15 +167,15 @@
        </textobject>
        <imageobject role="fo">
         <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png"
-                   width="75%" format="png"/>
+                   width="75%"/>
         <imagedata os="sled" fileref="yast2_extension_list_sled.png"
-                   width="75%" format="png"/>
+                   width="75%"/>
        </imageobject>
        <imageobject role="html">
         <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png"
-                   width="100%" format="png"/>
+                   width="100%"/>
         <imagedata os="sled" fileref="yast2_extension_list_sled.png"
-                   width="100%" format="png"/>
+                   width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -215,15 +215,15 @@
        </textobject>
        <imageobject role="fo">
         <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png"
-                   width="75%" format="png"/>
+                   width="75%"/>
         <imagedata os="sled" fileref="yast2_extension_install_sled.png"
-                   width="75%" format="png"/>
+                   width="75%"/>
        </imageobject>
        <imageobject role="html">
         <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png"
-                   width="100%" format="png"/>
+                   width="100%"/>
         <imagedata os="sled" fileref="yast2_extension_install_sled.png"
-                   width="100%" format="png"/>
+                   width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -308,15 +308,15 @@
        </textobject>
        <imageobject role="fo">
         <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png"
-                   width="75%" format="png"/>
+                   width="75%"/>
         <imagedata os="sled" fileref="yast2_extension_list_sled.png"
-                   width="75%" format="png"/>
+                   width="75%"/>
        </imageobject>
        <imageobject role="html">
         <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png"
-                   width="100%" format="png"/>
+                   width="100%"/>
         <imagedata os="sled" fileref="yast2_extension_list_sled.png"
-                   width="100%" format="png"/>
+                   width="100%"/>
 
        </imageobject>
       </mediaobject>
@@ -375,15 +375,15 @@
        </textobject>
        <imageobject role="fo">
         <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png"
-                   width="75%" format="png"/>
+                   width="75%"/>
         <imagedata os="sled" fileref="yast2_addon_installed_sled.png"
-                   width="75%" format="png"/>
+                   width="75%"/>
        </imageobject>
        <imageobject role="html">
         <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png"
-                   width="100%" format="png"/>
+                   width="100%"/>
         <imagedata os="sled" fileref="yast2_addon_installed_sled.png"
-                   width="100%" format="png"/>
+                   width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/xml/deployment_troubleshooting.xml
+++ b/xml/deployment_troubleshooting.xml
@@ -207,10 +207,10 @@
    <title>US keyboard layout</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="keyboard_us.svg" width="75%" format="SVG"/>
+     <imagedata fileref="keyboard_us.svg" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="keyboard_us.svg" width="75%" format="PNG"/>
+     <imagedata fileref="keyboard_us.svg" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/gnome_accessibility.xml
+++ b/xml/gnome_accessibility.xml
@@ -126,11 +126,11 @@
       <textobject><phrase>On-screen keyboard</phrase></textobject>
       <imageobject role="fo">
        <imagedata fileref="gnome_onscreen_kbd.png" width="95%"
-        format="PNG"></imagedata>
+       ></imagedata>
       </imageobject>
       <imageobject role="html">
        <imagedata fileref="gnome_onscreen_kbd.png" width="90%"
-        format="PNG"></imagedata>
+       ></imagedata>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/xml/gnome_crypto.xml
+++ b/xml/gnome_crypto.xml
@@ -48,10 +48,10 @@
   <title><guimenu>Passwords and Keys</guimenu> main window</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/xml/gnome_custom.xml
+++ b/xml/gnome_custom.xml
@@ -87,11 +87,11 @@
       <mediaobject>
        <imageobject role="fo">
         <imagedata fileref="preferences_background.png" width="45%"
-         format="PNG"/>
+        />
        </imageobject>
        <imageobject role="html">
         <imagedata fileref="preferences_background.png" width="45%"
-         format="PNG"/>
+        />
        </imageobject>
       </mediaobject>
      </figure>
@@ -198,10 +198,10 @@
    <title>Keyboard shortcut dialog</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_keyboard.png" width="100%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_keyboard.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -251,10 +251,10 @@
    <title>Enabling the compose key in tweaks</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -354,10 +354,10 @@
     <!-- <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="bluetooth_connect.png" width="95%" format="PNG"/>
+       <imagedata fileref="bluetooth_connect.png" width="95%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="bluetooth_connect.png" width="90%" format="PNG"/>
+       <imagedata fileref="bluetooth_connect.png" width="90%"/>
       </imageobject>
      </mediaobject>
     </informalfigure> -->
@@ -428,10 +428,10 @@
    <title><guimenu>Mouse and Touchpad</guimenu> settings dialog</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -498,11 +498,11 @@
     <mediaobject>
      <imageobject role="fo">
       <imagedata fileref="preferences_screen_single.png" width="100%"
-                 format="PNG"/>
+                />
      </imageobject>
      <imageobject role="html">
       <imagedata fileref="preferences_screen_single.png" width="80%"
-                 format="PNG"/>
+                />
      </imageobject>
     </mediaobject>
    </figure>
@@ -553,11 +553,11 @@ commented out the screen. Texts taken from GNOME help.
     <mediaobject>
      <imageobject role="fo">
       <imagedata fileref="preferences_screen.png" width="100%"
-                 format="PNG"/>
+                />
      </imageobject>
      <imageobject role="html">
       <imagedata fileref="preferences_screen.png" width="80%"
-                 format="PNG"/>
+                />
      </imageobject>
     </mediaobject>
    </figure>-->
@@ -661,10 +661,10 @@ commented out the screen. Texts taken from GNOME help.
    <title>Configuring sound settings</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="sound_devices.png" width="100%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="sound_devices.png" width="80%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -698,11 +698,11 @@ commented out the screen. Texts taken from GNOME help.
      <mediaobject>
       <imageobject role="fo">
        <imagedata fileref="preferences_preferred_apps.png" width="100%"
-        format="PNG"/>
+       />
       </imageobject>
       <imageobject role="html">
        <imagedata fileref="preferences_preferred_apps.png" width="80%"
-        format="PNG"/>
+       />
       </imageobject>
      </mediaobject>
     </figure>

--- a/xml/gnome_networking.xml
+++ b/xml/gnome_networking.xml
@@ -165,10 +165,10 @@
    <title>Network file browser</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="network_browser.png" width="100%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="100%"/>
      </imageobject>
     <imageobject role="html">
-     <imagedata fileref="network_browser.png" width="90%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -334,10 +334,10 @@
       <mediaobject>
        <textobject><phrase>Sharing options</phrase></textobject>
        <imageobject role="fo">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/xml/gnome_start.xml
+++ b/xml/gnome_start.xml
@@ -74,15 +74,15 @@
    <mediaobject>
     <imageobject role="fo">
      <imagedata os="sles;sled" fileref="login_sled.png" width="90%"
-                format="PNG"/>
+               />
      <imagedata os="osuse" fileref="login_gnome_osuse.png" width="90%"
-                format="PNG"/>
+               />
     </imageobject>
     <imageobject role="html">
      <imagedata os="sles;sled" fileref="login_sled.png" width="75%"
-                format="PNG"/>
+               />
      <imagedata os="osuse" fileref="login_gnome_osuse.png" width="90%"
-                format="PNG"/>
+               />
     </imageobject>
    </mediaobject>
   </figure>
@@ -128,15 +128,15 @@
       <mediaobject>
        <imageobject role="fo">
         <imagedata os="sles;sled" fileref="login_sessiontype_sle.png"
-        width="90%" format="PNG"/>
+        width="90%"/>
         <imagedata os="osuse" fileref="login_sessiontype_gnome_osuse.png"
-                   width="90%" format="PNG"/>
+                   width="90%"/>
        </imageobject>
        <imageobject role="html">
         <imagedata os="sles;sled" fileref="login_sessiontype_sle.png"
-        width="75%" format="PNG"/>
+        width="75%"/>
         <imagedata os="osuse" fileref="login_sessiontype_gnome_osuse.png"
-                   width="75%" format="PNG"/>
+                   width="75%"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -297,10 +297,10 @@
    <title>&gnome; desktop with activities overview</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="desktop_sled_menu.png" width="95%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="desktop_sled_menu.png" width="90%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -309,10 +309,10 @@
    <title>&gnome; desktop</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="desktop_gnome_osuse.png" width="95%" format="PNG"/>
+     <imagedata fileref="desktop_gnome_osuse.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="desktop_gnome_osuse.png" width="90%" format="PNG"/>
+     <imagedata fileref="desktop_gnome_osuse.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -360,11 +360,11 @@
     <mediaobject>
      <imageobject role="fo">
       <imagedata fileref="desktop_activities_overview.png" width="95%"
-       format="PNG"/>
+      />
      </imageobject>
      <imageobject role="html">
       <imagedata fileref="desktop_activities_overview.png" width="90%"
-       format="PNG"/>
+      />
      </imageobject>
     </mediaobject>
      </figure>
@@ -417,11 +417,11 @@
      <mediaobject>
       <imageobject role="fo">
        <imagedata fileref="desktop_app_menu_firefox.png" width="70%"
-        format="PNG"/>
+       />
       </imageobject>
       <imageobject role="html">
        <imagedata fileref="desktop_app_menu_firefox.png" width="70%"
-        format="PNG"/>
+       />
       </imageobject>
      </mediaobject>
     </figure>

--- a/xml/gnome_use.xml
+++ b/xml/gnome_use.xml
@@ -38,10 +38,10 @@
    <title>File manager</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -689,10 +689,10 @@
     <textobject><phrase><productname>Evolution</productname></phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" format="PNG" width="100%"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" format="PNG" width="80%"/>
+     <imagedata fileref="evolution.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -812,10 +812,10 @@
    <title><productname>Archive manager</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -1156,10 +1156,10 @@
    <title><productname>Document viewer</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evince.png" format="PNG" width="90%"/>
+     <imagedata fileref="evince.png" width="90%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evince.png" format="PNG" width="78%"/>
+     <imagedata fileref="evince.png" width="78%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/grub2.xml
+++ b/xml/grub2.xml
@@ -600,10 +600,10 @@
       <title>&grub; boot editor</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="grub2_edit_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="grub2_edit_config.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="grub2_edit_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="grub2_edit_config.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </figure>

--- a/xml/grub2_yast_i.xml
+++ b/xml/grub2_yast_i.xml
@@ -120,10 +120,10 @@
     <title>Boot code options</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%"/>
      </imageobject>
     </mediaobject>
   </figure>
@@ -266,10 +266,10 @@
     <title>Boot loader options</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_options.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_options.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_options.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_options.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -339,10 +339,10 @@
     <title>Kernel parameters</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/xml/help_user.xml
+++ b/xml/help_user.xml
@@ -91,10 +91,10 @@
    <title>Main window of &yelp;</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/journalctl.xml
+++ b/xml/journalctl.xml
@@ -417,10 +417,10 @@ enabled</screen>
    <title>&yast; systemd journal</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_journal.png" width="80%" format="PNG"/>
+     <imagedata fileref="yast2_journal.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_journal.png" width="85%" format="PNG"/>
+     <imagedata fileref="yast2_journal.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/klp.xml
+++ b/xml/klp.xml
@@ -95,10 +95,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="klp.png" width="80%" format="PNG"/>
+     <imagedata fileref="klp.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="klp.png" width="100%" format="PNG"/>
+     <imagedata fileref="klp.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>

--- a/xml/kvm_virtualization_basics.xml
+++ b/xml/kvm_virtualization_basics.xml
@@ -71,10 +71,10 @@
    <title>&kvm; virtualization architecture</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="kvm_qemu.png" width="100%" format="PNG"/>
+     <imagedata fileref="kvm_qemu.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="kvm_qemu.png" width="100%" format="PNG"/>
+     <imagedata fileref="kvm_qemu.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/libvirt_configuration_gui.xml
+++ b/xml/libvirt_configuration_gui.xml
@@ -28,10 +28,10 @@
   <title><guimenu>Details</guimenu> view of a &vmguest;</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="libvirt_vmm_details.png" width="75%" format="PNG"/>
+    <imagedata fileref="libvirt_vmm_details.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="libvirt_vmm_details.png" width="75%" format="PNG"/>
+    <imagedata fileref="libvirt_vmm_details.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -79,10 +79,10 @@
     <title>Overview details</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="libvirt_vmm_overview.png" width="70%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_overview.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="libvirt_vmm_overview.png" width="70%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_overview.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -95,10 +95,10 @@
     <title>&vmguest; title and description</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="libvirt_vmm_desc.png" width="40%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_desc.png" width="40%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="libvirt_vmm_desc.png" width="40%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_desc.png" width="40%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -125,10 +125,10 @@
     <title>Performance</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="libvirt_vmm_performance.png" width="70%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_performance.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="libvirt_vmm_performance.png" width="70%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_performance.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -148,10 +148,10 @@
     <title>Statistics charts</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="libvirt_vmm_polling_charts.png" width="40%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_polling_charts.png" width="40%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="libvirt_vmm_polling_charts.png" width="40%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_polling_charts.png" width="40%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -167,10 +167,10 @@
     <title>Processor view</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="libvirt_vmm_processor.png" width="70%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_processor.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="libvirt_vmm_processor.png" width="70%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_processor.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -229,10 +229,10 @@
     <title>Memory view</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="libvirt_vmm_memory.png" width="70%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_memory.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="libvirt_vmm_memory.png" width="70%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_memory.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -299,10 +299,10 @@
     <title>Boot options</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="libvirt_vmm_boot.png" width="70%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_boot.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="libvirt_vmm_boot.png" width="70%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_boot.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -346,10 +346,10 @@
      <title>Add a new storage</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="libvirt_vmm_storage1.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_storage1.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="libvirt_vmm_storage1.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_storage1.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -449,10 +449,10 @@
      <title>Add a new controller</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="libvirt_vmm_controller.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_controller.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="libvirt_vmm_controller.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_controller.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -499,10 +499,10 @@
      <title>Add a new network interface</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="libvirt_vmm_network.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_network.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="libvirt_vmm_network.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_network.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -562,10 +562,10 @@
      <title>Add a new input device</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="libvirt_vmm_input.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_input.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="libvirt_vmm_input.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_input.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -625,10 +625,10 @@
      <title>Add a new video device</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="libvirt_vmm_video.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_video.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="libvirt_vmm_video.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_video.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -673,10 +673,10 @@
      <title>Add a new USB redirector</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="libvirt_vmm_usb_redirector.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_usb_redirector.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="libvirt_vmm_usb_redirector.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_usb_redirector.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -988,10 +988,10 @@
       <title>Adding a PCI device</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="virt_add_pcidevice.png" width="75%" format="PNG"/>
+        <imagedata fileref="virt_add_pcidevice.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="virt_add_pcidevice.png" width="75%" format="PNG"/>
+        <imagedata fileref="virt_add_pcidevice.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -1067,10 +1067,10 @@
       <title>Adding a USB device</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="virt_add_usbdevice.png" width="75%" format="PNG"/>
+        <imagedata fileref="virt_add_usbdevice.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="virt_add_usbdevice.png" width="75%" format="PNG"/>
+        <imagedata fileref="virt_add_usbdevice.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </figure>

--- a/xml/libvirt_host.xml
+++ b/xml/libvirt_host.xml
@@ -523,10 +523,10 @@ Connection successfully activated (master waiting for slaves) \
         <title>Connection details</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="libvirt_vmm_conndetails.png" width="45%" format="PNG"/>
+          <imagedata fileref="libvirt_vmm_conndetails.png" width="45%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="libvirt_vmm_conndetails.png" width="45%" format="PNG"/>
+          <imagedata fileref="libvirt_vmm_conndetails.png" width="45%"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -544,10 +544,10 @@ Connection successfully activated (master waiting for slaves) \
         <title>Create virtual network</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="libvirt_vmm_vnet_ipv4.png" width="45%" format="PNG"/>
+          <imagedata fileref="libvirt_vmm_vnet_ipv4.png" width="45%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="libvirt_vmm_vnet_ipv4.png" width="45%" format="PNG"/>
+          <imagedata fileref="libvirt_vmm_vnet_ipv4.png" width="45%"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -1570,10 +1570,10 @@ done</screen>
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="virt_virt-manager_storage.png" width="60%" format="PNG"/>
+      <imagedata fileref="virt_virt-manager_storage.png" width="60%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="virt_virt-manager_storage.png" width="60%" format="PNG"/>
+      <imagedata fileref="virt_virt-manager_storage.png" width="60%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>
@@ -1598,10 +1598,10 @@ done</screen>
       <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="virt_virt-manager_storage_add.png" width="60%" format="PNG"/>
+         <imagedata fileref="virt_virt-manager_storage_add.png" width="60%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="virt_virt-manager_storage_add.png" width="60%" format="PNG"/>
+         <imagedata fileref="virt_virt-manager_storage_add.png" width="60%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>

--- a/xml/libvirt_managing.xml
+++ b/xml/libvirt_managing.xml
@@ -690,10 +690,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="virt_vmm_snapshots_list.png" width="75%" format="PNG"/>
+      <imagedata fileref="virt_vmm_snapshots_list.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="virt_vmm_snapshots_list.png" width="75%" format="PNG"/>
+      <imagedata fileref="virt_vmm_snapshots_list.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/xml/mobile.xml
+++ b/xml/mobile.xml
@@ -91,10 +91,10 @@
     <title>Integrating a mobile computer in an existing environment</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="90%" fileref="mobile_scpm.svg" format="SVG"/>
+      <imagedata width="90%" fileref="mobile_scpm.svg"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata width="75%" fileref="mobile_scpm.png" format="PNG"/>
+      <imagedata width="75%" fileref="mobile_scpm.png"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/xml/net_basic.xml
+++ b/xml/net_basic.xml
@@ -97,10 +97,10 @@
   <title>Simplified layer model for TCP/IP</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata width="100%" fileref="net_basic_osi.svg" format="SVG"/>
+    <imagedata width="100%" fileref="net_basic_osi.svg"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata width="75%" fileref="net_basic_osi.png" format="PNG"/>
+    <imagedata width="75%" fileref="net_basic_osi.png"/>
    </imageobject>
    <textobject><phrase>OSI and TCP</phrase>
    </textobject>
@@ -139,10 +139,10 @@
   <title>TCP/IP Ethernet packet</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata width="80%" fileref="net_basic_tcppacket.svg" format="SVG"/>
+    <imagedata width="80%" fileref="net_basic_tcppacket.svg"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata width="75%" fileref="net_basic_tcppacket.png" format="PNG"/>
+    <imagedata width="75%" fileref="net_basic_tcppacket.png"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/xml/net_bonding.xml
+++ b/xml/net_bonding.xml
@@ -152,10 +152,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="bond_configuration.png" width="70%" format="PNG"/>
+      <imagedata fileref="bond_configuration.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="bond_configuration.png" width="65%" format="PNG"/>
+      <imagedata fileref="bond_configuration.png" width="65%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/xml/net_dhcp.xml
+++ b/xml/net_dhcp.xml
@@ -158,10 +158,10 @@
       <title>DHCP server: card selection</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz1.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz1.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz1.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz1.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -180,10 +180,10 @@
       <title>DHCP server: global settings</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz2.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz2.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz2.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz2.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -203,10 +203,10 @@
       <title>DHCP server: dynamic DHCP</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz3.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz3.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz3.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz3.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -227,10 +227,10 @@
       <title>DHCP server: start-up</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_start.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_start.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_start.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_start.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -252,10 +252,10 @@
       <title>DHCP server: host management</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_statdhcp.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_statdhcp.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_statdhcp.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_statdhcp.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -298,10 +298,10 @@
        <title>DHCP server: chroot jail and declarations</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_chroot.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_chroot.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_chroot.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_chroot.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -323,10 +323,10 @@
        <title>DHCP server: selecting a declaration type</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_newdec.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_newdec.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_newdec.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_newdec.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -346,10 +346,10 @@
        <title>DHCP server: configuring subnets</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_sub.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_sub.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_sub.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_sub.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -369,10 +369,10 @@
        <title>DHCP server: TSIG configuration</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_tsig.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_tsig.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_tsig.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_tsig.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -399,10 +399,10 @@
        <title>DHCP server: interface configuration for dynamic DNS</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_dyndns.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_dyndns.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_dyndns.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_dyndns.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -456,10 +456,10 @@
        <title>DHCP server: network interface and firewall</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_fire.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_fire.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_fire.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_fire.png"/>
         </imageobject>
        </mediaobject>
       </figure>

--- a/xml/net_dns.xml
+++ b/xml/net_dns.xml
@@ -236,10 +236,10 @@
       <title>DNS server installation: forwarder settings</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dns_wiz_forw.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dns_wiz_forw.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dns_wiz_forw.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dns_wiz_forw.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -265,10 +265,10 @@
       <title>DNS server installation: DNS zones</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="72%" fileref="yast2_dns_wiz_zone.png" format="PNG"/>
+        <imagedata width="72%" fileref="yast2_dns_wiz_zone.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dns_wiz_zone.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dns_wiz_zone.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -285,10 +285,10 @@
       <title>DNS server installation: finish wizard</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="72%" fileref="yast2_dns_wiz_finish.png" format="PNG"/>
+        <imagedata width="72%" fileref="yast2_dns_wiz_finish.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dns_wiz_finish.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dns_wiz_finish.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -318,10 +318,10 @@
        <screenshot>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata width="75%" fileref="yast2_dns_def_startup.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_startup.png"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata width="75%" fileref="yast2_dns_def_startup.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_startup.png"/>
          </imageobject>
         </mediaobject>
        </screenshot>
@@ -363,10 +363,10 @@
        <screenshot>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata width="75%" fileref="yast2_dns_def_basicoptions.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_basicoptions.png"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata width="75%" fileref="yast2_dns_def_basicoptions.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_basicoptions.png"/>
          </imageobject>
         </mediaobject>
        </screenshot>
@@ -399,10 +399,10 @@
      <title>DNS server: logging</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata width="75%" fileref="yast2_dns_def_logging.png" format="PNG"/>
+       <imagedata width="75%" fileref="yast2_dns_def_logging.png"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata width="75%" fileref="yast2_dns_def_logging.png" format="PNG"/>
+       <imagedata width="75%" fileref="yast2_dns_def_logging.png"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -426,10 +426,10 @@
        <screenshot>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata width="75%" fileref="yast2_dns_def_acl.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_acl.png"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata width="75%" fileref="yast2_dns_def_acl.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_acl.png"/>
          </imageobject>
         </mediaobject>
        </screenshot>
@@ -461,10 +461,10 @@
     <screenshot>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata width="75%" fileref="yast2_dns_def_tsig.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_tsig.png"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata width="75%" fileref="yast2_dns_def_tsig.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_tsig.png"/>
          </imageobject>
         </mediaobject>
        </screenshot>
@@ -490,10 +490,10 @@
      <title>DNS server: secondary zone editor</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata width="75%" fileref="yast2_dns_def_zoneeditor.png" format="PNG"/>
+       <imagedata width="75%" fileref="yast2_dns_def_zoneeditor.png"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata width="75%" fileref="yast2_dns_def_zoneeditor.png" format="PNG"/>
+       <imagedata width="75%" fileref="yast2_dns_def_zoneeditor.png"/>
       </imageobject>
      </mediaobject>
     </figure> -->
@@ -537,10 +537,10 @@
      <title>DNS server: Zone Editor (Basics)</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata width="65%" fileref="yast2_dns_def_ddns.png" format="PNG"/>
+       <imagedata width="65%" fileref="yast2_dns_def_ddns.png"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata width="65%" fileref="yast2_dns_def_ddns.png" format="PNG"/>
+       <imagedata width="65%" fileref="yast2_dns_def_ddns.png"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -559,10 +559,10 @@
         <title>DNS server: Zone Editor (NS Records)</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata width="65%" fileref="yast2_dns_def_nsrec.png" format="PNG"/>
+          <imagedata width="65%" fileref="yast2_dns_def_nsrec.png"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata width="65%" fileref="yast2_dns_def_nsrec.png" format="PNG"/>
+          <imagedata width="65%" fileref="yast2_dns_def_nsrec.png"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -581,10 +581,10 @@
         <title>DNS server: Zone Editor (MX Records)</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata width="72%" fileref="yast2_dns_def_mxrec.png" format="PNG"/>
+          <imagedata width="72%" fileref="yast2_dns_def_mxrec.png"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata width="75%" fileref="yast2_dns_def_mxrec.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_mxrec.png"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -603,10 +603,10 @@
         <title>DNS server: Zone Editor (SOA)</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata width="75%" fileref="yast2_dns_def_soa.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_soa.png"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata width="75%" fileref="yast2_dns_def_soa.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_soa.png"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -663,10 +663,10 @@
         <title>Adding a record for a primary zone</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="yast2_dns_revzone1.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone1.png" width="70%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="yast2_dns_revzone1.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone1.png" width="70%"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -680,10 +680,10 @@
         <title>Adding a reverse zone</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="yast2_dns_revzone2.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone2.png" width="70%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="yast2_dns_revzone2.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone2.png" width="70%"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -700,10 +700,10 @@
         <title>Adding a reverse record</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="yast2_dns_revzone3.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone3.png" width="70%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="yast2_dns_revzone3.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone3.png" width="70%"/>
          </imageobject>
         </mediaobject>
        </figure>

--- a/xml/net_samba.xml
+++ b/xml/net_samba.xml
@@ -920,10 +920,10 @@ smbpasswd -a -m hostname</screen>
      <title>Determining Windows domain membership</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="ad_sambaclient.png" width="75%" format="PNG"/>
+       <imagedata fileref="ad_sambaclient.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="ad_sambaclient.png" format="PNG"/>
+       <imagedata fileref="ad_sambaclient.png"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -1060,10 +1060,10 @@ drwxrwxrwx. 2 root    root    0 Oct 24 22:31 subfolder
     <title>Windows Explorer <guimenu>Advanced Attributes</guimenu> dialog</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="samba_win_expl_advattr.png" width="75%" format="PNG"/>
+      <imagedata fileref="samba_win_expl_advattr.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="samba_win_expl_advattr.png" format="PNG"/>
+      <imagedata fileref="samba_win_expl_advattr.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -1083,10 +1083,10 @@ drwxrwxrwx. 2 root    root    0 Oct 24 22:31 subfolder
     <title>Windows Explorer directory listing with compressed files</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="samba_win_expl_view_compressed.png" width="75%" format="PNG"/>
+      <imagedata fileref="samba_win_expl_view_compressed.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="samba_win_expl_view_compressed.png" format="PNG"/>
+      <imagedata fileref="samba_win_expl_view_compressed.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -1166,10 +1166,10 @@ drwxrwxrwx. 2 root    root    0 Oct 24 22:31 subfolder
      <title>Adding a new Samba share with snapshots enabled</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_samba_snapshot.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_samba_snapshot.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_samba_snapshot.png" format="PNG"/>
+       <imagedata fileref="yast2_samba_snapshot.png"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -1182,10 +1182,10 @@ drwxrwxrwx. 2 root    root    0 Oct 24 22:31 subfolder
      <title>The <guimenu>Previous versions</guimenu> tab in Windows explorer</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="samba_winexpl_previous_versions.png" width="75%" format="PNG"/>
+       <imagedata fileref="samba_winexpl_previous_versions.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="samba_winexpl_previous_versions.png" format="PNG"/>
+       <imagedata fileref="samba_winexpl_previous_versions.png"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/xml/net_wicked.xml
+++ b/xml/net_wicked.xml
@@ -151,10 +151,10 @@
     <title><literal>wicked</literal> architecture</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="wicked_scheme.png" format="PNG"/>
+      <imagedata fileref="wicked_scheme.png"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="wicked_scheme.png" format="PNG" width="80%"/>
+      <imagedata fileref="wicked_scheme.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/xml/net_xntp.xml
+++ b/xml/net_xntp.xml
@@ -120,10 +120,10 @@
     <title>&yast;: NTP Server</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_ntp_selserv.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_ntp_selserv.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata width="75%" fileref="yast2_ntp_selserv.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_ntp_selserv.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -225,10 +225,10 @@
     <title>Advanced NTP configuration: security settings</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_xntp_adv_sec.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_xntp_adv_sec.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata width="75%" fileref="yast2_xntp_adv_sec.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_xntp_adv_sec.png"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/xml/net_yast.xml
+++ b/xml/net_yast.xml
@@ -83,10 +83,10 @@
    <title>Configuring network settings</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_net_icard.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_net_icard.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_net_icard.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_net_icard.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/network_scheme.xml
+++ b/xml/network_scheme.xml
@@ -10,10 +10,10 @@
  <info>
   <mediaobject>
    <imageobject role="html">
-    <imagedata fileref="network_schema.png" width="100%" format="PNG"/>
+    <imagedata fileref="network_schema.png" width="100%"/>
    </imageobject>
    <imageobject role="pdf">
-    <imagedata fileref="network_schema.svg" width="100%" format="SVG"/>
+    <imagedata fileref="network_schema.svg" width="100%"/>
    </imageobject>
   </mediaobject>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -28,10 +28,10 @@
  <informalfigure>
   <mediaobject>
    <imageobject role="html">
-    <imagedata fileref="network_schema.png" width="100%" format="PNG"/>
+    <imagedata fileref="network_schema.png" width="100%"/>
    </imageobject>
    <imageobject role="pdf">
-    <imagedata fileref="network_schema.svg" width="100%" format="SVG"/>
+    <imagedata fileref="network_schema.svg" width="100%"/>
    </imageobject>
   </mediaobject>
  </informalfigure>

--- a/xml/qemu_host_installation.xml
+++ b/xml/qemu_host_installation.xml
@@ -65,10 +65,10 @@
      <title>Installing the &kvm; hypervisor and tools</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_hypervisors.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_hypervisors.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_hypervisors.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_hypervisors.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -76,10 +76,10 @@
      <title>Installing the &kvm; hypervisor and tools</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_hypervisors_kde.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_hypervisors_kde.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_hypervisors_kde.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_hypervisors_kde.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -102,10 +102,10 @@
      <title>Network bridge</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_netbridge.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_netbridge.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_netbridge.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_netbridge.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/xml/qemu_running_vms_qemukvm.xml
+++ b/xml/qemu_running_vms_qemukvm.xml
@@ -281,10 +281,10 @@
      <title>&qemu; window with SLES as &vmguest;</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="qemu_win_sles.png" width="70%" format="PNG"/>
+       <imagedata fileref="qemu_win_sles.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="qemu_win_sles.png" width="70%" format="PNG"/>
+       <imagedata fileref="qemu_win_sles.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -1902,10 +1902,10 @@ sudo tunctl -d $tap<co xml:id="co-qemu-net-bridge-deltap"/></screen>
    <title>&qemu; VNC session</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="qemu_sles_vnc.png" width="70%" format="PNG"/>
+     <imagedata fileref="qemu_sles_vnc.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="qemu_sles_vnc.png" width="70%" format="PNG"/>
+     <imagedata fileref="qemu_sles_vnc.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -1966,10 +1966,10 @@ Password: ****
     <title>Authentication dialog in Remmina</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="qemu_vnc_pwd.png" width="70%" format="PNG"/>
+      <imagedata fileref="qemu_vnc_pwd.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="qemu_vnc_pwd.png" width="70%" format="PNG"/>
+      <imagedata fileref="qemu_vnc_pwd.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/xml/rmt_install.xml
+++ b/xml/rmt_install.xml
@@ -66,10 +66,10 @@
    <title>&rmt; pattern</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="rmt_installation.png" width="70%" format="PNG"/>
+     <imagedata fileref="rmt_installation.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="rmt_installation.png" width="70%" format="PNG"/>
+     <imagedata fileref="rmt_installation.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/rmt_mirroring.xml
+++ b/xml/rmt_mirroring.xml
@@ -95,10 +95,10 @@
      <textobject role="description"><phrase>Eye icon</phrase>
      </textobject>
      <imageobject role="fo">
-      <imagedata fileref="scc_eye_icon.png" width="0.8em" format="SVG"/>
+      <imagedata fileref="scc_eye_icon.png" width="0.8em"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="scc_eye_icon.png" width="1em" format="PNG"/>
+      <imagedata fileref="scc_eye_icon.png" width="1em"/>
      </imageobject>
      </inlinemediaobject> icon.
     </para>

--- a/xml/rmt_overview.xml
+++ b/xml/rmt_overview.xml
@@ -66,10 +66,10 @@
    <title>&rmt;</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="rmt_schema.png" width="70%" format="PNG"/>
+     <imagedata fileref="rmt_schema.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="rmt_schema.png" width="70%" format="PNG"/>
+     <imagedata fileref="rmt_schema.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/security_acls.xml
+++ b/xml/security_acls.xml
@@ -461,10 +461,10 @@
     <title>Minimum ACL: ACL entries compared to permission bits</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="acls_map_mini.png" width="75%" format="PNG"/>
+      <imagedata fileref="acls_map_mini.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="acls_map_mini.png" width="75%" format="PNG"/>
+      <imagedata fileref="acls_map_mini.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -479,10 +479,10 @@
     <title>Extended ACL: ACL entries compared to permission bits</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="acls_map_ext.png" width="75%" format="PNG"/>
+      <imagedata fileref="acls_map_ext.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="acls_map_ext.png" width="75%" format="PNG"/>
+      <imagedata fileref="acls_map_ext.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/xml/security_ad_support.xml
+++ b/xml/security_ad_support.xml
@@ -243,10 +243,10 @@
       <title>Schema of Winbind-based &ad; authentication</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="sled10_ad_schema.svg" width="85%" format="SVG"/>
+        <imagedata fileref="sled10_ad_schema.svg" width="85%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="sled10_ad_schema.png" width="75%" format="PNG"/>
+        <imagedata fileref="sled10_ad_schema.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -691,10 +691,10 @@
       <title>Main window of <guimenu>User logon management</guimenu></title>
       <mediaobject>
        <imageobject role="html">
-        <imagedata fileref="ad-overview.png" format="PNG"/>
+        <imagedata fileref="ad-overview.png"/>
        </imageobject>
        <imageobject role="fo">
-        <imagedata fileref="ad-overview.png" width="65%" format="PNG"/>
+        <imagedata fileref="ad-overview.png" width="65%"/>
        </imageobject>
        <textobject role="description">
         <phrase>
@@ -808,10 +808,10 @@
         <title>Enrolling into a domain</title>
         <mediaobject>
          <imageobject role="html">
-          <imagedata fileref="ad-enroll.png" format="PNG"/>
+          <imagedata fileref="ad-enroll.png"/>
          </imageobject>
          <imageobject role="fo">
-          <imagedata fileref="ad-enroll.png" width="60%" format="PNG"/>
+          <imagedata fileref="ad-enroll.png" width="60%"/>
          </imageobject>
          <textobject role="description">
           <phrase></phrase>
@@ -836,10 +836,10 @@
       <title>Configuration window of <guimenu>User logon management</guimenu></title>
       <mediaobject>
        <imageobject role="html">
-        <imagedata fileref="ad-config.png" format="PNG"/>
+        <imagedata fileref="ad-config.png"/>
        </imageobject>
        <imageobject role="fo">
-        <imagedata fileref="ad-config.png" width="70%" format="PNG"/>
+        <imagedata fileref="ad-config.png" width="70%"/>
        </imageobject>
        <textobject role="description">
         <phrase></phrase>
@@ -977,10 +977,10 @@
      <title>Determining Windows domain membership</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="ad_sambaclient.png" width="75%" format="PNG"/>
+       <imagedata fileref="ad_sambaclient.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="ad_sambaclient.png" width="75%" format="PNG"/>
+       <imagedata fileref="ad_sambaclient.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -1037,10 +1037,10 @@
      <title>Providing administrator credentials</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="ad_join1.png" width="30%" format="PNG"/>
+       <imagedata fileref="ad_join1.png" width="30%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="ad_join1.png" width="30%" format="PNG"/>
+       <imagedata fileref="ad_join1.png" width="30%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/xml/security_cryptctl.xml
+++ b/xml/security_cryptctl.xml
@@ -89,10 +89,10 @@
    <title>Key retrieval with <command>cryptctl</command> (model without connection to KMIP server)</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="cryptctl-keyretrieval.png" format="PNG"/>
+     <imagedata fileref="cryptctl-keyretrieval.png"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="cryptctl-keyretrieval.svg" width="70%" format="SVG"/>
+     <imagedata fileref="cryptctl-keyretrieval.svg" width="70%"/>
     </imageobject>
     <textobject role="description">
      <phrase>The client asks the server for the disk decryption key, the server

--- a/xml/security_firewall.xml
+++ b/xml/security_firewall.xml
@@ -165,10 +165,10 @@
    <title>iptables: a packet's possible paths</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata width="75%" fileref="fire_tables.svg" format="SVG"/>
+     <imagedata width="75%" fileref="fire_tables.svg"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata width="65%" fileref="fire_tables.png" format="PNG"/>
+     <imagedata width="65%" fileref="fire_tables.png"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/security_kerberos.xml
+++ b/xml/security_kerberos.xml
@@ -578,10 +578,10 @@
     <title>&krb; network topology</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="network_kerb.png" width="73%" format="PNG"/>
+      <imagedata fileref="network_kerb.png" width="73%"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="network_kerb.svg" width="73%" format="SVG"/>
+      <imagedata fileref="network_kerb.svg" width="73%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -1687,10 +1687,10 @@ Kerberos. cschroder, 16-12-2020
    <title><guimenu>LDAP and &krb; client</guimenu> window</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_auth_client_config.png" width="65%" format="PNG"/>
+     <imagedata fileref="yast2_auth_client_config.png" width="65%"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_auth_client_config.png" width="65%" format="PNG"/>
+     <imagedata fileref="yast2_auth_client_config.png" width="65%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -1711,10 +1711,10 @@ Kerberos. cschroder, 16-12-2020
     <informalfigure>
      <mediaobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_auth_client_krb5.png" width="65%" format="PNG"/>
+       <imagedata fileref="yast2_auth_client_krb5.png" width="65%"/>
       </imageobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_auth_client_krb5.png" width="65%" format="PNG"/>
+       <imagedata fileref="yast2_auth_client_krb5.png" width="65%"/>
       </imageobject>
       <textobject><phrase>Tab <guimenu>Authentication via Kerberos</guimenu></phrase>
       </textobject>

--- a/xml/security_ldap_directory_tree.xml
+++ b/xml/security_ldap_directory_tree.xml
@@ -47,7 +47,7 @@
      <imagedata fileref="ldap_tree.svg" width="85%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ldap_tree.png" width="85%" format="PNG"/>
+     <imagedata fileref="ldap_tree.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/security_nis.xml
+++ b/xml/security_nis.xml
@@ -103,15 +103,15 @@
       <mediaobject>
        <imageobject role="fo">
         <imagedata fileref="yast2_nis1_no_nis_installed.png" width="75%"
-                   format="PNG" os="sles;sled"/>
+                   os="sles;sled"/>
         <imagedata fileref="yast2_nis1_no_nis_installed_kde.png"
-                   width="75%" format="PNG" os="osuse"/>
+                   width="75%" os="osuse"/>
        </imageobject>
        <imageobject role="html">
         <imagedata fileref="yast2_nis1_no_nis_installed.png" width="75%"
-                   format="PNG" os="sles;sled"/>
+                   os="sles;sled"/>
         <imagedata fileref="yast2_nis1_no_nis_installed_kde.png" width="75%"
-                   format="PNG" os="osuse"/>
+                   os="osuse"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -170,16 +170,16 @@
         <title>Master server setup</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="yast2_nis_master.png" width="75%" format="PNG"
+          <imagedata fileref="yast2_nis_master.png" width="75%"
                      os="sles;sled"/>
           <imagedata fileref="yast2_nis_master_kde.png" width="75%"
-                     format="PNG" os="osuse"/>
+                     os="osuse"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="yast2_nis_master.png" width="75%" format="PNG"
+          <imagedata fileref="yast2_nis_master.png" width="75%"
                      os="sles;sled"/>
           <imagedata fileref="yast2_nis_master_kde.png" width="75%"
-                     format="PNG" os="osuse"/>
+                     os="osuse"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -207,15 +207,15 @@
         <mediaobject>
          <imageobject role="fo">
           <imagedata fileref="yast2_inst_nisserver2.png" width="75%"
-                     format="PNG" os="sles;sled"/>
+                     os="sles;sled"/>
           <imagedata fileref="yast2_inst_nisserver2_kde.png" width="75%"
-                     format="PNG" os="osuse"/>
+                     os="osuse"/>
          </imageobject>
          <imageobject role="html">
           <imagedata fileref="yast2_inst_nisserver2.png" width="75%"
-                     format="PNG" os="sles;sled"/>
+                     os="sles;sled"/>
           <imagedata fileref="yast2_inst_nisserver2_kde.png" width="75%"
-                     format="PNG" os="osuse"/>
+                     os="osuse"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -247,15 +247,15 @@
       <title>NIS server maps setup</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_nis_maps.png" width="75%" format="PNG"
+        <imagedata fileref="yast2_nis_maps.png" width="75%"
                    os="sles;sled"/>
-        <imagedata fileref="yast2_nis_maps_kde.png" width="75%" format="PNG"
+        <imagedata fileref="yast2_nis_maps_kde.png" width="75%"
                    os="osuse"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_nis_maps.png" width="75%" format="PNG"
+        <imagedata fileref="yast2_nis_maps.png" width="75%"
                    os="sles;sled"/>
-        <imagedata fileref="yast2_nis_maps_kde.png" width="75%" format="PNG"
+        <imagedata fileref="yast2_nis_maps_kde.png" width="75%"
                    os="osuse"/>
        </imageobject>
       </mediaobject>
@@ -280,15 +280,15 @@
       <title>Setting request permissions for a NIS server</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_nis_hosts.png" width="75%" format="PNG"
+        <imagedata fileref="yast2_nis_hosts.png" width="75%"
                    os="sles;sled"/>
-        <imagedata fileref="yast2_nis_hosts_kde.png" width="75%" format="PNG"
+        <imagedata fileref="yast2_nis_hosts_kde.png" width="75%"
                    os="osuse"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_nis_hosts.png" width="75%" format="PNG"
+        <imagedata fileref="yast2_nis_hosts.png" width="75%"
                    os="sles;sled"/>
-        <imagedata fileref="yast2_nis_hosts_kde.png" width="75%" format="PNG"
+        <imagedata fileref="yast2_nis_hosts_kde.png" width="75%"
                    os="osuse"/>
        </imageobject>
       </mediaobject>
@@ -416,10 +416,10 @@
      <title>Setting domain and address of a NIS server</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_inst_nisclient.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_inst_nisclient.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_inst_nisclient.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_inst_nisclient.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/xml/security_spectre_meltdown_checker.xml
+++ b/xml/security_spectre_meltdown_checker.xml
@@ -56,10 +56,10 @@
    <title>Output from spectre-meltdown-checker</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="spectre-meltdown.png" width="80%" format="PNG"/>
+     <imagedata fileref="spectre-meltdown.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="spectre-meltdown.png" width="100%" format="PNG"/>
+     <imagedata fileref="spectre-meltdown.png" width="100%"/>
     </imageobject>
     <textobject role="description"><phrase>Partial output of spectre-meltdown-checker.sh</phrase>
     </textobject>

--- a/xml/security_xca.xml
+++ b/xml/security_xca.xml
@@ -55,10 +55,10 @@ xml:id="cha-security-xca">
  <title>Create a new XCA database</title>
  <mediaobject>
   <imageobject role="html">
-   <imagedata fileref="sec-xca-2.png" width="80%" format="PNG"/>
+   <imagedata fileref="sec-xca-2.png" width="80%"/>
   </imageobject>
   <imageobject role="fo">
-   <imagedata fileref="sec-xca-2.png" width="80%" format="PNG"/>
+   <imagedata fileref="sec-xca-2.png" width="80%"/>
   </imageobject>
   <textobject role="description">
    <phrase>Create a new XCA database</phrase>

--- a/xml/security_yast2_security.xml
+++ b/xml/security_yast2_security.xml
@@ -81,10 +81,10 @@
    <title>&yast; security center and hardening: security overview</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata width="75%" fileref="yast2_security_overview.png" format="PNG"/>
+     <imagedata width="75%" fileref="yast2_security_overview.png"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_security_overview.png" format="PNG"/>
+     <imagedata fileref="yast2_security_overview.png"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/sle_update_upgrading.xml
+++ b/xml/sle_update_upgrading.xml
@@ -130,15 +130,15 @@
    <mediaobject>
     <imageobject role="fo">
      <imagedata os="sles" fileref="upgrade-paths_sles.svg" width="100%"
-      format="SVG"/>
+     />
      <imagedata os="sled" fileref="upgrade-paths_sled.svg" width="100%"
-      format="SVG"/>
+     />
     </imageobject>
     <imageobject role="html">
      <imagedata os="sles" fileref="upgrade-paths_sles.png" width="80%"
-      format="PNG"/>
+     />
      <imagedata os="sled" fileref="upgrade-paths_sled.png" width="80%"
-      format="PNG"/>
+     />
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/snapper.xml
+++ b/xml/snapper.xml
@@ -595,10 +595,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_list.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_list.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_list.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_list.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -611,10 +611,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_changes.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_changes.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_changes.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_changes.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -627,10 +627,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_diff.png" width="65%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_diff.png" width="65%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_diff.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_diff.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -645,10 +645,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_restore.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_restore.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_restore.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_restore.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -1114,10 +1114,10 @@ single | 4 |     |         |                       |
     <title>Boot loader: snapshots</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="boot_snapshots.png" width="75%" format="PNG"/>
+      <imagedata fileref="boot_snapshots.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="boot_snapshots.png" width="75%" format="PNG"/>
+      <imagedata fileref="boot_snapshots.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/xml/storage_fcoe.xml
+++ b/xml/storage_fcoe.xml
@@ -27,10 +27,10 @@
   <title>Open Fibre channel over ethernet SAN</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="fcoe_san_a.png" width="80%" format="PNG"/>
+    <imagedata fileref="fcoe_san_a.png" width="80%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="fcoe_san_a.png" width="100%" format="PNG"/>
+    <imagedata fileref="fcoe_san_a.png" width="100%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -98,10 +98,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="fcoe_inst_disk_activation_a.png" width="80%" format="PNG"/>
+     <imagedata fileref="fcoe_inst_disk_activation_a.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="fcoe_inst_disk_activation_a.png" width="10%" format="PNG"/>
+     <imagedata fileref="fcoe_inst_disk_activation_a.png" width="10%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -166,10 +166,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="fcoe_services_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="fcoe_services_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="fcoe_services_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="fcoe_services_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -225,10 +225,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="fcoe_notconfig_interface_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="fcoe_notconfig_interface_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="fcoe_notconfig_interface_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="fcoe_notconfig_interface_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -344,10 +344,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="fcoe_configtab_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="fcoe_configtab_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="fcoe_configtab_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="fcoe_configtab_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/xml/storage_filesystems.xml
+++ b/xml/storage_filesystems.xml
@@ -1497,10 +1497,10 @@ ID 263 gen 39 top level 256 path @/opt
    <informalfigure>
    <mediaobject>
    <imageobject role="fo">
-   <imagedata fileref="ext3_inode_yast_a.png" width="80%" format="PNG"/>
+   <imagedata fileref="ext3_inode_yast_a.png" width="80%"/>
    </imageobject>
    <imageobject role="html">
-   <imagedata fileref="ext3_inode_yast_a.png" width="100%" format="PNG"/>
+   <imagedata fileref="ext3_inode_yast_a.png" width="100%"/>
    </imageobject>
    </mediaobject>
    </informalfigure>
@@ -1747,10 +1747,10 @@ inode_ratio = 8192</screen>
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="ext4_inode_yast_a.png" width="60%" format="PNG"/>
+        <imagedata fileref="ext4_inode_yast_a.png" width="60%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="ext4_inode_yast_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="ext4_inode_yast_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/xml/storage_iscsi.xml
+++ b/xml/storage_iscsi.xml
@@ -24,10 +24,10 @@
   <title>iSCSI SAN with an iSNS server</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="iscsi_san_a.png" width="80%" format="PNG"/>
+    <imagedata fileref="iscsi_san_a.png" width="80%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="iscsi_san_a.png" width="100%" format="PNG"/>
+    <imagedata fileref="iscsi_san_a.png" width="100%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -141,10 +141,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="lio_service_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="lio_service_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="lio_service_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="lio_service_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -269,10 +269,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="lio_global_noauth_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="lio_global_noauth_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="lio_global_noauth_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="lio_global_noauth_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -384,10 +384,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="lio_targets_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="lio_targets_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="lio_targets_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="lio_targets_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -452,10 +452,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="lio_target_client_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="lio_target_client_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="lio_target_client_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="lio_target_client_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -838,10 +838,10 @@
       <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="iscsi_init_service_a.png" width="80%" format="PNG"/>
+         <imagedata fileref="iscsi_init_service_a.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="iscsi_init_service_a.png" width="100%" format="PNG"/>
+         <imagedata fileref="iscsi_init_service_a.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>

--- a/xml/storage_isns.xml
+++ b/xml/storage_isns.xml
@@ -63,10 +63,10 @@
    <title>iSNS discovery domains</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="isns_a.png" width="80%" format="PNG"/>
+     <imagedata fileref="isns_a.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="isns_a.png" width="100%" format="PNG"/>
+     <imagedata fileref="isns_a.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -200,10 +200,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="isns_config_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="isns_config_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="isns_config_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="isns_config_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -350,10 +350,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="isns_discdomains_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="isns_discdomains_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="isns_discdomains_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="isns_discdomains_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -398,10 +398,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="isns_iscsinodes_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="isns_iscsinodes_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="isns_iscsinodes_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="isns_iscsinodes_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/xml/storage_lvm.xml
+++ b/xml/storage_lvm.xml
@@ -65,10 +65,10 @@
    <title>Physical partitioning versus LVM</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="lvm.svg" width="80%" format="SVG"/>
+     <imagedata fileref="lvm.svg" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="lvm.png" width="100%" format="PNG"/>
+     <imagedata fileref="lvm.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -264,10 +264,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm4_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm4_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm4_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm4_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -348,10 +348,10 @@
      <title>Physical volumes in the volume group named DATA</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm5_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm5_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm5_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm5_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -445,10 +445,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm9_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm9_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm9_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm9_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -468,10 +468,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm10_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm10_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm10_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm10_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -486,10 +486,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm11_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm11_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm11_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm11_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -846,10 +846,10 @@ root's password:
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm8_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm8_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm8_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm8_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -942,10 +942,10 @@ root's password:
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm12_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm12_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm12_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm12_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/xml/storage_multipath.xml
+++ b/xml/storage_multipath.xml
@@ -455,10 +455,10 @@
           &yast; multipath dialog</phrase>
      </textobject>
      <imageobject role="fo">
-      <imagedata format="PNG" fileref="multipath-popup.png" width="50%"/>
+      <imagedata fileref="multipath-popup.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="multipath-popup.png" width="50%" format="PNG"/>
+      <imagedata fileref="multipath-popup.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/xml/storage_nfs.xml
+++ b/xml/storage_nfs.xml
@@ -210,15 +210,15 @@
       <mediaobject>
        <imageobject role="fo">
         <imagedata fileref="yast2_inst_nfsserver1.png" width="75%"
-                   format="PNG" os="sles;sled"/>
+                   os="sles;sled"/>
         <imagedata fileref="yast2_inst_nfsserver1_kde.png" width="75%"
-                   format="PNG" os="osuse"/>
+                   os="osuse"/>
        </imageobject>
        <imageobject role="html">
         <imagedata fileref="yast2_inst_nfsserver1.png" width="75%"
-                   format="PNG" os="sles;sled"/>
+                   os="sles;sled"/>
         <imagedata fileref="yast2_inst_nfsserver1_kde.png" width="75%"
-                   format="PNG" os="osuse"/>
+                   os="osuse"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -622,11 +622,11 @@ Nobody-Group = nobody</screen>
     <mediaobject>
      <imageobject role="fo">
       <imagedata fileref="yast2_nfsclient.png" width="75%"
-              format="PNG"/>
+             />
      </imageobject>
      <imageobject role="html">
       <imagedata fileref="yast2_nfsclient.png" width="75%"
-              format="PNG"/>
+             />
      </imageobject>
     </mediaobject>
    </figure>

--- a/xml/storage_raid.xml
+++ b/xml/storage_raid.xml
@@ -311,10 +311,10 @@
      <title>Example RAID 5 configuration</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_raid3_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_raid3_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_raid3_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_raid3_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/xml/storage_raid10.xml
+++ b/xml/storage_raid10.xml
@@ -866,10 +866,10 @@ ARRAY /dev/md2 UUID=<replaceable>UUID</replaceable></screen>
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="raid10_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="raid10_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="raid10_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="raid10_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -951,10 +951,10 @@ ARRAY /dev/md2 UUID=<replaceable>UUID</replaceable></screen>
        <informalfigure>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="raid10_classify_a.png" width="80%" format="PNG"/>
+          <imagedata fileref="raid10_classify_a.png" width="80%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="raid10_classify_a.png" width="100%" format="PNG"/>
+          <imagedata fileref="raid10_classify_a.png" width="100%"/>
          </imageobject>
         </mediaobject>
        </informalfigure>

--- a/xml/storage_raidroot.xml
+++ b/xml/storage_raidroot.xml
@@ -199,10 +199,10 @@
       <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install_a.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_a.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install_a.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_a.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -249,10 +249,10 @@
       <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install2_a.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install2_a.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install2_a.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install2_a.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -286,10 +286,10 @@
       <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install3_a.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install3_a.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install3_a.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install3_a.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -312,10 +312,10 @@
      <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install_editraid.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_editraid.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install_editraid.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_editraid.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -335,10 +335,10 @@
       <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install_filesystem.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_filesystem.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install_filesystem.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_filesystem.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -379,10 +379,10 @@
    	<informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install_swap.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_swap.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install_swap.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_swap.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -397,10 +397,10 @@
     <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install_boot.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_boot.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install_boot.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_boot.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -408,10 +408,10 @@
     <informalfigure>
       <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="raid_yast_install3_b.png" width="70%" format="PNG"/>
+       <imagedata fileref="raid_yast_install3_b.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="raid_yast_install3_b.png" width="70%" format="PNG"/>
+       <imagedata fileref="raid_yast_install3_b.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/xml/systemd.xml
+++ b/xml/systemd.xml
@@ -1116,10 +1116,10 @@ Startup finished in 2666ms (kernel) + 21961ms (userspace) = 24628ms</screen>
        <informalfigure>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="systemd_startup.svg" width="75%" format="SVG"/>
+          <imagedata fileref="systemd_startup.svg" width="75%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="systemd_startup.png" width="75%" format="PNG"/>
+          <imagedata fileref="systemd_startup.png" width="75%"/>
          </imageobject>
         </mediaobject>
        </informalfigure>
@@ -1212,10 +1212,10 @@ WantedBy=multi-user.target<co xml:id="co-service-wrapper-target"/></screen>
    <title>&ycc_runlevel;</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_runlevel.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_runlevel.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_runlevel.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_runlevel.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/troubleshooting.xml
+++ b/xml/troubleshooting.xml
@@ -501,10 +501,10 @@
     <title>Select disk</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="rescue_select_disk.png" width="50%" format="PNG"/>
+      <imagedata fileref="rescue_select_disk.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="rescue_select_disk.png" width="50%" format="PNG"/>
+      <imagedata fileref="rescue_select_disk.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/xml/tuning_kexec.xml
+++ b/xml/tuning_kexec.xml
@@ -808,10 +808,10 @@ KDUMP_NET_TIMEOUT=30</screen>
     <title>&yast; &kdump; module: start-up page</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_kdump_startup.png" width="60%" format="PNG"/>
+      <imagedata fileref="yast2_kdump_startup.png" width="60%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_kdump_startup.png" width="70%" format="PNG"/>
+      <imagedata fileref="yast2_kdump_startup.png" width="70%"/>
      </imageobject>
      <textobject><phrase>
         Screenshot of the &yast; &kdump; Module

--- a/xml/tuning_multikernel.xml
+++ b/xml/tuning_multikernel.xml
@@ -306,10 +306,10 @@
      <title>The &yast; software manager: multiversion view</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_sw_multiversion.png" width="90%" format="PNG"/>
+       <imagedata fileref="yast2_sw_multiversion.png" width="90%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_sw_multiversion.png" width="90%" format="PNG"/>
+       <imagedata fileref="yast2_sw_multiversion.png" width="90%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/xml/tuning_power.xml
+++ b/xml/tuning_power.xml
@@ -804,10 +804,10 @@ CPU | C0   | Cx   | Freq || POLL | C1   | C2   | C3
    <title>&powertop; in interactive mode</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="powertop_ncurses.png" width="75%" format="PNG"/>
+     <imagedata fileref="powertop_ncurses.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="powertop_ncurses.png" width="75%" format="PNG"/>
+     <imagedata fileref="powertop_ncurses.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -837,10 +837,10 @@ powerreport-20200108-104431.html
    <title>HTML &powertop; report</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="powertop_html.png" width="75%" format="PNG"/>
+     <imagedata fileref="powertop_html.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="powertop_html.png" width="75%" format="PNG"/>
+     <imagedata fileref="powertop_html.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/uefi.xml
+++ b/xml/uefi.xml
@@ -133,10 +133,10 @@ have a connection to the private portion of the Platform key.-->
      <title>Secure boot support</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/xml/updater_gnome.xml
+++ b/xml/updater_gnome.xml
@@ -44,12 +44,12 @@
   <title>Update notification on &gnome; desktop</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata os="osuse" fileref="gnome_update_notification_desktop_osuse.png" width="75%" format="PNG"/>
-    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%" format="PNG"/>
+    <imagedata os="osuse" fileref="gnome_update_notification_desktop_osuse.png" width="75%"/>
+    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata os="osuse" fileref="gnome_update_notification_desktop_osuse.png" width="75%" format="PNG"/>
-    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%" format="PNG"/>
+    <imagedata os="osuse" fileref="gnome_update_notification_desktop_osuse.png" width="75%"/>
+    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -72,10 +72,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="gupdater_updates.png" width="75%" format="PNG"/>
+      <imagedata fileref="gupdater_updates.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="gupdater_updates.png" width="75%" format="PNG"/>
+      <imagedata fileref="gupdater_updates.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/xml/updater_gnome_sw.xml
+++ b/xml/updater_gnome_sw.xml
@@ -55,10 +55,10 @@
   <title><guimenu>&gnome; Software</guimenu>&mdash;<guimenu>Updates</guimenu> view</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="gnome-software-updates.png" width="75%" format="PNG"/>
+    <imagedata fileref="gnome-software-updates.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="gnome-software-updates.png" width="75%" format="PNG"/>
+    <imagedata fileref="gnome-software-updates.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/xml/utilities.xml
+++ b/xml/utilities.xml
@@ -3286,10 +3286,10 @@ LINE2:free_memory#FF0000 \
      <title>Example graph created with RRDtool</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata width="75%" fileref="rrdtool_graph1.png" format="PNG"/>
+       <imagedata width="75%" fileref="rrdtool_graph1.png"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata width="55%" fileref="rrdtool_graph1.png" format="PNG"/>
+       <imagedata width="55%" fileref="rrdtool_graph1.png"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/xml/vnc.xml
+++ b/xml/vnc.xml
@@ -96,10 +96,10 @@ role='description'><phrase>Add new session</phrase></textobject><imageobject rol
      <textobject role="description"><phrase>vncviewer asking for connection details</phrase>
      </textobject>
      <imageobject role="html">
-      <imagedata fileref="vnc_connect.png" format="PNG"/>
+      <imagedata fileref="vnc_connect.png"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="vnc_connect.png" format="PNG"/>
+      <imagedata fileref="vnc_connect.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -145,10 +145,10 @@ role='description'><phrase>Add new session</phrase></textobject><imageobject rol
     <title>Remmina's main window</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -171,10 +171,10 @@ role='description'><phrase>Add new session</phrase></textobject><imageobject rol
     <title>Remote desktop preference</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina_session_details.png" width="80%" format="PNG"/>
+      <imagedata fileref="remmina_session_details.png" width="80%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina_session_details.png" width="80%" format="PNG"/>
+      <imagedata fileref="remmina_session_details.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -263,10 +263,10 @@ role='description'><phrase>Add new session</phrase></textobject><imageobject rol
      <title>Quick-starting</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="remmina_quickstart.png" width="40%" format="PNG"/>
+       <imagedata fileref="remmina_quickstart.png" width="40%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="remmina_quickstart.png" width="40%" format="PNG"/>
+       <imagedata fileref="remmina_quickstart.png" width="40%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -296,10 +296,10 @@ role='description'><phrase>Add new session</phrase></textobject><imageobject rol
      <title>Remmina viewing remote session</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>
+       <imagedata fileref="remmina_sle15inside.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>
+       <imagedata fileref="remmina_sle15inside.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -349,10 +349,10 @@ role='description'><phrase>Add new session</phrase></textobject><imageobject rol
     <title>Reading path to the profile file</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina_status.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina_status.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina_status.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina_status.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -433,10 +433,10 @@ role='description'><phrase>Add new session</phrase></textobject><imageobject rol
    <title>Remote administration</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="vnc_nosession.png" width="70%" format="PNG"/>
+     <imagedata fileref="vnc_nosession.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="vnc_nosession.png" width="70%" format="PNG"/>
+     <imagedata fileref="vnc_nosession.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -760,10 +760,10 @@ WINDOWMANAGER=icewm vncserver -geometry 1024x768</screen>
      <title>VNC session settings</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="vncmanager_session.png" width="85%" format="PNG"/>
+       <imagedata fileref="vncmanager_session.png" width="85%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="vncmanager_session.png" width="85%" format="PNG"/>
+       <imagedata fileref="vncmanager_session.png" width="85%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -861,10 +861,10 @@ WINDOWMANAGER=icewm vncserver -geometry 1024x768</screen>
      <title>Joining a persistent VNC session</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="vncmanager_whether.png" width="80%" format="PNG"/>
+       <imagedata fileref="vncmanager_whether.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="vncmanager_whether.png" width="80%" format="PNG"/>
+       <imagedata fileref="vncmanager_whether.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/xml/vt_tools.xml
+++ b/xml/vt_tools.xml
@@ -147,10 +147,10 @@ virsh # hostname
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="virt_virt-manager.png" width="80%" format="PNG"/>
+        <imagedata fileref="virt_virt-manager.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="virt_virt-manager.png" width="80%" format="PNG"/>
+        <imagedata fileref="virt_virt-manager.png" width="80%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -201,10 +201,10 @@ virsh # hostname
      <informalfigure pgwide="0">
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_vm.png" width="56%" format="PNG"/>
+        <imagedata fileref="yast2_vm.png" width="56%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_vm.png" width="56%" format="PNG"/>
+        <imagedata fileref="yast2_vm.png" width="56%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/xml/xen_administrating.xml
+++ b/xml/xen_administrating.xml
@@ -36,10 +36,10 @@
    <title>Boot loader settings</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="xen_bootloader.png" width="80%" format="PNG"/>
+     <imagedata fileref="xen_bootloader.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="xen_bootloader.png" width="80%" format="PNG"/>
+     <imagedata fileref="xen_bootloader.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/xen_virtualization_basics.xml
+++ b/xml/xen_virtualization_basics.xml
@@ -142,10 +142,10 @@
    <title>&xen; virtualization architecture</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="xen_master_fong_a.png" width="100%" format="PNG"/>
+     <imagedata fileref="xen_master_fong_a.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="xen_master_fong_a.png" width="100%" format="PNG"/>
+     <imagedata fileref="xen_master_fong_a.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -182,10 +182,10 @@
    <title>Desktop showing virtual machine manager and virtual machines</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="xen_fullscreen.png" width="100%" format="PNG"/>
+     <imagedata fileref="xen_fullscreen.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="xen_fullscreen.png" width="100%" format="PNG"/>
+     <imagedata fileref="xen_fullscreen.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/yast2_ftp.xml
+++ b/xml/yast2_ftp.xml
@@ -105,10 +105,10 @@
    <title>FTP server configuration — start-up</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_ftp-start-up.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_ftp-start-up.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_ftp-start-up.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_ftp-start-up.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/yast2_lang.xml
+++ b/xml/yast2_lang.xml
@@ -143,10 +143,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_language.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_language.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_language.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_language.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>
@@ -317,10 +317,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_timezone.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_timezone.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_timezone.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_timezone.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -415,10 +415,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_timezone_ntp.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_timezone_ntp.png" width="75%"/>
       </imageobject>
       <imageobject role="pdf">
-       <imagedata fileref="yast2_timezone_ntp.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_timezone_ntp.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/xml/yast2_ncurses.xml
+++ b/xml/yast2_ncurses.xml
@@ -29,10 +29,10 @@
   <title>Main window of &yast; in text mode</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="yast2_ncurses_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="yast2_ncurses_main.png" width="70%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="yast2_ncurses_main.png" width="75%" format="PNG"/>
+    <imagedata fileref="yast2_ncurses_main.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -169,10 +169,10 @@
    <title>The software installation module</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_ncurses_inst.png" width="70%" format="PNG"/>
+     <imagedata fileref="yast2_ncurses_inst.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_ncurses_inst.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_ncurses_inst.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/xml/yast2_sw.xml
+++ b/xml/yast2_sw.xml
@@ -215,10 +215,10 @@
      <phrase><guimenu>&yast;</guimenu> software manager screen</phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_sw_manager.png" width="70%" format="PNG"/>
+     <imagedata fileref="yast2_sw_manager.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_sw_manager.png" width="65%" format="PNG"/>
+     <imagedata fileref="yast2_sw_manager.png" width="65%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -666,10 +666,10 @@
     <title>Conflict management of the software manager</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_package_conflict.png" width="70%" format="PNG"/>
+      <imagedata fileref="yast2_package_conflict.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_package_conflict.png" width="65%" format="PNG"/>
+      <imagedata fileref="yast2_package_conflict.png" width="65%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/xml/yast2_sw_repo.xml
+++ b/xml/yast2_sw_repo.xml
@@ -85,10 +85,10 @@
      <title>Adding a software repository</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_addon_new.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_addon_new.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_addon_new.png" width="65%" format="PNG"/>
+       <imagedata fileref="yast2_addon_new.png" width="65%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/xml/yast2_userman.xml
+++ b/xml/yast2_userman.xml
@@ -37,12 +37,12 @@
    <title>&yast; user and group administration</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_users_main_qt.png" width="90%" format="PNG" os="sles;sled"/>
-     <imagedata fileref="yast2_users_main_kde.png" width="90%" format="PNG" os="osuse"/>
+     <imagedata fileref="yast2_users_main_qt.png" width="90%" os="sles;sled"/>
+     <imagedata fileref="yast2_users_main_kde.png" width="90%" os="osuse"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_users_main_qt.png" width="70%" format="PNG" os="sles;sled"/>
-     <imagedata fileref="yast2_users_main_kde.png" width="70%" format="PNG" os="osuse"/>
+     <imagedata fileref="yast2_users_main_qt.png" width="70%" os="sles;sled"/>
+     <imagedata fileref="yast2_users_main_kde.png" width="70%" os="osuse"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -554,15 +554,15 @@
       <mediaobject>
        <imageobject role="fo">
         <imagedata fileref="yast2_users_quota_qt.png" width="80%"
-                   format="PNG" os="sles;sled"/>
+                   os="sles;sled"/>
         <imagedata fileref="yast2_users_quota_kde.png" width="80%"
-                   format="PNG" os="osuse"/>
+                   os="osuse"/>
        </imageobject>
        <imageobject role="html">
         <imagedata fileref="yast2_users_quota_qt.png" width="70%"
-                   format="PNG" os="sles;sled"/>
+                   os="sles;sled"/>
         <imagedata fileref="yast2_users_quota_kde.png" width="70%"
-                   format="PNG" os="osuse"/>
+                   os="osuse"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -780,15 +780,15 @@
      <mediaobject>
       <imageobject role="fo">
        <imagedata fileref="yast2_groups_edit_qt.png" width="80%"
-                  format="PNG" os="sles;sled"/>
+                  os="sles;sled"/>
        <imagedata fileref="yast2_groups_edit_kde.png" width="80%"
-                  format="PNG" os="osuse"/>
+                  os="osuse"/>
       </imageobject>
       <imageobject role="html">
        <imagedata fileref="yast2_groups_edit_qt.png" width="75%"
-                  format="PNG" os="sles;sled"/>
+                  os="sles;sled"/>
        <imagedata fileref="yast2_groups_edit_kde.png" width="75%"
-                  format="PNG" os="osuse"/>
+                  os="osuse"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/xml/yast2_you.xml
+++ b/xml/yast2_you.xml
@@ -95,12 +95,12 @@
    <title>&yast; online update</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_you.png" width="75%" format="PNG" os="sles;sled"/>
-     <imagedata fileref="yast2_you_osuse.png" width="75%" format="PNG" os="osuse"/>
+     <imagedata fileref="yast2_you.png" width="75%" os="sles;sled"/>
+     <imagedata fileref="yast2_you_osuse.png" width="75%" os="osuse"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_you.png" width="75%" format="PNG" os="sles;sled"/>
-     <imagedata fileref="yast2_you_osuse.png" width="75%" format="PNG" os="osuse"/>
+     <imagedata fileref="yast2_you.png" width="75%" os="sles;sled"/>
+     <imagedata fileref="yast2_you_osuse.png" width="75%" os="osuse"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -277,10 +277,10 @@
    <title>Viewing retracted patches and history</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_retracted_patches.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_retracted_patches.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_retracted_patches.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_retracted_patches.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>  
@@ -331,10 +331,10 @@
    <title>&yast; online update configuration</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_autoupdate.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_autoupdate.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_autoupdate.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_autoupdate.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>


### PR DESCRIPTION
### PR creator: Description

We decided in our SLE sync call on 2022-09-26 to remove the `format` attribute from `<imagedata/>`.


### PR creator: Are there any relevant issues/feature requests?

* DOCTEAM-584


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 SP0
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
