### PR TITLE
Remove format attribute for <imagedata/> (l10n)

### DIFF
--- a/l10n/sled/de-de/xml/adm_support.xml
+++ b/l10n/sled/de-de/xml/adm_support.xml
@@ -135,10 +135,10 @@ CPU Load Average:         7 (3%) with 2 CPUs
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_support_main.png" width="70%" format="PNG"/>
+        <imagedata fileref="yast2_support_main.png" width="70%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_support_main.png" width="60%" format="PNG"/>
+        <imagedata fileref="yast2_support_main.png" width="60%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -176,10 +176,10 @@ CPU Load Average:         7 (3%) with 2 CPUs
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_support_conf.png" width="90%" format="PNG"/>
+        <imagedata fileref="yast2_support_conf.png" width="90%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_support_conf.png" width="80%" format="PNG"/>
+        <imagedata fileref="yast2_support_conf.png" width="80%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -740,10 +740,10 @@ Creating Tar Ball
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_support_conf_upload.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_support_conf_upload.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_support_conf_upload.png" width="60%" format="PNG"/>
+       <imagedata fileref="yast2_support_conf_upload.png" width="60%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sled/de-de/xml/apps_ekiga.xml
+++ b/l10n/sled/de-de/xml/apps_ekiga.xml
@@ -170,10 +170,10 @@
    <title><productname>Ekiga</productname> Benutzeroberfläche</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="ekiga_main.png" width="45%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="45%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ekiga_main.png" width="55%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="55%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/de-de/xml/apps_evolution.xml
+++ b/l10n/sled/de-de/xml/apps_evolution.xml
@@ -733,10 +733,10 @@
    <title><productname>Evolution</productname> window</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" width="100%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" width="86%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="86%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/de-de/xml/apps_firefox.xml
+++ b/l10n/sled/de-de/xml/apps_firefox.xml
@@ -29,7 +29,7 @@
   <note>
    <title>Verwenden der Menüleiste</title>
    <para>
-    Die meisten Funktionen von <productname>Firefox</productname> lassen sich über das Dreistrichmenü (<inlinemediaobject><textobject role="description"><phrase>Dreistrichmenü</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject>) aufrufen, andere dagegen nur über die Menüleiste.
+    Die meisten Funktionen von <productname>Firefox</productname> lassen sich über das Dreistrichmenü (<inlinemediaobject><textobject role="description"><phrase>Dreistrichmenü</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em"/></imageobject></inlinemediaobject>) aufrufen, andere dagegen nur über die Menüleiste.
    </para>
    <para>
     Die Menüleiste von <productname>Firefox</productname> ist standardmäßig ausgeblendet. Mit <keycap function="alt"/> blenden Sie sie vorübergehend ein. Die Leiste bleibt dann so lange sichtbar, bis Sie auf eine andere Stelle im Browserfenster klicken.

--- a/l10n/sled/de-de/xml/apps_gimp.xml
+++ b/l10n/sled/de-de/xml/apps_gimp.xml
@@ -125,10 +125,10 @@
     <title>Die Werkzeugsammlung</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="gimp-toolbox.png" width="35%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="35%"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="gimp-toolbox.png" width="30%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="30%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -547,10 +547,10 @@
        <title>Das Dialogfeld zur Farbauswahl</title>
        <mediaobject>
         <imageobject role="html">
-         <imagedata fileref="gimp-color.png" width="70%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="70%"/>
         </imageobject>
         <imageobject role="fo">
-         <imagedata fileref="gimp-color.png" width="80%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="80%"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -719,10 +719,10 @@
    <title>Das Druckfenster</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="gimp-print.png" width="75%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="75%"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="gimp-print.png" width="70%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/de-de/xml/apps_libreoffice.xml
+++ b/l10n/sled/de-de/xml/apps_libreoffice.xml
@@ -528,7 +528,7 @@
    </step>
    <step>
     <para>
-     Gehen Sie zu den Zertifikateinstellungen, indem Sie das Menü (<inlinemediaobject><textobject role="description"><phrase>Dreistrichmenü</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject>) öffnen und <menuchoice><guimenu>Einstellungen</guimenu>
+     Gehen Sie zu den Zertifikateinstellungen, indem Sie das Menü (<inlinemediaobject><textobject role="description"><phrase>Dreistrichmenü</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em"/></imageobject></inlinemediaobject>) öffnen und <menuchoice><guimenu>Einstellungen</guimenu>
       <guimenu>Datenschutz &amp; Sicherheit</guimenu></menuchoice> wählen.
     </para>
    </step>
@@ -573,10 +573,10 @@
    <title>Anpassungsdialogfeld in <guimenu>Writer</guimenu></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -728,10 +728,10 @@
    <title>Das Fenster „Optionen“</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_options.png" width="95%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_options.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/de-de/xml/apps_librevarious.xml
+++ b/l10n/sled/de-de/xml/apps_librevarious.xml
@@ -285,10 +285,10 @@
        <mediaobject>
         <textobject><phrase>Field selection</phrase></textobject>
         <imageobject role="fo">
-         <imagedata fileref="oo-wizard-base.png" width="90%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="90%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="oo-wizard-base.png" width="85%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="85%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>

--- a/l10n/sled/de-de/xml/apps_librewriter.xml
+++ b/l10n/sled/de-de/xml/apps_librewriter.xml
@@ -66,10 +66,10 @@
    <title>Ein LibreOffice-Assistent</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo-wizard.png" width="100%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo-wizard.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -232,10 +232,10 @@
     <title>Bereich „Styles“ (Formatvorlagen)</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo-stylist.png" width="40%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="40%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo-stylist.png" width="50%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -642,10 +642,10 @@
     <title><guimenu>Navigator-Werkzeug in Writer</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo_navigator.png" width="55%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo_navigator.png" width="45%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="45%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/de-de/xml/apps_totem.xml
+++ b/l10n/sled/de-de/xml/apps_totem.xml
@@ -59,10 +59,10 @@
    <title><guimenu>GNOME Videos</guimenu> – Fenster beim Starten</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -132,11 +132,11 @@
     <guimenu>Eject (Auswerfen)</guimenu> </menuchoice>.
    </para>
    <para>
-    Zum Anhalten der Wiedergabe eines Films oder Musiktitels klicken Sie auf die Schaltfläche <inlinemediaobject><textobject role="description"><phrase>GNOME Videos Pause</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_pause_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="totem_pause_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject> (GNOME Videos – Pause) oder auf <menuchoice> <guimenu>Movie (Film)</guimenu>
+    Zum Anhalten der Wiedergabe eines Films oder Musiktitels klicken Sie auf die Schaltfläche <inlinemediaobject><textobject role="description"><phrase>GNOME Videos Pause</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_pause_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="totem_pause_button-fallback.png" width="1em"/></imageobject></inlinemediaobject> (GNOME Videos – Pause) oder auf <menuchoice> <guimenu>Movie (Film)</guimenu>
     <guimenu>Play/Pause (Wiedergabe/Pause)</guimenu> </menuchoice> Wenn Sie einen Film oder Musiktitel anhalten, zeigt die Statusleiste <guimenu>Angehalten</guimenu> und die Zeitdauer an, über die der aktuelle Film oder Musiktitel abgespielt wurde.
    </para>
    <para>
-    Zum Fortsetzen der Wiedergabe des Films oder Musiktitels klicken Sie auf die Schaltfläche <inlinemediaobject><textobject role="description"><phrase>GNOME Videos Play</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_play_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="totem_play_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject> (GNOME Videos – Wiedergabe) oder auf <menuchoice> <guimenu>Movie (Film)</guimenu>
+    Zum Fortsetzen der Wiedergabe des Films oder Musiktitels klicken Sie auf die Schaltfläche <inlinemediaobject><textobject role="description"><phrase>GNOME Videos Play</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_play_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="totem_play_button-fallback.png" width="1em"/></imageobject></inlinemediaobject> (GNOME Videos – Wiedergabe) oder auf <menuchoice> <guimenu>Movie (Film)</guimenu>
     <guimenu>Play/Pause (Wiedergabe/Pause)</guimenu></menuchoice>
    </para>
    <para>
@@ -223,10 +223,10 @@
     <title>Allgemeine Einstellungen für <guimenu>GNOME Videos</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -268,10 +268,10 @@
     <title>Anzeigeeinstellungen für <guimenu>GNOME Videos</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -307,10 +307,10 @@
     <title>Audio-Einstellungen für <guimenu>GNOME Videos</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/de-de/xml/backup.xml
+++ b/l10n/sled/de-de/xml/backup.xml
@@ -20,10 +20,10 @@
  <mediaobject>
   <textobject><phrase>Backup application</phrase></textobject>
   <imageobject role="fo">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
   <imageobject role="html">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
  </mediaobject>
 </informalfigure>

--- a/l10n/sled/de-de/xml/chrony.xml
+++ b/l10n/sled/de-de/xml/chrony.xml
@@ -44,10 +44,10 @@
    <title>Fenster „NTP-Konfiguration“</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="ntp_client.png" width="70%" format="PNG"/>
+     <imagedata fileref="ntp_client.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ntp_client.png" width="70%" format="PNG"/>
+     <imagedata fileref="ntp_client.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -107,10 +107,10 @@
     <title>Hinzufügen eines Zeitservers</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="ntp_client_serveradd.png" width="70%" format="PNG"/>
+      <imagedata fileref="ntp_client_serveradd.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="ntp_client_serveradd.png" width="70%" format="PNG"/>
+      <imagedata fileref="ntp_client_serveradd.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/de-de/xml/deployment_expert_partitioner_lvm.xml
+++ b/l10n/sled/de-de/xml/deployment_expert_partitioner_lvm.xml
@@ -89,10 +89,10 @@
    <title>Anlegen einer Volume-Gruppe</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -109,10 +109,10 @@
    <title>Verwaltung von logischen Volumes</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/de-de/xml/deployment_expert_partitioner_overview.xml
+++ b/l10n/sled/de-de/xml/deployment_expert_partitioner_overview.xml
@@ -24,10 +24,10 @@
   <title>YaST-Partitionierung</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -221,10 +221,10 @@
         <title>Btrfs-Subvolumes im YaST-Partitionierer</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
         </mediaobject>
        </figure>

--- a/l10n/sled/de-de/xml/deployment_expert_partitioner_raid.xml
+++ b/l10n/sled/de-de/xml/deployment_expert_partitioner_raid.xml
@@ -56,10 +56,10 @@
    <title>RAID-Partitionen</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/de-de/xml/deployment_register.xml
+++ b/l10n/sled/de-de/xml/deployment_register.xml
@@ -104,11 +104,11 @@
        </textobject>
        <imageobject role="fo">
         
-        <imagedata os="sled" fileref="yast2_extension_list_sled.png" width="75%" format="png"/>
+        <imagedata os="sled" fileref="yast2_extension_list_sled.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
         
-        <imagedata os="sled" fileref="yast2_extension_list_sled.png" width="100%" format="png"/>
+        <imagedata os="sled" fileref="yast2_extension_list_sled.png" width="100%"/>
 
        </imageobject>
       </mediaobject>
@@ -157,11 +157,11 @@
        </textobject>
        <imageobject role="fo">
         
-        <imagedata os="sled" fileref="yast2_addon_installed_sled.png" width="75%" format="png"/>
+        <imagedata os="sled" fileref="yast2_addon_installed_sled.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
         
-        <imagedata os="sled" fileref="yast2_addon_installed_sled.png" width="100%" format="png"/>
+        <imagedata os="sled" fileref="yast2_addon_installed_sled.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/l10n/sled/de-de/xml/deployment_troubleshooting.xml
+++ b/l10n/sled/de-de/xml/deployment_troubleshooting.xml
@@ -156,10 +156,10 @@
    <title>US-Tastaturbelegung</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="keyboard_us.svg" width="75%" format="SVG"/>
+     <imagedata fileref="keyboard_us.svg" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="keyboard_us.png" width="75%" format="PNG"/>
+     <imagedata fileref="keyboard_us.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/de-de/xml/gnome_accessibility.xml
+++ b/l10n/sled/de-de/xml/gnome_accessibility.xml
@@ -90,10 +90,10 @@
      <mediaobject>
       <textobject><phrase>On-screen keyboard</phrase></textobject>
       <imageobject role="fo">
-       <imagedata fileref="gnome_onscreen_kbd.png" width="95%" format="PNG"/>
+       <imagedata fileref="gnome_onscreen_kbd.png" width="95%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="gnome_onscreen_kbd.png" width="90%" format="PNG"/>
+       <imagedata fileref="gnome_onscreen_kbd.png" width="90%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sled/de-de/xml/gnome_crypto.xml
+++ b/l10n/sled/de-de/xml/gnome_crypto.xml
@@ -22,10 +22,10 @@
   <title>Hauptfenster <guimenu>Passwörter und Schlüssel</guimenu></title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sled/de-de/xml/gnome_custom.xml
+++ b/l10n/sled/de-de/xml/gnome_custom.xml
@@ -61,10 +61,10 @@
      <title>GNOME-Hintergrundeinstellungen</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="preferences_background.png" width="45%" format="PNG"/>
+        <imagedata fileref="preferences_background.png" width="45%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="preferences_background.png" width="45%" format="PNG"/>
+        <imagedata fileref="preferences_background.png" width="45%"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -148,10 +148,10 @@
    <title>Dialogfeld für Tastenkombinationen</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_keyboard.png" width="100%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_keyboard.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -178,10 +178,10 @@
    <title>Aktivieren der Compose-Taste in Tweaks</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -307,10 +307,10 @@
    <title>Einstellungsdialogfeld für <guimenu>Maus und Touchpad</guimenu></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -362,10 +362,10 @@
     <title>Dialogfeld mit Einstellungen für einen einzelnen Monitor</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="preferences_screen_single.png" width="100%" format="PNG"/>
+      <imagedata fileref="preferences_screen_single.png" width="100%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="preferences_screen_single.png" width="80%" format="PNG"/>
+      <imagedata fileref="preferences_screen_single.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -486,10 +486,10 @@
    <title>Konfigurieren der Audioeinstellungen</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="sound_devices.png" width="100%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="sound_devices.png" width="80%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -515,10 +515,10 @@
      <title>Standardanwendungen</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="preferences_preferred_apps.png" width="100%" format="PNG"/>
+       <imagedata fileref="preferences_preferred_apps.png" width="100%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="preferences_preferred_apps.png" width="80%" format="PNG"/>
+       <imagedata fileref="preferences_preferred_apps.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/de-de/xml/gnome_networking.xml
+++ b/l10n/sled/de-de/xml/gnome_networking.xml
@@ -104,10 +104,10 @@
    <title>Netzwerk-Datei-Browser</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="network_browser.png" width="100%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="100%"/>
      </imageobject>
     <imageobject role="html">
-     <imagedata fileref="network_browser.png" width="90%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -256,10 +256,10 @@
       <mediaobject>
        <textobject><phrase>Sharing options</phrase></textobject>
        <imageobject role="fo">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/l10n/sled/de-de/xml/gnome_start.xml
+++ b/l10n/sled/de-de/xml/gnome_start.xml
@@ -37,11 +37,11 @@
    <title>Standardmäßiger GNOME-Anmeldebildschirm</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata os="sles;sled" fileref="login_sled.png" width="90%" format="PNG"/>
+     <imagedata os="sles;sled" fileref="login_sled.png" width="90%"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata os="sles;sled" fileref="login_sled.png" width="75%" format="PNG"/>
+     <imagedata os="sles;sled" fileref="login_sled.png" width="75%"/>
      
     </imageobject>
    </mediaobject>
@@ -83,11 +83,11 @@
       <title>Standardmäßiger GNOME-Anmeldebildschirm – Sitzungstyp</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="90%" format="PNG"/>
+        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="90%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="75%" format="PNG"/>
+        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="75%"/>
         
        </imageobject>
       </mediaobject>
@@ -211,10 +211,10 @@
    <title>GNOME-Desktop mit Aktivitätenübersicht</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="desktop_sled_menu.png" width="95%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="desktop_sled_menu.png" width="90%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -259,10 +259,10 @@
      <title><guimenu>Aktivitätenübersicht</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="desktop_activities_overview.png" width="95%" format="PNG"/>
+      <imagedata fileref="desktop_activities_overview.png" width="95%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="desktop_activities_overview.png" width="90%" format="PNG"/>
+      <imagedata fileref="desktop_activities_overview.png" width="90%"/>
      </imageobject>
     </mediaobject>
      </figure>
@@ -299,10 +299,10 @@
      <title><guimenu>Anwendungsmenü</guimenu> für <productname>Firefox</productname></title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="desktop_app_menu_firefox.png" width="70%" format="PNG"/>
+       <imagedata fileref="desktop_app_menu_firefox.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="desktop_app_menu_firefox.png" width="70%" format="PNG"/>
+       <imagedata fileref="desktop_app_menu_firefox.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/de-de/xml/gnome_use.xml
+++ b/l10n/sled/de-de/xml/gnome_use.xml
@@ -26,10 +26,10 @@
    <title>Datei-Manager</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -573,10 +573,10 @@
     <textobject><phrase><productname>Evolution</productname></phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" format="PNG" width="100%"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" format="PNG" width="80%"/>
+     <imagedata fileref="evolution.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -673,10 +673,10 @@
    <title><productname>Archive manager</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -971,10 +971,10 @@
    <title><productname>Document viewer</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evince.png" format="PNG" width="90%"/>
+     <imagedata fileref="evince.png" width="90%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evince.png" format="PNG" width="78%"/>
+     <imagedata fileref="evince.png" width="78%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/de-de/xml/grub2.xml
+++ b/l10n/sled/de-de/xml/grub2.xml
@@ -438,10 +438,10 @@
       <title>Booteditor in GRUB 2</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="grub2_edit_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="grub2_edit_config.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="grub2_edit_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="grub2_edit_config.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </figure>

--- a/l10n/sled/de-de/xml/grub2_yast_i.xml
+++ b/l10n/sled/de-de/xml/grub2_yast_i.xml
@@ -93,10 +93,10 @@
     <title>Bootcode-Optionen</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%"/>
      </imageobject>
     </mediaobject>
   </figure>
@@ -215,10 +215,10 @@
     <title>Bootloader-Optionen</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_options.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_options.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_options.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_options.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -277,10 +277,10 @@
     <title>Kernel-Parameter</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/de-de/xml/help_user.xml
+++ b/l10n/sled/de-de/xml/help_user.xml
@@ -61,10 +61,10 @@
    <title>Hauptfenster der Hilfe</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/de-de/xml/journalctl.xml
+++ b/l10n/sled/de-de/xml/journalctl.xml
@@ -336,10 +336,10 @@ enabled</screen>
    <title>YaST-systemd-Journal</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_journal.png" width="80%" format="PNG"/>
+     <imagedata fileref="yast2_journal.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_journal.png" width="85%" format="PNG"/>
+     <imagedata fileref="yast2_journal.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/de-de/xml/klp.xml
+++ b/l10n/sled/de-de/xml/klp.xml
@@ -64,10 +64,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="klp.png" width="80%" format="PNG"/>
+     <imagedata fileref="klp.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="klp.png" width="100%" format="PNG"/>
+     <imagedata fileref="klp.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>

--- a/l10n/sled/de-de/xml/net_basic.xml
+++ b/l10n/sled/de-de/xml/net_basic.xml
@@ -60,10 +60,10 @@
   <title>Vereinfachtes Schichtmodell für TCP/IP</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata width="100%" fileref="net_basic_osi.svg" format="SVG"/>
+    <imagedata width="100%" fileref="net_basic_osi.svg"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata width="75%" fileref="net_basic_osi.png" format="PNG"/>
+    <imagedata width="75%" fileref="net_basic_osi.png"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -80,10 +80,10 @@
   <title>TCP/IP-Ethernet-Paket</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata width="80%" fileref="net_basic_tcppacket.svg" format="SVG"/>
+    <imagedata width="80%" fileref="net_basic_tcppacket.svg"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata width="75%" fileref="net_basic_tcppacket.png" format="PNG"/>
+    <imagedata width="75%" fileref="net_basic_tcppacket.png"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sled/de-de/xml/net_bonding.xml
+++ b/l10n/sled/de-de/xml/net_bonding.xml
@@ -114,10 +114,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="bond_configuration.png" width="70%" format="PNG"/>
+      <imagedata fileref="bond_configuration.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="bond_configuration.png" width="65%" format="PNG"/>
+      <imagedata fileref="bond_configuration.png" width="65%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sled/de-de/xml/net_wicked.xml
+++ b/l10n/sled/de-de/xml/net_wicked.xml
@@ -79,10 +79,10 @@
     <title><literal>wicked</literal>-Architektur</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="wicked_scheme.png" format="PNG"/>
+      <imagedata fileref="wicked_scheme.png"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="wicked_scheme.png" format="PNG" width="80%"/>
+      <imagedata fileref="wicked_scheme.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/de-de/xml/net_yast.xml
+++ b/l10n/sled/de-de/xml/net_yast.xml
@@ -43,10 +43,10 @@
    <title>Konfigurieren der Netzwerkeinstellungen</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_net_icard.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_net_icard.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_net_icard.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_net_icard.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/de-de/xml/network_scheme.xml
+++ b/l10n/sled/de-de/xml/network_scheme.xml
@@ -4,10 +4,10 @@
  <info>
   <mediaobject>
    <imageobject role="html">
-    <imagedata fileref="network_schema.png" width="100%" format="PNG"/>
+    <imagedata fileref="network_schema.png" width="100%"/>
    </imageobject>
    <imageobject role="pdf">
-    <imagedata fileref="network_schema.svg" width="100%" format="SVG"/>
+    <imagedata fileref="network_schema.svg" width="100%"/>
    </imageobject>
   </mediaobject>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -21,10 +21,10 @@
  <informalfigure>
   <mediaobject>
    <imageobject role="html">
-    <imagedata fileref="network_schema.png" width="100%" format="PNG"/>
+    <imagedata fileref="network_schema.png" width="100%"/>
    </imageobject>
    <imageobject role="pdf">
-    <imagedata fileref="network_schema.svg" width="100%" format="SVG"/>
+    <imagedata fileref="network_schema.svg" width="100%"/>
    </imageobject>
   </mediaobject>
  </informalfigure>

--- a/l10n/sled/de-de/xml/sle_update_upgrading.xml
+++ b/l10n/sled/de-de/xml/sle_update_upgrading.xml
@@ -71,11 +71,11 @@
    <mediaobject>
     <imageobject role="fo">
      
-     <imagedata os="sled" fileref="upgrade-paths_sled.png" width="100%" format="PNG"/>
+     <imagedata os="sled" fileref="upgrade-paths_sled.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
      
-     <imagedata os="sled" fileref="upgrade-paths_sled.png" width="80%" format="PNG"/>
+     <imagedata os="sled" fileref="upgrade-paths_sled.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/de-de/xml/snapper.xml
+++ b/l10n/sled/de-de/xml/snapper.xml
@@ -417,10 +417,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_list.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_list.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_list.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_list.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -432,10 +432,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_changes.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_changes.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_changes.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_changes.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -447,10 +447,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_diff.png" width="65%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_diff.png" width="65%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_diff.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_diff.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -462,10 +462,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_restore.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_restore.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_restore.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_restore.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -827,10 +827,10 @@ single | 4 |     |         |                       |
     <title>Bootloader: Snapshots</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="boot_snapshots.png" width="75%" format="PNG"/>
+      <imagedata fileref="boot_snapshots.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="boot_snapshots.png" width="75%" format="PNG"/>
+      <imagedata fileref="boot_snapshots.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/de-de/xml/systemd.xml
+++ b/l10n/sled/de-de/xml/systemd.xml
@@ -1046,10 +1046,10 @@ Startup finished in 2666ms (kernel) + 21961ms (userspace) = 24628ms</screen>
        <informalfigure>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="systemd_startup.svg" width="75%" format="SVG"/>
+          <imagedata fileref="systemd_startup.svg" width="75%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="systemd_startup.png" width="75%" format="PNG"/>
+          <imagedata fileref="systemd_startup.png" width="75%"/>
          </imageobject>
         </mediaobject>
        </informalfigure>
@@ -1132,10 +1132,10 @@ WantedBy=multi-user.target<co xml:id="co-service-wrapper-target"/></screen>
    <title>Services Manager</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_runlevel.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_runlevel.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_runlevel.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_runlevel.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/de-de/xml/tuning_multikernel.xml
+++ b/l10n/sled/de-de/xml/tuning_multikernel.xml
@@ -236,10 +236,10 @@
      <title>Der YaST-Software-Manager: Multiversionsanzeige</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_sw_multiversion.png" width="90%" format="PNG"/>
+       <imagedata fileref="yast2_sw_multiversion.png" width="90%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_sw_multiversion.png" width="90%" format="PNG"/>
+       <imagedata fileref="yast2_sw_multiversion.png" width="90%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/de-de/xml/uefi.xml
+++ b/l10n/sled/de-de/xml/uefi.xml
@@ -83,10 +83,10 @@
      <title>Secure Boot-Unterstützung</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/de-de/xml/updater_gnome.xml
+++ b/l10n/sled/de-de/xml/updater_gnome.xml
@@ -25,11 +25,11 @@
   <mediaobject>
    <imageobject role="fo">
     
-    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%" format="PNG"/>
+    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
     
-    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%" format="PNG"/>
+    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -47,10 +47,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="gupdater_updates.png" width="75%" format="PNG"/>
+      <imagedata fileref="gupdater_updates.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="gupdater_updates.png" width="75%" format="PNG"/>
+      <imagedata fileref="gupdater_updates.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sled/de-de/xml/updater_gnome_sw.xml
+++ b/l10n/sled/de-de/xml/updater_gnome_sw.xml
@@ -42,10 +42,10 @@
   <title><guimenu>GNOME Software</guimenu> – Ansicht <guimenu>Aktualisierungen</guimenu></title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="gnome-software-updates.png" width="75%" format="PNG"/>
+    <imagedata fileref="gnome-software-updates.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="gnome-software-updates.png" width="75%" format="PNG"/>
+    <imagedata fileref="gnome-software-updates.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sled/de-de/xml/vnc.xml
+++ b/l10n/sled/de-de/xml/vnc.xml
@@ -56,10 +56,10 @@
      <textobject role="description"><phrase>vncviewer asking for connection details</phrase>
      </textobject>
      <imageobject role="html">
-      <imagedata fileref="vnc_connect.png" format="PNG"/>
+      <imagedata fileref="vnc_connect.png"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="vnc_connect.png" format="PNG"/>
+      <imagedata fileref="vnc_connect.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -99,10 +99,10 @@
     <title>Hauptfenster von Remmina</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -114,16 +114,16 @@
   <sect2 xml:id="vnc-remmina-addnew">
    <title>Hinzufügen von Remote-Sitzungen</title>
    <para>
-    Um eine neue Remote-Sitzung hinzuzufügen und zu speichern, klicken Sie auf <inlinemediaobject><textobject role="description"><phrase>Neue Sitzung hinzufügen</phrase></textobject><imageobject role="fo"><imagedata fileref="remmina_plus.png" width="1.2em" format="PNG"/></imageobject><imageobject role="html"><imagedata fileref="remmina_plus.png" width="1.2em" format="PNG"/></imageobject></inlinemediaobject> oben links im Hauptfenster. Das Fenster <guimenu>Remote Desktop Preference</guimenu> wird geöffnet.
+    Um eine neue Remote-Sitzung hinzuzufügen und zu speichern, klicken Sie auf <inlinemediaobject><textobject role="description"><phrase>Neue Sitzung hinzufügen</phrase></textobject><imageobject role="fo"><imagedata fileref="remmina_plus.png" width="1.2em"/></imageobject><imageobject role="html"><imagedata fileref="remmina_plus.png" width="1.2em"/></imageobject></inlinemediaobject> oben links im Hauptfenster. Das Fenster <guimenu>Remote Desktop Preference</guimenu> wird geöffnet.
    </para>
    <figure>
     <title>Remote Desktop Preference</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina_session_details.png" width="80%" format="PNG"/>
+      <imagedata fileref="remmina_session_details.png" width="80%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina_session_details.png" width="80%" format="PNG"/>
+      <imagedata fileref="remmina_session_details.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -203,10 +203,10 @@
      <title>Schnellstart</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="remmina_quickstart.png" width="40%" format="PNG"/>
+       <imagedata fileref="remmina_quickstart.png" width="40%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="remmina_quickstart.png" width="40%" format="PNG"/>
+       <imagedata fileref="remmina_quickstart.png" width="40%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -229,10 +229,10 @@
      <title>Remmina-Remote-Sitzung mit Anzeige</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>
+       <imagedata fileref="remmina_sle15inside.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>
+       <imagedata fileref="remmina_sle15inside.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -267,10 +267,10 @@
     <title>Pfad zur Profildatei</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina_status.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina_status.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina_status.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina_status.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -332,10 +332,10 @@
    <title>Fernverwaltung</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="vnc_nosession.png" width="70%" format="PNG"/>
+     <imagedata fileref="vnc_nosession.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="vnc_nosession.png" width="70%" format="PNG"/>
+     <imagedata fileref="vnc_nosession.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -561,10 +561,10 @@ WINDOWMANAGER=icewm vncserver -geometry 1024x768</screen>
      <title>VNC-Sitzungseinstellungen</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="vncmanager_session.png" width="85%" format="PNG"/>
+       <imagedata fileref="vncmanager_session.png" width="85%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="vncmanager_session.png" width="85%" format="PNG"/>
+       <imagedata fileref="vncmanager_session.png" width="85%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -649,10 +649,10 @@ WINDOWMANAGER=icewm vncserver -geometry 1024x768</screen>
      <title>Beitreten zu einer permanenten VNC-Sitzung</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="vncmanager_whether.png" width="80%" format="PNG"/>
+       <imagedata fileref="vncmanager_whether.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="vncmanager_whether.png" width="80%" format="PNG"/>
+       <imagedata fileref="vncmanager_whether.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/de-de/xml/yast2_lang.xml
+++ b/l10n/sled/de-de/xml/yast2_lang.xml
@@ -91,10 +91,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_language.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_language.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_language.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_language.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>
@@ -225,10 +225,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_timezone.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_timezone.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_timezone.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_timezone.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -306,10 +306,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_timezone_ntp.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_timezone_ntp.png" width="75%"/>
       </imageobject>
       <imageobject role="pdf">
-       <imagedata fileref="yast2_timezone_ntp.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_timezone_ntp.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sled/de-de/xml/yast2_ncurses.xml
+++ b/l10n/sled/de-de/xml/yast2_ncurses.xml
@@ -15,10 +15,10 @@
   <title>Hauptfenster von YaST im Textmodus</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="yast2_ncurses_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="yast2_ncurses_main.png" width="70%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="yast2_ncurses_main.png" width="75%" format="PNG"/>
+    <imagedata fileref="yast2_ncurses_main.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -99,10 +99,10 @@
    <title>Das Software-Installationsmodul</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_ncurses_inst.png" width="70%" format="PNG"/>
+     <imagedata fileref="yast2_ncurses_inst.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_ncurses_inst.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_ncurses_inst.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/de-de/xml/yast2_sw.xml
+++ b/l10n/sled/de-de/xml/yast2_sw.xml
@@ -152,10 +152,10 @@
      <phrase><guimenu>YaST</guimenu> software manager screen</phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_sw_manager.png" width="70%" format="PNG"/>
+     <imagedata fileref="yast2_sw_manager.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_sw_manager.png" width="65%" format="PNG"/>
+     <imagedata fileref="yast2_sw_manager.png" width="65%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -477,10 +477,10 @@
     <title>Konfliktverwaltung des Software-Managers</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_package_conflict.png" width="70%" format="PNG"/>
+      <imagedata fileref="yast2_package_conflict.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_package_conflict.png" width="65%" format="PNG"/>
+      <imagedata fileref="yast2_package_conflict.png" width="65%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/de-de/xml/yast2_sw_repo.xml
+++ b/l10n/sled/de-de/xml/yast2_sw_repo.xml
@@ -52,10 +52,10 @@
      <title>Hinzufügen eines Software-Repositorys</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_addon_new.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_addon_new.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_addon_new.png" width="65%" format="PNG"/>
+       <imagedata fileref="yast2_addon_new.png" width="65%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/de-de/xml/yast2_userman.xml
+++ b/l10n/sled/de-de/xml/yast2_userman.xml
@@ -22,11 +22,11 @@
    <title>YaST – Verwaltung von Benutzern und Gruppen</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_users_main_qt.png" width="90%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_users_main_qt.png" width="90%" os="sles;sled"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_users_main_qt.png" width="70%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_users_main_qt.png" width="70%" os="sles;sled"/>
      
     </imageobject>
    </mediaobject>
@@ -379,11 +379,11 @@
      <informalfigure os="sles;sled">
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_users_quota_qt.png" width="80%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_users_quota_qt.png" width="80%" os="sles;sled"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_users_quota_qt.png" width="70%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_users_quota_qt.png" width="70%" os="sles;sled"/>
         
        </imageobject>
       </mediaobject>
@@ -549,11 +549,11 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_groups_edit_qt.png" width="80%" format="PNG" os="sles;sled"/>
+       <imagedata fileref="yast2_groups_edit_qt.png" width="80%" os="sles;sled"/>
        
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_groups_edit_qt.png" width="75%" format="PNG" os="sles;sled"/>
+       <imagedata fileref="yast2_groups_edit_qt.png" width="75%" os="sles;sled"/>
        
       </imageobject>
      </mediaobject>

--- a/l10n/sled/de-de/xml/yast2_you.xml
+++ b/l10n/sled/de-de/xml/yast2_you.xml
@@ -73,11 +73,11 @@
    <title>YaST-Online-Aktualisierung</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_you.png" width="75%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_you.png" width="75%" os="sles;sled"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_you.png" width="75%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_you.png" width="75%" os="sles;sled"/>
      
     </imageobject>
    </mediaobject>
@@ -204,10 +204,10 @@
    <title>Anzeigen von zurückgezogenen Patches und ihres Verlaufs</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_retracted_patches.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_retracted_patches.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_retracted_patches.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_retracted_patches.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>  
@@ -245,10 +245,10 @@
    <title>Konfiguration der YaST-Online-Aktualisierung</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_autoupdate.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_autoupdate.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_autoupdate.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_autoupdate.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/ja-jp/xml/adm_support.xml
+++ b/l10n/sled/ja-jp/xml/adm_support.xml
@@ -135,10 +135,10 @@ CPU Load Average:         7 (3%) with 2 CPUs
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_support_main.png" width="70%" format="PNG"/>
+        <imagedata fileref="yast2_support_main.png" width="70%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_support_main.png" width="60%" format="PNG"/>
+        <imagedata fileref="yast2_support_main.png" width="60%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -176,10 +176,10 @@ CPU Load Average:         7 (3%) with 2 CPUs
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_support_conf.png" width="90%" format="PNG"/>
+        <imagedata fileref="yast2_support_conf.png" width="90%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_support_conf.png" width="80%" format="PNG"/>
+        <imagedata fileref="yast2_support_conf.png" width="80%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -740,10 +740,10 @@ Creating Tar Ball
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_support_conf_upload.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_support_conf_upload.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_support_conf_upload.png" width="60%" format="PNG"/>
+       <imagedata fileref="yast2_support_conf_upload.png" width="60%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sled/ja-jp/xml/apps_ekiga.xml
+++ b/l10n/sled/ja-jp/xml/apps_ekiga.xml
@@ -170,10 +170,10 @@
    <title><productname>Ekiga</productname> ユーザインターフェイス</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="ekiga_main.png" width="45%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="45%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ekiga_main.png" width="55%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="55%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/ja-jp/xml/apps_evolution.xml
+++ b/l10n/sled/ja-jp/xml/apps_evolution.xml
@@ -733,10 +733,10 @@
    <title><productname>Evolution</productname> ウィンドウ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" width="100%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" width="86%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="86%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/ja-jp/xml/apps_firefox.xml
+++ b/l10n/sled/ja-jp/xml/apps_firefox.xml
@@ -29,7 +29,7 @@
   <note>
    <title>メニューバーの使用</title>
    <para>
-    <productname>Firefox</productname>のほとんどの機能は3行ボタン(<inlinemediaobject><textobject role="description"><phrase>3行ボタン</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject>)から使用できますが、一部の機能はメニューバーからのみ使用できます。
+    <productname>Firefox</productname>のほとんどの機能は3行ボタン(<inlinemediaobject><textobject role="description"><phrase>3行ボタン</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em"/></imageobject></inlinemediaobject>)から使用できますが、一部の機能はメニューバーからのみ使用できます。
    </para>
    <para>
     <productname>Firefox</productname>のメニューバーは、デフォルトで非表示になっています。メニューバーを一時的に表示するには、<keycap function="alt"/>を押します。これにより、ブラウザウィンドウ内のどこかをクリックするまで、メニューバーが表示されます。

--- a/l10n/sled/ja-jp/xml/apps_gimp.xml
+++ b/l10n/sled/ja-jp/xml/apps_gimp.xml
@@ -125,10 +125,10 @@
     <title>ツールボックス</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="gimp-toolbox.png" width="35%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="35%"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="gimp-toolbox.png" width="30%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="30%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -547,10 +547,10 @@
        <title>［Basic Color Selector］ダイアログ</title>
        <mediaobject>
         <imageobject role="html">
-         <imagedata fileref="gimp-color.png" width="70%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="70%"/>
         </imageobject>
         <imageobject role="fo">
-         <imagedata fileref="gimp-color.png" width="80%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="80%"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -719,10 +719,10 @@
    <title>印刷ダイアログ</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="gimp-print.png" width="75%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="75%"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="gimp-print.png" width="70%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/ja-jp/xml/apps_libreoffice.xml
+++ b/l10n/sled/ja-jp/xml/apps_libreoffice.xml
@@ -528,7 +528,7 @@
    </step>
    <step>
     <para>
-     メニュー(<inlinemediaobject><textobject role="description"><phrase>3行ボタン</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject>)を開いて証明書の設定に移動し、<menuchoice><guimenu>設定</guimenu>
+     メニュー(<inlinemediaobject><textobject role="description"><phrase>3行ボタン</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em"/></imageobject></inlinemediaobject>)を開いて証明書の設定に移動し、<menuchoice><guimenu>設定</guimenu>
       <guimenu>プライバシーとセキュリティ</guimenu></menuchoice>の順に選択します。
     </para>
    </step>
@@ -573,10 +573,10 @@
    <title><guimenu>Writer</guimenu>のカスタマイズダイアログ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -728,10 +728,10 @@
    <title>オプションウィンドウ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_options.png" width="95%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_options.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/ja-jp/xml/apps_librevarious.xml
+++ b/l10n/sled/ja-jp/xml/apps_librevarious.xml
@@ -285,10 +285,10 @@
        <mediaobject>
         <textobject><phrase>Field selection</phrase></textobject>
         <imageobject role="fo">
-         <imagedata fileref="oo-wizard-base.png" width="90%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="90%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="oo-wizard-base.png" width="85%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="85%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>

--- a/l10n/sled/ja-jp/xml/apps_librewriter.xml
+++ b/l10n/sled/ja-jp/xml/apps_librewriter.xml
@@ -66,10 +66,10 @@
    <title>LibreOfficeウィザード</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo-wizard.png" width="100%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo-wizard.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -231,10 +231,10 @@
     <title>スタイルパネル</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo-stylist.png" width="40%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="40%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo-stylist.png" width="50%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -641,10 +641,10 @@
     <title><guimenu>Writer</guimenu>のナビゲータツール</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo_navigator.png" width="55%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo_navigator.png" width="45%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="45%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/ja-jp/xml/apps_totem.xml
+++ b/l10n/sled/ja-jp/xml/apps_totem.xml
@@ -59,10 +59,10 @@
    <title><guimenu>GNOME Videos</guimenu>のスタートアップウィンドウ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -132,11 +132,11 @@
     <guimenu>取り出し</guimenu> </menuchoice>をクリックします。
    </para>
    <para>
-    再生中の動画または楽曲を一時停止するには、<inlinemediaobject><textobject role="description"><phrase>GNOME Videos Pause (GNOMEビデオを一時停止)</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_pause_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="totem_pause_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject>ボタンをクリックするか、<menuchoice> <guimenu>Movie (動画)</guimenu>
+    再生中の動画または楽曲を一時停止するには、<inlinemediaobject><textobject role="description"><phrase>GNOME Videos Pause (GNOMEビデオを一時停止)</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_pause_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="totem_pause_button-fallback.png" width="1em"/></imageobject></inlinemediaobject>ボタンをクリックするか、<menuchoice> <guimenu>Movie (動画)</guimenu>
     <guimenu>Play/Pause (再生/一時停止)</guimenu> </menuchoice>の順にクリックします。動画または楽曲を一時停止すると、ステータスバーで<guimenu>一時停止中</guimenu>と表示され、現在の動画または楽曲の経過時間が示されます。
    </para>
    <para>
-    動画または楽曲の再生を再開するには、<inlinemediaobject><textobject role="description"><phrase>GNOME Videos Play (GNOMEビデオを再生)</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_play_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="totem_play_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject>ボタンをクリックするか、<menuchoice> <guimenu>Movie (動画)</guimenu>
+    動画または楽曲の再生を再開するには、<inlinemediaobject><textobject role="description"><phrase>GNOME Videos Play (GNOMEビデオを再生)</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_play_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="totem_play_button-fallback.png" width="1em"/></imageobject></inlinemediaobject>ボタンをクリックするか、<menuchoice> <guimenu>Movie (動画)</guimenu>
     <guimenu>Play/Pause (再生/一時停止)</guimenu></menuchoice>の順にクリックします。
    </para>
    <para>
@@ -223,10 +223,10 @@
     <title><guimenu>GNOME Videos</guimenu>の一般的な初期設定</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -268,10 +268,10 @@
     <title><guimenu>GNOME Videos</guimenu>の表示の初期設定</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -307,10 +307,10 @@
     <title><guimenu>GNOME Videos</guimenu>のオーディオ初期設定</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/ja-jp/xml/backup.xml
+++ b/l10n/sled/ja-jp/xml/backup.xml
@@ -20,10 +20,10 @@
  <mediaobject>
   <textobject><phrase>Backup application</phrase></textobject>
   <imageobject role="fo">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
   <imageobject role="html">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
  </mediaobject>
 </informalfigure>

--- a/l10n/sled/ja-jp/xml/chrony.xml
+++ b/l10n/sled/ja-jp/xml/chrony.xml
@@ -44,10 +44,10 @@
    <title>［NTP設定］ウィンドウ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="ntp_client.png" width="70%" format="PNG"/>
+     <imagedata fileref="ntp_client.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ntp_client.png" width="70%" format="PNG"/>
+     <imagedata fileref="ntp_client.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -107,10 +107,10 @@
     <title>タイムサーバの追加</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="ntp_client_serveradd.png" width="70%" format="PNG"/>
+      <imagedata fileref="ntp_client_serveradd.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="ntp_client_serveradd.png" width="70%" format="PNG"/>
+      <imagedata fileref="ntp_client_serveradd.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/ja-jp/xml/gnome_accessibility.xml
+++ b/l10n/sled/ja-jp/xml/gnome_accessibility.xml
@@ -90,10 +90,10 @@
      <mediaobject>
       <textobject><phrase>On-screen keyboard</phrase></textobject>
       <imageobject role="fo">
-       <imagedata fileref="gnome_onscreen_kbd.png" width="95%" format="PNG"/>
+       <imagedata fileref="gnome_onscreen_kbd.png" width="95%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="gnome_onscreen_kbd.png" width="90%" format="PNG"/>
+       <imagedata fileref="gnome_onscreen_kbd.png" width="90%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sled/ja-jp/xml/gnome_crypto.xml
+++ b/l10n/sled/ja-jp/xml/gnome_crypto.xml
@@ -22,10 +22,10 @@
   <title><guimenu>パスワードと鍵</guimenu>のメインウィンドウ</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sled/ja-jp/xml/gnome_custom.xml
+++ b/l10n/sled/ja-jp/xml/gnome_custom.xml
@@ -61,10 +61,10 @@
      <title>GNOME背景の設定</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="preferences_background.png" width="45%" format="PNG"/>
+        <imagedata fileref="preferences_background.png" width="45%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="preferences_background.png" width="45%" format="PNG"/>
+        <imagedata fileref="preferences_background.png" width="45%"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -148,10 +148,10 @@
    <title>キーボードショートカットダイアログ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_keyboard.png" width="100%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_keyboard.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -178,10 +178,10 @@
    <title>Tweaksでの&lt;Compose&gt;キーの有効化</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -307,10 +307,10 @@
    <title><guimenu>マウスとタッチパッド</guimenu>の設定ダイアログ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -362,10 +362,10 @@
     <title>単一のモニタ設定のダイアログ</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="preferences_screen_single.png" width="100%" format="PNG"/>
+      <imagedata fileref="preferences_screen_single.png" width="100%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="preferences_screen_single.png" width="80%" format="PNG"/>
+      <imagedata fileref="preferences_screen_single.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -486,10 +486,10 @@
    <title>サウンドの設定</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="sound_devices.png" width="100%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="sound_devices.png" width="80%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -515,10 +515,10 @@
      <title>デフォルトのアプリケーション</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="preferences_preferred_apps.png" width="100%" format="PNG"/>
+       <imagedata fileref="preferences_preferred_apps.png" width="100%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="preferences_preferred_apps.png" width="80%" format="PNG"/>
+       <imagedata fileref="preferences_preferred_apps.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/ja-jp/xml/gnome_networking.xml
+++ b/l10n/sled/ja-jp/xml/gnome_networking.xml
@@ -104,10 +104,10 @@
    <title>ネットワークファイルブラウザ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="network_browser.png" width="100%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="100%"/>
      </imageobject>
     <imageobject role="html">
-     <imagedata fileref="network_browser.png" width="90%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -256,10 +256,10 @@
       <mediaobject>
        <textobject><phrase>Sharing options</phrase></textobject>
        <imageobject role="fo">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/l10n/sled/ja-jp/xml/gnome_start.xml
+++ b/l10n/sled/ja-jp/xml/gnome_start.xml
@@ -37,11 +37,11 @@
    <title>デフォルトのGNOMEログイン画面</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata os="sles;sled" fileref="login_sled.png" width="90%" format="PNG"/>
+     <imagedata os="sles;sled" fileref="login_sled.png" width="90%"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata os="sles;sled" fileref="login_sled.png" width="75%" format="PNG"/>
+     <imagedata os="sles;sled" fileref="login_sled.png" width="75%"/>
      
     </imageobject>
    </mediaobject>
@@ -83,11 +83,11 @@
       <title>デフォルトのGNOMEログイン画面 - セッションタイプ</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="90%" format="PNG"/>
+        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="90%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="75%" format="PNG"/>
+        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="75%"/>
         
        </imageobject>
       </mediaobject>
@@ -211,10 +211,10 @@
    <title>GNOMEデスクトップとActivities Overview (アクティビティ画面)</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="desktop_sled_menu.png" width="95%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="desktop_sled_menu.png" width="90%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -259,10 +259,10 @@
      <title><guimenu>アクティビティ</guimenu>画面</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="desktop_activities_overview.png" width="95%" format="PNG"/>
+      <imagedata fileref="desktop_activities_overview.png" width="95%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="desktop_activities_overview.png" width="90%" format="PNG"/>
+      <imagedata fileref="desktop_activities_overview.png" width="90%"/>
      </imageobject>
     </mediaobject>
      </figure>
@@ -299,10 +299,10 @@
      <title><productname>Firefox</productname>の<guimenu>アプリケーション</guimenu>メニュー</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="desktop_app_menu_firefox.png" width="70%" format="PNG"/>
+       <imagedata fileref="desktop_app_menu_firefox.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="desktop_app_menu_firefox.png" width="70%" format="PNG"/>
+       <imagedata fileref="desktop_app_menu_firefox.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/ja-jp/xml/gnome_use.xml
+++ b/l10n/sled/ja-jp/xml/gnome_use.xml
@@ -26,10 +26,10 @@
    <title>ファイルマネージャ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -573,10 +573,10 @@
     <textobject><phrase><productname>Evolution</productname></phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" format="PNG" width="100%"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" format="PNG" width="80%"/>
+     <imagedata fileref="evolution.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -673,10 +673,10 @@
    <title><productname>Archive manager</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -971,10 +971,10 @@
    <title><productname>Document viewer</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evince.png" format="PNG" width="90%"/>
+     <imagedata fileref="evince.png" width="90%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evince.png" format="PNG" width="78%"/>
+     <imagedata fileref="evince.png" width="78%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/ja-jp/xml/grub2.xml
+++ b/l10n/sled/ja-jp/xml/grub2.xml
@@ -438,10 +438,10 @@
       <title>GRUB 2ブートエディタ</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="grub2_edit_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="grub2_edit_config.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="grub2_edit_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="grub2_edit_config.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </figure>

--- a/l10n/sled/ja-jp/xml/grub2_yast_i.xml
+++ b/l10n/sled/ja-jp/xml/grub2_yast_i.xml
@@ -93,10 +93,10 @@
     <title>ブートコードオプション</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%"/>
      </imageobject>
     </mediaobject>
   </figure>
@@ -215,10 +215,10 @@
     <title>ブートローダオプション</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_options.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_options.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_options.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_options.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -277,10 +277,10 @@
     <title>カーネルパラメータ</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/ja-jp/xml/help_user.xml
+++ b/l10n/sled/ja-jp/xml/help_user.xml
@@ -61,10 +61,10 @@
    <title>ヘルプのメインウィンドウ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/ja-jp/xml/journalctl.xml
+++ b/l10n/sled/ja-jp/xml/journalctl.xml
@@ -336,10 +336,10 @@ enabled</screen>
    <title>YaST systemdジャーナル</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_journal.png" width="80%" format="PNG"/>
+     <imagedata fileref="yast2_journal.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_journal.png" width="85%" format="PNG"/>
+     <imagedata fileref="yast2_journal.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/ja-jp/xml/klp.xml
+++ b/l10n/sled/ja-jp/xml/klp.xml
@@ -64,10 +64,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="klp.png" width="80%" format="PNG"/>
+     <imagedata fileref="klp.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="klp.png" width="100%" format="PNG"/>
+     <imagedata fileref="klp.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>

--- a/l10n/sled/ja-jp/xml/net_basic.xml
+++ b/l10n/sled/ja-jp/xml/net_basic.xml
@@ -60,10 +60,10 @@
   <title>TCP/IPの簡易階層モデル</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata width="100%" fileref="net_basic_osi.svg" format="SVG"/>
+    <imagedata width="100%" fileref="net_basic_osi.svg"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata width="75%" fileref="net_basic_osi.png" format="PNG"/>
+    <imagedata width="75%" fileref="net_basic_osi.png"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -80,10 +80,10 @@
   <title>TCP/IPイーサネットパケット</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata width="80%" fileref="net_basic_tcppacket.svg" format="SVG"/>
+    <imagedata width="80%" fileref="net_basic_tcppacket.svg"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata width="75%" fileref="net_basic_tcppacket.png" format="PNG"/>
+    <imagedata width="75%" fileref="net_basic_tcppacket.png"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sled/ja-jp/xml/net_bonding.xml
+++ b/l10n/sled/ja-jp/xml/net_bonding.xml
@@ -114,10 +114,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="bond_configuration.png" width="70%" format="PNG"/>
+      <imagedata fileref="bond_configuration.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="bond_configuration.png" width="65%" format="PNG"/>
+      <imagedata fileref="bond_configuration.png" width="65%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sled/ja-jp/xml/net_wicked.xml
+++ b/l10n/sled/ja-jp/xml/net_wicked.xml
@@ -79,10 +79,10 @@
     <title><literal>wicked</literal>アーキテクチャ</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="wicked_scheme.png" format="PNG"/>
+      <imagedata fileref="wicked_scheme.png"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="wicked_scheme.png" format="PNG" width="80%"/>
+      <imagedata fileref="wicked_scheme.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/ja-jp/xml/net_yast.xml
+++ b/l10n/sled/ja-jp/xml/net_yast.xml
@@ -43,10 +43,10 @@
    <title>ネットワーク設定の実行</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_net_icard.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_net_icard.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_net_icard.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_net_icard.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/ja-jp/xml/network_scheme.xml
+++ b/l10n/sled/ja-jp/xml/network_scheme.xml
@@ -4,10 +4,10 @@
  <info>
   <mediaobject>
    <imageobject role="html">
-    <imagedata fileref="network_schema.png" width="100%" format="PNG"/>
+    <imagedata fileref="network_schema.png" width="100%"/>
    </imageobject>
    <imageobject role="pdf">
-    <imagedata fileref="network_schema.svg" width="100%" format="SVG"/>
+    <imagedata fileref="network_schema.svg" width="100%"/>
    </imageobject>
   </mediaobject>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -21,10 +21,10 @@
  <informalfigure>
   <mediaobject>
    <imageobject role="html">
-    <imagedata fileref="network_schema.png" width="100%" format="PNG"/>
+    <imagedata fileref="network_schema.png" width="100%"/>
    </imageobject>
    <imageobject role="pdf">
-    <imagedata fileref="network_schema.svg" width="100%" format="SVG"/>
+    <imagedata fileref="network_schema.svg" width="100%"/>
    </imageobject>
   </mediaobject>
  </informalfigure>

--- a/l10n/sled/ja-jp/xml/snapper.xml
+++ b/l10n/sled/ja-jp/xml/snapper.xml
@@ -417,10 +417,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_list.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_list.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_list.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_list.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -432,10 +432,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_changes.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_changes.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_changes.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_changes.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -447,10 +447,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_diff.png" width="65%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_diff.png" width="65%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_diff.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_diff.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -462,10 +462,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_restore.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_restore.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_restore.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_restore.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -827,10 +827,10 @@ single | 4 |     |         |                       |
     <title>ブートローダ: スナップショット</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="boot_snapshots.png" width="75%" format="PNG"/>
+      <imagedata fileref="boot_snapshots.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="boot_snapshots.png" width="75%" format="PNG"/>
+      <imagedata fileref="boot_snapshots.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/ja-jp/xml/systemd.xml
+++ b/l10n/sled/ja-jp/xml/systemd.xml
@@ -1048,10 +1048,10 @@ Startup finished in 2666ms (kernel) + 21961ms (userspace) = 24628ms</screen>
        <informalfigure>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="systemd_startup.svg" width="75%" format="SVG"/>
+          <imagedata fileref="systemd_startup.svg" width="75%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="systemd_startup.png" width="75%" format="PNG"/>
+          <imagedata fileref="systemd_startup.png" width="75%"/>
          </imageobject>
         </mediaobject>
        </informalfigure>
@@ -1134,10 +1134,10 @@ WantedBy=multi-user.target<co xml:id="co-service-wrapper-target"/></screen>
    <title>サービスマネージャ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_runlevel.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_runlevel.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_runlevel.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_runlevel.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/ja-jp/xml/tuning_multikernel.xml
+++ b/l10n/sled/ja-jp/xml/tuning_multikernel.xml
@@ -236,10 +236,10 @@
      <title>YaSTソフトウェアマネージャ: マルチバージョン表示</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_sw_multiversion.png" width="90%" format="PNG"/>
+       <imagedata fileref="yast2_sw_multiversion.png" width="90%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_sw_multiversion.png" width="90%" format="PNG"/>
+       <imagedata fileref="yast2_sw_multiversion.png" width="90%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/ja-jp/xml/uefi.xml
+++ b/l10n/sled/ja-jp/xml/uefi.xml
@@ -83,10 +83,10 @@
      <title>セキュアブートサポート</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/ja-jp/xml/updater_gnome.xml
+++ b/l10n/sled/ja-jp/xml/updater_gnome.xml
@@ -25,11 +25,11 @@
   <mediaobject>
    <imageobject role="fo">
     
-    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%" format="PNG"/>
+    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
     
-    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%" format="PNG"/>
+    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -47,10 +47,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="gupdater_updates.png" width="75%" format="PNG"/>
+      <imagedata fileref="gupdater_updates.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="gupdater_updates.png" width="75%" format="PNG"/>
+      <imagedata fileref="gupdater_updates.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sled/ja-jp/xml/updater_gnome_sw.xml
+++ b/l10n/sled/ja-jp/xml/updater_gnome_sw.xml
@@ -42,10 +42,10 @@
   <title><guimenu>GNOMEソフトウェア</guimenu>—<guimenu>更新</guimenu>ビュー</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="gnome-software-updates.png" width="75%" format="PNG"/>
+    <imagedata fileref="gnome-software-updates.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="gnome-software-updates.png" width="75%" format="PNG"/>
+    <imagedata fileref="gnome-software-updates.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sled/ja-jp/xml/vnc.xml
+++ b/l10n/sled/ja-jp/xml/vnc.xml
@@ -56,10 +56,10 @@
      <textobject role="description"><phrase>vncviewer asking for connection details</phrase>
      </textobject>
      <imageobject role="html">
-      <imagedata fileref="vnc_connect.png" format="PNG"/>
+      <imagedata fileref="vnc_connect.png"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="vnc_connect.png" format="PNG"/>
+      <imagedata fileref="vnc_connect.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -99,10 +99,10 @@
     <title>Remminaのメインウィンドウ</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -114,16 +114,16 @@
   <sect2 xml:id="vnc-remmina-addnew">
    <title>リモートセッションの追加</title>
    <para>
-    新しいリモートセッションを追加して保存するには、メインウィンドウの左上で、<inlinemediaobject><textobject role="description"><phrase>新しいセッションの追加</phrase></textobject><imageobject role="fo"><imagedata fileref="remmina_plus.png" width="1.2em" format="PNG"/></imageobject><imageobject role="html"><imagedata fileref="remmina_plus.png" width="1.2em" format="PNG"/></imageobject></inlinemediaobject>をクリックします。<guimenu>リモートデスクトップ初期設定</guimenu>ウィンドウが開きます。
+    新しいリモートセッションを追加して保存するには、メインウィンドウの左上で、<inlinemediaobject><textobject role="description"><phrase>新しいセッションの追加</phrase></textobject><imageobject role="fo"><imagedata fileref="remmina_plus.png" width="1.2em"/></imageobject><imageobject role="html"><imagedata fileref="remmina_plus.png" width="1.2em"/></imageobject></inlinemediaobject>をクリックします。<guimenu>リモートデスクトップ初期設定</guimenu>ウィンドウが開きます。
    </para>
    <figure>
     <title>リモートデスクトップ初期設定</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina_session_details.png" width="80%" format="PNG"/>
+      <imagedata fileref="remmina_session_details.png" width="80%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina_session_details.png" width="80%" format="PNG"/>
+      <imagedata fileref="remmina_session_details.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -203,10 +203,10 @@
      <title>クイックスタート</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="remmina_quickstart.png" width="40%" format="PNG"/>
+       <imagedata fileref="remmina_quickstart.png" width="40%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="remmina_quickstart.png" width="40%" format="PNG"/>
+       <imagedata fileref="remmina_quickstart.png" width="40%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -229,10 +229,10 @@
      <title>Remminaのリモートセッションの表示</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>
+       <imagedata fileref="remmina_sle15inside.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>
+       <imagedata fileref="remmina_sle15inside.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -267,10 +267,10 @@
     <title>プロファイルファイルへのパスの読み込み</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina_status.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina_status.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina_status.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina_status.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -332,10 +332,10 @@
    <title>リモート管理</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="vnc_nosession.png" width="70%" format="PNG"/>
+     <imagedata fileref="vnc_nosession.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="vnc_nosession.png" width="70%" format="PNG"/>
+     <imagedata fileref="vnc_nosession.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -561,10 +561,10 @@ WINDOWMANAGER=icewm vncserver -geometry 1024x768</screen>
      <title>VNCセッション設定</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="vncmanager_session.png" width="85%" format="PNG"/>
+       <imagedata fileref="vncmanager_session.png" width="85%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="vncmanager_session.png" width="85%" format="PNG"/>
+       <imagedata fileref="vncmanager_session.png" width="85%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -649,10 +649,10 @@ WINDOWMANAGER=icewm vncserver -geometry 1024x768</screen>
      <title>永続的VNCセッションへの参加</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="vncmanager_whether.png" width="80%" format="PNG"/>
+       <imagedata fileref="vncmanager_whether.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="vncmanager_whether.png" width="80%" format="PNG"/>
+       <imagedata fileref="vncmanager_whether.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/ja-jp/xml/yast2_lang.xml
+++ b/l10n/sled/ja-jp/xml/yast2_lang.xml
@@ -91,10 +91,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_language.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_language.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_language.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_language.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>
@@ -225,10 +225,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_timezone.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_timezone.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_timezone.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_timezone.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -306,10 +306,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_timezone_ntp.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_timezone_ntp.png" width="75%"/>
       </imageobject>
       <imageobject role="pdf">
-       <imagedata fileref="yast2_timezone_ntp.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_timezone_ntp.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sled/ja-jp/xml/yast2_ncurses.xml
+++ b/l10n/sled/ja-jp/xml/yast2_ncurses.xml
@@ -15,10 +15,10 @@
   <title>テキストモードのYaSTのメインウィンドウ</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="yast2_ncurses_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="yast2_ncurses_main.png" width="70%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="yast2_ncurses_main.png" width="75%" format="PNG"/>
+    <imagedata fileref="yast2_ncurses_main.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -99,10 +99,10 @@
    <title>ソフトウェアインストールモジュール</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_ncurses_inst.png" width="70%" format="PNG"/>
+     <imagedata fileref="yast2_ncurses_inst.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_ncurses_inst.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_ncurses_inst.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/ja-jp/xml/yast2_sw.xml
+++ b/l10n/sled/ja-jp/xml/yast2_sw.xml
@@ -152,10 +152,10 @@
      <phrase><guimenu>YaST</guimenu> software manager screen</phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_sw_manager.png" width="70%" format="PNG"/>
+     <imagedata fileref="yast2_sw_manager.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_sw_manager.png" width="65%" format="PNG"/>
+     <imagedata fileref="yast2_sw_manager.png" width="65%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -477,10 +477,10 @@
     <title>ソフトウェアマネージャの競合管理</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_package_conflict.png" width="70%" format="PNG"/>
+      <imagedata fileref="yast2_package_conflict.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_package_conflict.png" width="65%" format="PNG"/>
+      <imagedata fileref="yast2_package_conflict.png" width="65%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/ja-jp/xml/yast2_sw_repo.xml
+++ b/l10n/sled/ja-jp/xml/yast2_sw_repo.xml
@@ -52,10 +52,10 @@
      <title>ソフトウェアリポジトリの追加</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_addon_new.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_addon_new.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_addon_new.png" width="65%" format="PNG"/>
+       <imagedata fileref="yast2_addon_new.png" width="65%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/ja-jp/xml/yast2_userman.xml
+++ b/l10n/sled/ja-jp/xml/yast2_userman.xml
@@ -22,11 +22,11 @@
    <title>YaSTのユーザとグループの管理</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_users_main_qt.png" width="90%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_users_main_qt.png" width="90%" os="sles;sled"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_users_main_qt.png" width="70%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_users_main_qt.png" width="70%" os="sles;sled"/>
      
     </imageobject>
    </mediaobject>
@@ -379,11 +379,11 @@
      <informalfigure os="sles;sled">
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_users_quota_qt.png" width="80%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_users_quota_qt.png" width="80%" os="sles;sled"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_users_quota_qt.png" width="70%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_users_quota_qt.png" width="70%" os="sles;sled"/>
         
        </imageobject>
       </mediaobject>
@@ -549,11 +549,11 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_groups_edit_qt.png" width="80%" format="PNG" os="sles;sled"/>
+       <imagedata fileref="yast2_groups_edit_qt.png" width="80%" os="sles;sled"/>
        
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_groups_edit_qt.png" width="75%" format="PNG" os="sles;sled"/>
+       <imagedata fileref="yast2_groups_edit_qt.png" width="75%" os="sles;sled"/>
        
       </imageobject>
      </mediaobject>

--- a/l10n/sled/ja-jp/xml/yast2_you.xml
+++ b/l10n/sled/ja-jp/xml/yast2_you.xml
@@ -73,11 +73,11 @@
    <title>YaSTオンラインアップデート</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_you.png" width="75%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_you.png" width="75%" os="sles;sled"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_you.png" width="75%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_you.png" width="75%" os="sles;sled"/>
      
     </imageobject>
    </mediaobject>
@@ -204,10 +204,10 @@
    <title>撤回されたパッチと履歴の表示</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_retracted_patches.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_retracted_patches.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_retracted_patches.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_retracted_patches.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>  
@@ -245,10 +245,10 @@
    <title>YaSTオンライン更新設定</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_autoupdate.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_autoupdate.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_autoupdate.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_autoupdate.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/pt-br/xml/adm_support.xml
+++ b/l10n/sled/pt-br/xml/adm_support.xml
@@ -135,10 +135,10 @@ CPU Load Average:         7 (3%) with 2 CPUs
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_support_main.png" width="70%" format="PNG"/>
+        <imagedata fileref="yast2_support_main.png" width="70%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_support_main.png" width="60%" format="PNG"/>
+        <imagedata fileref="yast2_support_main.png" width="60%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -176,10 +176,10 @@ CPU Load Average:         7 (3%) with 2 CPUs
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_support_conf.png" width="90%" format="PNG"/>
+        <imagedata fileref="yast2_support_conf.png" width="90%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_support_conf.png" width="80%" format="PNG"/>
+        <imagedata fileref="yast2_support_conf.png" width="80%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -740,10 +740,10 @@ Creating Tar Ball
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_support_conf_upload.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_support_conf_upload.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_support_conf_upload.png" width="60%" format="PNG"/>
+       <imagedata fileref="yast2_support_conf_upload.png" width="60%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sled/pt-br/xml/apps_ekiga.xml
+++ b/l10n/sled/pt-br/xml/apps_ekiga.xml
@@ -170,10 +170,10 @@
    <title>Interface do usuário do <productname>Ekiga</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="ekiga_main.png" width="45%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="45%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ekiga_main.png" width="55%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="55%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/pt-br/xml/apps_evolution.xml
+++ b/l10n/sled/pt-br/xml/apps_evolution.xml
@@ -733,10 +733,10 @@
    <title><productname>Evolution</productname> janela</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" width="100%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" width="86%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="86%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/pt-br/xml/apps_firefox.xml
+++ b/l10n/sled/pt-br/xml/apps_firefox.xml
@@ -29,7 +29,7 @@
   <note>
    <title>Usando a barra de menus</title>
    <para>
-    Embora a maioria das funções do <productname>Firefox</productname> esteja disponível por meio do botão de três linhas (<inlinemediaobject><textobject role="description"><phrase>Botão de três linhas</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject>), algumas estão disponíveis apenas na barra de menus.
+    Embora a maioria das funções do <productname>Firefox</productname> esteja disponível por meio do botão de três linhas (<inlinemediaobject><textobject role="description"><phrase>Botão de três linhas</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em"/></imageobject></inlinemediaobject>), algumas estão disponíveis apenas na barra de menus.
    </para>
    <para>
     Por padrão, a barra de menus do <productname>Firefox</productname> fica oculta. Para mostrá-la temporariamente, pressione <keycap function="alt"/>. Ela permanecerá exibida até você clicar em algum outro lugar na janela do browser.

--- a/l10n/sled/pt-br/xml/apps_gimp.xml
+++ b/l10n/sled/pt-br/xml/apps_gimp.xml
@@ -125,10 +125,10 @@
     <title>Caixa de ferramentas</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="gimp-toolbox.png" width="35%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="35%"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="gimp-toolbox.png" width="30%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="30%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -547,10 +547,10 @@
        <title>Caixa de diálogo do seletor de cores básicas</title>
        <mediaobject>
         <imageobject role="html">
-         <imagedata fileref="gimp-color.png" width="70%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="70%"/>
         </imageobject>
         <imageobject role="fo">
-         <imagedata fileref="gimp-color.png" width="80%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="80%"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -719,10 +719,10 @@
    <title>Caixa de diálogo de impressão</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="gimp-print.png" width="75%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="75%"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="gimp-print.png" width="70%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/pt-br/xml/apps_libreoffice.xml
+++ b/l10n/sled/pt-br/xml/apps_libreoffice.xml
@@ -528,7 +528,7 @@
    </step>
    <step>
     <para>
-     Vá para as preferências de certificados abrindo o menu (<inlinemediaobject><textobject role="description"><phrase>Botão de três linhas</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject>) e selecione <menuchoice><guimenu>Configurações</guimenu>
+     Vá para as preferências de certificados abrindo o menu (<inlinemediaobject><textobject role="description"><phrase>Botão de três linhas</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em"/></imageobject></inlinemediaobject>) e selecione <menuchoice><guimenu>Configurações</guimenu>
       <guimenu>Privacidade e segurança</guimenu></menuchoice>.
     </para>
    </step>
@@ -573,10 +573,10 @@
    <title>Caixa de diálogo de personalização no <guimenu>Writer</guimenu></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -728,10 +728,10 @@
    <title>Janela de opções</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_options.png" width="95%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_options.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/pt-br/xml/apps_librevarious.xml
+++ b/l10n/sled/pt-br/xml/apps_librevarious.xml
@@ -285,10 +285,10 @@
        <mediaobject>
         <textobject><phrase>Field selection</phrase></textobject>
         <imageobject role="fo">
-         <imagedata fileref="oo-wizard-base.png" width="90%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="90%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="oo-wizard-base.png" width="85%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="85%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>

--- a/l10n/sled/pt-br/xml/apps_librewriter.xml
+++ b/l10n/sled/pt-br/xml/apps_librewriter.xml
@@ -66,10 +66,10 @@
    <title>Um assistente do LibreOffice</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo-wizard.png" width="100%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo-wizard.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -231,10 +231,10 @@
     <title>Painel Estilos</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo-stylist.png" width="40%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="40%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo-stylist.png" width="50%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -641,10 +641,10 @@
     <title>Ferramenta Navegador no <guimenu>Writer</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo_navigator.png" width="55%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo_navigator.png" width="45%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="45%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/pt-br/xml/apps_totem.xml
+++ b/l10n/sled/pt-br/xml/apps_totem.xml
@@ -59,10 +59,10 @@
    <title>Janela de inicialização do <guimenu>GNOME Videos</guimenu></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -132,11 +132,11 @@
     <guimenu>Ejetar</guimenu> </menuchoice>.
    </para>
    <para>
-    Para pausar um filme ou uma música em reprodução, clique no botão <inlinemediaobject><textobject role="description"><phrase>Pausar do GNOME Videos</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_pause_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="totem_pause_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject> ou clique em <menuchoice> <guimenu>Filme</guimenu>
+    Para pausar um filme ou uma música em reprodução, clique no botão <inlinemediaobject><textobject role="description"><phrase>Pausar do GNOME Videos</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_pause_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="totem_pause_button-fallback.png" width="1em"/></imageobject></inlinemediaobject> ou clique em <menuchoice> <guimenu>Filme</guimenu>
     <guimenu>Reproduzir/Pausar</guimenu> </menuchoice>. Ao pausar um filme ou uma música, aparece <guimenu>Pausado</guimenu> na barra de status e o tempo decorrido do filme ou da música atual.
    </para>
    <para>
-    Para continuar a reprodução de um filme ou uma música, clique no botão <inlinemediaobject><textobject role="description"><phrase>Reproduzir do GNOME Videos</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_play_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="totem_play_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject> ou clique em <menuchoice> <guimenu>Filme</guimenu>
+    Para continuar a reprodução de um filme ou uma música, clique no botão <inlinemediaobject><textobject role="description"><phrase>Reproduzir do GNOME Videos</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_play_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="totem_play_button-fallback.png" width="1em"/></imageobject></inlinemediaobject> ou clique em <menuchoice> <guimenu>Filme</guimenu>
     <guimenu>Reproduzir/Pausar</guimenu></menuchoice>.
    </para>
    <para>
@@ -223,10 +223,10 @@
     <title>Preferências gerais do <guimenu>GNOME Videos</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -268,10 +268,10 @@
     <title>Preferências de vídeo do <guimenu>GNOME Videos</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -307,10 +307,10 @@
     <title>Preferências de áudio do <guimenu>GNOME Videos</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/pt-br/xml/backup.xml
+++ b/l10n/sled/pt-br/xml/backup.xml
@@ -20,10 +20,10 @@
  <mediaobject>
   <textobject><phrase>Backup application</phrase></textobject>
   <imageobject role="fo">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
   <imageobject role="html">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
  </mediaobject>
 </informalfigure>

--- a/l10n/sled/pt-br/xml/chrony.xml
+++ b/l10n/sled/pt-br/xml/chrony.xml
@@ -44,10 +44,10 @@
    <title>Janela de configuração do NTP</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="ntp_client.png" width="70%" format="PNG"/>
+     <imagedata fileref="ntp_client.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ntp_client.png" width="70%" format="PNG"/>
+     <imagedata fileref="ntp_client.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -107,10 +107,10 @@
     <title>Adicionando um servidor de horário</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="ntp_client_serveradd.png" width="70%" format="PNG"/>
+      <imagedata fileref="ntp_client_serveradd.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="ntp_client_serveradd.png" width="70%" format="PNG"/>
+      <imagedata fileref="ntp_client_serveradd.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/pt-br/xml/gnome_accessibility.xml
+++ b/l10n/sled/pt-br/xml/gnome_accessibility.xml
@@ -90,10 +90,10 @@
      <mediaobject>
       <textobject><phrase>On-screen keyboard</phrase></textobject>
       <imageobject role="fo">
-       <imagedata fileref="gnome_onscreen_kbd.png" width="95%" format="PNG"/>
+       <imagedata fileref="gnome_onscreen_kbd.png" width="95%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="gnome_onscreen_kbd.png" width="90%" format="PNG"/>
+       <imagedata fileref="gnome_onscreen_kbd.png" width="90%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sled/pt-br/xml/gnome_crypto.xml
+++ b/l10n/sled/pt-br/xml/gnome_crypto.xml
@@ -22,10 +22,10 @@
   <title>Janela principal <guimenu>Senhas e chaves</guimenu></title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sled/pt-br/xml/gnome_custom.xml
+++ b/l10n/sled/pt-br/xml/gnome_custom.xml
@@ -61,10 +61,10 @@
      <title>Configurações de segundo plano do GNOME</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="preferences_background.png" width="45%" format="PNG"/>
+        <imagedata fileref="preferences_background.png" width="45%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="preferences_background.png" width="45%" format="PNG"/>
+        <imagedata fileref="preferences_background.png" width="45%"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -148,10 +148,10 @@
    <title>Caixa de diálogo de atalhos de teclado</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_keyboard.png" width="100%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_keyboard.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -178,10 +178,10 @@
    <title>Habilitando a tecla de composição em ajustes</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -307,10 +307,10 @@
    <title>Caixa de diálogo de configurações <guimenu>Mouse e Touchpad</guimenu></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -362,10 +362,10 @@
     <title>Caixa de diálogo de configurações de um monitor</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="preferences_screen_single.png" width="100%" format="PNG"/>
+      <imagedata fileref="preferences_screen_single.png" width="100%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="preferences_screen_single.png" width="80%" format="PNG"/>
+      <imagedata fileref="preferences_screen_single.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -486,10 +486,10 @@
    <title>Definindo configurações de som</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="sound_devices.png" width="100%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="sound_devices.png" width="80%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -515,10 +515,10 @@
      <title>Aplicativos padrão</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="preferences_preferred_apps.png" width="100%" format="PNG"/>
+       <imagedata fileref="preferences_preferred_apps.png" width="100%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="preferences_preferred_apps.png" width="80%" format="PNG"/>
+       <imagedata fileref="preferences_preferred_apps.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/pt-br/xml/gnome_networking.xml
+++ b/l10n/sled/pt-br/xml/gnome_networking.xml
@@ -104,10 +104,10 @@
    <title>Browser de arquivos de rede</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="network_browser.png" width="100%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="100%"/>
      </imageobject>
     <imageobject role="html">
-     <imagedata fileref="network_browser.png" width="90%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -256,10 +256,10 @@
       <mediaobject>
        <textobject><phrase>Sharing options</phrase></textobject>
        <imageobject role="fo">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/l10n/sled/pt-br/xml/gnome_start.xml
+++ b/l10n/sled/pt-br/xml/gnome_start.xml
@@ -37,11 +37,11 @@
    <title>Tela de login padrão do GNOME</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata os="sles;sled" fileref="login_sled.png" width="90%" format="PNG"/>
+     <imagedata os="sles;sled" fileref="login_sled.png" width="90%"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata os="sles;sled" fileref="login_sled.png" width="75%" format="PNG"/>
+     <imagedata os="sles;sled" fileref="login_sled.png" width="75%"/>
      
     </imageobject>
    </mediaobject>
@@ -83,11 +83,11 @@
       <title>Tela de login padrão do GNOME — tipo de sessão</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="90%" format="PNG"/>
+        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="90%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="75%" format="PNG"/>
+        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="75%"/>
         
        </imageobject>
       </mediaobject>
@@ -211,10 +211,10 @@
    <title>Visão geral da área de trabalho do GNOME com atividades</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="desktop_sled_menu.png" width="95%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="desktop_sled_menu.png" width="90%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -259,10 +259,10 @@
      <title>Visão geral <guimenu>Atividades</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="desktop_activities_overview.png" width="95%" format="PNG"/>
+      <imagedata fileref="desktop_activities_overview.png" width="95%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="desktop_activities_overview.png" width="90%" format="PNG"/>
+      <imagedata fileref="desktop_activities_overview.png" width="90%"/>
      </imageobject>
     </mediaobject>
      </figure>
@@ -299,10 +299,10 @@
      <title>Menu <guimenu>Aplicativo</guimenu> do <productname>Firefox</productname></title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="desktop_app_menu_firefox.png" width="70%" format="PNG"/>
+       <imagedata fileref="desktop_app_menu_firefox.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="desktop_app_menu_firefox.png" width="70%" format="PNG"/>
+       <imagedata fileref="desktop_app_menu_firefox.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/pt-br/xml/gnome_use.xml
+++ b/l10n/sled/pt-br/xml/gnome_use.xml
@@ -26,10 +26,10 @@
    <title>Gerenciador de arquivos</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -573,10 +573,10 @@
     <textobject><phrase><productname>Evolution</productname></phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" format="PNG" width="100%"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" format="PNG" width="80%"/>
+     <imagedata fileref="evolution.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -673,10 +673,10 @@
    <title><productname>Archive manager</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -971,10 +971,10 @@
    <title><productname>Document viewer</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evince.png" format="PNG" width="90%"/>
+     <imagedata fileref="evince.png" width="90%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evince.png" format="PNG" width="78%"/>
+     <imagedata fileref="evince.png" width="78%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/pt-br/xml/grub2.xml
+++ b/l10n/sled/pt-br/xml/grub2.xml
@@ -438,10 +438,10 @@
       <title>Editor de boot do GRUB 2</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="grub2_edit_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="grub2_edit_config.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="grub2_edit_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="grub2_edit_config.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </figure>

--- a/l10n/sled/pt-br/xml/grub2_yast_i.xml
+++ b/l10n/sled/pt-br/xml/grub2_yast_i.xml
@@ -93,10 +93,10 @@
     <title>Opções de código de boot</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%"/>
      </imageobject>
     </mediaobject>
   </figure>
@@ -215,10 +215,10 @@
     <title>Opções do carregador de boot</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_options.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_options.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_options.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_options.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -277,10 +277,10 @@
     <title>Parâmetros kernel</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/pt-br/xml/help_user.xml
+++ b/l10n/sled/pt-br/xml/help_user.xml
@@ -61,10 +61,10 @@
    <title>Janela principal da ajuda</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/pt-br/xml/journalctl.xml
+++ b/l10n/sled/pt-br/xml/journalctl.xml
@@ -336,10 +336,10 @@ enabled</screen>
    <title>Diário do systemd no YaST</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_journal.png" width="80%" format="PNG"/>
+     <imagedata fileref="yast2_journal.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_journal.png" width="85%" format="PNG"/>
+     <imagedata fileref="yast2_journal.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/pt-br/xml/klp.xml
+++ b/l10n/sled/pt-br/xml/klp.xml
@@ -64,10 +64,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="klp.png" width="80%" format="PNG"/>
+     <imagedata fileref="klp.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="klp.png" width="100%" format="PNG"/>
+     <imagedata fileref="klp.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>

--- a/l10n/sled/pt-br/xml/net_basic.xml
+++ b/l10n/sled/pt-br/xml/net_basic.xml
@@ -60,10 +60,10 @@
   <title>Modelo simplificado de camadas para TCP/IP</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata width="100%" fileref="net_basic_osi.svg" format="SVG"/>
+    <imagedata width="100%" fileref="net_basic_osi.svg"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata width="75%" fileref="net_basic_osi.png" format="PNG"/>
+    <imagedata width="75%" fileref="net_basic_osi.png"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -80,10 +80,10 @@
   <title>Pacote Ethernet TCP/IP</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata width="80%" fileref="net_basic_tcppacket.svg" format="SVG"/>
+    <imagedata width="80%" fileref="net_basic_tcppacket.svg"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata width="75%" fileref="net_basic_tcppacket.png" format="PNG"/>
+    <imagedata width="75%" fileref="net_basic_tcppacket.png"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sled/pt-br/xml/net_bonding.xml
+++ b/l10n/sled/pt-br/xml/net_bonding.xml
@@ -114,10 +114,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="bond_configuration.png" width="70%" format="PNG"/>
+      <imagedata fileref="bond_configuration.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="bond_configuration.png" width="65%" format="PNG"/>
+      <imagedata fileref="bond_configuration.png" width="65%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sled/pt-br/xml/net_wicked.xml
+++ b/l10n/sled/pt-br/xml/net_wicked.xml
@@ -79,10 +79,10 @@
     <title>Arquitetura do <literal>wicked</literal></title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="wicked_scheme.png" format="PNG"/>
+      <imagedata fileref="wicked_scheme.png"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="wicked_scheme.png" format="PNG" width="80%"/>
+      <imagedata fileref="wicked_scheme.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/pt-br/xml/net_yast.xml
+++ b/l10n/sled/pt-br/xml/net_yast.xml
@@ -43,10 +43,10 @@
    <title>Definindo as configurações de rede</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_net_icard.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_net_icard.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_net_icard.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_net_icard.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/pt-br/xml/network_scheme.xml
+++ b/l10n/sled/pt-br/xml/network_scheme.xml
@@ -4,10 +4,10 @@
  <info>
   <mediaobject>
    <imageobject role="html">
-    <imagedata fileref="network_schema.png" width="100%" format="PNG"/>
+    <imagedata fileref="network_schema.png" width="100%"/>
    </imageobject>
    <imageobject role="pdf">
-    <imagedata fileref="network_schema.svg" width="100%" format="SVG"/>
+    <imagedata fileref="network_schema.svg" width="100%"/>
    </imageobject>
   </mediaobject>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -21,10 +21,10 @@
  <informalfigure>
   <mediaobject>
    <imageobject role="html">
-    <imagedata fileref="network_schema.png" width="100%" format="PNG"/>
+    <imagedata fileref="network_schema.png" width="100%"/>
    </imageobject>
    <imageobject role="pdf">
-    <imagedata fileref="network_schema.svg" width="100%" format="SVG"/>
+    <imagedata fileref="network_schema.svg" width="100%"/>
    </imageobject>
   </mediaobject>
  </informalfigure>

--- a/l10n/sled/pt-br/xml/snapper.xml
+++ b/l10n/sled/pt-br/xml/snapper.xml
@@ -417,10 +417,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_list.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_list.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_list.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_list.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -432,10 +432,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_changes.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_changes.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_changes.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_changes.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -447,10 +447,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_diff.png" width="65%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_diff.png" width="65%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_diff.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_diff.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -462,10 +462,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_restore.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_restore.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_restore.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_restore.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -827,10 +827,10 @@ single | 4 |     |         |                       |
     <title>Carregador de boot: instantâneos</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="boot_snapshots.png" width="75%" format="PNG"/>
+      <imagedata fileref="boot_snapshots.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="boot_snapshots.png" width="75%" format="PNG"/>
+      <imagedata fileref="boot_snapshots.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/pt-br/xml/systemd.xml
+++ b/l10n/sled/pt-br/xml/systemd.xml
@@ -1046,10 +1046,10 @@ Startup finished in 2666ms (kernel) + 21961ms (userspace) = 24628ms</screen>
        <informalfigure>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="systemd_startup.svg" width="75%" format="SVG"/>
+          <imagedata fileref="systemd_startup.svg" width="75%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="systemd_startup.png" width="75%" format="PNG"/>
+          <imagedata fileref="systemd_startup.png" width="75%"/>
          </imageobject>
         </mediaobject>
        </informalfigure>
@@ -1132,10 +1132,10 @@ WantedBy=multi-user.target<co xml:id="co-service-wrapper-target"/></screen>
    <title>Gerenciador de Serviços</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_runlevel.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_runlevel.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_runlevel.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_runlevel.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/pt-br/xml/tuning_multikernel.xml
+++ b/l10n/sled/pt-br/xml/tuning_multikernel.xml
@@ -236,10 +236,10 @@
      <title>Gerenciador de software do YaST: exibição multiversão</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_sw_multiversion.png" width="90%" format="PNG"/>
+       <imagedata fileref="yast2_sw_multiversion.png" width="90%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_sw_multiversion.png" width="90%" format="PNG"/>
+       <imagedata fileref="yast2_sw_multiversion.png" width="90%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/pt-br/xml/uefi.xml
+++ b/l10n/sled/pt-br/xml/uefi.xml
@@ -83,10 +83,10 @@
      <title>Suporte a boot seguro</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/pt-br/xml/updater_gnome.xml
+++ b/l10n/sled/pt-br/xml/updater_gnome.xml
@@ -25,11 +25,11 @@
   <mediaobject>
    <imageobject role="fo">
     
-    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%" format="PNG"/>
+    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
     
-    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%" format="PNG"/>
+    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -47,10 +47,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="gupdater_updates.png" width="75%" format="PNG"/>
+      <imagedata fileref="gupdater_updates.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="gupdater_updates.png" width="75%" format="PNG"/>
+      <imagedata fileref="gupdater_updates.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sled/pt-br/xml/updater_gnome_sw.xml
+++ b/l10n/sled/pt-br/xml/updater_gnome_sw.xml
@@ -42,10 +42,10 @@
   <title><guimenu>GNOME Software</guimenu>: tela <guimenu>Atualizações</guimenu></title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="gnome-software-updates.png" width="75%" format="PNG"/>
+    <imagedata fileref="gnome-software-updates.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="gnome-software-updates.png" width="75%" format="PNG"/>
+    <imagedata fileref="gnome-software-updates.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sled/pt-br/xml/vnc.xml
+++ b/l10n/sled/pt-br/xml/vnc.xml
@@ -56,10 +56,10 @@
      <textobject role="description"><phrase>vncviewer asking for connection details</phrase>
      </textobject>
      <imageobject role="html">
-      <imagedata fileref="vnc_connect.png" format="PNG"/>
+      <imagedata fileref="vnc_connect.png"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="vnc_connect.png" format="PNG"/>
+      <imagedata fileref="vnc_connect.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -99,10 +99,10 @@
     <title>Janela principal do Remmina</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -114,16 +114,16 @@
   <sect2 xml:id="vnc-remmina-addnew">
    <title>Adicionando sessões remotas</title>
    <para>
-    Para adicionar e gravar uma nova sessão remota, clique em <inlinemediaobject><textobject role="description"><phrase>Adicionar nova sessão</phrase></textobject><imageobject role="fo"><imagedata fileref="remmina_plus.png" width="1.2em" format="PNG"/></imageobject><imageobject role="html"><imagedata fileref="remmina_plus.png" width="1.2em" format="PNG"/></imageobject></inlinemediaobject> na parte superior esquerda da janela principal. A janela <guimenu>Preferência da Área de Trabalho Remota</guimenu> é aberta.
+    Para adicionar e gravar uma nova sessão remota, clique em <inlinemediaobject><textobject role="description"><phrase>Adicionar nova sessão</phrase></textobject><imageobject role="fo"><imagedata fileref="remmina_plus.png" width="1.2em"/></imageobject><imageobject role="html"><imagedata fileref="remmina_plus.png" width="1.2em"/></imageobject></inlinemediaobject> na parte superior esquerda da janela principal. A janela <guimenu>Preferência da Área de Trabalho Remota</guimenu> é aberta.
    </para>
    <figure>
     <title>Preferência da área de trabalho remota</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina_session_details.png" width="80%" format="PNG"/>
+      <imagedata fileref="remmina_session_details.png" width="80%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina_session_details.png" width="80%" format="PNG"/>
+      <imagedata fileref="remmina_session_details.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -203,10 +203,10 @@
      <title>Iniciando rapidamente</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="remmina_quickstart.png" width="40%" format="PNG"/>
+       <imagedata fileref="remmina_quickstart.png" width="40%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="remmina_quickstart.png" width="40%" format="PNG"/>
+       <imagedata fileref="remmina_quickstart.png" width="40%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -229,10 +229,10 @@
      <title>Vendo sessão remota no Remmina</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>
+       <imagedata fileref="remmina_sle15inside.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>
+       <imagedata fileref="remmina_sle15inside.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -267,10 +267,10 @@
     <title>Lendo o caminho para o arquivo de perfil</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina_status.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina_status.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina_status.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina_status.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -332,10 +332,10 @@
    <title>Administração remota</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="vnc_nosession.png" width="70%" format="PNG"/>
+     <imagedata fileref="vnc_nosession.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="vnc_nosession.png" width="70%" format="PNG"/>
+     <imagedata fileref="vnc_nosession.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -561,10 +561,10 @@ WINDOWMANAGER=icewm vncserver -geometry 1024x768</screen>
      <title>Configurações de sessão VNC</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="vncmanager_session.png" width="85%" format="PNG"/>
+       <imagedata fileref="vncmanager_session.png" width="85%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="vncmanager_session.png" width="85%" format="PNG"/>
+       <imagedata fileref="vncmanager_session.png" width="85%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -649,10 +649,10 @@ WINDOWMANAGER=icewm vncserver -geometry 1024x768</screen>
      <title>Ingressando em uma sessão VNC persistente</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="vncmanager_whether.png" width="80%" format="PNG"/>
+       <imagedata fileref="vncmanager_whether.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="vncmanager_whether.png" width="80%" format="PNG"/>
+       <imagedata fileref="vncmanager_whether.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/pt-br/xml/yast2_lang.xml
+++ b/l10n/sled/pt-br/xml/yast2_lang.xml
@@ -91,10 +91,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_language.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_language.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_language.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_language.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>
@@ -225,10 +225,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_timezone.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_timezone.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_timezone.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_timezone.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -306,10 +306,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_timezone_ntp.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_timezone_ntp.png" width="75%"/>
       </imageobject>
       <imageobject role="pdf">
-       <imagedata fileref="yast2_timezone_ntp.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_timezone_ntp.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sled/pt-br/xml/yast2_ncurses.xml
+++ b/l10n/sled/pt-br/xml/yast2_ncurses.xml
@@ -15,10 +15,10 @@
   <title>Janela principal do YaST em modo de texto</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="yast2_ncurses_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="yast2_ncurses_main.png" width="70%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="yast2_ncurses_main.png" width="75%" format="PNG"/>
+    <imagedata fileref="yast2_ncurses_main.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -99,10 +99,10 @@
    <title>Módulo de instalação de software</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_ncurses_inst.png" width="70%" format="PNG"/>
+     <imagedata fileref="yast2_ncurses_inst.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_ncurses_inst.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_ncurses_inst.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/pt-br/xml/yast2_sw.xml
+++ b/l10n/sled/pt-br/xml/yast2_sw.xml
@@ -152,10 +152,10 @@
      <phrase><guimenu>YaST</guimenu> software manager screen</phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_sw_manager.png" width="70%" format="PNG"/>
+     <imagedata fileref="yast2_sw_manager.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_sw_manager.png" width="65%" format="PNG"/>
+     <imagedata fileref="yast2_sw_manager.png" width="65%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -477,10 +477,10 @@
     <title>Gerenciamento de conflitos do gerenciador de software</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_package_conflict.png" width="70%" format="PNG"/>
+      <imagedata fileref="yast2_package_conflict.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_package_conflict.png" width="65%" format="PNG"/>
+      <imagedata fileref="yast2_package_conflict.png" width="65%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/pt-br/xml/yast2_sw_repo.xml
+++ b/l10n/sled/pt-br/xml/yast2_sw_repo.xml
@@ -52,10 +52,10 @@
      <title>Adicionando um repositório de software</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_addon_new.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_addon_new.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_addon_new.png" width="65%" format="PNG"/>
+       <imagedata fileref="yast2_addon_new.png" width="65%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/pt-br/xml/yast2_userman.xml
+++ b/l10n/sled/pt-br/xml/yast2_userman.xml
@@ -22,11 +22,11 @@
    <title>Administração de usuário e grupo do YaST</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_users_main_qt.png" width="90%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_users_main_qt.png" width="90%" os="sles;sled"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_users_main_qt.png" width="70%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_users_main_qt.png" width="70%" os="sles;sled"/>
      
     </imageobject>
    </mediaobject>
@@ -379,11 +379,11 @@
      <informalfigure os="sles;sled">
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_users_quota_qt.png" width="80%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_users_quota_qt.png" width="80%" os="sles;sled"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_users_quota_qt.png" width="70%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_users_quota_qt.png" width="70%" os="sles;sled"/>
         
        </imageobject>
       </mediaobject>
@@ -549,11 +549,11 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_groups_edit_qt.png" width="80%" format="PNG" os="sles;sled"/>
+       <imagedata fileref="yast2_groups_edit_qt.png" width="80%" os="sles;sled"/>
        
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_groups_edit_qt.png" width="75%" format="PNG" os="sles;sled"/>
+       <imagedata fileref="yast2_groups_edit_qt.png" width="75%" os="sles;sled"/>
        
       </imageobject>
      </mediaobject>

--- a/l10n/sled/pt-br/xml/yast2_you.xml
+++ b/l10n/sled/pt-br/xml/yast2_you.xml
@@ -73,11 +73,11 @@
    <title>Atualização online do YaST</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_you.png" width="75%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_you.png" width="75%" os="sles;sled"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_you.png" width="75%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_you.png" width="75%" os="sles;sled"/>
      
     </imageobject>
    </mediaobject>
@@ -204,10 +204,10 @@
    <title>Vendo os patches recolhidos e o histórico</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_retracted_patches.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_retracted_patches.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_retracted_patches.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_retracted_patches.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>  
@@ -245,10 +245,10 @@
    <title>Configuração da atualização online do YaST</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_autoupdate.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_autoupdate.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_autoupdate.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_autoupdate.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-cn/xml/adm_support.xml
+++ b/l10n/sled/zh-cn/xml/adm_support.xml
@@ -135,10 +135,10 @@ CPU Load Average:         7 (3%) with 2 CPUs
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_support_main.png" width="70%" format="PNG"/>
+        <imagedata fileref="yast2_support_main.png" width="70%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_support_main.png" width="60%" format="PNG"/>
+        <imagedata fileref="yast2_support_main.png" width="60%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -176,10 +176,10 @@ CPU Load Average:         7 (3%) with 2 CPUs
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_support_conf.png" width="90%" format="PNG"/>
+        <imagedata fileref="yast2_support_conf.png" width="90%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_support_conf.png" width="80%" format="PNG"/>
+        <imagedata fileref="yast2_support_conf.png" width="80%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -740,10 +740,10 @@ Creating Tar Ball
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_support_conf_upload.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_support_conf_upload.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_support_conf_upload.png" width="60%" format="PNG"/>
+       <imagedata fileref="yast2_support_conf_upload.png" width="60%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sled/zh-cn/xml/apparmor_changehat.xml
+++ b/l10n/sled/zh-cn/xml/apparmor_changehat.xml
@@ -188,10 +188,10 @@
      <title>Adminer 登录页</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata format="PNG" fileref="aa_changehat_adminer.png" width="75%"/>
+       <imagedata fileref="aa_changehat_adminer.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="aa_changehat_adminer.png" width="40%" format="PNG"/>
+       <imagedata fileref="aa_changehat_adminer.png" width="40%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -422,10 +422,10 @@ apparmor module is loaded.
      <textobject role="description"><phrase><phrase>AppArmor</phrase> profile dialog</phrase>
      </textobject>
      <imageobject role="fo">
-      <imagedata format="PNG" fileref="hats_in_profiles.png" width="75%"/>
+      <imagedata fileref="hats_in_profiles.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="hats_in_profiles.png" width="75%" format="PNG"/>
+      <imagedata fileref="hats_in_profiles.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>
@@ -439,10 +439,10 @@ apparmor module is loaded.
        <textobject role="description"><phrase>Enter hat name</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata format="PNG" fileref="hat_createhat.png" width="50%"/>
+        <imagedata fileref="hat_createhat.png" width="50%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="hat_createhat.png" width="35%" format="PNG"/>
+        <imagedata fileref="hat_createhat.png" width="35%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/l10n/sled/zh-cn/xml/apparmor_profiles_man.xml
+++ b/l10n/sled/zh-cn/xml/apparmor_profiles_man.xml
@@ -1248,10 +1248,10 @@ New Mode: r
      <title><command>aa-notify GNOME 中的消息</command></title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata format="PNG" fileref="aa-notify.png" width="75%"/>
+       <imagedata fileref="aa-notify.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="aa-notify.png" width="40%" format="PNG"/>
+       <imagedata fileref="aa-notify.png" width="40%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/zh-cn/xml/apparmor_profiles_yast.xml
+++ b/l10n/sled/zh-cn/xml/apparmor_profiles_yast.xml
@@ -82,10 +82,10 @@
       <textobject role="description"><phrase>Choose the profile to edit</phrase>
       </textobject>
       <imageobject role="fo">
-       <imagedata format="PNG" fileref="edit_1.png" width="75%"/>
+       <imagedata fileref="edit_1.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata format="PNG" fileref="edit_1.png"/>
+       <imagedata fileref="edit_1.png"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -104,10 +104,10 @@
       <textobject role="description"><phrase><phrase>AppArmor</phrase> profile dialog</phrase>
       </textobject>
       <imageobject role="fo">
-       <imagedata format="PNG" fileref="edit_2.png" width="75%"/>
+       <imagedata fileref="edit_2.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata format="PNG" fileref="edit_2.png"/>
+       <imagedata fileref="edit_2.png"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -159,10 +159,10 @@
         <textobject role="description"><phrase>Select a file to add</phrase>
         </textobject>
         <imageobject role="fo">
-         <imagedata format="PNG" fileref="add_2_addentry_file.png" width="60%"/>
+         <imagedata fileref="add_2_addentry_file.png" width="60%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="add_2_addentry_file.png" width="35%" format="PNG"/>
+         <imagedata fileref="add_2_addentry_file.png" width="35%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -183,10 +183,10 @@
 	  add</phrase>
         </textobject>
         <imageobject role="fo">
-         <imagedata format="PNG" fileref="add_2_addentry_file.png" width="60%"/>
+         <imagedata fileref="add_2_addentry_file.png" width="60%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="add_2_addentry_file.png" width="35%" format="PNG"/>
+         <imagedata fileref="add_2_addentry_file.png" width="35%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -203,10 +203,10 @@
         <textobject role="description"><phrase>Select capabilities</phrase>
         </textobject>
         <imageobject role="fo">
-         <imagedata format="PNG" fileref="add_2_addentry_network.png" width="50%"/>
+         <imagedata fileref="add_2_addentry_network.png" width="50%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata format="PNG" fileref="add_2_addentry_network.png" width="35%"/>
+         <imagedata fileref="add_2_addentry_network.png" width="35%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -223,10 +223,10 @@
         <textobject role="description"><phrase>Select capabilities</phrase>
         </textobject>
         <imageobject role="fo">
-         <imagedata format="PNG" fileref="add_2_addentry_capability.png" width="75%"/>
+         <imagedata fileref="add_2_addentry_capability.png" width="75%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata format="PNG" fileref="add_2_addentry_capability.png"/>
+         <imagedata fileref="add_2_addentry_capability.png"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -250,10 +250,10 @@
        <mediaobject>
         <textobject><phrase>enter subprofile name in popup window</phrase></textobject>
         <imageobject role="fo">
-         <imagedata fileref="add_2_addentry_hat.png" width="50%" format="PNG"/>
+         <imagedata fileref="add_2_addentry_hat.png" width="50%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="add_2_addentry_hat.png" format="PNG" width="60%"/>
+         <imagedata fileref="add_2_addentry_hat.png" width="60%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -325,10 +325,10 @@
 	panel</phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata format="PNG" fileref="sd_controlpanel_1.png" width="75%"/>
+     <imagedata fileref="sd_controlpanel_1.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata format="PNG" fileref="sd_controlpanel_1.png"/>
+     <imagedata fileref="sd_controlpanel_1.png"/>
     </imageobject>
    </mediaobject>
   </informalfigure>

--- a/l10n/sled/zh-cn/xml/apparmor_support.xml
+++ b/l10n/sled/zh-cn/xml/apparmor_support.xml
@@ -465,10 +465,10 @@ Profile /etc/apparmor.d/usr.sbin.squid failed to load
      <textobject><phrase>error message with hint for correcting the error</phrase>
       </textobject>
      <imageobject role="fo">
-      <imagedata fileref="aa_syncheck.png" width="60%" format="PNG"/>
+      <imagedata fileref="aa_syncheck.png" width="60%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="aa_syncheck.png" width="60%" format="PNG"/>
+      <imagedata fileref="aa_syncheck.png" width="60%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sled/zh-cn/xml/apps_ekiga.xml
+++ b/l10n/sled/zh-cn/xml/apps_ekiga.xml
@@ -170,10 +170,10 @@
    <title><productname>Ekiga</productname> 用户界面</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="ekiga_main.png" width="45%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="45%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ekiga_main.png" width="55%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="55%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-cn/xml/apps_evolution.xml
+++ b/l10n/sled/zh-cn/xml/apps_evolution.xml
@@ -733,10 +733,10 @@
    <title><productname>Evolution</productname> window</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" width="100%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" width="86%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="86%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-cn/xml/apps_firefox.xml
+++ b/l10n/sled/zh-cn/xml/apps_firefox.xml
@@ -29,7 +29,7 @@
   <note>
    <title>使用菜单栏</title>
    <para>
-    <productname>Firefox</productname> 的大多数功能都可通过三条横线按钮 (<inlinemediaobject><textobject role="description"><phrase>三条横线按钮</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject>) 访问，有些功能只能通过菜单栏访问。
+    <productname>Firefox</productname> 的大多数功能都可通过三条横线按钮 (<inlinemediaobject><textobject role="description"><phrase>三条横线按钮</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em"/></imageobject></inlinemediaobject>) 访问，有些功能只能通过菜单栏访问。
    </para>
    <para>
     <productname>Firefox</productname> 的菜单栏默认会隐藏起来。要暂时显示菜单栏，请按 <keycap function="alt"/>。菜单栏随后将一直显示，直到您单击浏览器窗口中的其他位置。

--- a/l10n/sled/zh-cn/xml/apps_gimp.xml
+++ b/l10n/sled/zh-cn/xml/apps_gimp.xml
@@ -125,10 +125,10 @@
     <title>工具箱</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="gimp-toolbox.png" width="35%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="35%"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="gimp-toolbox.png" width="30%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="30%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -547,10 +547,10 @@
        <title>基本颜色选择器对话框</title>
        <mediaobject>
         <imageobject role="html">
-         <imagedata fileref="gimp-color.png" width="70%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="70%"/>
         </imageobject>
         <imageobject role="fo">
-         <imagedata fileref="gimp-color.png" width="80%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="80%"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -719,10 +719,10 @@
    <title>打印对话框</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="gimp-print.png" width="75%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="75%"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="gimp-print.png" width="70%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-cn/xml/apps_libreoffice.xml
+++ b/l10n/sled/zh-cn/xml/apps_libreoffice.xml
@@ -528,7 +528,7 @@
    </step>
    <step>
     <para>
-     转到证书首选项，方法是打开菜单 (<inlinemediaobject><textobject role="description"><phrase>三条横线按钮</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject>)，然后选择<menuchoice><guimenu>设置</guimenu>
+     转到证书首选项，方法是打开菜单 (<inlinemediaobject><textobject role="description"><phrase>三条横线按钮</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em"/></imageobject></inlinemediaobject>)，然后选择<menuchoice><guimenu>设置</guimenu>
       <guimenu>隐私与安全</guimenu></menuchoice>。
     </para>
    </step>
@@ -573,10 +573,10 @@
    <title><guimenu>Writer</guimenu> 中的自定义对话框</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -728,10 +728,10 @@
    <title>选项窗口</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_options.png" width="95%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_options.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-cn/xml/apps_librevarious.xml
+++ b/l10n/sled/zh-cn/xml/apps_librevarious.xml
@@ -285,10 +285,10 @@
        <mediaobject>
         <textobject><phrase>Field selection</phrase></textobject>
         <imageobject role="fo">
-         <imagedata fileref="oo-wizard-base.png" width="90%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="90%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="oo-wizard-base.png" width="85%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="85%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>

--- a/l10n/sled/zh-cn/xml/apps_librewriter.xml
+++ b/l10n/sled/zh-cn/xml/apps_librewriter.xml
@@ -66,10 +66,10 @@
    <title>LibreOffice 向导</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo-wizard.png" width="100%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo-wizard.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -231,10 +231,10 @@
     <title>“样式”面板</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo-stylist.png" width="40%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="40%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo-stylist.png" width="50%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -641,10 +641,10 @@
     <title><guimenu>Writer</guimenu> 中的导航工具</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo_navigator.png" width="55%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo_navigator.png" width="45%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="45%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/zh-cn/xml/apps_totem.xml
+++ b/l10n/sled/zh-cn/xml/apps_totem.xml
@@ -59,10 +59,10 @@
    <title><guimenu>GNOME Videos</guimenu> 启动窗口</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -132,11 +132,11 @@
     <guimenu> 弹出</guimenu> </menuchoice>。
    </para>
    <para>
-    要暂停正在播放的电影或歌曲，请单击 <inlinemediaobject><textobject role="description"><phrase>GNOME Videos 暂停</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_pause_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="totem_pause_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject> 按钮,或单击<menuchoice> <guimenu>电影</guimenu>
+    要暂停正在播放的电影或歌曲，请单击 <inlinemediaobject><textobject role="description"><phrase>GNOME Videos 暂停</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_pause_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="totem_pause_button-fallback.png" width="1em"/></imageobject></inlinemediaobject> 按钮,或单击<menuchoice> <guimenu>电影</guimenu>
     <guimenu>播放/暂停</guimenu> </menuchoice>。暂停电影或歌曲后，状态栏会显示<guimenu>已暂停</guimenu>以及当前电影或歌曲的已经过时间。
    </para>
    <para>
-    要继续播放电影或歌曲，请单击 <inlinemediaobject><textobject role="description"><phrase>GNOME Videos 播放</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_play_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="totem_play_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject> 按钮,或单击<menuchoice> <guimenu>电影</guimenu>
+    要继续播放电影或歌曲，请单击 <inlinemediaobject><textobject role="description"><phrase>GNOME Videos 播放</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_play_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="totem_play_button-fallback.png" width="1em"/></imageobject></inlinemediaobject> 按钮,或单击<menuchoice> <guimenu>电影</guimenu>
     <guimenu>播放/暂停</guimenu></menuchoice>。
    </para>
    <para>
@@ -223,10 +223,10 @@
     <title><guimenu>GNOME Videos</guimenu> 常规自选设置</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -268,10 +268,10 @@
     <title><guimenu>GNOME Videos</guimenu> 显示自选设置</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -307,10 +307,10 @@
     <title><guimenu>GNOME Videos</guimenu> 音频自选设置</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/zh-cn/xml/art_modules.xml
+++ b/l10n/sled/zh-cn/xml/art_modules.xml
@@ -966,10 +966,10 @@
         <phrase><guimenu>Add-On Product</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_addon_new.png" width="90%" format="PNG"/>
+        <imagedata fileref="yast2_addon_new.png" width="90%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_addon_new.png" width="80%" format="PNG"/>
+        <imagedata fileref="yast2_addon_new.png" width="80%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -1034,11 +1034,11 @@
        </textobject>
        <imageobject role="fo">
         
-        <imagedata os="sled" fileref="yast2_addon_installed_sled.png" width="90%" format="png"/>
+        <imagedata os="sled" fileref="yast2_addon_installed_sled.png" width="90%"/>
        </imageobject>
        <imageobject role="html">
         
-        <imagedata os="sled" fileref="yast2_addon_installed_sled.png" width="80%" format="png"/>
+        <imagedata os="sled" fileref="yast2_addon_installed_sled.png" width="80%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/l10n/sled/zh-cn/xml/audit_components.xml
+++ b/l10n/sled/zh-cn/xml/audit_components.xml
@@ -153,7 +153,7 @@
    <title>Linux 审计组件简介</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="audit_components.png" width="75%" format="PNG"/>
+     <imagedata fileref="audit_components.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -1800,10 +1800,10 @@ Syscall Report
    <title>流程图 — 程序与系统调用之间的关系</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="audit_mkgraph.png" width="75%" format="PNG"/>
+     <imagedata fileref="audit_mkgraph.png" width="75%"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="audit_mkgraph.png" width="100%" format="PNG"/>
+     <imagedata fileref="audit_mkgraph.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -1838,10 +1838,10 @@ total  type
    <title>条形图 — 常见事件类型</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="audit_mkbar.png" width="75%" format="PNG"/>
+     <imagedata fileref="audit_mkbar.png" width="75%"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="audit_mkbar.png" width="100%" format="PNG"/>
+     <imagedata fileref="audit_mkbar.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-cn/xml/backup.xml
+++ b/l10n/sled/zh-cn/xml/backup.xml
@@ -20,10 +20,10 @@
  <mediaobject>
   <textobject><phrase>Backup application</phrase></textobject>
   <imageobject role="fo">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
   <imageobject role="html">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
  </mediaobject>
 </informalfigure>

--- a/l10n/sled/zh-cn/xml/chrony.xml
+++ b/l10n/sled/zh-cn/xml/chrony.xml
@@ -44,10 +44,10 @@
    <title>NTP 配置窗口</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="ntp_client.png" width="70%" format="PNG"/>
+     <imagedata fileref="ntp_client.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ntp_client.png" width="70%" format="PNG"/>
+     <imagedata fileref="ntp_client.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -107,10 +107,10 @@
     <title>添加时间服务器</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="ntp_client_serveradd.png" width="70%" format="PNG"/>
+      <imagedata fileref="ntp_client_serveradd.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="ntp_client_serveradd.png" width="70%" format="PNG"/>
+      <imagedata fileref="ntp_client_serveradd.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/zh-cn/xml/gnome_accessibility.xml
+++ b/l10n/sled/zh-cn/xml/gnome_accessibility.xml
@@ -90,10 +90,10 @@
      <mediaobject>
       <textobject><phrase>On-screen keyboard</phrase></textobject>
       <imageobject role="fo">
-       <imagedata fileref="gnome_onscreen_kbd.png" width="95%" format="PNG"/>
+       <imagedata fileref="gnome_onscreen_kbd.png" width="95%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="gnome_onscreen_kbd.png" width="90%" format="PNG"/>
+       <imagedata fileref="gnome_onscreen_kbd.png" width="90%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sled/zh-cn/xml/gnome_crypto.xml
+++ b/l10n/sled/zh-cn/xml/gnome_crypto.xml
@@ -22,10 +22,10 @@
   <title><guimenu>口令和密钥</guimenu>主窗口</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sled/zh-cn/xml/gnome_custom.xml
+++ b/l10n/sled/zh-cn/xml/gnome_custom.xml
@@ -61,10 +61,10 @@
      <title>GNOME 背景设置</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="preferences_background.png" width="45%" format="PNG"/>
+        <imagedata fileref="preferences_background.png" width="45%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="preferences_background.png" width="45%" format="PNG"/>
+        <imagedata fileref="preferences_background.png" width="45%"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -148,10 +148,10 @@
    <title>键盘快捷键对话框</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_keyboard.png" width="100%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_keyboard.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -178,10 +178,10 @@
    <title>在 tweaks 中启用组合键</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -307,10 +307,10 @@
    <title><guimenu>鼠标和触摸板</guimenu>设置对话框</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -362,10 +362,10 @@
     <title>“单监视器设置”对话框</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="preferences_screen_single.png" width="100%" format="PNG"/>
+      <imagedata fileref="preferences_screen_single.png" width="100%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="preferences_screen_single.png" width="80%" format="PNG"/>
+      <imagedata fileref="preferences_screen_single.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -486,10 +486,10 @@
    <title>配置声音设置</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="sound_devices.png" width="100%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="sound_devices.png" width="80%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -515,10 +515,10 @@
      <title>默认应用程序</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="preferences_preferred_apps.png" width="100%" format="PNG"/>
+       <imagedata fileref="preferences_preferred_apps.png" width="100%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="preferences_preferred_apps.png" width="80%" format="PNG"/>
+       <imagedata fileref="preferences_preferred_apps.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/zh-cn/xml/gnome_networking.xml
+++ b/l10n/sled/zh-cn/xml/gnome_networking.xml
@@ -104,10 +104,10 @@
    <title>网络文件浏览器</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="network_browser.png" width="100%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="100%"/>
      </imageobject>
     <imageobject role="html">
-     <imagedata fileref="network_browser.png" width="90%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -256,10 +256,10 @@
       <mediaobject>
        <textobject><phrase>Sharing options</phrase></textobject>
        <imageobject role="fo">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/l10n/sled/zh-cn/xml/gnome_start.xml
+++ b/l10n/sled/zh-cn/xml/gnome_start.xml
@@ -37,11 +37,11 @@
    <title>默认 GNOME 登录屏幕</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata os="sles;sled" fileref="login_sled.png" width="90%" format="PNG"/>
+     <imagedata os="sles;sled" fileref="login_sled.png" width="90%"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata os="sles;sled" fileref="login_sled.png" width="75%" format="PNG"/>
+     <imagedata os="sles;sled" fileref="login_sled.png" width="75%"/>
      
     </imageobject>
    </mediaobject>
@@ -83,11 +83,11 @@
       <title>默认 GNOME 登录屏幕 - 会话类型</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="90%" format="PNG"/>
+        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="90%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="75%" format="PNG"/>
+        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="75%"/>
         
        </imageobject>
       </mediaobject>
@@ -211,10 +211,10 @@
    <title>GNOME 桌面及活动概览</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="desktop_sled_menu.png" width="95%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="desktop_sled_menu.png" width="90%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -259,10 +259,10 @@
      <title><guimenu>活动</guimenu>概览</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="desktop_activities_overview.png" width="95%" format="PNG"/>
+      <imagedata fileref="desktop_activities_overview.png" width="95%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="desktop_activities_overview.png" width="90%" format="PNG"/>
+      <imagedata fileref="desktop_activities_overview.png" width="90%"/>
      </imageobject>
     </mediaobject>
      </figure>
@@ -299,10 +299,10 @@
      <title><productname>Firefox</productname> 的<guimenu>应用程序</guimenu>菜单</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="desktop_app_menu_firefox.png" width="70%" format="PNG"/>
+       <imagedata fileref="desktop_app_menu_firefox.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="desktop_app_menu_firefox.png" width="70%" format="PNG"/>
+       <imagedata fileref="desktop_app_menu_firefox.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/zh-cn/xml/gnome_use.xml
+++ b/l10n/sled/zh-cn/xml/gnome_use.xml
@@ -26,10 +26,10 @@
    <title>文件管理器</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -573,10 +573,10 @@
     <textobject><phrase><productname>Evolution</productname></phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" format="PNG" width="100%"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" format="PNG" width="80%"/>
+     <imagedata fileref="evolution.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -673,10 +673,10 @@
    <title><productname>Archive manager</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -971,10 +971,10 @@
    <title><productname>Document viewer</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evince.png" format="PNG" width="90%"/>
+     <imagedata fileref="evince.png" width="90%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evince.png" format="PNG" width="78%"/>
+     <imagedata fileref="evince.png" width="78%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-cn/xml/grub2.xml
+++ b/l10n/sled/zh-cn/xml/grub2.xml
@@ -438,10 +438,10 @@
       <title>GRUB 2 引导编辑器</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="grub2_edit_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="grub2_edit_config.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="grub2_edit_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="grub2_edit_config.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </figure>

--- a/l10n/sled/zh-cn/xml/grub2_yast_i.xml
+++ b/l10n/sled/zh-cn/xml/grub2_yast_i.xml
@@ -93,10 +93,10 @@
     <title>引导代码选项</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%"/>
      </imageobject>
     </mediaobject>
   </figure>
@@ -215,10 +215,10 @@
     <title>引导加载程序选项</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_options.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_options.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_options.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_options.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -277,10 +277,10 @@
     <title>内核参数</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/zh-cn/xml/help_user.xml
+++ b/l10n/sled/zh-cn/xml/help_user.xml
@@ -61,10 +61,10 @@
    <title>帮助主窗口</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-cn/xml/journalctl.xml
+++ b/l10n/sled/zh-cn/xml/journalctl.xml
@@ -336,10 +336,10 @@ enabled</screen>
    <title>YaST systemd 日志</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_journal.png" width="80%" format="PNG"/>
+     <imagedata fileref="yast2_journal.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_journal.png" width="85%" format="PNG"/>
+     <imagedata fileref="yast2_journal.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-cn/xml/klp.xml
+++ b/l10n/sled/zh-cn/xml/klp.xml
@@ -64,10 +64,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="klp.png" width="80%" format="PNG"/>
+     <imagedata fileref="klp.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="klp.png" width="100%" format="PNG"/>
+     <imagedata fileref="klp.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>

--- a/l10n/sled/zh-cn/xml/net_basic.xml
+++ b/l10n/sled/zh-cn/xml/net_basic.xml
@@ -60,10 +60,10 @@
   <title>TCP/IP 的简化层模型</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata width="100%" fileref="net_basic_osi.svg" format="SVG"/>
+    <imagedata width="100%" fileref="net_basic_osi.svg"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata width="75%" fileref="net_basic_osi.png" format="PNG"/>
+    <imagedata width="75%" fileref="net_basic_osi.png"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -80,10 +80,10 @@
   <title>TCP/IP 以太网数据包</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata width="80%" fileref="net_basic_tcppacket.svg" format="SVG"/>
+    <imagedata width="80%" fileref="net_basic_tcppacket.svg"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata width="75%" fileref="net_basic_tcppacket.png" format="PNG"/>
+    <imagedata width="75%" fileref="net_basic_tcppacket.png"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sled/zh-cn/xml/net_bonding.xml
+++ b/l10n/sled/zh-cn/xml/net_bonding.xml
@@ -114,10 +114,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="bond_configuration.png" width="70%" format="PNG"/>
+      <imagedata fileref="bond_configuration.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="bond_configuration.png" width="65%" format="PNG"/>
+      <imagedata fileref="bond_configuration.png" width="65%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sled/zh-cn/xml/net_wicked.xml
+++ b/l10n/sled/zh-cn/xml/net_wicked.xml
@@ -79,10 +79,10 @@
     <title><literal>wicked</literal> 体系结构</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="wicked_scheme.png" format="PNG"/>
+      <imagedata fileref="wicked_scheme.png"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="wicked_scheme.png" format="PNG" width="80%"/>
+      <imagedata fileref="wicked_scheme.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/zh-cn/xml/net_yast.xml
+++ b/l10n/sled/zh-cn/xml/net_yast.xml
@@ -43,10 +43,10 @@
    <title>配置网络设置</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_net_icard.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_net_icard.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_net_icard.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_net_icard.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-cn/xml/network_scheme.xml
+++ b/l10n/sled/zh-cn/xml/network_scheme.xml
@@ -4,10 +4,10 @@
  <info>
   <mediaobject>
    <imageobject role="html">
-    <imagedata fileref="network_schema.png" width="100%" format="PNG"/>
+    <imagedata fileref="network_schema.png" width="100%"/>
    </imageobject>
    <imageobject role="pdf">
-    <imagedata fileref="network_schema.svg" width="100%" format="SVG"/>
+    <imagedata fileref="network_schema.svg" width="100%"/>
    </imageobject>
   </mediaobject>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -21,10 +21,10 @@
  <informalfigure>
   <mediaobject>
    <imageobject role="html">
-    <imagedata fileref="network_schema.png" width="100%" format="PNG"/>
+    <imagedata fileref="network_schema.png" width="100%"/>
    </imageobject>
    <imageobject role="pdf">
-    <imagedata fileref="network_schema.svg" width="100%" format="SVG"/>
+    <imagedata fileref="network_schema.svg" width="100%"/>
    </imageobject>
   </mediaobject>
  </informalfigure>

--- a/l10n/sled/zh-cn/xml/security_acls.xml
+++ b/l10n/sled/zh-cn/xml/security_acls.xml
@@ -310,10 +310,10 @@
     <title>最小 ACL：与权限位相比的 ACL 项</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="acls_map_mini.png" width="75%" format="PNG"/>
+      <imagedata fileref="acls_map_mini.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="acls_map_mini.png" width="75%" format="PNG"/>
+      <imagedata fileref="acls_map_mini.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -324,10 +324,10 @@
     <title>扩展 ACL：与权限位相比的 ACL 项</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="acls_map_ext.png" width="75%" format="PNG"/>
+      <imagedata fileref="acls_map_ext.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="acls_map_ext.png" width="75%" format="PNG"/>
+      <imagedata fileref="acls_map_ext.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/zh-cn/xml/security_ad_support.xml
+++ b/l10n/sled/zh-cn/xml/security_ad_support.xml
@@ -175,10 +175,10 @@
       <title>基于 Winbind 的 Active Directory 身份验证的纲要</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="sled10_ad_schema.svg" width="85%" format="SVG"/>
+        <imagedata fileref="sled10_ad_schema.svg" width="85%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="sled10_ad_schema.png" width="75%" format="PNG"/>
+        <imagedata fileref="sled10_ad_schema.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -541,10 +541,10 @@
       <title><guimenu>用户登录管理</guimenu>的主窗口</title>
       <mediaobject>
        <imageobject role="html">
-        <imagedata fileref="ad-overview.png" format="PNG"/>
+        <imagedata fileref="ad-overview.png"/>
        </imageobject>
        <imageobject role="fo">
-        <imagedata fileref="ad-overview.png" width="65%" format="PNG"/>
+        <imagedata fileref="ad-overview.png" width="65%"/>
        </imageobject>
        <textobject role="description">
         <phrase>
@@ -639,10 +639,10 @@
         <title>注册到域中</title>
         <mediaobject>
          <imageobject role="html">
-          <imagedata fileref="ad-enroll.png" format="PNG"/>
+          <imagedata fileref="ad-enroll.png"/>
          </imageobject>
          <imageobject role="fo">
-          <imagedata fileref="ad-enroll.png" width="60%" format="PNG"/>
+          <imagedata fileref="ad-enroll.png" width="60%"/>
          </imageobject>
          <textobject role="description">
           <phrase/>
@@ -665,10 +665,10 @@
       <title><guimenu>用户登录管理</guimenu>的配置窗口</title>
       <mediaobject>
        <imageobject role="html">
-        <imagedata fileref="ad-config.png" format="PNG"/>
+        <imagedata fileref="ad-config.png"/>
        </imageobject>
        <imageobject role="fo">
-        <imagedata fileref="ad-config.png" width="70%" format="PNG"/>
+        <imagedata fileref="ad-config.png" width="70%"/>
        </imageobject>
        <textobject role="description">
         <phrase/>
@@ -758,10 +758,10 @@
      <title>确定 Windows 域成员资格</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="ad_sambaclient.png" width="75%" format="PNG"/>
+       <imagedata fileref="ad_sambaclient.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="ad_sambaclient.png" width="75%" format="PNG"/>
+       <imagedata fileref="ad_sambaclient.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -804,10 +804,10 @@
      <title>提供管理员身份凭证</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="ad_join1.png" width="30%" format="PNG"/>
+       <imagedata fileref="ad_join1.png" width="30%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="ad_join1.png" width="30%" format="PNG"/>
+       <imagedata fileref="ad_join1.png" width="30%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/zh-cn/xml/security_cryptctl.xml
+++ b/l10n/sled/zh-cn/xml/security_cryptctl.xml
@@ -59,10 +59,10 @@
    <title>使用 <command>cryptctl</command> 检索密钥（不连接 KMIP 服务器的模式）</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="cryptctl-keyretrieval.png" format="PNG"/>
+     <imagedata fileref="cryptctl-keyretrieval.png"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="cryptctl-keyretrieval.svg" width="70%" format="SVG"/>
+     <imagedata fileref="cryptctl-keyretrieval.svg" width="70%"/>
     </imageobject>
     <textobject role="description">
      <phrase>The client asks the server for the disk decryption key, the server

--- a/l10n/sled/zh-cn/xml/security_firewall.xml
+++ b/l10n/sled/zh-cn/xml/security_firewall.xml
@@ -113,10 +113,10 @@
    <title>iptable：包的可能路径</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata width="75%" fileref="fire_tables.svg" format="SVG"/>
+     <imagedata width="75%" fileref="fire_tables.svg"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata width="65%" fileref="fire_tables.png" format="PNG"/>
+     <imagedata width="65%" fileref="fire_tables.png"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-cn/xml/security_ldap_directory_tree.xml
+++ b/l10n/sled/zh-cn/xml/security_ldap_directory_tree.xml
@@ -26,7 +26,7 @@
      <imagedata fileref="ldap_tree.svg" width="85%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ldap_tree.png" width="85%" format="PNG"/>
+     <imagedata fileref="ldap_tree.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-cn/xml/security_nis.xml
+++ b/l10n/sled/zh-cn/xml/security_nis.xml
@@ -52,10 +52,10 @@
      <title>设置 NIS 服务器的域和地址</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_inst_nisclient.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_inst_nisclient.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_inst_nisclient.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_inst_nisclient.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/zh-cn/xml/security_spectre_meltdown_checker.xml
+++ b/l10n/sled/zh-cn/xml/security_spectre_meltdown_checker.xml
@@ -35,10 +35,10 @@
    <title>spectre-meltdown-checker 的输出</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="spectre-meltdown.png" width="80%" format="PNG"/>
+     <imagedata fileref="spectre-meltdown.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="spectre-meltdown.png" width="100%" format="PNG"/>
+     <imagedata fileref="spectre-meltdown.png" width="100%"/>
     </imageobject>
     <textobject role="description"><phrase>Partial output of spectre-meltdown-checker.sh</phrase>
     </textobject>

--- a/l10n/sled/zh-cn/xml/security_xca.xml
+++ b/l10n/sled/zh-cn/xml/security_xca.xml
@@ -34,10 +34,10 @@
  <title>创建新 XCA 数据库</title>
  <mediaobject>
   <imageobject role="html">
-   <imagedata fileref="sec-xca-2.png" width="80%" format="PNG"/>
+   <imagedata fileref="sec-xca-2.png" width="80%"/>
   </imageobject>
   <imageobject role="fo">
-   <imagedata fileref="sec-xca-2.png" width="80%" format="PNG"/>
+   <imagedata fileref="sec-xca-2.png" width="80%"/>
   </imageobject>
   <textobject role="description">
    <phrase>Create a new XCA database</phrase>

--- a/l10n/sled/zh-cn/xml/security_yast2_security.xml
+++ b/l10n/sled/zh-cn/xml/security_yast2_security.xml
@@ -56,10 +56,10 @@
    <title>YaST 安全和强化中心：安全概览</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata width="75%" fileref="yast2_security_overview.png" format="PNG"/>
+     <imagedata width="75%" fileref="yast2_security_overview.png"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_security_overview.png" format="PNG"/>
+     <imagedata fileref="yast2_security_overview.png"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-cn/xml/snapper.xml
+++ b/l10n/sled/zh-cn/xml/snapper.xml
@@ -417,10 +417,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_list.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_list.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_list.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_list.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -432,10 +432,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_changes.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_changes.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_changes.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_changes.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -447,10 +447,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_diff.png" width="65%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_diff.png" width="65%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_diff.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_diff.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -462,10 +462,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_restore.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_restore.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_restore.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_restore.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -827,10 +827,10 @@ single | 4 |     |         |                       |
     <title>引导加载程序：快照</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="boot_snapshots.png" width="75%" format="PNG"/>
+      <imagedata fileref="boot_snapshots.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="boot_snapshots.png" width="75%" format="PNG"/>
+      <imagedata fileref="boot_snapshots.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/zh-cn/xml/systemd.xml
+++ b/l10n/sled/zh-cn/xml/systemd.xml
@@ -1046,10 +1046,10 @@ Startup finished in 2666ms (kernel) + 21961ms (userspace) = 24628ms</screen>
        <informalfigure>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="systemd_startup.svg" width="75%" format="SVG"/>
+          <imagedata fileref="systemd_startup.svg" width="75%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="systemd_startup.png" width="75%" format="PNG"/>
+          <imagedata fileref="systemd_startup.png" width="75%"/>
          </imageobject>
         </mediaobject>
        </informalfigure>
@@ -1132,10 +1132,10 @@ WantedBy=multi-user.target<co xml:id="co-service-wrapper-target"/></screen>
    <title>服务管理器</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_runlevel.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_runlevel.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_runlevel.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_runlevel.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-cn/xml/tuning_kexec.xml
+++ b/l10n/sled/zh-cn/xml/tuning_kexec.xml
@@ -527,10 +527,10 @@ KDUMP_NET_TIMEOUT=30</screen>
     <title>YaST Kdump 模块：启动页</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_kdump_startup.png" width="60%" format="PNG"/>
+      <imagedata fileref="yast2_kdump_startup.png" width="60%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_kdump_startup.png" width="70%" format="PNG"/>
+      <imagedata fileref="yast2_kdump_startup.png" width="70%"/>
      </imageobject>
      <textobject><phrase>
         Screenshot of the YaST Kdump Module

--- a/l10n/sled/zh-cn/xml/tuning_multikernel.xml
+++ b/l10n/sled/zh-cn/xml/tuning_multikernel.xml
@@ -236,10 +236,10 @@
      <title>YaST 软件管理器：多版本视图</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_sw_multiversion.png" width="90%" format="PNG"/>
+       <imagedata fileref="yast2_sw_multiversion.png" width="90%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_sw_multiversion.png" width="90%" format="PNG"/>
+       <imagedata fileref="yast2_sw_multiversion.png" width="90%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/zh-cn/xml/tuning_power.xml
+++ b/l10n/sled/zh-cn/xml/tuning_power.xml
@@ -442,10 +442,10 @@ CPU | C0   | Cx   | Freq || POLL | C1   | C2   | C3
    <title>处于交互模式的 powerTOP</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="powertop_ncurses.png" width="75%" format="PNG"/>
+     <imagedata fileref="powertop_ncurses.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="powertop_ncurses.png" width="75%" format="PNG"/>
+     <imagedata fileref="powertop_ncurses.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -472,10 +472,10 @@ powerreport-20200108-104431.html
    <title>HTML powerTOP 报告</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="powertop_html.png" width="75%" format="PNG"/>
+     <imagedata fileref="powertop_html.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="powertop_html.png" width="75%" format="PNG"/>
+     <imagedata fileref="powertop_html.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-cn/xml/uefi.xml
+++ b/l10n/sled/zh-cn/xml/uefi.xml
@@ -83,10 +83,10 @@
      <title>安全引导支持</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/zh-cn/xml/updater_gnome.xml
+++ b/l10n/sled/zh-cn/xml/updater_gnome.xml
@@ -25,11 +25,11 @@
   <mediaobject>
    <imageobject role="fo">
     
-    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%" format="PNG"/>
+    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
     
-    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%" format="PNG"/>
+    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -47,10 +47,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="gupdater_updates.png" width="75%" format="PNG"/>
+      <imagedata fileref="gupdater_updates.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="gupdater_updates.png" width="75%" format="PNG"/>
+      <imagedata fileref="gupdater_updates.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sled/zh-cn/xml/updater_gnome_sw.xml
+++ b/l10n/sled/zh-cn/xml/updater_gnome_sw.xml
@@ -42,10 +42,10 @@
   <title><guimenu>GNOME Software</guimenu> — <guimenu>更新</guimenu>视图</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="gnome-software-updates.png" width="75%" format="PNG"/>
+    <imagedata fileref="gnome-software-updates.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="gnome-software-updates.png" width="75%" format="PNG"/>
+    <imagedata fileref="gnome-software-updates.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sled/zh-cn/xml/utilities.xml
+++ b/l10n/sled/zh-cn/xml/utilities.xml
@@ -2672,10 +2672,10 @@ LINE2:free_memory#FF0000 \
      <title>使用 RRDtool 创建的示例图表</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata width="75%" fileref="rrdtool_graph1.png" format="PNG"/>
+       <imagedata width="75%" fileref="rrdtool_graph1.png"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata width="55%" fileref="rrdtool_graph1.png" format="PNG"/>
+       <imagedata width="55%" fileref="rrdtool_graph1.png"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/zh-cn/xml/vnc.xml
+++ b/l10n/sled/zh-cn/xml/vnc.xml
@@ -56,10 +56,10 @@
      <textobject role="description"><phrase>vncviewer asking for connection details</phrase>
      </textobject>
      <imageobject role="html">
-      <imagedata fileref="vnc_connect.png" format="PNG"/>
+      <imagedata fileref="vnc_connect.png"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="vnc_connect.png" format="PNG"/>
+      <imagedata fileref="vnc_connect.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -99,10 +99,10 @@
     <title>Remmina 的主窗口</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -114,16 +114,16 @@
   <sect2 xml:id="vnc-remmina-addnew">
    <title>添加远程会话</title>
    <para>
-    要添加和保存新远程会话，请单击主窗口右上方的 <inlinemediaobject><textobject role="description"><phrase>添加新会话</phrase></textobject><imageobject role="fo"><imagedata fileref="remmina_plus.png" width="1.2em" format="PNG"/></imageobject><imageobject role="html"><imagedata fileref="remmina_plus.png" width="1.2em" format="PNG"/></imageobject></inlinemediaobject>。<guimenu>远程桌面首选项</guimenu>窗口即会打开。
+    要添加和保存新远程会话，请单击主窗口右上方的 <inlinemediaobject><textobject role="description"><phrase>添加新会话</phrase></textobject><imageobject role="fo"><imagedata fileref="remmina_plus.png" width="1.2em"/></imageobject><imageobject role="html"><imagedata fileref="remmina_plus.png" width="1.2em"/></imageobject></inlinemediaobject>。<guimenu>远程桌面首选项</guimenu>窗口即会打开。
    </para>
    <figure>
     <title>远程桌面首选项</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina_session_details.png" width="80%" format="PNG"/>
+      <imagedata fileref="remmina_session_details.png" width="80%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina_session_details.png" width="80%" format="PNG"/>
+      <imagedata fileref="remmina_session_details.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -203,10 +203,10 @@
      <title>快速启动</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="remmina_quickstart.png" width="40%" format="PNG"/>
+       <imagedata fileref="remmina_quickstart.png" width="40%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="remmina_quickstart.png" width="40%" format="PNG"/>
+       <imagedata fileref="remmina_quickstart.png" width="40%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -229,10 +229,10 @@
      <title>正在查看远程会话的 Remmina</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>
+       <imagedata fileref="remmina_sle15inside.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>
+       <imagedata fileref="remmina_sle15inside.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -267,10 +267,10 @@
     <title>读取配置文件的路径</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina_status.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina_status.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina_status.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina_status.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -332,10 +332,10 @@
    <title>远程管理</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="vnc_nosession.png" width="70%" format="PNG"/>
+     <imagedata fileref="vnc_nosession.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="vnc_nosession.png" width="70%" format="PNG"/>
+     <imagedata fileref="vnc_nosession.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -561,10 +561,10 @@ WINDOWMANAGER=icewm vncserver -geometry 1024x768</screen>
      <title>VNC 会话设置</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="vncmanager_session.png" width="85%" format="PNG"/>
+       <imagedata fileref="vncmanager_session.png" width="85%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="vncmanager_session.png" width="85%" format="PNG"/>
+       <imagedata fileref="vncmanager_session.png" width="85%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -649,10 +649,10 @@ WINDOWMANAGER=icewm vncserver -geometry 1024x768</screen>
      <title>加入永久 VNC 会话</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="vncmanager_whether.png" width="80%" format="PNG"/>
+       <imagedata fileref="vncmanager_whether.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="vncmanager_whether.png" width="80%" format="PNG"/>
+       <imagedata fileref="vncmanager_whether.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/zh-cn/xml/yast2_lang.xml
+++ b/l10n/sled/zh-cn/xml/yast2_lang.xml
@@ -91,10 +91,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_language.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_language.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_language.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_language.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>
@@ -225,10 +225,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_timezone.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_timezone.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_timezone.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_timezone.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -306,10 +306,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_timezone_ntp.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_timezone_ntp.png" width="75%"/>
       </imageobject>
       <imageobject role="pdf">
-       <imagedata fileref="yast2_timezone_ntp.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_timezone_ntp.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sled/zh-cn/xml/yast2_ncurses.xml
+++ b/l10n/sled/zh-cn/xml/yast2_ncurses.xml
@@ -15,10 +15,10 @@
   <title>文本模式下的 YaST 主窗口</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="yast2_ncurses_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="yast2_ncurses_main.png" width="70%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="yast2_ncurses_main.png" width="75%" format="PNG"/>
+    <imagedata fileref="yast2_ncurses_main.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -99,10 +99,10 @@
    <title>软件安装模块</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_ncurses_inst.png" width="70%" format="PNG"/>
+     <imagedata fileref="yast2_ncurses_inst.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_ncurses_inst.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_ncurses_inst.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-cn/xml/yast2_sw.xml
+++ b/l10n/sled/zh-cn/xml/yast2_sw.xml
@@ -152,10 +152,10 @@
      <phrase><guimenu>YaST</guimenu> software manager screen</phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_sw_manager.png" width="70%" format="PNG"/>
+     <imagedata fileref="yast2_sw_manager.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_sw_manager.png" width="65%" format="PNG"/>
+     <imagedata fileref="yast2_sw_manager.png" width="65%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -477,10 +477,10 @@
     <title>软件管理器的冲突管理</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_package_conflict.png" width="70%" format="PNG"/>
+      <imagedata fileref="yast2_package_conflict.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_package_conflict.png" width="65%" format="PNG"/>
+      <imagedata fileref="yast2_package_conflict.png" width="65%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/zh-cn/xml/yast2_sw_repo.xml
+++ b/l10n/sled/zh-cn/xml/yast2_sw_repo.xml
@@ -52,10 +52,10 @@
      <title>添加软件源</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_addon_new.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_addon_new.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_addon_new.png" width="65%" format="PNG"/>
+       <imagedata fileref="yast2_addon_new.png" width="65%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/zh-cn/xml/yast2_userman.xml
+++ b/l10n/sled/zh-cn/xml/yast2_userman.xml
@@ -22,11 +22,11 @@
    <title>YaST 用户和组管理</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_users_main_qt.png" width="90%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_users_main_qt.png" width="90%" os="sles;sled"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_users_main_qt.png" width="70%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_users_main_qt.png" width="70%" os="sles;sled"/>
      
     </imageobject>
    </mediaobject>
@@ -379,11 +379,11 @@
      <informalfigure os="sles;sled">
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_users_quota_qt.png" width="80%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_users_quota_qt.png" width="80%" os="sles;sled"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_users_quota_qt.png" width="70%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_users_quota_qt.png" width="70%" os="sles;sled"/>
         
        </imageobject>
       </mediaobject>
@@ -549,11 +549,11 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_groups_edit_qt.png" width="80%" format="PNG" os="sles;sled"/>
+       <imagedata fileref="yast2_groups_edit_qt.png" width="80%" os="sles;sled"/>
        
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_groups_edit_qt.png" width="75%" format="PNG" os="sles;sled"/>
+       <imagedata fileref="yast2_groups_edit_qt.png" width="75%" os="sles;sled"/>
        
       </imageobject>
      </mediaobject>

--- a/l10n/sled/zh-cn/xml/yast2_you.xml
+++ b/l10n/sled/zh-cn/xml/yast2_you.xml
@@ -73,11 +73,11 @@
    <title>YaST 联机更新</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_you.png" width="75%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_you.png" width="75%" os="sles;sled"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_you.png" width="75%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_you.png" width="75%" os="sles;sled"/>
      
     </imageobject>
    </mediaobject>
@@ -204,10 +204,10 @@
    <title>查看已撤回的补丁和历史记录</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_retracted_patches.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_retracted_patches.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_retracted_patches.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_retracted_patches.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>  
@@ -245,10 +245,10 @@
    <title>YaST 联机更新配置</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_autoupdate.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_autoupdate.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_autoupdate.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_autoupdate.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-tw/xml/adm_support.xml
+++ b/l10n/sled/zh-tw/xml/adm_support.xml
@@ -135,10 +135,10 @@ CPU Load Average:         7 (3%) with 2 CPUs
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_support_main.png" width="70%" format="PNG"/>
+        <imagedata fileref="yast2_support_main.png" width="70%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_support_main.png" width="60%" format="PNG"/>
+        <imagedata fileref="yast2_support_main.png" width="60%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -176,10 +176,10 @@ CPU Load Average:         7 (3%) with 2 CPUs
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_support_conf.png" width="90%" format="PNG"/>
+        <imagedata fileref="yast2_support_conf.png" width="90%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_support_conf.png" width="80%" format="PNG"/>
+        <imagedata fileref="yast2_support_conf.png" width="80%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -740,10 +740,10 @@ Creating Tar Ball
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_support_conf_upload.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_support_conf_upload.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_support_conf_upload.png" width="60%" format="PNG"/>
+       <imagedata fileref="yast2_support_conf_upload.png" width="60%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sled/zh-tw/xml/apps_ekiga.xml
+++ b/l10n/sled/zh-tw/xml/apps_ekiga.xml
@@ -170,10 +170,10 @@
    <title><productname>Ekiga</productname> 使用者介面</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="ekiga_main.png" width="45%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="45%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ekiga_main.png" width="55%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="55%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-tw/xml/apps_evolution.xml
+++ b/l10n/sled/zh-tw/xml/apps_evolution.xml
@@ -733,10 +733,10 @@
    <title><productname>Evolution</productname> window</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" width="100%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" width="86%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="86%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-tw/xml/apps_firefox.xml
+++ b/l10n/sled/zh-tw/xml/apps_firefox.xml
@@ -29,7 +29,7 @@
   <note>
    <title>使用選單列</title>
    <para>
-    <productname>Firefox</productname> 的大多數功能都可透過三條橫線按鈕 (<inlinemediaobject><textobject role="description"><phrase>三條橫線按鈕</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject>) 存取，有些功能只能透過選單列存取。
+    <productname>Firefox</productname> 的大多數功能都可透過三條橫線按鈕 (<inlinemediaobject><textobject role="description"><phrase>三條橫線按鈕</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em"/></imageobject></inlinemediaobject>) 存取，有些功能只能透過選單列存取。
    </para>
    <para>
     <productname>Firefox</productname> 的選單列預設會隱藏起來。若要暫時顯示選單列，請按 <keycap function="alt"/>。選單列隨後將一直顯示，直至您按一下瀏覽器視窗中的其他位置。

--- a/l10n/sled/zh-tw/xml/apps_gimp.xml
+++ b/l10n/sled/zh-tw/xml/apps_gimp.xml
@@ -125,10 +125,10 @@
     <title>工具箱</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="gimp-toolbox.png" width="35%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="35%"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="gimp-toolbox.png" width="30%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="30%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -547,10 +547,10 @@
        <title>基本色彩選擇器對話方塊</title>
        <mediaobject>
         <imageobject role="html">
-         <imagedata fileref="gimp-color.png" width="70%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="70%"/>
         </imageobject>
         <imageobject role="fo">
-         <imagedata fileref="gimp-color.png" width="80%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="80%"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -719,10 +719,10 @@
    <title>列印對話方塊</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="gimp-print.png" width="75%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="75%"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="gimp-print.png" width="70%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-tw/xml/apps_libreoffice.xml
+++ b/l10n/sled/zh-tw/xml/apps_libreoffice.xml
@@ -528,7 +528,7 @@
    </step>
    <step>
     <para>
-     移至憑證優先設定，方法是開啟功能表 (<inlinemediaobject><textobject role="description"><phrase>三條橫線按鈕</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject>)，然後選取<menuchoice><guimenu>設定</guimenu>
+     移至憑證優先設定，方法是開啟功能表 (<inlinemediaobject><textobject role="description"><phrase>三條橫線按鈕</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em"/></imageobject></inlinemediaobject>)，然後選取<menuchoice><guimenu>設定</guimenu>
       <guimenu>隱私權與安全性</guimenu></menuchoice>。
     </para>
    </step>
@@ -573,10 +573,10 @@
    <title><guimenu>Writer</guimenu> 中的自訂對話方塊</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -728,10 +728,10 @@
    <title>選項視窗</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_options.png" width="95%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_options.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-tw/xml/apps_librevarious.xml
+++ b/l10n/sled/zh-tw/xml/apps_librevarious.xml
@@ -285,10 +285,10 @@
        <mediaobject>
         <textobject><phrase>Field selection</phrase></textobject>
         <imageobject role="fo">
-         <imagedata fileref="oo-wizard-base.png" width="90%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="90%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="oo-wizard-base.png" width="85%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="85%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>

--- a/l10n/sled/zh-tw/xml/apps_librewriter.xml
+++ b/l10n/sled/zh-tw/xml/apps_librewriter.xml
@@ -66,10 +66,10 @@
    <title>LibreOffice 精靈</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo-wizard.png" width="100%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo-wizard.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -231,10 +231,10 @@
     <title>「樣式」面板</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo-stylist.png" width="40%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="40%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo-stylist.png" width="50%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -641,10 +641,10 @@
     <title><guimenu>Writer</guimenu> 中的助手工具</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo_navigator.png" width="55%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo_navigator.png" width="45%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="45%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/zh-tw/xml/apps_totem.xml
+++ b/l10n/sled/zh-tw/xml/apps_totem.xml
@@ -59,10 +59,10 @@
    <title><guimenu>GNOME Videos</guimenu> 啟動視窗</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -132,11 +132,11 @@
     <guimenu>退出</guimenu> </menuchoice>。
    </para>
    <para>
-    若要暫停正在播放的影片或曲目，請按一下 <inlinemediaobject><textobject role="description"><phrase>GNOME Videos 暫停</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_pause_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="totem_pause_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject> 按鈕,或按一下<menuchoice> <guimenu>影片</guimenu>
+    若要暫停正在播放的影片或曲目，請按一下 <inlinemediaobject><textobject role="description"><phrase>GNOME Videos 暫停</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_pause_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="totem_pause_button-fallback.png" width="1em"/></imageobject></inlinemediaobject> 按鈕,或按一下<menuchoice> <guimenu>影片</guimenu>
     <guimenu>播放/暫停</guimenu> </menuchoice>。暫停影片或曲目後，狀態列會顯示<guimenu>已暫停</guimenu>和目前影片或曲目已播放的時間。
    </para>
    <para>
-    若要繼續播放影片或曲目，請按一下 <inlinemediaobject><textobject role="description"><phrase>GNOME Videos 播放</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_play_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="totem_play_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject> 按鈕,或按一下<menuchoice> <guimenu>影片</guimenu>
+    若要繼續播放影片或曲目，請按一下 <inlinemediaobject><textobject role="description"><phrase>GNOME Videos 播放</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_play_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="totem_play_button-fallback.png" width="1em"/></imageobject></inlinemediaobject> 按鈕,或按一下<menuchoice> <guimenu>影片</guimenu>
     <guimenu>播放/暫停</guimenu></menuchoice>。
    </para>
    <para>
@@ -223,10 +223,10 @@
     <title><guimenu>GNOME Videos</guimenu> 一般偏好設定</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -268,10 +268,10 @@
     <title><guimenu>GNOME Videos</guimenu> 顯示偏好設定</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -307,10 +307,10 @@
     <title><guimenu>GNOME Videos</guimenu> 音效偏好設定</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/zh-tw/xml/backup.xml
+++ b/l10n/sled/zh-tw/xml/backup.xml
@@ -20,10 +20,10 @@
  <mediaobject>
   <textobject><phrase>Backup application</phrase></textobject>
   <imageobject role="fo">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
   <imageobject role="html">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
  </mediaobject>
 </informalfigure>

--- a/l10n/sled/zh-tw/xml/chrony.xml
+++ b/l10n/sled/zh-tw/xml/chrony.xml
@@ -44,10 +44,10 @@
    <title>NTP 組態視窗</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="ntp_client.png" width="70%" format="PNG"/>
+     <imagedata fileref="ntp_client.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ntp_client.png" width="70%" format="PNG"/>
+     <imagedata fileref="ntp_client.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -107,10 +107,10 @@
     <title>新增時間伺服器</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="ntp_client_serveradd.png" width="70%" format="PNG"/>
+      <imagedata fileref="ntp_client_serveradd.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="ntp_client_serveradd.png" width="70%" format="PNG"/>
+      <imagedata fileref="ntp_client_serveradd.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/zh-tw/xml/gnome_accessibility.xml
+++ b/l10n/sled/zh-tw/xml/gnome_accessibility.xml
@@ -90,10 +90,10 @@
      <mediaobject>
       <textobject><phrase>On-screen keyboard</phrase></textobject>
       <imageobject role="fo">
-       <imagedata fileref="gnome_onscreen_kbd.png" width="95%" format="PNG"/>
+       <imagedata fileref="gnome_onscreen_kbd.png" width="95%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="gnome_onscreen_kbd.png" width="90%" format="PNG"/>
+       <imagedata fileref="gnome_onscreen_kbd.png" width="90%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sled/zh-tw/xml/gnome_crypto.xml
+++ b/l10n/sled/zh-tw/xml/gnome_crypto.xml
@@ -22,10 +22,10 @@
   <title><guimenu>密碼及金鑰</guimenu>主視窗</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sled/zh-tw/xml/gnome_custom.xml
+++ b/l10n/sled/zh-tw/xml/gnome_custom.xml
@@ -61,10 +61,10 @@
      <title>GNOME 背景設定</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="preferences_background.png" width="45%" format="PNG"/>
+        <imagedata fileref="preferences_background.png" width="45%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="preferences_background.png" width="45%" format="PNG"/>
+        <imagedata fileref="preferences_background.png" width="45%"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -148,10 +148,10 @@
    <title>鍵盤快速鍵對話方塊</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_keyboard.png" width="100%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_keyboard.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -178,10 +178,10 @@
    <title>在 tweaks 中啟用按鍵組合</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -307,10 +307,10 @@
    <title><guimenu>滑鼠和觸控板</guimenu>設定對話方塊</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -362,10 +362,10 @@
     <title>「單監視器設定」對話方塊</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="preferences_screen_single.png" width="100%" format="PNG"/>
+      <imagedata fileref="preferences_screen_single.png" width="100%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="preferences_screen_single.png" width="80%" format="PNG"/>
+      <imagedata fileref="preferences_screen_single.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -486,10 +486,10 @@
    <title>組態音效設定</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="sound_devices.png" width="100%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="sound_devices.png" width="80%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -515,10 +515,10 @@
      <title>預設應用程式</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="preferences_preferred_apps.png" width="100%" format="PNG"/>
+       <imagedata fileref="preferences_preferred_apps.png" width="100%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="preferences_preferred_apps.png" width="80%" format="PNG"/>
+       <imagedata fileref="preferences_preferred_apps.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/zh-tw/xml/gnome_networking.xml
+++ b/l10n/sled/zh-tw/xml/gnome_networking.xml
@@ -104,10 +104,10 @@
    <title>網路檔案瀏覽器</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="network_browser.png" width="100%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="100%"/>
      </imageobject>
     <imageobject role="html">
-     <imagedata fileref="network_browser.png" width="90%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -256,10 +256,10 @@
       <mediaobject>
        <textobject><phrase>Sharing options</phrase></textobject>
        <imageobject role="fo">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/l10n/sled/zh-tw/xml/gnome_start.xml
+++ b/l10n/sled/zh-tw/xml/gnome_start.xml
@@ -37,11 +37,11 @@
    <title>預設 GNOME 登入畫面</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata os="sles;sled" fileref="login_sled.png" width="90%" format="PNG"/>
+     <imagedata os="sles;sled" fileref="login_sled.png" width="90%"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata os="sles;sled" fileref="login_sled.png" width="75%" format="PNG"/>
+     <imagedata os="sles;sled" fileref="login_sled.png" width="75%"/>
      
     </imageobject>
    </mediaobject>
@@ -83,11 +83,11 @@
       <title>預設 GNOME 登入畫面 - 工作階段類型</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="90%" format="PNG"/>
+        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="90%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="75%" format="PNG"/>
+        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="75%"/>
         
        </imageobject>
       </mediaobject>
@@ -211,10 +211,10 @@
    <title>GNOME 桌面及活動綜覽</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="desktop_sled_menu.png" width="95%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="desktop_sled_menu.png" width="90%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -259,10 +259,10 @@
      <title><guimenu>活動</guimenu>綜覽</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="desktop_activities_overview.png" width="95%" format="PNG"/>
+      <imagedata fileref="desktop_activities_overview.png" width="95%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="desktop_activities_overview.png" width="90%" format="PNG"/>
+      <imagedata fileref="desktop_activities_overview.png" width="90%"/>
      </imageobject>
     </mediaobject>
      </figure>
@@ -299,10 +299,10 @@
      <title><productname>Firefox</productname> 的<guimenu>應用程式</guimenu>功能表</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="desktop_app_menu_firefox.png" width="70%" format="PNG"/>
+       <imagedata fileref="desktop_app_menu_firefox.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="desktop_app_menu_firefox.png" width="70%" format="PNG"/>
+       <imagedata fileref="desktop_app_menu_firefox.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/zh-tw/xml/gnome_use.xml
+++ b/l10n/sled/zh-tw/xml/gnome_use.xml
@@ -26,10 +26,10 @@
    <title>檔案管理員</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -573,10 +573,10 @@
     <textobject><phrase><productname>Evolution</productname></phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" format="PNG" width="100%"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" format="PNG" width="80%"/>
+     <imagedata fileref="evolution.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -673,10 +673,10 @@
    <title><productname>Archive manager</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -971,10 +971,10 @@
    <title><productname>Document viewer</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evince.png" format="PNG" width="90%"/>
+     <imagedata fileref="evince.png" width="90%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evince.png" format="PNG" width="78%"/>
+     <imagedata fileref="evince.png" width="78%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-tw/xml/grub2.xml
+++ b/l10n/sled/zh-tw/xml/grub2.xml
@@ -438,10 +438,10 @@
       <title>GRUB 2 開機編輯器</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="grub2_edit_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="grub2_edit_config.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="grub2_edit_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="grub2_edit_config.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </figure>

--- a/l10n/sled/zh-tw/xml/grub2_yast_i.xml
+++ b/l10n/sled/zh-tw/xml/grub2_yast_i.xml
@@ -93,10 +93,10 @@
     <title>開機代碼選項</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%"/>
      </imageobject>
     </mediaobject>
   </figure>
@@ -215,10 +215,10 @@
     <title>開機載入程式選項</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_options.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_options.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_options.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_options.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -277,10 +277,10 @@
     <title>核心參數</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/zh-tw/xml/help_user.xml
+++ b/l10n/sled/zh-tw/xml/help_user.xml
@@ -61,10 +61,10 @@
    <title>說明的主視窗</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-tw/xml/journalctl.xml
+++ b/l10n/sled/zh-tw/xml/journalctl.xml
@@ -336,10 +336,10 @@ enabled</screen>
    <title>YaST systemd 日誌</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_journal.png" width="80%" format="PNG"/>
+     <imagedata fileref="yast2_journal.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_journal.png" width="85%" format="PNG"/>
+     <imagedata fileref="yast2_journal.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-tw/xml/klp.xml
+++ b/l10n/sled/zh-tw/xml/klp.xml
@@ -64,10 +64,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="klp.png" width="80%" format="PNG"/>
+     <imagedata fileref="klp.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="klp.png" width="100%" format="PNG"/>
+     <imagedata fileref="klp.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>

--- a/l10n/sled/zh-tw/xml/net_basic.xml
+++ b/l10n/sled/zh-tw/xml/net_basic.xml
@@ -60,10 +60,10 @@
   <title>TCP/IP 的簡化層模型</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata width="100%" fileref="net_basic_osi.svg" format="SVG"/>
+    <imagedata width="100%" fileref="net_basic_osi.svg"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata width="75%" fileref="net_basic_osi.png" format="PNG"/>
+    <imagedata width="75%" fileref="net_basic_osi.png"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -80,10 +80,10 @@
   <title>TCP/IP 乙太網路封包</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata width="80%" fileref="net_basic_tcppacket.svg" format="SVG"/>
+    <imagedata width="80%" fileref="net_basic_tcppacket.svg"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata width="75%" fileref="net_basic_tcppacket.png" format="PNG"/>
+    <imagedata width="75%" fileref="net_basic_tcppacket.png"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sled/zh-tw/xml/net_bonding.xml
+++ b/l10n/sled/zh-tw/xml/net_bonding.xml
@@ -114,10 +114,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="bond_configuration.png" width="70%" format="PNG"/>
+      <imagedata fileref="bond_configuration.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="bond_configuration.png" width="65%" format="PNG"/>
+      <imagedata fileref="bond_configuration.png" width="65%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sled/zh-tw/xml/net_wicked.xml
+++ b/l10n/sled/zh-tw/xml/net_wicked.xml
@@ -79,10 +79,10 @@
     <title><literal>wicked</literal> 架構</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="wicked_scheme.png" format="PNG"/>
+      <imagedata fileref="wicked_scheme.png"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="wicked_scheme.png" format="PNG" width="80%"/>
+      <imagedata fileref="wicked_scheme.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/zh-tw/xml/net_yast.xml
+++ b/l10n/sled/zh-tw/xml/net_yast.xml
@@ -43,10 +43,10 @@
    <title>組態網路設定</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_net_icard.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_net_icard.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_net_icard.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_net_icard.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-tw/xml/network_scheme.xml
+++ b/l10n/sled/zh-tw/xml/network_scheme.xml
@@ -4,10 +4,10 @@
  <info>
   <mediaobject>
    <imageobject role="html">
-    <imagedata fileref="network_schema.png" width="100%" format="PNG"/>
+    <imagedata fileref="network_schema.png" width="100%"/>
    </imageobject>
    <imageobject role="pdf">
-    <imagedata fileref="network_schema.svg" width="100%" format="SVG"/>
+    <imagedata fileref="network_schema.svg" width="100%"/>
    </imageobject>
   </mediaobject>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -21,10 +21,10 @@
  <informalfigure>
   <mediaobject>
    <imageobject role="html">
-    <imagedata fileref="network_schema.png" width="100%" format="PNG"/>
+    <imagedata fileref="network_schema.png" width="100%"/>
    </imageobject>
    <imageobject role="pdf">
-    <imagedata fileref="network_schema.svg" width="100%" format="SVG"/>
+    <imagedata fileref="network_schema.svg" width="100%"/>
    </imageobject>
   </mediaobject>
  </informalfigure>

--- a/l10n/sled/zh-tw/xml/snapper.xml
+++ b/l10n/sled/zh-tw/xml/snapper.xml
@@ -417,10 +417,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_list.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_list.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_list.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_list.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -432,10 +432,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_changes.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_changes.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_changes.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_changes.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -447,10 +447,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_diff.png" width="65%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_diff.png" width="65%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_diff.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_diff.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -462,10 +462,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_restore.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_restore.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_restore.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_restore.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -827,10 +827,10 @@ single | 4 |     |         |                       |
     <title>開機載入程式：快照</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="boot_snapshots.png" width="75%" format="PNG"/>
+      <imagedata fileref="boot_snapshots.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="boot_snapshots.png" width="75%" format="PNG"/>
+      <imagedata fileref="boot_snapshots.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/zh-tw/xml/systemd.xml
+++ b/l10n/sled/zh-tw/xml/systemd.xml
@@ -1051,10 +1051,10 @@ Startup finished in 2666ms (kernel) + 21961ms (userspace) = 24628ms</screen>
        <informalfigure>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="systemd_startup.svg" width="75%" format="SVG"/>
+          <imagedata fileref="systemd_startup.svg" width="75%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="systemd_startup.png" width="75%" format="PNG"/>
+          <imagedata fileref="systemd_startup.png" width="75%"/>
          </imageobject>
         </mediaobject>
        </informalfigure>
@@ -1137,10 +1137,10 @@ WantedBy=multi-user.target<co xml:id="co-service-wrapper-target"/></screen>
    <title>服務管理員</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_runlevel.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_runlevel.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_runlevel.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_runlevel.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-tw/xml/tuning_multikernel.xml
+++ b/l10n/sled/zh-tw/xml/tuning_multikernel.xml
@@ -236,10 +236,10 @@
      <title>YaST 軟體管理員：多版本檢視</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_sw_multiversion.png" width="90%" format="PNG"/>
+       <imagedata fileref="yast2_sw_multiversion.png" width="90%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_sw_multiversion.png" width="90%" format="PNG"/>
+       <imagedata fileref="yast2_sw_multiversion.png" width="90%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/zh-tw/xml/uefi.xml
+++ b/l10n/sled/zh-tw/xml/uefi.xml
@@ -83,10 +83,10 @@
      <title>安全開機支援</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/zh-tw/xml/updater_gnome.xml
+++ b/l10n/sled/zh-tw/xml/updater_gnome.xml
@@ -25,11 +25,11 @@
   <mediaobject>
    <imageobject role="fo">
     
-    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%" format="PNG"/>
+    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
     
-    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%" format="PNG"/>
+    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -47,10 +47,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="gupdater_updates.png" width="75%" format="PNG"/>
+      <imagedata fileref="gupdater_updates.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="gupdater_updates.png" width="75%" format="PNG"/>
+      <imagedata fileref="gupdater_updates.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sled/zh-tw/xml/updater_gnome_sw.xml
+++ b/l10n/sled/zh-tw/xml/updater_gnome_sw.xml
@@ -42,10 +42,10 @@
   <title><guimenu>GNOME Software</guimenu> — <guimenu>更新</guimenu>檢視</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="gnome-software-updates.png" width="75%" format="PNG"/>
+    <imagedata fileref="gnome-software-updates.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="gnome-software-updates.png" width="75%" format="PNG"/>
+    <imagedata fileref="gnome-software-updates.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sled/zh-tw/xml/vnc.xml
+++ b/l10n/sled/zh-tw/xml/vnc.xml
@@ -56,10 +56,10 @@
      <textobject role="description"><phrase>vncviewer asking for connection details</phrase>
      </textobject>
      <imageobject role="html">
-      <imagedata fileref="vnc_connect.png" format="PNG"/>
+      <imagedata fileref="vnc_connect.png"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="vnc_connect.png" format="PNG"/>
+      <imagedata fileref="vnc_connect.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -99,10 +99,10 @@
     <title>Remmina 的主視窗</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -114,16 +114,16 @@
   <sect2 xml:id="vnc-remmina-addnew">
    <title>新增遠端工作階段</title>
    <para>
-    若要新增和儲存新的遠端工作階段，請按一下主視窗右上方的 <inlinemediaobject><textobject role="description"><phrase>新增新工作階段</phrase></textobject><imageobject role="fo"><imagedata fileref="remmina_plus.png" width="1.2em" format="PNG"/></imageobject><imageobject role="html"><imagedata fileref="remmina_plus.png" width="1.2em" format="PNG"/></imageobject></inlinemediaobject>。<guimenu>遠端桌面優先設定</guimenu>視窗即會開啟。
+    若要新增和儲存新的遠端工作階段，請按一下主視窗右上方的 <inlinemediaobject><textobject role="description"><phrase>新增新工作階段</phrase></textobject><imageobject role="fo"><imagedata fileref="remmina_plus.png" width="1.2em"/></imageobject><imageobject role="html"><imagedata fileref="remmina_plus.png" width="1.2em"/></imageobject></inlinemediaobject>。<guimenu>遠端桌面優先設定</guimenu>視窗即會開啟。
    </para>
    <figure>
     <title>遠端桌面優先設定</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina_session_details.png" width="80%" format="PNG"/>
+      <imagedata fileref="remmina_session_details.png" width="80%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina_session_details.png" width="80%" format="PNG"/>
+      <imagedata fileref="remmina_session_details.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -203,10 +203,10 @@
      <title>快速啟動</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="remmina_quickstart.png" width="40%" format="PNG"/>
+       <imagedata fileref="remmina_quickstart.png" width="40%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="remmina_quickstart.png" width="40%" format="PNG"/>
+       <imagedata fileref="remmina_quickstart.png" width="40%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -229,10 +229,10 @@
      <title>正在檢視遠端工作階段的 Remmina</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>
+       <imagedata fileref="remmina_sle15inside.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>
+       <imagedata fileref="remmina_sle15inside.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -267,10 +267,10 @@
     <title>讀取設定檔的路徑</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina_status.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina_status.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina_status.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina_status.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -332,10 +332,10 @@
    <title>遠端管理</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="vnc_nosession.png" width="70%" format="PNG"/>
+     <imagedata fileref="vnc_nosession.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="vnc_nosession.png" width="70%" format="PNG"/>
+     <imagedata fileref="vnc_nosession.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -561,10 +561,10 @@ WINDOWMANAGER=icewm vncserver -geometry 1024x768</screen>
      <title>VNC 工作階段設定</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="vncmanager_session.png" width="85%" format="PNG"/>
+       <imagedata fileref="vncmanager_session.png" width="85%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="vncmanager_session.png" width="85%" format="PNG"/>
+       <imagedata fileref="vncmanager_session.png" width="85%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -649,10 +649,10 @@ WINDOWMANAGER=icewm vncserver -geometry 1024x768</screen>
      <title>加入永久 VNC 工作階段</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="vncmanager_whether.png" width="80%" format="PNG"/>
+       <imagedata fileref="vncmanager_whether.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="vncmanager_whether.png" width="80%" format="PNG"/>
+       <imagedata fileref="vncmanager_whether.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/zh-tw/xml/yast2_lang.xml
+++ b/l10n/sled/zh-tw/xml/yast2_lang.xml
@@ -91,10 +91,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_language.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_language.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_language.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_language.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>
@@ -225,10 +225,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_timezone.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_timezone.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_timezone.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_timezone.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -306,10 +306,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_timezone_ntp.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_timezone_ntp.png" width="75%"/>
       </imageobject>
       <imageobject role="pdf">
-       <imagedata fileref="yast2_timezone_ntp.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_timezone_ntp.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sled/zh-tw/xml/yast2_ncurses.xml
+++ b/l10n/sled/zh-tw/xml/yast2_ncurses.xml
@@ -15,10 +15,10 @@
   <title>文字模式下的 YaST 主視窗</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="yast2_ncurses_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="yast2_ncurses_main.png" width="70%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="yast2_ncurses_main.png" width="75%" format="PNG"/>
+    <imagedata fileref="yast2_ncurses_main.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -99,10 +99,10 @@
    <title>軟體安裝模組</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_ncurses_inst.png" width="70%" format="PNG"/>
+     <imagedata fileref="yast2_ncurses_inst.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_ncurses_inst.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_ncurses_inst.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sled/zh-tw/xml/yast2_sw.xml
+++ b/l10n/sled/zh-tw/xml/yast2_sw.xml
@@ -152,10 +152,10 @@
      <phrase><guimenu>YaST</guimenu> software manager screen</phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_sw_manager.png" width="70%" format="PNG"/>
+     <imagedata fileref="yast2_sw_manager.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_sw_manager.png" width="65%" format="PNG"/>
+     <imagedata fileref="yast2_sw_manager.png" width="65%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -477,10 +477,10 @@
     <title>軟體管理員的衝突管理</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_package_conflict.png" width="70%" format="PNG"/>
+      <imagedata fileref="yast2_package_conflict.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_package_conflict.png" width="65%" format="PNG"/>
+      <imagedata fileref="yast2_package_conflict.png" width="65%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sled/zh-tw/xml/yast2_sw_repo.xml
+++ b/l10n/sled/zh-tw/xml/yast2_sw_repo.xml
@@ -52,10 +52,10 @@
      <title>新增軟體儲存庫</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_addon_new.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_addon_new.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_addon_new.png" width="65%" format="PNG"/>
+       <imagedata fileref="yast2_addon_new.png" width="65%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sled/zh-tw/xml/yast2_userman.xml
+++ b/l10n/sled/zh-tw/xml/yast2_userman.xml
@@ -22,11 +22,11 @@
    <title>YaST 使用者及群組管理</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_users_main_qt.png" width="90%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_users_main_qt.png" width="90%" os="sles;sled"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_users_main_qt.png" width="70%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_users_main_qt.png" width="70%" os="sles;sled"/>
      
     </imageobject>
    </mediaobject>
@@ -379,11 +379,11 @@
      <informalfigure os="sles;sled">
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_users_quota_qt.png" width="80%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_users_quota_qt.png" width="80%" os="sles;sled"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_users_quota_qt.png" width="70%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_users_quota_qt.png" width="70%" os="sles;sled"/>
         
        </imageobject>
       </mediaobject>
@@ -549,11 +549,11 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_groups_edit_qt.png" width="80%" format="PNG" os="sles;sled"/>
+       <imagedata fileref="yast2_groups_edit_qt.png" width="80%" os="sles;sled"/>
        
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_groups_edit_qt.png" width="75%" format="PNG" os="sles;sled"/>
+       <imagedata fileref="yast2_groups_edit_qt.png" width="75%" os="sles;sled"/>
        
       </imageobject>
      </mediaobject>

--- a/l10n/sled/zh-tw/xml/yast2_you.xml
+++ b/l10n/sled/zh-tw/xml/yast2_you.xml
@@ -73,11 +73,11 @@
    <title>YaST 線上更新</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_you.png" width="75%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_you.png" width="75%" os="sles;sled"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_you.png" width="75%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_you.png" width="75%" os="sles;sled"/>
      
     </imageobject>
    </mediaobject>
@@ -204,10 +204,10 @@
    <title>檢視已收回的修補程式和歷程</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_retracted_patches.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_retracted_patches.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_retracted_patches.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_retracted_patches.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>  
@@ -245,10 +245,10 @@
    <title>YaST 線上更新組態</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_autoupdate.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_autoupdate.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_autoupdate.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_autoupdate.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/de-de/xml/adm_support.xml
+++ b/l10n/sles/de-de/xml/adm_support.xml
@@ -135,10 +135,10 @@ CPU Load Average:         7 (3%) with 2 CPUs
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_support_main.png" width="70%" format="PNG"/>
+        <imagedata fileref="yast2_support_main.png" width="70%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_support_main.png" width="60%" format="PNG"/>
+        <imagedata fileref="yast2_support_main.png" width="60%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -176,10 +176,10 @@ CPU Load Average:         7 (3%) with 2 CPUs
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_support_conf.png" width="90%" format="PNG"/>
+        <imagedata fileref="yast2_support_conf.png" width="90%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_support_conf.png" width="80%" format="PNG"/>
+        <imagedata fileref="yast2_support_conf.png" width="80%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -740,10 +740,10 @@ Creating Tar Ball
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_support_conf_upload.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_support_conf_upload.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_support_conf_upload.png" width="60%" format="PNG"/>
+       <imagedata fileref="yast2_support_conf_upload.png" width="60%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/de-de/xml/apache2_yast_i.xml
+++ b/l10n/sles/de-de/xml/apache2_yast_i.xml
@@ -45,10 +45,10 @@
     <title>HTTP-Server-Assistent: Standardhost</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_apache_wizard3.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_apache_wizard3.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_apache_wizard3.png" format="PNG"/>
+      <imagedata fileref="yast2_apache_wizard3.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -154,10 +154,10 @@
     <title>HTTP-Server-Assistent: Zusammenfassung</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_apache_wizard5.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_apache_wizard5.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_apache_wizard5.png" format="PNG"/>
+      <imagedata fileref="yast2_apache_wizard5.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -180,10 +180,10 @@
     <title>Konfiguration des HTTP-Servers: Überwachen von Ports und Adressen</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_apache_config_listen.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_apache_config_listen.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_apache_config_listen.png" format="PNG"/>
+      <imagedata fileref="yast2_apache_config_listen.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -197,10 +197,10 @@
     <title>Konfiguration des HTTP-Servers: Server-Module</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_apache_config_modules.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_apache_config_modules.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_apache_config_modules.png" format="PNG"/>
+      <imagedata fileref="yast2_apache_config_modules.png"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/de-de/xml/apps_ekiga.xml
+++ b/l10n/sles/de-de/xml/apps_ekiga.xml
@@ -170,10 +170,10 @@
    <title><productname>Ekiga</productname> Benutzeroberfläche</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="ekiga_main.png" width="45%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="45%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ekiga_main.png" width="55%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="55%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/de-de/xml/apps_evolution.xml
+++ b/l10n/sles/de-de/xml/apps_evolution.xml
@@ -733,10 +733,10 @@
    <title><productname>Evolution</productname> window</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" width="100%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" width="86%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="86%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/de-de/xml/apps_firefox.xml
+++ b/l10n/sles/de-de/xml/apps_firefox.xml
@@ -29,7 +29,7 @@
   <note>
    <title>Verwenden der Menüleiste</title>
    <para>
-    Die meisten Funktionen von <productname>Firefox</productname> lassen sich über das Dreistrichmenü (<inlinemediaobject><textobject role="description"><phrase>Dreistrichmenü</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject>) aufrufen, andere dagegen nur über die Menüleiste.
+    Die meisten Funktionen von <productname>Firefox</productname> lassen sich über das Dreistrichmenü (<inlinemediaobject><textobject role="description"><phrase>Dreistrichmenü</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em"/></imageobject></inlinemediaobject>) aufrufen, andere dagegen nur über die Menüleiste.
    </para>
    <para>
     Die Menüleiste von <productname>Firefox</productname> ist standardmäßig ausgeblendet. Mit <keycap function="alt"/> blenden Sie sie vorübergehend ein. Die Leiste bleibt dann so lange sichtbar, bis Sie auf eine andere Stelle im Browserfenster klicken.

--- a/l10n/sles/de-de/xml/apps_gimp.xml
+++ b/l10n/sles/de-de/xml/apps_gimp.xml
@@ -125,10 +125,10 @@
     <title>Die Werkzeugsammlung</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="gimp-toolbox.png" width="35%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="35%"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="gimp-toolbox.png" width="30%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="30%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -547,10 +547,10 @@
        <title>Das Dialogfeld zur Farbauswahl</title>
        <mediaobject>
         <imageobject role="html">
-         <imagedata fileref="gimp-color.png" width="70%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="70%"/>
         </imageobject>
         <imageobject role="fo">
-         <imagedata fileref="gimp-color.png" width="80%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="80%"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -719,10 +719,10 @@
    <title>Das Druckfenster</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="gimp-print.png" width="75%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="75%"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="gimp-print.png" width="70%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/de-de/xml/apps_libreoffice.xml
+++ b/l10n/sles/de-de/xml/apps_libreoffice.xml
@@ -492,10 +492,10 @@
    <title>Anpassungsdialogfeld in <guimenu>Writer</guimenu></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -647,10 +647,10 @@
    <title>Das Fenster „Optionen“</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_options.png" width="95%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_options.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/de-de/xml/apps_librevarious.xml
+++ b/l10n/sles/de-de/xml/apps_librevarious.xml
@@ -285,10 +285,10 @@
        <mediaobject>
         <textobject><phrase>Field selection</phrase></textobject>
         <imageobject role="fo">
-         <imagedata fileref="oo-wizard-base.png" width="90%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="90%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="oo-wizard-base.png" width="85%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="85%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>

--- a/l10n/sles/de-de/xml/apps_librewriter.xml
+++ b/l10n/sles/de-de/xml/apps_librewriter.xml
@@ -66,10 +66,10 @@
    <title>Ein LibreOffice-Assistent</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo-wizard.png" width="100%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo-wizard.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -232,10 +232,10 @@
     <title>Bereich „Styles“ (Formatvorlagen)</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo-stylist.png" width="40%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="40%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo-stylist.png" width="50%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -642,10 +642,10 @@
     <title><guimenu>Navigator-Werkzeug in Writer</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo_navigator.png" width="55%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo_navigator.png" width="45%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="45%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/de-de/xml/apps_totem.xml
+++ b/l10n/sles/de-de/xml/apps_totem.xml
@@ -59,10 +59,10 @@
    <title><guimenu>GNOME Videos</guimenu> – Fenster beim Starten</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -132,11 +132,11 @@
     <guimenu>Eject (Auswerfen)</guimenu> </menuchoice>.
    </para>
    <para>
-    Zum Anhalten der Wiedergabe eines Films oder Musiktitels klicken Sie auf die Schaltfläche <inlinemediaobject><textobject role="description"><phrase>GNOME Videos Pause</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_pause_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="totem_pause_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject> (GNOME Videos – Pause) oder auf <menuchoice> <guimenu>Movie (Film)</guimenu>
+    Zum Anhalten der Wiedergabe eines Films oder Musiktitels klicken Sie auf die Schaltfläche <inlinemediaobject><textobject role="description"><phrase>GNOME Videos Pause</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_pause_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="totem_pause_button-fallback.png" width="1em"/></imageobject></inlinemediaobject> (GNOME Videos – Pause) oder auf <menuchoice> <guimenu>Movie (Film)</guimenu>
     <guimenu>Play/Pause (Wiedergabe/Pause)</guimenu> </menuchoice> Wenn Sie einen Film oder Musiktitel anhalten, zeigt die Statusleiste <guimenu>Angehalten</guimenu> und die Zeitdauer an, über die der aktuelle Film oder Musiktitel abgespielt wurde.
    </para>
    <para>
-    Zum Fortsetzen der Wiedergabe des Films oder Musiktitels klicken Sie auf die Schaltfläche <inlinemediaobject><textobject role="description"><phrase>GNOME Videos Play</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_play_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="totem_play_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject> (GNOME Videos – Wiedergabe) oder auf <menuchoice> <guimenu>Movie (Film)</guimenu>
+    Zum Fortsetzen der Wiedergabe des Films oder Musiktitels klicken Sie auf die Schaltfläche <inlinemediaobject><textobject role="description"><phrase>GNOME Videos Play</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_play_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="totem_play_button-fallback.png" width="1em"/></imageobject></inlinemediaobject> (GNOME Videos – Wiedergabe) oder auf <menuchoice> <guimenu>Movie (Film)</guimenu>
     <guimenu>Play/Pause (Wiedergabe/Pause)</guimenu></menuchoice>
    </para>
    <para>
@@ -223,10 +223,10 @@
     <title>Allgemeine Einstellungen für <guimenu>GNOME Videos</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -268,10 +268,10 @@
     <title>Anzeigeeinstellungen für <guimenu>GNOME Videos</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -307,10 +307,10 @@
     <title>Audio-Einstellungen für <guimenu>GNOME Videos</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/de-de/xml/backup.xml
+++ b/l10n/sles/de-de/xml/backup.xml
@@ -20,10 +20,10 @@
  <mediaobject>
   <textobject><phrase>Backup application</phrase></textobject>
   <imageobject role="fo">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
   <imageobject role="html">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
  </mediaobject>
 </informalfigure>

--- a/l10n/sles/de-de/xml/chrony.xml
+++ b/l10n/sles/de-de/xml/chrony.xml
@@ -40,10 +40,10 @@
    <title>Fenster „NTP-Konfiguration“</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="ntp_client.png" width="70%" format="PNG"/>
+     <imagedata fileref="ntp_client.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ntp_client.png" width="70%" format="PNG"/>
+     <imagedata fileref="ntp_client.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -103,10 +103,10 @@
     <title>Hinzufügen eines Zeitservers</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="ntp_client_serveradd.png" width="70%" format="PNG"/>
+      <imagedata fileref="ntp_client_serveradd.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="ntp_client_serveradd.png" width="70%" format="PNG"/>
+      <imagedata fileref="ntp_client_serveradd.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/de-de/xml/deployment_expert_partitioner_lvm.xml
+++ b/l10n/sles/de-de/xml/deployment_expert_partitioner_lvm.xml
@@ -88,10 +88,10 @@
    <title>Anlegen einer Volume-Gruppe</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -108,10 +108,10 @@
    <title>Verwaltung von logischen Volumes</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/de-de/xml/deployment_expert_partitioner_overview.xml
+++ b/l10n/sles/de-de/xml/deployment_expert_partitioner_overview.xml
@@ -24,10 +24,10 @@
   <title>YaST-Partitionierung</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -231,10 +231,10 @@
         <title>Btrfs-Subvolumes im YaST-Partitionierer</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
         </mediaobject>
        </figure>

--- a/l10n/sles/de-de/xml/deployment_expert_partitioner_raid.xml
+++ b/l10n/sles/de-de/xml/deployment_expert_partitioner_raid.xml
@@ -56,10 +56,10 @@
    <title>RAID-Partitionen</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/de-de/xml/deployment_register.xml
+++ b/l10n/sles/de-de/xml/deployment_register.xml
@@ -80,11 +80,11 @@
         <phrase><guimenu>Registration</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -113,11 +113,11 @@
         <phrase><guimenu>Extension and Module Selection</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -143,11 +143,11 @@
         <phrase><guimenu>Installation Summary</guimenu> screen</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -212,11 +212,11 @@
         <phrase><guimenu>Extension and Module Selection</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%"/>
         
 
        </imageobject>
@@ -265,11 +265,11 @@
         <phrase><guimenu>Installed Add-on Products</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>

--- a/l10n/sles/de-de/xml/deployment_troubleshooting.xml
+++ b/l10n/sles/de-de/xml/deployment_troubleshooting.xml
@@ -160,10 +160,10 @@
    <title>US-Tastaturbelegung</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="keyboard_us.svg" width="75%" format="SVG"/>
+     <imagedata fileref="keyboard_us.svg" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="keyboard_us.png" width="75%" format="PNG"/>
+     <imagedata fileref="keyboard_us.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/de-de/xml/gnome_accessibility.xml
+++ b/l10n/sles/de-de/xml/gnome_accessibility.xml
@@ -90,10 +90,10 @@
      <mediaobject>
       <textobject><phrase>On-screen keyboard</phrase></textobject>
       <imageobject role="fo">
-       <imagedata fileref="gnome_onscreen_kbd.png" width="95%" format="PNG"/>
+       <imagedata fileref="gnome_onscreen_kbd.png" width="95%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="gnome_onscreen_kbd.png" width="90%" format="PNG"/>
+       <imagedata fileref="gnome_onscreen_kbd.png" width="90%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/de-de/xml/gnome_crypto.xml
+++ b/l10n/sles/de-de/xml/gnome_crypto.xml
@@ -22,10 +22,10 @@
   <title>Hauptfenster <guimenu>Passwörter und Schlüssel</guimenu></title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sles/de-de/xml/gnome_custom.xml
+++ b/l10n/sles/de-de/xml/gnome_custom.xml
@@ -61,10 +61,10 @@
      <title>GNOME-Hintergrundeinstellungen</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="preferences_background.png" width="45%" format="PNG"/>
+        <imagedata fileref="preferences_background.png" width="45%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="preferences_background.png" width="45%" format="PNG"/>
+        <imagedata fileref="preferences_background.png" width="45%"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -148,10 +148,10 @@
    <title>Dialogfeld für Tastenkombinationen</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_keyboard.png" width="100%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_keyboard.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -178,10 +178,10 @@
    <title>Aktivieren der Compose-Taste in Tweaks</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -307,10 +307,10 @@
    <title>Einstellungsdialogfeld für <guimenu>Maus und Touchpad</guimenu></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -362,10 +362,10 @@
     <title>Dialogfeld mit Einstellungen für einen einzelnen Monitor</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="preferences_screen_single.png" width="100%" format="PNG"/>
+      <imagedata fileref="preferences_screen_single.png" width="100%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="preferences_screen_single.png" width="80%" format="PNG"/>
+      <imagedata fileref="preferences_screen_single.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -486,10 +486,10 @@
    <title>Konfigurieren der Audioeinstellungen</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="sound_devices.png" width="100%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="sound_devices.png" width="80%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -515,10 +515,10 @@
      <title>Standardanwendungen</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="preferences_preferred_apps.png" width="100%" format="PNG"/>
+       <imagedata fileref="preferences_preferred_apps.png" width="100%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="preferences_preferred_apps.png" width="80%" format="PNG"/>
+       <imagedata fileref="preferences_preferred_apps.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/de-de/xml/gnome_networking.xml
+++ b/l10n/sles/de-de/xml/gnome_networking.xml
@@ -104,10 +104,10 @@
    <title>Netzwerk-Datei-Browser</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="network_browser.png" width="100%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="100%"/>
      </imageobject>
     <imageobject role="html">
-     <imagedata fileref="network_browser.png" width="90%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -256,10 +256,10 @@
       <mediaobject>
        <textobject><phrase>Sharing options</phrase></textobject>
        <imageobject role="fo">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/l10n/sles/de-de/xml/gnome_start.xml
+++ b/l10n/sles/de-de/xml/gnome_start.xml
@@ -37,11 +37,11 @@
    <title>Standardmäßiger GNOME-Anmeldebildschirm</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata os="sles;sled" fileref="login_sled.png" width="90%" format="PNG"/>
+     <imagedata os="sles;sled" fileref="login_sled.png" width="90%"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata os="sles;sled" fileref="login_sled.png" width="75%" format="PNG"/>
+     <imagedata os="sles;sled" fileref="login_sled.png" width="75%"/>
      
     </imageobject>
    </mediaobject>
@@ -83,11 +83,11 @@
       <title>Standardmäßiger GNOME-Anmeldebildschirm – Sitzungstyp</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="90%" format="PNG"/>
+        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="90%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="75%" format="PNG"/>
+        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="75%"/>
         
        </imageobject>
       </mediaobject>
@@ -197,10 +197,10 @@
    <title>GNOME-Desktop mit Aktivitätenübersicht</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="desktop_sled_menu.png" width="95%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="desktop_sled_menu.png" width="90%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -245,10 +245,10 @@
      <title><guimenu>Aktivitätenübersicht</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="desktop_activities_overview.png" width="95%" format="PNG"/>
+      <imagedata fileref="desktop_activities_overview.png" width="95%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="desktop_activities_overview.png" width="90%" format="PNG"/>
+      <imagedata fileref="desktop_activities_overview.png" width="90%"/>
      </imageobject>
     </mediaobject>
      </figure>
@@ -285,10 +285,10 @@
      <title><guimenu>Anwendungsmenü</guimenu> für <productname>Firefox</productname></title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="desktop_app_menu_firefox.png" width="70%" format="PNG"/>
+       <imagedata fileref="desktop_app_menu_firefox.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="desktop_app_menu_firefox.png" width="70%" format="PNG"/>
+       <imagedata fileref="desktop_app_menu_firefox.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/de-de/xml/gnome_use.xml
+++ b/l10n/sles/de-de/xml/gnome_use.xml
@@ -26,10 +26,10 @@
    <title>Datei-Manager</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -573,10 +573,10 @@
     <textobject><phrase><productname>Evolution</productname></phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" format="PNG" width="100%"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" format="PNG" width="80%"/>
+     <imagedata fileref="evolution.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -673,10 +673,10 @@
    <title><productname>Archive manager</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -971,10 +971,10 @@
    <title><productname>Document viewer</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evince.png" format="PNG" width="90%"/>
+     <imagedata fileref="evince.png" width="90%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evince.png" format="PNG" width="78%"/>
+     <imagedata fileref="evince.png" width="78%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/de-de/xml/grub2.xml
+++ b/l10n/sles/de-de/xml/grub2.xml
@@ -438,10 +438,10 @@
       <title>Booteditor in GRUB 2</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="grub2_edit_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="grub2_edit_config.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="grub2_edit_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="grub2_edit_config.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </figure>

--- a/l10n/sles/de-de/xml/grub2_yast_i.xml
+++ b/l10n/sles/de-de/xml/grub2_yast_i.xml
@@ -93,10 +93,10 @@
     <title>Bootcode-Optionen</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%"/>
      </imageobject>
     </mediaobject>
   </figure>
@@ -215,10 +215,10 @@
     <title>Bootloader-Optionen</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_options.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_options.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_options.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_options.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -277,10 +277,10 @@
     <title>Kernel-Parameter</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/de-de/xml/help_user.xml
+++ b/l10n/sles/de-de/xml/help_user.xml
@@ -61,10 +61,10 @@
    <title>Hauptfenster der Hilfe</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/de-de/xml/journalctl.xml
+++ b/l10n/sles/de-de/xml/journalctl.xml
@@ -336,10 +336,10 @@ enabled</screen>
    <title>YaST-systemd-Journal</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_journal.png" width="80%" format="PNG"/>
+     <imagedata fileref="yast2_journal.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_journal.png" width="85%" format="PNG"/>
+     <imagedata fileref="yast2_journal.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/de-de/xml/klp.xml
+++ b/l10n/sles/de-de/xml/klp.xml
@@ -64,10 +64,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="klp.png" width="80%" format="PNG"/>
+     <imagedata fileref="klp.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="klp.png" width="100%" format="PNG"/>
+     <imagedata fileref="klp.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>

--- a/l10n/sles/de-de/xml/net_basic.xml
+++ b/l10n/sles/de-de/xml/net_basic.xml
@@ -60,10 +60,10 @@
   <title>Vereinfachtes Schichtmodell für TCP/IP</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata width="100%" fileref="net_basic_osi.svg" format="SVG"/>
+    <imagedata width="100%" fileref="net_basic_osi.svg"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata width="75%" fileref="net_basic_osi.png" format="PNG"/>
+    <imagedata width="75%" fileref="net_basic_osi.png"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -80,10 +80,10 @@
   <title>TCP/IP-Ethernet-Paket</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata width="80%" fileref="net_basic_tcppacket.svg" format="SVG"/>
+    <imagedata width="80%" fileref="net_basic_tcppacket.svg"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata width="75%" fileref="net_basic_tcppacket.png" format="PNG"/>
+    <imagedata width="75%" fileref="net_basic_tcppacket.png"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sles/de-de/xml/net_bonding.xml
+++ b/l10n/sles/de-de/xml/net_bonding.xml
@@ -114,10 +114,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="bond_configuration.png" width="70%" format="PNG"/>
+      <imagedata fileref="bond_configuration.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="bond_configuration.png" width="65%" format="PNG"/>
+      <imagedata fileref="bond_configuration.png" width="65%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sles/de-de/xml/net_dhcp.xml
+++ b/l10n/sles/de-de/xml/net_dhcp.xml
@@ -86,10 +86,10 @@
       <title>DHCP-Server: Kartenauswahl</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz1.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz1.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz1.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz1.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -102,10 +102,10 @@
       <title>DHCP-Server: globale Einstellungen</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz2.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz2.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz2.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz2.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -118,10 +118,10 @@
       <title>DHCP-Server: dynamisches DHCP</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz3.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz3.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz3.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz3.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -135,10 +135,10 @@
       <title>DHCP-Server: Start</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_start.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_start.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_start.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_start.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -151,10 +151,10 @@
       <title>DHCP-Server: Host-Verwaltung</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_statdhcp.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_statdhcp.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_statdhcp.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_statdhcp.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -178,10 +178,10 @@
        <title>DHCP-Server: Chroot Jail und Deklarationen</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_chroot.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_chroot.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_chroot.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_chroot.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -197,10 +197,10 @@
        <title>DHCP-Server: Auswählen eines Deklarationstyps</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_newdec.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_newdec.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_newdec.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_newdec.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -216,10 +216,10 @@
        <title>DHCP-Server: Konfigurieren von Subnetzen</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_sub.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_sub.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_sub.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_sub.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -235,10 +235,10 @@
        <title>DHCP-Server: TSIG-Konfiguration</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_tsig.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_tsig.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_tsig.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_tsig.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -254,10 +254,10 @@
        <title>DHCP-Server: Schnittstellenkonfiguration für dynamisches DNS</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_dyndns.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_dyndns.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_dyndns.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_dyndns.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -293,10 +293,10 @@
        <title>DHCP-Server: Netzwerkschnittstelle und Firewall</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_fire.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_fire.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_fire.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_fire.png"/>
         </imageobject>
        </mediaobject>
       </figure>

--- a/l10n/sles/de-de/xml/net_dns.xml
+++ b/l10n/sles/de-de/xml/net_dns.xml
@@ -169,10 +169,10 @@
       <title>DNS-Server-Installation: Forwarder-Einstellungen</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dns_wiz_forw.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dns_wiz_forw.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dns_wiz_forw.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dns_wiz_forw.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -188,10 +188,10 @@
       <title>DNS-Server-Installation: DNS-Zonen</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="72%" fileref="yast2_dns_wiz_zone.png" format="PNG"/>
+        <imagedata width="72%" fileref="yast2_dns_wiz_zone.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dns_wiz_zone.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dns_wiz_zone.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -204,10 +204,10 @@
       <title>DNS-Server-Installation: Wizard beenden</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="72%" fileref="yast2_dns_wiz_finish.png" format="PNG"/>
+        <imagedata width="72%" fileref="yast2_dns_wiz_finish.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dns_wiz_finish.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dns_wiz_finish.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -254,10 +254,10 @@
      <title>DNS-Server: Protokollieren</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata width="75%" fileref="yast2_dns_def_logging.png" format="PNG"/>
+       <imagedata width="75%" fileref="yast2_dns_def_logging.png"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata width="75%" fileref="yast2_dns_def_logging.png" format="PNG"/>
+       <imagedata width="75%" fileref="yast2_dns_def_logging.png"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -318,10 +318,10 @@
      <title>DNS-Server: Zonen-Editor (Grundlagen)</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata width="65%" fileref="yast2_dns_def_ddns.png" format="PNG"/>
+       <imagedata width="65%" fileref="yast2_dns_def_ddns.png"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata width="65%" fileref="yast2_dns_def_ddns.png" format="PNG"/>
+       <imagedata width="65%" fileref="yast2_dns_def_ddns.png"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -336,10 +336,10 @@
         <title>DNS-Server: Zonen-Editor (NS-Einträge)</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata width="65%" fileref="yast2_dns_def_nsrec.png" format="PNG"/>
+          <imagedata width="65%" fileref="yast2_dns_def_nsrec.png"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata width="65%" fileref="yast2_dns_def_nsrec.png" format="PNG"/>
+          <imagedata width="65%" fileref="yast2_dns_def_nsrec.png"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -355,10 +355,10 @@
         <title>DNS-Server: Zonen-Editor (MX-Einträge)</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata width="72%" fileref="yast2_dns_def_mxrec.png" format="PNG"/>
+          <imagedata width="72%" fileref="yast2_dns_def_mxrec.png"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata width="75%" fileref="yast2_dns_def_mxrec.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_mxrec.png"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -374,10 +374,10 @@
         <title>DNS-Server: Zonen-Editor (SOA)</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata width="75%" fileref="yast2_dns_def_soa.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_soa.png"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata width="75%" fileref="yast2_dns_def_soa.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_soa.png"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -418,10 +418,10 @@
         <title>Hinzufügen eines Eintrags für eine primäre Zone</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="yast2_dns_revzone1.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone1.png" width="70%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="yast2_dns_revzone1.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone1.png" width="70%"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -434,10 +434,10 @@
         <title>Hinzufügen einer Reverse Zone</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="yast2_dns_revzone2.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone2.png" width="70%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="yast2_dns_revzone2.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone2.png" width="70%"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -450,10 +450,10 @@
         <title>Hinzufügen eines Reverse-Eintrags</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="yast2_dns_revzone3.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone3.png" width="70%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="yast2_dns_revzone3.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone3.png" width="70%"/>
          </imageobject>
         </mediaobject>
        </figure>

--- a/l10n/sles/de-de/xml/net_wicked.xml
+++ b/l10n/sles/de-de/xml/net_wicked.xml
@@ -79,10 +79,10 @@
     <title><literal>wicked</literal>-Architektur</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="wicked_scheme.png" format="PNG"/>
+      <imagedata fileref="wicked_scheme.png"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="wicked_scheme.png" format="PNG" width="80%"/>
+      <imagedata fileref="wicked_scheme.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/de-de/xml/net_yast.xml
+++ b/l10n/sles/de-de/xml/net_yast.xml
@@ -48,10 +48,10 @@
    <title>Konfigurieren der Netzwerkeinstellungen</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_net_icard.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_net_icard.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_net_icard.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_net_icard.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/de-de/xml/network_scheme.xml
+++ b/l10n/sles/de-de/xml/network_scheme.xml
@@ -4,10 +4,10 @@
  <info>
   <mediaobject>
    <imageobject role="html">
-    <imagedata fileref="network_schema.png" width="100%" format="PNG"/>
+    <imagedata fileref="network_schema.png" width="100%"/>
    </imageobject>
    <imageobject role="pdf">
-    <imagedata fileref="network_schema.svg" width="100%" format="SVG"/>
+    <imagedata fileref="network_schema.svg" width="100%"/>
    </imageobject>
   </mediaobject>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -21,10 +21,10 @@
  <informalfigure>
   <mediaobject>
    <imageobject role="html">
-    <imagedata fileref="network_schema.png" width="100%" format="PNG"/>
+    <imagedata fileref="network_schema.png" width="100%"/>
    </imageobject>
    <imageobject role="pdf">
-    <imagedata fileref="network_schema.svg" width="100%" format="SVG"/>
+    <imagedata fileref="network_schema.svg" width="100%"/>
    </imageobject>
   </mediaobject>
  </informalfigure>

--- a/l10n/sles/de-de/xml/sle_update_upgrading.xml
+++ b/l10n/sles/de-de/xml/sle_update_upgrading.xml
@@ -72,11 +72,11 @@
    <title>Überblick über die unterstützten Upgrade-Pfade</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="100%" format="PNG"/>
+     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="100%"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="80%" format="PNG"/>
+     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="80%"/>
      
     </imageobject>
    </mediaobject>

--- a/l10n/sles/de-de/xml/snapper.xml
+++ b/l10n/sles/de-de/xml/snapper.xml
@@ -417,10 +417,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_list.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_list.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_list.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_list.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -432,10 +432,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_changes.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_changes.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_changes.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_changes.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -447,10 +447,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_diff.png" width="65%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_diff.png" width="65%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_diff.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_diff.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -462,10 +462,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_restore.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_restore.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_restore.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_restore.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -827,10 +827,10 @@ single | 4 |     |         |                       |
     <title>Bootloader: Snapshots</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="boot_snapshots.png" width="75%" format="PNG"/>
+      <imagedata fileref="boot_snapshots.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="boot_snapshots.png" width="75%" format="PNG"/>
+      <imagedata fileref="boot_snapshots.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/de-de/xml/systemd.xml
+++ b/l10n/sles/de-de/xml/systemd.xml
@@ -1046,10 +1046,10 @@ Startup finished in 2666ms (kernel) + 21961ms (userspace) = 24628ms</screen>
        <informalfigure>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="systemd_startup.svg" width="75%" format="SVG"/>
+          <imagedata fileref="systemd_startup.svg" width="75%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="systemd_startup.png" width="75%" format="PNG"/>
+          <imagedata fileref="systemd_startup.png" width="75%"/>
          </imageobject>
         </mediaobject>
        </informalfigure>
@@ -1132,10 +1132,10 @@ WantedBy=multi-user.target<co xml:id="co-service-wrapper-target"/></screen>
    <title>Services Manager</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_runlevel.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_runlevel.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_runlevel.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_runlevel.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/de-de/xml/tuning_multikernel.xml
+++ b/l10n/sles/de-de/xml/tuning_multikernel.xml
@@ -236,10 +236,10 @@
      <title>Der YaST-Software-Manager: Multiversionsanzeige</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_sw_multiversion.png" width="90%" format="PNG"/>
+       <imagedata fileref="yast2_sw_multiversion.png" width="90%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_sw_multiversion.png" width="90%" format="PNG"/>
+       <imagedata fileref="yast2_sw_multiversion.png" width="90%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/de-de/xml/uefi.xml
+++ b/l10n/sles/de-de/xml/uefi.xml
@@ -83,10 +83,10 @@
      <title>Secure Boot-Unterstützung</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/de-de/xml/updater_gnome.xml
+++ b/l10n/sles/de-de/xml/updater_gnome.xml
@@ -25,11 +25,11 @@
   <mediaobject>
    <imageobject role="fo">
     
-    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%" format="PNG"/>
+    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
     
-    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%" format="PNG"/>
+    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -47,10 +47,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="gupdater_updates.png" width="75%" format="PNG"/>
+      <imagedata fileref="gupdater_updates.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="gupdater_updates.png" width="75%" format="PNG"/>
+      <imagedata fileref="gupdater_updates.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sles/de-de/xml/updater_gnome_sw.xml
+++ b/l10n/sles/de-de/xml/updater_gnome_sw.xml
@@ -42,10 +42,10 @@
   <title><guimenu>GNOME Software</guimenu> – Ansicht <guimenu>Aktualisierungen</guimenu></title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="gnome-software-updates.png" width="75%" format="PNG"/>
+    <imagedata fileref="gnome-software-updates.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="gnome-software-updates.png" width="75%" format="PNG"/>
+    <imagedata fileref="gnome-software-updates.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sles/de-de/xml/vnc.xml
+++ b/l10n/sles/de-de/xml/vnc.xml
@@ -56,10 +56,10 @@
      <textobject role="description"><phrase>vncviewer asking for connection details</phrase>
      </textobject>
      <imageobject role="html">
-      <imagedata fileref="vnc_connect.png" format="PNG"/>
+      <imagedata fileref="vnc_connect.png"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="vnc_connect.png" format="PNG"/>
+      <imagedata fileref="vnc_connect.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -99,10 +99,10 @@
     <title>Hauptfenster von Remmina</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -114,16 +114,16 @@
   <sect2 xml:id="vnc-remmina-addnew">
    <title>Hinzufügen von Remote-Sitzungen</title>
    <para>
-    Um eine neue Remote-Sitzung hinzuzufügen und zu speichern, klicken Sie auf <inlinemediaobject><textobject role="description"><phrase>Neue Sitzung hinzufügen</phrase></textobject><imageobject role="fo"><imagedata fileref="remmina_plus.png" width="1.2em" format="PNG"/></imageobject><imageobject role="html"><imagedata fileref="remmina_plus.png" width="1.2em" format="PNG"/></imageobject></inlinemediaobject> oben links im Hauptfenster. Das Fenster <guimenu>Remote Desktop Preference</guimenu> wird geöffnet.
+    Um eine neue Remote-Sitzung hinzuzufügen und zu speichern, klicken Sie auf <inlinemediaobject><textobject role="description"><phrase>Neue Sitzung hinzufügen</phrase></textobject><imageobject role="fo"><imagedata fileref="remmina_plus.png" width="1.2em"/></imageobject><imageobject role="html"><imagedata fileref="remmina_plus.png" width="1.2em"/></imageobject></inlinemediaobject> oben links im Hauptfenster. Das Fenster <guimenu>Remote Desktop Preference</guimenu> wird geöffnet.
    </para>
    <figure>
     <title>Remote Desktop Preference</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina_session_details.png" width="80%" format="PNG"/>
+      <imagedata fileref="remmina_session_details.png" width="80%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina_session_details.png" width="80%" format="PNG"/>
+      <imagedata fileref="remmina_session_details.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -203,10 +203,10 @@
      <title>Schnellstart</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="remmina_quickstart.png" width="40%" format="PNG"/>
+       <imagedata fileref="remmina_quickstart.png" width="40%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="remmina_quickstart.png" width="40%" format="PNG"/>
+       <imagedata fileref="remmina_quickstart.png" width="40%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -229,10 +229,10 @@
      <title>Remmina-Remote-Sitzung mit Anzeige</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>
+       <imagedata fileref="remmina_sle15inside.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>
+       <imagedata fileref="remmina_sle15inside.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -267,10 +267,10 @@
     <title>Pfad zur Profildatei</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina_status.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina_status.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina_status.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina_status.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -332,10 +332,10 @@
    <title>Fernverwaltung</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="vnc_nosession.png" width="70%" format="PNG"/>
+     <imagedata fileref="vnc_nosession.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="vnc_nosession.png" width="70%" format="PNG"/>
+     <imagedata fileref="vnc_nosession.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -561,10 +561,10 @@ WINDOWMANAGER=icewm vncserver -geometry 1024x768</screen>
      <title>VNC-Sitzungseinstellungen</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="vncmanager_session.png" width="85%" format="PNG"/>
+       <imagedata fileref="vncmanager_session.png" width="85%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="vncmanager_session.png" width="85%" format="PNG"/>
+       <imagedata fileref="vncmanager_session.png" width="85%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -649,10 +649,10 @@ WINDOWMANAGER=icewm vncserver -geometry 1024x768</screen>
      <title>Beitreten zu einer permanenten VNC-Sitzung</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="vncmanager_whether.png" width="80%" format="PNG"/>
+       <imagedata fileref="vncmanager_whether.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="vncmanager_whether.png" width="80%" format="PNG"/>
+       <imagedata fileref="vncmanager_whether.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/de-de/xml/yast2_ftp.xml
+++ b/l10n/sles/de-de/xml/yast2_ftp.xml
@@ -67,10 +67,10 @@
    <title>FTP-Serverkonfiguration – Start</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_ftp-start-up.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_ftp-start-up.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_ftp-start-up.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_ftp-start-up.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/de-de/xml/yast2_lang.xml
+++ b/l10n/sles/de-de/xml/yast2_lang.xml
@@ -91,10 +91,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_language.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_language.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_language.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_language.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>
@@ -225,10 +225,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_timezone.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_timezone.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_timezone.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_timezone.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -306,10 +306,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_timezone_ntp.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_timezone_ntp.png" width="75%"/>
       </imageobject>
       <imageobject role="pdf">
-       <imagedata fileref="yast2_timezone_ntp.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_timezone_ntp.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/de-de/xml/yast2_ncurses.xml
+++ b/l10n/sles/de-de/xml/yast2_ncurses.xml
@@ -15,10 +15,10 @@
   <title>Hauptfenster von YaST im Textmodus</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="yast2_ncurses_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="yast2_ncurses_main.png" width="70%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="yast2_ncurses_main.png" width="75%" format="PNG"/>
+    <imagedata fileref="yast2_ncurses_main.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -99,10 +99,10 @@
    <title>Das Software-Installationsmodul</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_ncurses_inst.png" width="70%" format="PNG"/>
+     <imagedata fileref="yast2_ncurses_inst.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_ncurses_inst.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_ncurses_inst.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/de-de/xml/yast2_sw.xml
+++ b/l10n/sles/de-de/xml/yast2_sw.xml
@@ -152,10 +152,10 @@
      <phrase><guimenu>YaST</guimenu> software manager screen</phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_sw_manager.png" width="70%" format="PNG"/>
+     <imagedata fileref="yast2_sw_manager.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_sw_manager.png" width="65%" format="PNG"/>
+     <imagedata fileref="yast2_sw_manager.png" width="65%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -475,10 +475,10 @@
     <title>Konfliktverwaltung des Software-Managers</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_package_conflict.png" width="70%" format="PNG"/>
+      <imagedata fileref="yast2_package_conflict.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_package_conflict.png" width="65%" format="PNG"/>
+      <imagedata fileref="yast2_package_conflict.png" width="65%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/de-de/xml/yast2_sw_repo.xml
+++ b/l10n/sles/de-de/xml/yast2_sw_repo.xml
@@ -52,10 +52,10 @@
      <title>Hinzufügen eines Software-Repositorys</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_addon_new.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_addon_new.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_addon_new.png" width="65%" format="PNG"/>
+       <imagedata fileref="yast2_addon_new.png" width="65%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/de-de/xml/yast2_userman.xml
+++ b/l10n/sles/de-de/xml/yast2_userman.xml
@@ -22,11 +22,11 @@
    <title>YaST – Verwaltung von Benutzern und Gruppen</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_users_main_qt.png" width="90%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_users_main_qt.png" width="90%" os="sles;sled"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_users_main_qt.png" width="70%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_users_main_qt.png" width="70%" os="sles;sled"/>
      
     </imageobject>
    </mediaobject>
@@ -388,11 +388,11 @@
      <informalfigure os="sles;sled">
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_users_quota_qt.png" width="80%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_users_quota_qt.png" width="80%" os="sles;sled"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_users_quota_qt.png" width="70%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_users_quota_qt.png" width="70%" os="sles;sled"/>
         
        </imageobject>
       </mediaobject>
@@ -558,11 +558,11 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_groups_edit_qt.png" width="80%" format="PNG" os="sles;sled"/>
+       <imagedata fileref="yast2_groups_edit_qt.png" width="80%" os="sles;sled"/>
        
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_groups_edit_qt.png" width="75%" format="PNG" os="sles;sled"/>
+       <imagedata fileref="yast2_groups_edit_qt.png" width="75%" os="sles;sled"/>
        
       </imageobject>
      </mediaobject>

--- a/l10n/sles/de-de/xml/yast2_you.xml
+++ b/l10n/sles/de-de/xml/yast2_you.xml
@@ -73,11 +73,11 @@
    <title>YaST-Online-Aktualisierung</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_you.png" width="75%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_you.png" width="75%" os="sles;sled"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_you.png" width="75%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_you.png" width="75%" os="sles;sled"/>
      
     </imageobject>
    </mediaobject>
@@ -204,10 +204,10 @@
    <title>Anzeigen von zurückgezogenen Patches und ihres Verlaufs</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_retracted_patches.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_retracted_patches.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_retracted_patches.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_retracted_patches.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>  
@@ -245,10 +245,10 @@
    <title>Konfiguration der YaST-Online-Aktualisierung</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_autoupdate.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_autoupdate.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_autoupdate.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_autoupdate.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/es-es/xml/deployment_expert_partitioner_lvm.xml
+++ b/l10n/sles/es-es/xml/deployment_expert_partitioner_lvm.xml
@@ -88,10 +88,10 @@
    <title>Creación de un grupo de volúmenes</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -108,10 +108,10 @@
    <title>Gestión de volúmenes lógicos</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/es-es/xml/deployment_expert_partitioner_overview.xml
+++ b/l10n/sles/es-es/xml/deployment_expert_partitioner_overview.xml
@@ -24,10 +24,10 @@
   <title>Particionador de YaST</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -231,10 +231,10 @@
         <title>Subvolúmenes Btrfs en el particionador de YaST</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
         </mediaobject>
        </figure>

--- a/l10n/sles/es-es/xml/deployment_expert_partitioner_raid.xml
+++ b/l10n/sles/es-es/xml/deployment_expert_partitioner_raid.xml
@@ -56,10 +56,10 @@
    <title>Particiones RAID</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/es-es/xml/deployment_register.xml
+++ b/l10n/sles/es-es/xml/deployment_register.xml
@@ -80,11 +80,11 @@
         <phrase><guimenu>Registration</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -113,11 +113,11 @@
         <phrase><guimenu>Extension and Module Selection</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -143,11 +143,11 @@
         <phrase><guimenu>Installation Summary</guimenu> screen</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -212,11 +212,11 @@
         <phrase><guimenu>Extension and Module Selection</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%"/>
         
 
        </imageobject>
@@ -265,11 +265,11 @@
         <phrase><guimenu>Installed Add-on Products</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>

--- a/l10n/sles/es-es/xml/deployment_troubleshooting.xml
+++ b/l10n/sles/es-es/xml/deployment_troubleshooting.xml
@@ -160,10 +160,10 @@
    <title>Disposición del teclado de EE. UU.</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="keyboard_us.svg" width="75%" format="SVG"/>
+     <imagedata fileref="keyboard_us.svg" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="keyboard_us.png" width="75%" format="PNG"/>
+     <imagedata fileref="keyboard_us.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/es-es/xml/sle_update_upgrading.xml
+++ b/l10n/sles/es-es/xml/sle_update_upgrading.xml
@@ -72,11 +72,11 @@
    <title>Resumen de las vías de actualización admitidas</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="100%" format="PNG"/>
+     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="100%"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="80%" format="PNG"/>
+     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="80%"/>
      
     </imageobject>
    </mediaobject>

--- a/l10n/sles/fr-fr/xml/deployment_expert_partitioner_lvm.xml
+++ b/l10n/sles/fr-fr/xml/deployment_expert_partitioner_lvm.xml
@@ -88,10 +88,10 @@
    <title>Création d&apos;un groupe de volumes</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -108,10 +108,10 @@
    <title>Gestion des volumes logiques</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/fr-fr/xml/deployment_expert_partitioner_overview.xml
+++ b/l10n/sles/fr-fr/xml/deployment_expert_partitioner_overview.xml
@@ -24,10 +24,10 @@
   <title>Outil de partitionnement de YaST</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -231,10 +231,10 @@
         <title>Sous-volumes Btrfs dans le partitionneur YaST</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
         </mediaobject>
        </figure>

--- a/l10n/sles/fr-fr/xml/deployment_expert_partitioner_raid.xml
+++ b/l10n/sles/fr-fr/xml/deployment_expert_partitioner_raid.xml
@@ -56,10 +56,10 @@
    <title>Partitions RAID</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/fr-fr/xml/deployment_register.xml
+++ b/l10n/sles/fr-fr/xml/deployment_register.xml
@@ -80,11 +80,11 @@
         <phrase><guimenu>Registration</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -113,11 +113,11 @@
         <phrase><guimenu>Extension and Module Selection</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -143,11 +143,11 @@
         <phrase><guimenu>Installation Summary</guimenu> screen</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -211,11 +211,11 @@
         <phrase><guimenu>Extension and Module Selection</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%"/>
         
 
        </imageobject>
@@ -264,11 +264,11 @@
         <phrase><guimenu>Installed Add-on Products</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>

--- a/l10n/sles/fr-fr/xml/deployment_troubleshooting.xml
+++ b/l10n/sles/fr-fr/xml/deployment_troubleshooting.xml
@@ -160,10 +160,10 @@
    <title>Configuration américaine du clavier</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="keyboard_us.svg" width="75%" format="SVG"/>
+     <imagedata fileref="keyboard_us.svg" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="keyboard_us.png" width="75%" format="PNG"/>
+     <imagedata fileref="keyboard_us.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/fr-fr/xml/sle_update_upgrading.xml
+++ b/l10n/sles/fr-fr/xml/sle_update_upgrading.xml
@@ -72,11 +72,11 @@
    <title>Aperçu des chemins de mise à niveau pris en charge</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="100%" format="PNG"/>
+     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="100%"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="80%" format="PNG"/>
+     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="80%"/>
      
     </imageobject>
    </mediaobject>

--- a/l10n/sles/it-it/xml/deployment_expert_partitioner_lvm.xml
+++ b/l10n/sles/it-it/xml/deployment_expert_partitioner_lvm.xml
@@ -88,10 +88,10 @@
    <title>Creazione di un gruppo di volumi</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -108,10 +108,10 @@
    <title>Gestione dei volumi logici</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/it-it/xml/deployment_expert_partitioner_overview.xml
+++ b/l10n/sles/it-it/xml/deployment_expert_partitioner_overview.xml
@@ -24,10 +24,10 @@
   <title>YaST Partitioner</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -231,10 +231,10 @@
         <title>Sottovolumi Btrfs nel partitioner di YaST</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
         </mediaobject>
        </figure>

--- a/l10n/sles/it-it/xml/deployment_expert_partitioner_raid.xml
+++ b/l10n/sles/it-it/xml/deployment_expert_partitioner_raid.xml
@@ -56,10 +56,10 @@
    <title>Partizioni RAID</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/it-it/xml/deployment_register.xml
+++ b/l10n/sles/it-it/xml/deployment_register.xml
@@ -80,11 +80,11 @@
         <phrase><guimenu>Registration</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -113,11 +113,11 @@
         <phrase><guimenu>Extension and Module Selection</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -143,11 +143,11 @@
         <phrase><guimenu>Installation Summary</guimenu> screen</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -212,11 +212,11 @@
         <phrase><guimenu>Extension and Module Selection</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%"/>
         
 
        </imageobject>
@@ -265,11 +265,11 @@
         <phrase><guimenu>Installed Add-on Products</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>

--- a/l10n/sles/it-it/xml/deployment_troubleshooting.xml
+++ b/l10n/sles/it-it/xml/deployment_troubleshooting.xml
@@ -160,10 +160,10 @@
    <title>Layout di tastiera USA</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="keyboard_us.svg" width="75%" format="SVG"/>
+     <imagedata fileref="keyboard_us.svg" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="keyboard_us.png" width="75%" format="PNG"/>
+     <imagedata fileref="keyboard_us.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/it-it/xml/sle_update_upgrading.xml
+++ b/l10n/sles/it-it/xml/sle_update_upgrading.xml
@@ -72,11 +72,11 @@
    <title>Panoramica dei percorsi di upgrade supportati</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="100%" format="PNG"/>
+     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="100%"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="80%" format="PNG"/>
+     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="80%"/>
      
     </imageobject>
    </mediaobject>

--- a/l10n/sles/ja-jp/xml/adm_support.xml
+++ b/l10n/sles/ja-jp/xml/adm_support.xml
@@ -135,10 +135,10 @@ CPU Load Average:         7 (3%) with 2 CPUs
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_support_main.png" width="70%" format="PNG"/>
+        <imagedata fileref="yast2_support_main.png" width="70%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_support_main.png" width="60%" format="PNG"/>
+        <imagedata fileref="yast2_support_main.png" width="60%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -176,10 +176,10 @@ CPU Load Average:         7 (3%) with 2 CPUs
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_support_conf.png" width="90%" format="PNG"/>
+        <imagedata fileref="yast2_support_conf.png" width="90%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_support_conf.png" width="80%" format="PNG"/>
+        <imagedata fileref="yast2_support_conf.png" width="80%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -740,10 +740,10 @@ Creating Tar Ball
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_support_conf_upload.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_support_conf_upload.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_support_conf_upload.png" width="60%" format="PNG"/>
+       <imagedata fileref="yast2_support_conf_upload.png" width="60%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/ja-jp/xml/apache2_yast_i.xml
+++ b/l10n/sles/ja-jp/xml/apache2_yast_i.xml
@@ -45,10 +45,10 @@
     <title>HTTPサーバウィザード: デフォルトホスト</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_apache_wizard3.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_apache_wizard3.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_apache_wizard3.png" format="PNG"/>
+      <imagedata fileref="yast2_apache_wizard3.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -154,10 +154,10 @@
     <title>HTTPサーバウィザード: 概要</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_apache_wizard5.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_apache_wizard5.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_apache_wizard5.png" format="PNG"/>
+      <imagedata fileref="yast2_apache_wizard5.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -180,10 +180,10 @@
     <title>HTTPサーバの設定: リスンポートとアドレス</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_apache_config_listen.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_apache_config_listen.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_apache_config_listen.png" format="PNG"/>
+      <imagedata fileref="yast2_apache_config_listen.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -197,10 +197,10 @@
     <title>HTTPサーバの設定: サーバモジュール</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_apache_config_modules.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_apache_config_modules.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_apache_config_modules.png" format="PNG"/>
+      <imagedata fileref="yast2_apache_config_modules.png"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/ja-jp/xml/apps_ekiga.xml
+++ b/l10n/sles/ja-jp/xml/apps_ekiga.xml
@@ -170,10 +170,10 @@
    <title><productname>Ekiga</productname> ユーザインターフェイス</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="ekiga_main.png" width="45%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="45%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ekiga_main.png" width="55%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="55%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/ja-jp/xml/apps_evolution.xml
+++ b/l10n/sles/ja-jp/xml/apps_evolution.xml
@@ -733,10 +733,10 @@
    <title><productname>Evolution</productname> ウィンドウ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" width="100%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" width="86%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="86%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/ja-jp/xml/apps_firefox.xml
+++ b/l10n/sles/ja-jp/xml/apps_firefox.xml
@@ -29,7 +29,7 @@
   <note>
    <title>メニューバーの使用</title>
    <para>
-    <productname>Firefox</productname>のほとんどの機能は3行ボタン(<inlinemediaobject><textobject role="description"><phrase>3行ボタン</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject>)から使用できますが、一部の機能はメニューバーからのみ使用できます。
+    <productname>Firefox</productname>のほとんどの機能は3行ボタン(<inlinemediaobject><textobject role="description"><phrase>3行ボタン</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em"/></imageobject></inlinemediaobject>)から使用できますが、一部の機能はメニューバーからのみ使用できます。
    </para>
    <para>
     <productname>Firefox</productname>のメニューバーは、デフォルトで非表示になっています。メニューバーを一時的に表示するには、<keycap function="alt"/>を押します。これにより、ブラウザウィンドウ内のどこかをクリックするまで、メニューバーが表示されます。

--- a/l10n/sles/ja-jp/xml/apps_gimp.xml
+++ b/l10n/sles/ja-jp/xml/apps_gimp.xml
@@ -125,10 +125,10 @@
     <title>ツールボックス</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="gimp-toolbox.png" width="35%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="35%"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="gimp-toolbox.png" width="30%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="30%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -547,10 +547,10 @@
        <title>［Basic Color Selector］ダイアログ</title>
        <mediaobject>
         <imageobject role="html">
-         <imagedata fileref="gimp-color.png" width="70%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="70%"/>
         </imageobject>
         <imageobject role="fo">
-         <imagedata fileref="gimp-color.png" width="80%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="80%"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -719,10 +719,10 @@
    <title>印刷ダイアログ</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="gimp-print.png" width="75%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="75%"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="gimp-print.png" width="70%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/ja-jp/xml/apps_libreoffice.xml
+++ b/l10n/sles/ja-jp/xml/apps_libreoffice.xml
@@ -492,10 +492,10 @@
    <title><guimenu>Writer</guimenu>のカスタマイズダイアログ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -647,10 +647,10 @@
    <title>オプションウィンドウ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_options.png" width="95%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_options.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/ja-jp/xml/apps_librevarious.xml
+++ b/l10n/sles/ja-jp/xml/apps_librevarious.xml
@@ -285,10 +285,10 @@
        <mediaobject>
         <textobject><phrase>Field selection</phrase></textobject>
         <imageobject role="fo">
-         <imagedata fileref="oo-wizard-base.png" width="90%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="90%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="oo-wizard-base.png" width="85%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="85%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>

--- a/l10n/sles/ja-jp/xml/apps_librewriter.xml
+++ b/l10n/sles/ja-jp/xml/apps_librewriter.xml
@@ -66,10 +66,10 @@
    <title>LibreOfficeウィザード</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo-wizard.png" width="100%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo-wizard.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -231,10 +231,10 @@
     <title>スタイルパネル</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo-stylist.png" width="40%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="40%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo-stylist.png" width="50%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -641,10 +641,10 @@
     <title><guimenu>Writer</guimenu>のナビゲータツール</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo_navigator.png" width="55%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo_navigator.png" width="45%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="45%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/ja-jp/xml/apps_totem.xml
+++ b/l10n/sles/ja-jp/xml/apps_totem.xml
@@ -59,10 +59,10 @@
    <title><guimenu>GNOME Videos</guimenu>のスタートアップウィンドウ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -132,11 +132,11 @@
     <guimenu>取り出し</guimenu> </menuchoice>をクリックします。
    </para>
    <para>
-    再生中の動画または楽曲を一時停止するには、<inlinemediaobject><textobject role="description"><phrase>GNOME Videos Pause (GNOMEビデオを一時停止)</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_pause_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="totem_pause_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject>ボタンをクリックするか、<menuchoice> <guimenu>Movie (動画)</guimenu>
+    再生中の動画または楽曲を一時停止するには、<inlinemediaobject><textobject role="description"><phrase>GNOME Videos Pause (GNOMEビデオを一時停止)</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_pause_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="totem_pause_button-fallback.png" width="1em"/></imageobject></inlinemediaobject>ボタンをクリックするか、<menuchoice> <guimenu>Movie (動画)</guimenu>
     <guimenu>Play/Pause (再生/一時停止)</guimenu> </menuchoice>の順にクリックします。動画または楽曲を一時停止すると、ステータスバーで<guimenu>一時停止中</guimenu>と表示され、現在の動画または楽曲の経過時間が示されます。
    </para>
    <para>
-    動画または楽曲の再生を再開するには、<inlinemediaobject><textobject role="description"><phrase>GNOME Videos Play (GNOMEビデオを再生)</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_play_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="totem_play_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject>ボタンをクリックするか、<menuchoice> <guimenu>Movie (動画)</guimenu>
+    動画または楽曲の再生を再開するには、<inlinemediaobject><textobject role="description"><phrase>GNOME Videos Play (GNOMEビデオを再生)</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_play_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="totem_play_button-fallback.png" width="1em"/></imageobject></inlinemediaobject>ボタンをクリックするか、<menuchoice> <guimenu>Movie (動画)</guimenu>
     <guimenu>Play/Pause (再生/一時停止)</guimenu></menuchoice>の順にクリックします。
    </para>
    <para>
@@ -223,10 +223,10 @@
     <title><guimenu>GNOME Videos</guimenu>の一般的な初期設定</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -268,10 +268,10 @@
     <title><guimenu>GNOME Videos</guimenu>の表示の初期設定</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -307,10 +307,10 @@
     <title><guimenu>GNOME Videos</guimenu>のオーディオ初期設定</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/ja-jp/xml/backup.xml
+++ b/l10n/sles/ja-jp/xml/backup.xml
@@ -20,10 +20,10 @@
  <mediaobject>
   <textobject><phrase>Backup application</phrase></textobject>
   <imageobject role="fo">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
   <imageobject role="html">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
  </mediaobject>
 </informalfigure>

--- a/l10n/sles/ja-jp/xml/chrony.xml
+++ b/l10n/sles/ja-jp/xml/chrony.xml
@@ -40,10 +40,10 @@
    <title>［NTP設定］ウィンドウ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="ntp_client.png" width="70%" format="PNG"/>
+     <imagedata fileref="ntp_client.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ntp_client.png" width="70%" format="PNG"/>
+     <imagedata fileref="ntp_client.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -103,10 +103,10 @@
     <title>タイムサーバの追加</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="ntp_client_serveradd.png" width="70%" format="PNG"/>
+      <imagedata fileref="ntp_client_serveradd.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="ntp_client_serveradd.png" width="70%" format="PNG"/>
+      <imagedata fileref="ntp_client_serveradd.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/ja-jp/xml/deployment_expert_partitioner_lvm.xml
+++ b/l10n/sles/ja-jp/xml/deployment_expert_partitioner_lvm.xml
@@ -88,10 +88,10 @@
    <title>ボリュームグループの作成</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -108,10 +108,10 @@
    <title>論理ボリューム管理</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/ja-jp/xml/deployment_expert_partitioner_overview.xml
+++ b/l10n/sles/ja-jp/xml/deployment_expert_partitioner_overview.xml
@@ -24,10 +24,10 @@
   <title>YaSTのパーティション設定</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -231,10 +231,10 @@
         <title>YaSTのパーティショナでのBtrfsサブボリューム</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
         </mediaobject>
        </figure>

--- a/l10n/sles/ja-jp/xml/deployment_expert_partitioner_raid.xml
+++ b/l10n/sles/ja-jp/xml/deployment_expert_partitioner_raid.xml
@@ -56,10 +56,10 @@
    <title>RAIDパーティション</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/ja-jp/xml/deployment_register.xml
+++ b/l10n/sles/ja-jp/xml/deployment_register.xml
@@ -80,11 +80,11 @@
         <phrase><guimenu>Registration</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -113,11 +113,11 @@
         <phrase><guimenu>Extension and Module Selection</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -143,11 +143,11 @@
         <phrase><guimenu>Installation Summary</guimenu> screen</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -212,11 +212,11 @@
         <phrase><guimenu>Extension and Module Selection</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%"/>
         
 
        </imageobject>
@@ -265,11 +265,11 @@
         <phrase><guimenu>Installed Add-on Products</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>

--- a/l10n/sles/ja-jp/xml/deployment_troubleshooting.xml
+++ b/l10n/sles/ja-jp/xml/deployment_troubleshooting.xml
@@ -160,10 +160,10 @@
    <title>USキーボードレイアウト</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="keyboard_us.svg" width="75%" format="SVG"/>
+     <imagedata fileref="keyboard_us.svg" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="keyboard_us.png" width="75%" format="PNG"/>
+     <imagedata fileref="keyboard_us.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/ja-jp/xml/gnome_accessibility.xml
+++ b/l10n/sles/ja-jp/xml/gnome_accessibility.xml
@@ -90,10 +90,10 @@
      <mediaobject>
       <textobject><phrase>On-screen keyboard</phrase></textobject>
       <imageobject role="fo">
-       <imagedata fileref="gnome_onscreen_kbd.png" width="95%" format="PNG"/>
+       <imagedata fileref="gnome_onscreen_kbd.png" width="95%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="gnome_onscreen_kbd.png" width="90%" format="PNG"/>
+       <imagedata fileref="gnome_onscreen_kbd.png" width="90%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/ja-jp/xml/gnome_crypto.xml
+++ b/l10n/sles/ja-jp/xml/gnome_crypto.xml
@@ -22,10 +22,10 @@
   <title><guimenu>パスワードと鍵</guimenu>のメインウィンドウ</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sles/ja-jp/xml/gnome_custom.xml
+++ b/l10n/sles/ja-jp/xml/gnome_custom.xml
@@ -61,10 +61,10 @@
      <title>GNOME背景の設定</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="preferences_background.png" width="45%" format="PNG"/>
+        <imagedata fileref="preferences_background.png" width="45%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="preferences_background.png" width="45%" format="PNG"/>
+        <imagedata fileref="preferences_background.png" width="45%"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -148,10 +148,10 @@
    <title>キーボードショートカットダイアログ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_keyboard.png" width="100%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_keyboard.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -178,10 +178,10 @@
    <title>Tweaksでの&lt;Compose&gt;キーの有効化</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -307,10 +307,10 @@
    <title><guimenu>マウスとタッチパッド</guimenu>の設定ダイアログ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -362,10 +362,10 @@
     <title>単一のモニタ設定のダイアログ</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="preferences_screen_single.png" width="100%" format="PNG"/>
+      <imagedata fileref="preferences_screen_single.png" width="100%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="preferences_screen_single.png" width="80%" format="PNG"/>
+      <imagedata fileref="preferences_screen_single.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -486,10 +486,10 @@
    <title>サウンドの設定</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="sound_devices.png" width="100%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="sound_devices.png" width="80%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -515,10 +515,10 @@
      <title>デフォルトのアプリケーション</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="preferences_preferred_apps.png" width="100%" format="PNG"/>
+       <imagedata fileref="preferences_preferred_apps.png" width="100%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="preferences_preferred_apps.png" width="80%" format="PNG"/>
+       <imagedata fileref="preferences_preferred_apps.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/ja-jp/xml/gnome_networking.xml
+++ b/l10n/sles/ja-jp/xml/gnome_networking.xml
@@ -104,10 +104,10 @@
    <title>ネットワークファイルブラウザ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="network_browser.png" width="100%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="100%"/>
      </imageobject>
     <imageobject role="html">
-     <imagedata fileref="network_browser.png" width="90%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -256,10 +256,10 @@
       <mediaobject>
        <textobject><phrase>Sharing options</phrase></textobject>
        <imageobject role="fo">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/l10n/sles/ja-jp/xml/gnome_start.xml
+++ b/l10n/sles/ja-jp/xml/gnome_start.xml
@@ -37,11 +37,11 @@
    <title>デフォルトのGNOMEログイン画面</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata os="sles;sled" fileref="login_sled.png" width="90%" format="PNG"/>
+     <imagedata os="sles;sled" fileref="login_sled.png" width="90%"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata os="sles;sled" fileref="login_sled.png" width="75%" format="PNG"/>
+     <imagedata os="sles;sled" fileref="login_sled.png" width="75%"/>
      
     </imageobject>
    </mediaobject>
@@ -83,11 +83,11 @@
       <title>デフォルトのGNOMEログイン画面 - セッションタイプ</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="90%" format="PNG"/>
+        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="90%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="75%" format="PNG"/>
+        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="75%"/>
         
        </imageobject>
       </mediaobject>
@@ -197,10 +197,10 @@
    <title>GNOMEデスクトップとActivities Overview (アクティビティ画面)</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="desktop_sled_menu.png" width="95%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="desktop_sled_menu.png" width="90%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -245,10 +245,10 @@
      <title><guimenu>アクティビティ</guimenu>画面</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="desktop_activities_overview.png" width="95%" format="PNG"/>
+      <imagedata fileref="desktop_activities_overview.png" width="95%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="desktop_activities_overview.png" width="90%" format="PNG"/>
+      <imagedata fileref="desktop_activities_overview.png" width="90%"/>
      </imageobject>
     </mediaobject>
      </figure>
@@ -285,10 +285,10 @@
      <title><productname>Firefox</productname>の<guimenu>アプリケーション</guimenu>メニュー</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="desktop_app_menu_firefox.png" width="70%" format="PNG"/>
+       <imagedata fileref="desktop_app_menu_firefox.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="desktop_app_menu_firefox.png" width="70%" format="PNG"/>
+       <imagedata fileref="desktop_app_menu_firefox.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/ja-jp/xml/gnome_use.xml
+++ b/l10n/sles/ja-jp/xml/gnome_use.xml
@@ -26,10 +26,10 @@
    <title>ファイルマネージャ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -573,10 +573,10 @@
     <textobject><phrase><productname>Evolution</productname></phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" format="PNG" width="100%"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" format="PNG" width="80%"/>
+     <imagedata fileref="evolution.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -673,10 +673,10 @@
    <title><productname>Archive manager</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -971,10 +971,10 @@
    <title><productname>Document viewer</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evince.png" format="PNG" width="90%"/>
+     <imagedata fileref="evince.png" width="90%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evince.png" format="PNG" width="78%"/>
+     <imagedata fileref="evince.png" width="78%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/ja-jp/xml/grub2.xml
+++ b/l10n/sles/ja-jp/xml/grub2.xml
@@ -438,10 +438,10 @@
       <title>GRUB 2ブートエディタ</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="grub2_edit_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="grub2_edit_config.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="grub2_edit_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="grub2_edit_config.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </figure>

--- a/l10n/sles/ja-jp/xml/grub2_yast_i.xml
+++ b/l10n/sles/ja-jp/xml/grub2_yast_i.xml
@@ -93,10 +93,10 @@
     <title>ブートコードオプション</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%"/>
      </imageobject>
     </mediaobject>
   </figure>
@@ -215,10 +215,10 @@
     <title>ブートローダオプション</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_options.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_options.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_options.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_options.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -277,10 +277,10 @@
     <title>カーネルパラメータ</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/ja-jp/xml/help_user.xml
+++ b/l10n/sles/ja-jp/xml/help_user.xml
@@ -61,10 +61,10 @@
    <title>ヘルプのメインウィンドウ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/ja-jp/xml/journalctl.xml
+++ b/l10n/sles/ja-jp/xml/journalctl.xml
@@ -336,10 +336,10 @@ enabled</screen>
    <title>YaST systemdジャーナル</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_journal.png" width="80%" format="PNG"/>
+     <imagedata fileref="yast2_journal.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_journal.png" width="85%" format="PNG"/>
+     <imagedata fileref="yast2_journal.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/ja-jp/xml/klp.xml
+++ b/l10n/sles/ja-jp/xml/klp.xml
@@ -64,10 +64,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="klp.png" width="80%" format="PNG"/>
+     <imagedata fileref="klp.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="klp.png" width="100%" format="PNG"/>
+     <imagedata fileref="klp.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>

--- a/l10n/sles/ja-jp/xml/net_basic.xml
+++ b/l10n/sles/ja-jp/xml/net_basic.xml
@@ -60,10 +60,10 @@
   <title>TCP/IPの簡易階層モデル</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata width="100%" fileref="net_basic_osi.svg" format="SVG"/>
+    <imagedata width="100%" fileref="net_basic_osi.svg"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata width="75%" fileref="net_basic_osi.png" format="PNG"/>
+    <imagedata width="75%" fileref="net_basic_osi.png"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -80,10 +80,10 @@
   <title>TCP/IPイーサネットパケット</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata width="80%" fileref="net_basic_tcppacket.svg" format="SVG"/>
+    <imagedata width="80%" fileref="net_basic_tcppacket.svg"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata width="75%" fileref="net_basic_tcppacket.png" format="PNG"/>
+    <imagedata width="75%" fileref="net_basic_tcppacket.png"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sles/ja-jp/xml/net_bonding.xml
+++ b/l10n/sles/ja-jp/xml/net_bonding.xml
@@ -114,10 +114,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="bond_configuration.png" width="70%" format="PNG"/>
+      <imagedata fileref="bond_configuration.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="bond_configuration.png" width="65%" format="PNG"/>
+      <imagedata fileref="bond_configuration.png" width="65%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sles/ja-jp/xml/net_dhcp.xml
+++ b/l10n/sles/ja-jp/xml/net_dhcp.xml
@@ -86,10 +86,10 @@
       <title>DHCPサーバ: カードの選択</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz1.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz1.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz1.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz1.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -102,10 +102,10 @@
       <title>DHCPサーバ: グローバル設定</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz2.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz2.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz2.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz2.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -118,10 +118,10 @@
       <title>DHCPサーバ: ダイナミックDHCP</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz3.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz3.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz3.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz3.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -135,10 +135,10 @@
       <title>DHCPサーバ: 起動</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_start.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_start.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_start.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_start.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -151,10 +151,10 @@
       <title>DHCPサーバ: ホスト管理</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_statdhcp.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_statdhcp.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_statdhcp.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_statdhcp.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -178,10 +178,10 @@
        <title>DHCPサーバ: chroot jailと宣言</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_chroot.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_chroot.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_chroot.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_chroot.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -197,10 +197,10 @@
        <title>DHCPサーバ: 宣言タイプの選択</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_newdec.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_newdec.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_newdec.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_newdec.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -216,10 +216,10 @@
        <title>DHCPサーバ: サブネットの設定</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_sub.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_sub.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_sub.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_sub.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -235,10 +235,10 @@
        <title>DHCPサーバ: TSIGの設定</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_tsig.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_tsig.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_tsig.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_tsig.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -254,10 +254,10 @@
        <title>DHCPサーバ: ダイナミックDNS用のインタフェースの設定</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_dyndns.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_dyndns.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_dyndns.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_dyndns.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -293,10 +293,10 @@
        <title>DHCPサーバ: ネットワークインタフェースとファイアウォール</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_fire.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_fire.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_fire.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_fire.png"/>
         </imageobject>
        </mediaobject>
       </figure>

--- a/l10n/sles/ja-jp/xml/net_dns.xml
+++ b/l10n/sles/ja-jp/xml/net_dns.xml
@@ -169,10 +169,10 @@
       <title>DNSサーバのインストール: フォワーダの設定</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dns_wiz_forw.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dns_wiz_forw.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dns_wiz_forw.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dns_wiz_forw.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -188,10 +188,10 @@
       <title>DNSサーバのインストール: DNSゾーン</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="72%" fileref="yast2_dns_wiz_zone.png" format="PNG"/>
+        <imagedata width="72%" fileref="yast2_dns_wiz_zone.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dns_wiz_zone.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dns_wiz_zone.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -204,10 +204,10 @@
       <title>DNSサーバのインストール: 完了ウィザード</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="72%" fileref="yast2_dns_wiz_finish.png" format="PNG"/>
+        <imagedata width="72%" fileref="yast2_dns_wiz_finish.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dns_wiz_finish.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dns_wiz_finish.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -254,10 +254,10 @@
      <title>DNSサーバ: ログの記録</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata width="75%" fileref="yast2_dns_def_logging.png" format="PNG"/>
+       <imagedata width="75%" fileref="yast2_dns_def_logging.png"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata width="75%" fileref="yast2_dns_def_logging.png" format="PNG"/>
+       <imagedata width="75%" fileref="yast2_dns_def_logging.png"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -318,10 +318,10 @@
      <title>DNSサーバ: ゾーンエディタ(基本)</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata width="65%" fileref="yast2_dns_def_ddns.png" format="PNG"/>
+       <imagedata width="65%" fileref="yast2_dns_def_ddns.png"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata width="65%" fileref="yast2_dns_def_ddns.png" format="PNG"/>
+       <imagedata width="65%" fileref="yast2_dns_def_ddns.png"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -336,10 +336,10 @@
         <title>DNSサーバ: ゾーンエディタ(NSレコード)</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata width="65%" fileref="yast2_dns_def_nsrec.png" format="PNG"/>
+          <imagedata width="65%" fileref="yast2_dns_def_nsrec.png"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata width="65%" fileref="yast2_dns_def_nsrec.png" format="PNG"/>
+          <imagedata width="65%" fileref="yast2_dns_def_nsrec.png"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -355,10 +355,10 @@
         <title>DNSサーバ: ゾーンエディタ(MXレコード)</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata width="72%" fileref="yast2_dns_def_mxrec.png" format="PNG"/>
+          <imagedata width="72%" fileref="yast2_dns_def_mxrec.png"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata width="75%" fileref="yast2_dns_def_mxrec.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_mxrec.png"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -374,10 +374,10 @@
         <title>DNSサーバ: ゾーンエディタ(SOA)</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata width="75%" fileref="yast2_dns_def_soa.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_soa.png"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata width="75%" fileref="yast2_dns_def_soa.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_soa.png"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -418,10 +418,10 @@
         <title>プライマリゾーンのレコードを追加</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="yast2_dns_revzone1.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone1.png" width="70%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="yast2_dns_revzone1.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone1.png" width="70%"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -434,10 +434,10 @@
         <title>逆引きゾーンの追加</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="yast2_dns_revzone2.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone2.png" width="70%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="yast2_dns_revzone2.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone2.png" width="70%"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -450,10 +450,10 @@
         <title>逆引きレコードの追加</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="yast2_dns_revzone3.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone3.png" width="70%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="yast2_dns_revzone3.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone3.png" width="70%"/>
          </imageobject>
         </mediaobject>
        </figure>

--- a/l10n/sles/ja-jp/xml/net_samba.xml
+++ b/l10n/sles/ja-jp/xml/net_samba.xml
@@ -608,10 +608,10 @@ smbpasswd -a -m hostname</screen>
      <title>Windowsドメインメンバーシップの決定</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="ad_sambaclient.png" width="75%" format="PNG"/>
+       <imagedata fileref="ad_sambaclient.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="ad_sambaclient.png" format="PNG"/>
+       <imagedata fileref="ad_sambaclient.png"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -728,10 +728,10 @@ drwxrwxrwx. 2 root    root    0 Oct 24 22:31 subfolder
     <title>Windowsエクスプローラの<guimenu>属性の詳細</guimenu>ダイアログ</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="samba_win_expl_advattr.png" width="75%" format="PNG"/>
+      <imagedata fileref="samba_win_expl_advattr.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="samba_win_expl_advattr.png" format="PNG"/>
+      <imagedata fileref="samba_win_expl_advattr.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -745,10 +745,10 @@ drwxrwxrwx. 2 root    root    0 Oct 24 22:31 subfolder
     <title>Windowsエクスプローラでの圧縮ファイルのディレクトリリスト</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="samba_win_expl_view_compressed.png" width="75%" format="PNG"/>
+      <imagedata fileref="samba_win_expl_view_compressed.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="samba_win_expl_view_compressed.png" format="PNG"/>
+      <imagedata fileref="samba_win_expl_view_compressed.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -810,10 +810,10 @@ drwxrwxrwx. 2 root    root    0 Oct 24 22:31 subfolder
      <title>スナップショットが有効な新しいSamba共有の追加</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_samba_snapshot.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_samba_snapshot.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_samba_snapshot.png" format="PNG"/>
+       <imagedata fileref="yast2_samba_snapshot.png"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -824,10 +824,10 @@ drwxrwxrwx. 2 root    root    0 Oct 24 22:31 subfolder
      <title>Windowsエクスプローラの<guimenu>以前のバージョン</guimenu>タブ</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="samba_winexpl_previous_versions.png" width="75%" format="PNG"/>
+       <imagedata fileref="samba_winexpl_previous_versions.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="samba_winexpl_previous_versions.png" format="PNG"/>
+       <imagedata fileref="samba_winexpl_previous_versions.png"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/ja-jp/xml/net_wicked.xml
+++ b/l10n/sles/ja-jp/xml/net_wicked.xml
@@ -80,10 +80,10 @@
     <title><literal>wicked</literal>アーキテクチャ</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="wicked_scheme.png" format="PNG"/>
+      <imagedata fileref="wicked_scheme.png"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="wicked_scheme.png" format="PNG" width="80%"/>
+      <imagedata fileref="wicked_scheme.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/ja-jp/xml/net_yast.xml
+++ b/l10n/sles/ja-jp/xml/net_yast.xml
@@ -48,10 +48,10 @@
    <title>ネットワーク設定の実行</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_net_icard.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_net_icard.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_net_icard.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_net_icard.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/ja-jp/xml/network_scheme.xml
+++ b/l10n/sles/ja-jp/xml/network_scheme.xml
@@ -4,10 +4,10 @@
  <info>
   <mediaobject>
    <imageobject role="html">
-    <imagedata fileref="network_schema.png" width="100%" format="PNG"/>
+    <imagedata fileref="network_schema.png" width="100%"/>
    </imageobject>
    <imageobject role="pdf">
-    <imagedata fileref="network_schema.svg" width="100%" format="SVG"/>
+    <imagedata fileref="network_schema.svg" width="100%"/>
    </imageobject>
   </mediaobject>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -21,10 +21,10 @@
  <informalfigure>
   <mediaobject>
    <imageobject role="html">
-    <imagedata fileref="network_schema.png" width="100%" format="PNG"/>
+    <imagedata fileref="network_schema.png" width="100%"/>
    </imageobject>
    <imageobject role="pdf">
-    <imagedata fileref="network_schema.svg" width="100%" format="SVG"/>
+    <imagedata fileref="network_schema.svg" width="100%"/>
    </imageobject>
   </mediaobject>
  </informalfigure>

--- a/l10n/sles/ja-jp/xml/sle_update_upgrading.xml
+++ b/l10n/sles/ja-jp/xml/sle_update_upgrading.xml
@@ -72,11 +72,11 @@
    <title>サポートされているアップグレードパスの概要</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="100%" format="PNG"/>
+     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="100%"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="80%" format="PNG"/>
+     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="80%"/>
      
     </imageobject>
    </mediaobject>

--- a/l10n/sles/ja-jp/xml/snapper.xml
+++ b/l10n/sles/ja-jp/xml/snapper.xml
@@ -417,10 +417,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_list.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_list.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_list.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_list.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -432,10 +432,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_changes.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_changes.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_changes.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_changes.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -447,10 +447,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_diff.png" width="65%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_diff.png" width="65%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_diff.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_diff.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -462,10 +462,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_restore.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_restore.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_restore.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_restore.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -827,10 +827,10 @@ single | 4 |     |         |                       |
     <title>ブートローダ: スナップショット</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="boot_snapshots.png" width="75%" format="PNG"/>
+      <imagedata fileref="boot_snapshots.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="boot_snapshots.png" width="75%" format="PNG"/>
+      <imagedata fileref="boot_snapshots.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/ja-jp/xml/storage_fcoe.xml
+++ b/l10n/sles/ja-jp/xml/storage_fcoe.xml
@@ -14,10 +14,10 @@
   <title>Open Fibre Channel over Ethernet SAN</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="fcoe_san_a.svg" width="80%" format="SVG"/>
+    <imagedata fileref="fcoe_san_a.svg" width="80%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="fcoe_san_a.png" width="100%" format="PNG"/>
+    <imagedata fileref="fcoe_san_a.png" width="100%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -61,10 +61,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="fcoe_inst_disk_activation_a.png" width="80%" format="PNG"/>
+     <imagedata fileref="fcoe_inst_disk_activation_a.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="fcoe_inst_disk_activation_a.png" width="10%" format="PNG"/>
+     <imagedata fileref="fcoe_inst_disk_activation_a.png" width="10%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -108,10 +108,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="fcoe_services_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="fcoe_services_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="fcoe_services_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="fcoe_services_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -149,10 +149,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="fcoe_notconfig_interface_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="fcoe_notconfig_interface_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="fcoe_notconfig_interface_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="fcoe_notconfig_interface_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -243,10 +243,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="fcoe_configtab_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="fcoe_configtab_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="fcoe_configtab_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="fcoe_configtab_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/ja-jp/xml/storage_filesystems.xml
+++ b/l10n/sles/ja-jp/xml/storage_filesystems.xml
@@ -1043,10 +1043,10 @@ inode_ratio = 8192</screen>
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="ext4_inode_yast_a.png" width="60%" format="PNG"/>
+        <imagedata fileref="ext4_inode_yast_a.png" width="60%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="ext4_inode_yast_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="ext4_inode_yast_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/l10n/sles/ja-jp/xml/storage_iscsi.xml
+++ b/l10n/sles/ja-jp/xml/storage_iscsi.xml
@@ -14,10 +14,10 @@
   <title>iSNSサーバによるiSCSI SAN</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="iscsi_san_a.svg" width="80%" format="SVG"/>
+    <imagedata fileref="iscsi_san_a.svg" width="80%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="iscsi_san_a.png" width="100%" format="PNG"/>
+    <imagedata fileref="iscsi_san_a.png" width="100%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -94,10 +94,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="lio_service_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="lio_service_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="lio_service_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="lio_service_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -184,10 +184,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="lio_global_noauth_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="lio_global_noauth_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="lio_global_noauth_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="lio_global_noauth_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -263,10 +263,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="lio_targets_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="lio_targets_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="lio_targets_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="lio_targets_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -313,10 +313,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="lio_target_client_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="lio_target_client_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="lio_target_client_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="lio_target_client_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -623,10 +623,10 @@
       <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="iscsi_init_service_a.png" width="80%" format="PNG"/>
+         <imagedata fileref="iscsi_init_service_a.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="iscsi_init_service_a.png" width="100%" format="PNG"/>
+         <imagedata fileref="iscsi_init_service_a.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>

--- a/l10n/sles/ja-jp/xml/storage_isns.xml
+++ b/l10n/sles/ja-jp/xml/storage_isns.xml
@@ -37,10 +37,10 @@
    <title>iSNS検出ドメイン</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="isns_a.png" width="80%" format="PNG"/>
+     <imagedata fileref="isns_a.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="isns_a.png" width="100%" format="PNG"/>
+     <imagedata fileref="isns_a.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -138,10 +138,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="isns_config_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="isns_config_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="isns_config_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="isns_config_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -252,10 +252,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="isns_discdomains_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="isns_discdomains_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="isns_discdomains_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="isns_discdomains_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -296,10 +296,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="isns_iscsinodes_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="isns_iscsinodes_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="isns_iscsinodes_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="isns_iscsinodes_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/l10n/sles/ja-jp/xml/storage_lvm.xml
+++ b/l10n/sles/ja-jp/xml/storage_lvm.xml
@@ -33,10 +33,10 @@
    <title>物理パーティショニング対LVM</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="lvm.svg" width="80%" format="SVG"/>
+     <imagedata fileref="lvm.svg" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="lvm.png" width="100%" format="PNG"/>
+     <imagedata fileref="lvm.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -160,10 +160,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm4_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm4_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm4_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm4_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -227,10 +227,10 @@
      <title>DATAという名前のボリュームグループ内の物理ボリューム</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm5_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm5_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm5_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm5_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -307,10 +307,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm9_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm9_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm9_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm9_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -325,10 +325,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm10_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm10_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm10_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm10_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -340,10 +340,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm11_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm11_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm11_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm11_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -575,10 +575,10 @@ root's password:
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm8_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm8_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm8_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm8_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -653,10 +653,10 @@ root's password:
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm12_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm12_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm12_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm12_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/ja-jp/xml/storage_nfs.xml
+++ b/l10n/sles/ja-jp/xml/storage_nfs.xml
@@ -144,11 +144,11 @@
       <title>NFSサーバ設定ツール</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_inst_nfsserver1.png" width="75%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_inst_nfsserver1.png" width="75%" os="sles;sled"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_inst_nfsserver1.png" width="75%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_inst_nfsserver1.png" width="75%" os="sles;sled"/>
         
        </imageobject>
       </mediaobject>

--- a/l10n/sles/ja-jp/xml/storage_raid.xml
+++ b/l10n/sles/ja-jp/xml/storage_raid.xml
@@ -227,10 +227,10 @@
      <title>RAID 5設定の例</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_raid3_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_raid3_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_raid3_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_raid3_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/ja-jp/xml/storage_raid10.xml
+++ b/l10n/sles/ja-jp/xml/storage_raid10.xml
@@ -726,10 +726,10 @@ ARRAY /dev/md2 UUID=<replaceable>UUID</replaceable></screen>
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="raid10_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="raid10_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="raid10_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="raid10_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -780,10 +780,10 @@ ARRAY /dev/md2 UUID=<replaceable>UUID</replaceable></screen>
        <informalfigure>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="raid10_classify_a.png" width="80%" format="PNG"/>
+          <imagedata fileref="raid10_classify_a.png" width="80%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="raid10_classify_a.png" width="100%" format="PNG"/>
+          <imagedata fileref="raid10_classify_a.png" width="100%"/>
          </imageobject>
         </mediaobject>
        </informalfigure>

--- a/l10n/sles/ja-jp/xml/storage_raidroot.xml
+++ b/l10n/sles/ja-jp/xml/storage_raidroot.xml
@@ -123,10 +123,10 @@
       <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install2_a.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install2_a.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install2_a.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install2_a.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -155,10 +155,10 @@
       <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install3_a.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install3_a.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install3_a.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install3_a.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -178,10 +178,10 @@
      <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install_editraid.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_editraid.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install_editraid.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_editraid.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -198,10 +198,10 @@
       <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install_filesystem.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_filesystem.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install_filesystem.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_filesystem.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -221,10 +221,10 @@
    	<informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install_swap.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_swap.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install_swap.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_swap.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -236,10 +236,10 @@
     <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install_boot.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_boot.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install_boot.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_boot.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -247,10 +247,10 @@
     <informalfigure>
       <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="raid_yast_install3_b.png" width="70%" format="PNG"/>
+       <imagedata fileref="raid_yast_install3_b.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="raid_yast_install3_b.png" width="70%" format="PNG"/>
+       <imagedata fileref="raid_yast_install3_b.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/ja-jp/xml/systemd.xml
+++ b/l10n/sles/ja-jp/xml/systemd.xml
@@ -1048,10 +1048,10 @@ Startup finished in 2666ms (kernel) + 21961ms (userspace) = 24628ms</screen>
        <informalfigure>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="systemd_startup.svg" width="75%" format="SVG"/>
+          <imagedata fileref="systemd_startup.svg" width="75%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="systemd_startup.png" width="75%" format="PNG"/>
+          <imagedata fileref="systemd_startup.png" width="75%"/>
          </imageobject>
         </mediaobject>
        </informalfigure>
@@ -1134,10 +1134,10 @@ WantedBy=multi-user.target<co xml:id="co-service-wrapper-target"/></screen>
    <title>サービスマネージャ</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_runlevel.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_runlevel.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_runlevel.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_runlevel.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/ja-jp/xml/tuning_multikernel.xml
+++ b/l10n/sles/ja-jp/xml/tuning_multikernel.xml
@@ -236,10 +236,10 @@
      <title>YaSTソフトウェアマネージャ: マルチバージョン表示</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_sw_multiversion.png" width="90%" format="PNG"/>
+       <imagedata fileref="yast2_sw_multiversion.png" width="90%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_sw_multiversion.png" width="90%" format="PNG"/>
+       <imagedata fileref="yast2_sw_multiversion.png" width="90%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/ja-jp/xml/uefi.xml
+++ b/l10n/sles/ja-jp/xml/uefi.xml
@@ -83,10 +83,10 @@
      <title>セキュアブートサポート</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/ja-jp/xml/updater_gnome.xml
+++ b/l10n/sles/ja-jp/xml/updater_gnome.xml
@@ -25,11 +25,11 @@
   <mediaobject>
    <imageobject role="fo">
     
-    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%" format="PNG"/>
+    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
     
-    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%" format="PNG"/>
+    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -47,10 +47,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="gupdater_updates.png" width="75%" format="PNG"/>
+      <imagedata fileref="gupdater_updates.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="gupdater_updates.png" width="75%" format="PNG"/>
+      <imagedata fileref="gupdater_updates.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sles/ja-jp/xml/updater_gnome_sw.xml
+++ b/l10n/sles/ja-jp/xml/updater_gnome_sw.xml
@@ -42,10 +42,10 @@
   <title><guimenu>GNOMEソフトウェア</guimenu>—<guimenu>更新</guimenu>ビュー</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="gnome-software-updates.png" width="75%" format="PNG"/>
+    <imagedata fileref="gnome-software-updates.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="gnome-software-updates.png" width="75%" format="PNG"/>
+    <imagedata fileref="gnome-software-updates.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sles/ja-jp/xml/vnc.xml
+++ b/l10n/sles/ja-jp/xml/vnc.xml
@@ -56,10 +56,10 @@
      <textobject role="description"><phrase>vncviewer asking for connection details</phrase>
      </textobject>
      <imageobject role="html">
-      <imagedata fileref="vnc_connect.png" format="PNG"/>
+      <imagedata fileref="vnc_connect.png"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="vnc_connect.png" format="PNG"/>
+      <imagedata fileref="vnc_connect.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -99,10 +99,10 @@
     <title>Remminaのメインウィンドウ</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -114,16 +114,16 @@
   <sect2 xml:id="vnc-remmina-addnew">
    <title>リモートセッションの追加</title>
    <para>
-    新しいリモートセッションを追加して保存するには、メインウィンドウの左上で、<inlinemediaobject><textobject role="description"><phrase>新しいセッションの追加</phrase></textobject><imageobject role="fo"><imagedata fileref="remmina_plus.png" width="1.2em" format="PNG"/></imageobject><imageobject role="html"><imagedata fileref="remmina_plus.png" width="1.2em" format="PNG"/></imageobject></inlinemediaobject>をクリックします。<guimenu>リモートデスクトップ初期設定</guimenu>ウィンドウが開きます。
+    新しいリモートセッションを追加して保存するには、メインウィンドウの左上で、<inlinemediaobject><textobject role="description"><phrase>新しいセッションの追加</phrase></textobject><imageobject role="fo"><imagedata fileref="remmina_plus.png" width="1.2em"/></imageobject><imageobject role="html"><imagedata fileref="remmina_plus.png" width="1.2em"/></imageobject></inlinemediaobject>をクリックします。<guimenu>リモートデスクトップ初期設定</guimenu>ウィンドウが開きます。
    </para>
    <figure>
     <title>リモートデスクトップ初期設定</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina_session_details.png" width="80%" format="PNG"/>
+      <imagedata fileref="remmina_session_details.png" width="80%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina_session_details.png" width="80%" format="PNG"/>
+      <imagedata fileref="remmina_session_details.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -203,10 +203,10 @@
      <title>クイックスタート</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="remmina_quickstart.png" width="40%" format="PNG"/>
+       <imagedata fileref="remmina_quickstart.png" width="40%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="remmina_quickstart.png" width="40%" format="PNG"/>
+       <imagedata fileref="remmina_quickstart.png" width="40%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -229,10 +229,10 @@
      <title>Remminaのリモートセッションの表示</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>
+       <imagedata fileref="remmina_sle15inside.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>
+       <imagedata fileref="remmina_sle15inside.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -267,10 +267,10 @@
     <title>プロファイルファイルへのパスの読み込み</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina_status.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina_status.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina_status.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina_status.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -332,10 +332,10 @@
    <title>リモート管理</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="vnc_nosession.png" width="70%" format="PNG"/>
+     <imagedata fileref="vnc_nosession.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="vnc_nosession.png" width="70%" format="PNG"/>
+     <imagedata fileref="vnc_nosession.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -561,10 +561,10 @@ WINDOWMANAGER=icewm vncserver -geometry 1024x768</screen>
      <title>VNCセッション設定</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="vncmanager_session.png" width="85%" format="PNG"/>
+       <imagedata fileref="vncmanager_session.png" width="85%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="vncmanager_session.png" width="85%" format="PNG"/>
+       <imagedata fileref="vncmanager_session.png" width="85%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -649,10 +649,10 @@ WINDOWMANAGER=icewm vncserver -geometry 1024x768</screen>
      <title>永続的VNCセッションへの参加</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="vncmanager_whether.png" width="80%" format="PNG"/>
+       <imagedata fileref="vncmanager_whether.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="vncmanager_whether.png" width="80%" format="PNG"/>
+       <imagedata fileref="vncmanager_whether.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/ja-jp/xml/yast2_ftp.xml
+++ b/l10n/sles/ja-jp/xml/yast2_ftp.xml
@@ -67,10 +67,10 @@
    <title>FTPサーバの設定 - 起動</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_ftp-start-up.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_ftp-start-up.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_ftp-start-up.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_ftp-start-up.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/ja-jp/xml/yast2_lang.xml
+++ b/l10n/sles/ja-jp/xml/yast2_lang.xml
@@ -91,10 +91,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_language.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_language.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_language.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_language.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>
@@ -225,10 +225,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_timezone.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_timezone.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_timezone.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_timezone.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -306,10 +306,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_timezone_ntp.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_timezone_ntp.png" width="75%"/>
       </imageobject>
       <imageobject role="pdf">
-       <imagedata fileref="yast2_timezone_ntp.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_timezone_ntp.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/ja-jp/xml/yast2_ncurses.xml
+++ b/l10n/sles/ja-jp/xml/yast2_ncurses.xml
@@ -15,10 +15,10 @@
   <title>テキストモードのYaSTのメインウィンドウ</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="yast2_ncurses_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="yast2_ncurses_main.png" width="70%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="yast2_ncurses_main.png" width="75%" format="PNG"/>
+    <imagedata fileref="yast2_ncurses_main.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -99,10 +99,10 @@
    <title>ソフトウェアインストールモジュール</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_ncurses_inst.png" width="70%" format="PNG"/>
+     <imagedata fileref="yast2_ncurses_inst.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_ncurses_inst.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_ncurses_inst.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/ja-jp/xml/yast2_sw.xml
+++ b/l10n/sles/ja-jp/xml/yast2_sw.xml
@@ -152,10 +152,10 @@
      <phrase><guimenu>YaST</guimenu> software manager screen</phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_sw_manager.png" width="70%" format="PNG"/>
+     <imagedata fileref="yast2_sw_manager.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_sw_manager.png" width="65%" format="PNG"/>
+     <imagedata fileref="yast2_sw_manager.png" width="65%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -477,10 +477,10 @@
     <title>ソフトウェアマネージャの競合管理</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_package_conflict.png" width="70%" format="PNG"/>
+      <imagedata fileref="yast2_package_conflict.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_package_conflict.png" width="65%" format="PNG"/>
+      <imagedata fileref="yast2_package_conflict.png" width="65%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/ja-jp/xml/yast2_sw_repo.xml
+++ b/l10n/sles/ja-jp/xml/yast2_sw_repo.xml
@@ -52,10 +52,10 @@
      <title>ソフトウェアリポジトリの追加</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_addon_new.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_addon_new.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_addon_new.png" width="65%" format="PNG"/>
+       <imagedata fileref="yast2_addon_new.png" width="65%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/ja-jp/xml/yast2_userman.xml
+++ b/l10n/sles/ja-jp/xml/yast2_userman.xml
@@ -22,11 +22,11 @@
    <title>YaSTのユーザとグループの管理</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_users_main_qt.png" width="90%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_users_main_qt.png" width="90%" os="sles;sled"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_users_main_qt.png" width="70%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_users_main_qt.png" width="70%" os="sles;sled"/>
      
     </imageobject>
    </mediaobject>
@@ -388,11 +388,11 @@
      <informalfigure os="sles;sled">
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_users_quota_qt.png" width="80%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_users_quota_qt.png" width="80%" os="sles;sled"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_users_quota_qt.png" width="70%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_users_quota_qt.png" width="70%" os="sles;sled"/>
         
        </imageobject>
       </mediaobject>
@@ -558,11 +558,11 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_groups_edit_qt.png" width="80%" format="PNG" os="sles;sled"/>
+       <imagedata fileref="yast2_groups_edit_qt.png" width="80%" os="sles;sled"/>
        
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_groups_edit_qt.png" width="75%" format="PNG" os="sles;sled"/>
+       <imagedata fileref="yast2_groups_edit_qt.png" width="75%" os="sles;sled"/>
        
       </imageobject>
      </mediaobject>

--- a/l10n/sles/ja-jp/xml/yast2_you.xml
+++ b/l10n/sles/ja-jp/xml/yast2_you.xml
@@ -73,11 +73,11 @@
    <title>YaSTオンラインアップデート</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_you.png" width="75%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_you.png" width="75%" os="sles;sled"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_you.png" width="75%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_you.png" width="75%" os="sles;sled"/>
      
     </imageobject>
    </mediaobject>
@@ -204,10 +204,10 @@
    <title>撤回されたパッチと履歴の表示</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_retracted_patches.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_retracted_patches.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_retracted_patches.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_retracted_patches.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>  
@@ -245,10 +245,10 @@
    <title>YaSTオンライン更新設定</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_autoupdate.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_autoupdate.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_autoupdate.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_autoupdate.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/ko-kr/xml/deployment_expert_partitioner_lvm.xml
+++ b/l10n/sles/ko-kr/xml/deployment_expert_partitioner_lvm.xml
@@ -88,10 +88,10 @@
    <title>볼륨 그룹 생성</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -108,10 +108,10 @@
    <title>논리적 볼륨 관리</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/ko-kr/xml/deployment_expert_partitioner_overview.xml
+++ b/l10n/sles/ko-kr/xml/deployment_expert_partitioner_overview.xml
@@ -24,10 +24,10 @@
   <title>YaST 파티션 도구</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -231,10 +231,10 @@
         <title>YaST 파티션 도구의 BTRFS 하위 볼륨</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
         </mediaobject>
        </figure>

--- a/l10n/sles/ko-kr/xml/deployment_expert_partitioner_raid.xml
+++ b/l10n/sles/ko-kr/xml/deployment_expert_partitioner_raid.xml
@@ -56,10 +56,10 @@
    <title>RAID 파티션</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/ko-kr/xml/deployment_register.xml
+++ b/l10n/sles/ko-kr/xml/deployment_register.xml
@@ -80,11 +80,11 @@
         <phrase><guimenu>Registration</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -113,11 +113,11 @@
         <phrase><guimenu>Extension and Module Selection</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -143,11 +143,11 @@
         <phrase><guimenu>Installation Summary</guimenu> screen</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -212,11 +212,11 @@
         <phrase><guimenu>Extension and Module Selection</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%"/>
         
 
        </imageobject>
@@ -265,11 +265,11 @@
         <phrase><guimenu>Installed Add-on Products</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>

--- a/l10n/sles/ko-kr/xml/deployment_troubleshooting.xml
+++ b/l10n/sles/ko-kr/xml/deployment_troubleshooting.xml
@@ -160,10 +160,10 @@
    <title>US 키보드 레이아웃</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="keyboard_us.svg" width="75%" format="SVG"/>
+     <imagedata fileref="keyboard_us.svg" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="keyboard_us.png" width="75%" format="PNG"/>
+     <imagedata fileref="keyboard_us.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/ko-kr/xml/sle_update_upgrading.xml
+++ b/l10n/sles/ko-kr/xml/sle_update_upgrading.xml
@@ -72,11 +72,11 @@
    <title>지원 업그레이드 경로 개요</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="100%" format="PNG"/>
+     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="100%"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="80%" format="PNG"/>
+     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="80%"/>
      
     </imageobject>
    </mediaobject>

--- a/l10n/sles/pt-br/xml/apps_ekiga.xml
+++ b/l10n/sles/pt-br/xml/apps_ekiga.xml
@@ -170,10 +170,10 @@
    <title>Interface do usuário do <productname>Ekiga</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="ekiga_main.png" width="45%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="45%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ekiga_main.png" width="55%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="55%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/pt-br/xml/apps_evolution.xml
+++ b/l10n/sles/pt-br/xml/apps_evolution.xml
@@ -733,10 +733,10 @@
    <title><productname>Evolution</productname> janela</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" width="100%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" width="86%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="86%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/pt-br/xml/apps_firefox.xml
+++ b/l10n/sles/pt-br/xml/apps_firefox.xml
@@ -29,7 +29,7 @@
   <note>
    <title>Usando a barra de menus</title>
    <para>
-    Embora a maioria das funções do <productname>Firefox</productname> esteja disponível por meio do botão de três linhas (<inlinemediaobject><textobject role="description"><phrase>Botão de três linhas</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject>), algumas estão disponíveis apenas na barra de menus.
+    Embora a maioria das funções do <productname>Firefox</productname> esteja disponível por meio do botão de três linhas (<inlinemediaobject><textobject role="description"><phrase>Botão de três linhas</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em"/></imageobject></inlinemediaobject>), algumas estão disponíveis apenas na barra de menus.
    </para>
    <para>
     Por padrão, a barra de menus do <productname>Firefox</productname> fica oculta. Para mostrá-la temporariamente, pressione <keycap function="alt"/>. Ela permanecerá exibida até você clicar em algum outro lugar na janela do browser.

--- a/l10n/sles/pt-br/xml/apps_gimp.xml
+++ b/l10n/sles/pt-br/xml/apps_gimp.xml
@@ -125,10 +125,10 @@
     <title>Caixa de ferramentas</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="gimp-toolbox.png" width="35%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="35%"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="gimp-toolbox.png" width="30%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="30%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -547,10 +547,10 @@
        <title>Caixa de diálogo do seletor de cores básicas</title>
        <mediaobject>
         <imageobject role="html">
-         <imagedata fileref="gimp-color.png" width="70%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="70%"/>
         </imageobject>
         <imageobject role="fo">
-         <imagedata fileref="gimp-color.png" width="80%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="80%"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -719,10 +719,10 @@
    <title>Caixa de diálogo de impressão</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="gimp-print.png" width="75%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="75%"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="gimp-print.png" width="70%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/pt-br/xml/apps_libreoffice.xml
+++ b/l10n/sles/pt-br/xml/apps_libreoffice.xml
@@ -492,10 +492,10 @@
    <title>Caixa de diálogo de personalização no <guimenu>Writer</guimenu></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -647,10 +647,10 @@
    <title>Janela de opções</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_options.png" width="95%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_options.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/pt-br/xml/apps_librevarious.xml
+++ b/l10n/sles/pt-br/xml/apps_librevarious.xml
@@ -285,10 +285,10 @@
        <mediaobject>
         <textobject><phrase>Field selection</phrase></textobject>
         <imageobject role="fo">
-         <imagedata fileref="oo-wizard-base.png" width="90%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="90%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="oo-wizard-base.png" width="85%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="85%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>

--- a/l10n/sles/pt-br/xml/apps_librewriter.xml
+++ b/l10n/sles/pt-br/xml/apps_librewriter.xml
@@ -66,10 +66,10 @@
    <title>Um assistente do LibreOffice</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo-wizard.png" width="100%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo-wizard.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -231,10 +231,10 @@
     <title>Painel Estilos</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo-stylist.png" width="40%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="40%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo-stylist.png" width="50%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -641,10 +641,10 @@
     <title>Ferramenta Navegador no <guimenu>Writer</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo_navigator.png" width="55%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo_navigator.png" width="45%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="45%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/pt-br/xml/apps_totem.xml
+++ b/l10n/sles/pt-br/xml/apps_totem.xml
@@ -59,10 +59,10 @@
    <title>Janela de inicialização do <guimenu>GNOME Videos</guimenu></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -132,11 +132,11 @@
     <guimenu> Ejetar</guimenu> </menuchoice>.
    </para>
    <para>
-    Para pausar um filme ou uma música em reprodução, clique no botão <inlinemediaobject><textobject role="description"><phrase>Pausar do GNOME Videos</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_pause_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="totem_pause_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject> ou clique em <menuchoice> <guimenu>Filme</guimenu>
+    Para pausar um filme ou uma música em reprodução, clique no botão <inlinemediaobject><textobject role="description"><phrase>Pausar do GNOME Videos</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_pause_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="totem_pause_button-fallback.png" width="1em"/></imageobject></inlinemediaobject> ou clique em <menuchoice> <guimenu>Filme</guimenu>
     <guimenu>Reproduzir/Pausar</guimenu> </menuchoice>. Ao pausar um filme ou uma música, aparece <guimenu>Pausado</guimenu> na barra de status e o tempo decorrido do filme ou da música atual.
    </para>
    <para>
-    Para continuar a reprodução de um filme ou uma música, clique no botão <inlinemediaobject><textobject role="description"><phrase>Reproduzir do GNOME Videos</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_play_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="totem_play_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject> ou clique em <menuchoice> <guimenu>Filme</guimenu>
+    Para continuar a reprodução de um filme ou uma música, clique no botão <inlinemediaobject><textobject role="description"><phrase>Reproduzir do GNOME Videos</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_play_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="totem_play_button-fallback.png" width="1em"/></imageobject></inlinemediaobject> ou clique em <menuchoice> <guimenu>Filme</guimenu>
     <guimenu>Reproduzir/Pausar</guimenu></menuchoice>.
    </para>
    <para>
@@ -223,10 +223,10 @@
     <title>Preferências gerais do <guimenu>GNOME Videos</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -268,10 +268,10 @@
     <title>Preferências de vídeo do <guimenu>GNOME Videos</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -307,10 +307,10 @@
     <title>Preferências de áudio do <guimenu>GNOME Videos</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/pt-br/xml/backup.xml
+++ b/l10n/sles/pt-br/xml/backup.xml
@@ -20,10 +20,10 @@
  <mediaobject>
   <textobject><phrase>Backup application</phrase></textobject>
   <imageobject role="fo">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
   <imageobject role="html">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
  </mediaobject>
 </informalfigure>

--- a/l10n/sles/pt-br/xml/deployment_expert_partitioner_lvm.xml
+++ b/l10n/sles/pt-br/xml/deployment_expert_partitioner_lvm.xml
@@ -88,10 +88,10 @@
    <title>Criando um grupo de volume</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -108,10 +108,10 @@
    <title>Gerenciamento de volumes lógicos</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/pt-br/xml/deployment_expert_partitioner_overview.xml
+++ b/l10n/sles/pt-br/xml/deployment_expert_partitioner_overview.xml
@@ -24,10 +24,10 @@
   <title>O particionador do YaST</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -231,10 +231,10 @@
         <title>Subvolumes Btrfs no particionador do YaST</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
         </mediaobject>
        </figure>

--- a/l10n/sles/pt-br/xml/deployment_expert_partitioner_raid.xml
+++ b/l10n/sles/pt-br/xml/deployment_expert_partitioner_raid.xml
@@ -56,10 +56,10 @@
    <title>Partições RAID</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/pt-br/xml/deployment_register.xml
+++ b/l10n/sles/pt-br/xml/deployment_register.xml
@@ -80,11 +80,11 @@
         <phrase><guimenu>Registration</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -113,11 +113,11 @@
         <phrase><guimenu>Extension and Module Selection</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -143,11 +143,11 @@
         <phrase><guimenu>Installation Summary</guimenu> screen</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -212,11 +212,11 @@
         <phrase><guimenu>Extension and Module Selection</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%"/>
         
 
        </imageobject>
@@ -265,11 +265,11 @@
         <phrase><guimenu>Installed Add-on Products</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>

--- a/l10n/sles/pt-br/xml/deployment_troubleshooting.xml
+++ b/l10n/sles/pt-br/xml/deployment_troubleshooting.xml
@@ -160,10 +160,10 @@
    <title>Layout do teclado dos EUA</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="keyboard_us.svg" width="75%" format="SVG"/>
+     <imagedata fileref="keyboard_us.svg" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="keyboard_us.png" width="75%" format="PNG"/>
+     <imagedata fileref="keyboard_us.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/pt-br/xml/gnome_accessibility.xml
+++ b/l10n/sles/pt-br/xml/gnome_accessibility.xml
@@ -90,10 +90,10 @@
      <mediaobject>
       <textobject><phrase>On-screen keyboard</phrase></textobject>
       <imageobject role="fo">
-       <imagedata fileref="gnome_onscreen_kbd.png" width="95%" format="PNG"/>
+       <imagedata fileref="gnome_onscreen_kbd.png" width="95%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="gnome_onscreen_kbd.png" width="90%" format="PNG"/>
+       <imagedata fileref="gnome_onscreen_kbd.png" width="90%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/pt-br/xml/gnome_crypto.xml
+++ b/l10n/sles/pt-br/xml/gnome_crypto.xml
@@ -22,10 +22,10 @@
   <title>Janela principal <guimenu>Senhas e chaves</guimenu></title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sles/pt-br/xml/gnome_custom.xml
+++ b/l10n/sles/pt-br/xml/gnome_custom.xml
@@ -61,10 +61,10 @@
      <title>Configurações de segundo plano do GNOME</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="preferences_background.png" width="45%" format="PNG"/>
+        <imagedata fileref="preferences_background.png" width="45%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="preferences_background.png" width="45%" format="PNG"/>
+        <imagedata fileref="preferences_background.png" width="45%"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -148,10 +148,10 @@
    <title>Caixa de diálogo de atalhos de teclado</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_keyboard.png" width="100%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_keyboard.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -178,10 +178,10 @@
    <title>Habilitando a tecla de composição em ajustes</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -307,10 +307,10 @@
    <title>Caixa de diálogo de configurações <guimenu>Mouse e Touchpad</guimenu></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -362,10 +362,10 @@
     <title>Caixa de diálogo de configurações de um monitor</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="preferences_screen_single.png" width="100%" format="PNG"/>
+      <imagedata fileref="preferences_screen_single.png" width="100%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="preferences_screen_single.png" width="80%" format="PNG"/>
+      <imagedata fileref="preferences_screen_single.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -486,10 +486,10 @@
    <title>Definindo configurações de som</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="sound_devices.png" width="100%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="sound_devices.png" width="80%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -515,10 +515,10 @@
      <title>Aplicativos padrão</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="preferences_preferred_apps.png" width="100%" format="PNG"/>
+       <imagedata fileref="preferences_preferred_apps.png" width="100%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="preferences_preferred_apps.png" width="80%" format="PNG"/>
+       <imagedata fileref="preferences_preferred_apps.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/pt-br/xml/gnome_networking.xml
+++ b/l10n/sles/pt-br/xml/gnome_networking.xml
@@ -104,10 +104,10 @@
    <title>Browser de arquivos de rede</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="network_browser.png" width="100%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="100%"/>
      </imageobject>
     <imageobject role="html">
-     <imagedata fileref="network_browser.png" width="90%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -256,10 +256,10 @@
       <mediaobject>
        <textobject><phrase>Sharing options</phrase></textobject>
        <imageobject role="fo">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/l10n/sles/pt-br/xml/gnome_start.xml
+++ b/l10n/sles/pt-br/xml/gnome_start.xml
@@ -37,11 +37,11 @@
    <title>Tela de login padrão do GNOME</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata os="sles;sled" fileref="login_sled.png" width="90%" format="PNG"/>
+     <imagedata os="sles;sled" fileref="login_sled.png" width="90%"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata os="sles;sled" fileref="login_sled.png" width="75%" format="PNG"/>
+     <imagedata os="sles;sled" fileref="login_sled.png" width="75%"/>
      
     </imageobject>
    </mediaobject>
@@ -83,11 +83,11 @@
       <title>Tela de login padrão do GNOME — tipo de sessão</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="90%" format="PNG"/>
+        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="90%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="75%" format="PNG"/>
+        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="75%"/>
         
        </imageobject>
       </mediaobject>
@@ -197,10 +197,10 @@
    <title>Visão geral da área de trabalho do GNOME com atividades</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="desktop_sled_menu.png" width="95%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="desktop_sled_menu.png" width="90%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -245,10 +245,10 @@
      <title>Visão geral <guimenu>Atividades</guimenu></title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="desktop_activities_overview.png" width="95%" format="PNG"/>
+      <imagedata fileref="desktop_activities_overview.png" width="95%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="desktop_activities_overview.png" width="90%" format="PNG"/>
+      <imagedata fileref="desktop_activities_overview.png" width="90%"/>
      </imageobject>
     </mediaobject>
      </figure>
@@ -285,10 +285,10 @@
      <title>Menu <guimenu>Aplicativo</guimenu> do <productname>Firefox</productname></title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="desktop_app_menu_firefox.png" width="70%" format="PNG"/>
+       <imagedata fileref="desktop_app_menu_firefox.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="desktop_app_menu_firefox.png" width="70%" format="PNG"/>
+       <imagedata fileref="desktop_app_menu_firefox.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/pt-br/xml/gnome_use.xml
+++ b/l10n/sles/pt-br/xml/gnome_use.xml
@@ -26,10 +26,10 @@
    <title>Gerenciador de arquivos</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -573,10 +573,10 @@
     <textobject><phrase><productname>Evolution</productname></phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" format="PNG" width="100%"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" format="PNG" width="80%"/>
+     <imagedata fileref="evolution.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -673,10 +673,10 @@
    <title><productname>Archive manager</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -971,10 +971,10 @@
    <title><productname>Document viewer</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evince.png" format="PNG" width="90%"/>
+     <imagedata fileref="evince.png" width="90%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evince.png" format="PNG" width="78%"/>
+     <imagedata fileref="evince.png" width="78%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/pt-br/xml/help_user.xml
+++ b/l10n/sles/pt-br/xml/help_user.xml
@@ -61,10 +61,10 @@
    <title>Janela principal da ajuda</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/pt-br/xml/sle_update_upgrading.xml
+++ b/l10n/sles/pt-br/xml/sle_update_upgrading.xml
@@ -72,11 +72,11 @@
    <title>Visão geral dos caminhos de upgrade suportados</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="100%" format="PNG"/>
+     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="100%"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="80%" format="PNG"/>
+     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="80%"/>
      
     </imageobject>
    </mediaobject>

--- a/l10n/sles/zh-cn/xml/adm_support.xml
+++ b/l10n/sles/zh-cn/xml/adm_support.xml
@@ -135,10 +135,10 @@ CPU Load Average:         7 (3%) with 2 CPUs
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_support_main.png" width="70%" format="PNG"/>
+        <imagedata fileref="yast2_support_main.png" width="70%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_support_main.png" width="60%" format="PNG"/>
+        <imagedata fileref="yast2_support_main.png" width="60%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -176,10 +176,10 @@ CPU Load Average:         7 (3%) with 2 CPUs
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_support_conf.png" width="90%" format="PNG"/>
+        <imagedata fileref="yast2_support_conf.png" width="90%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_support_conf.png" width="80%" format="PNG"/>
+        <imagedata fileref="yast2_support_conf.png" width="80%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -740,10 +740,10 @@ Creating Tar Ball
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_support_conf_upload.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_support_conf_upload.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_support_conf_upload.png" width="60%" format="PNG"/>
+       <imagedata fileref="yast2_support_conf_upload.png" width="60%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/zh-cn/xml/apache2_yast_i.xml
+++ b/l10n/sles/zh-cn/xml/apache2_yast_i.xml
@@ -45,10 +45,10 @@
     <title>HTTP 服务器向导：默认主机</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_apache_wizard3.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_apache_wizard3.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_apache_wizard3.png" format="PNG"/>
+      <imagedata fileref="yast2_apache_wizard3.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -154,10 +154,10 @@
     <title>HTTP 服务器向导：摘要</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_apache_wizard5.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_apache_wizard5.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_apache_wizard5.png" format="PNG"/>
+      <imagedata fileref="yast2_apache_wizard5.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -180,10 +180,10 @@
     <title>HTTP 服务器配置：侦听端口和地址</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_apache_config_listen.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_apache_config_listen.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_apache_config_listen.png" format="PNG"/>
+      <imagedata fileref="yast2_apache_config_listen.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -197,10 +197,10 @@
     <title>HTTP 服务器配置：服务器模块</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_apache_config_modules.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_apache_config_modules.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_apache_config_modules.png" format="PNG"/>
+      <imagedata fileref="yast2_apache_config_modules.png"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/zh-cn/xml/apparmor_changehat.xml
+++ b/l10n/sles/zh-cn/xml/apparmor_changehat.xml
@@ -188,10 +188,10 @@
      <title>Adminer 登录页</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata format="PNG" fileref="aa_changehat_adminer.png" width="75%"/>
+       <imagedata fileref="aa_changehat_adminer.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="aa_changehat_adminer.png" width="40%" format="PNG"/>
+       <imagedata fileref="aa_changehat_adminer.png" width="40%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -422,10 +422,10 @@ apparmor module is loaded.
      <textobject role="description"><phrase><phrase>AppArmor</phrase> profile dialog</phrase>
      </textobject>
      <imageobject role="fo">
-      <imagedata format="PNG" fileref="hats_in_profiles.png" width="75%"/>
+      <imagedata fileref="hats_in_profiles.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="hats_in_profiles.png" width="75%" format="PNG"/>
+      <imagedata fileref="hats_in_profiles.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>
@@ -439,10 +439,10 @@ apparmor module is loaded.
        <textobject role="description"><phrase>Enter hat name</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata format="PNG" fileref="hat_createhat.png" width="50%"/>
+        <imagedata fileref="hat_createhat.png" width="50%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="hat_createhat.png" width="35%" format="PNG"/>
+        <imagedata fileref="hat_createhat.png" width="35%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/l10n/sles/zh-cn/xml/apparmor_profiles_man.xml
+++ b/l10n/sles/zh-cn/xml/apparmor_profiles_man.xml
@@ -1248,10 +1248,10 @@ New Mode: r
      <title><command>aa-notify GNOME 中的消息</command></title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata format="PNG" fileref="aa-notify.png" width="75%"/>
+       <imagedata fileref="aa-notify.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="aa-notify.png" width="40%" format="PNG"/>
+       <imagedata fileref="aa-notify.png" width="40%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/zh-cn/xml/apparmor_profiles_yast.xml
+++ b/l10n/sles/zh-cn/xml/apparmor_profiles_yast.xml
@@ -82,10 +82,10 @@
       <textobject role="description"><phrase>Choose the profile to edit</phrase>
       </textobject>
       <imageobject role="fo">
-       <imagedata format="PNG" fileref="edit_1.png" width="75%"/>
+       <imagedata fileref="edit_1.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata format="PNG" fileref="edit_1.png"/>
+       <imagedata fileref="edit_1.png"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -104,10 +104,10 @@
       <textobject role="description"><phrase><phrase>AppArmor</phrase> profile dialog</phrase>
       </textobject>
       <imageobject role="fo">
-       <imagedata format="PNG" fileref="edit_2.png" width="75%"/>
+       <imagedata fileref="edit_2.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata format="PNG" fileref="edit_2.png"/>
+       <imagedata fileref="edit_2.png"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -159,10 +159,10 @@
         <textobject role="description"><phrase>Select a file to add</phrase>
         </textobject>
         <imageobject role="fo">
-         <imagedata format="PNG" fileref="add_2_addentry_file.png" width="60%"/>
+         <imagedata fileref="add_2_addentry_file.png" width="60%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="add_2_addentry_file.png" width="35%" format="PNG"/>
+         <imagedata fileref="add_2_addentry_file.png" width="35%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -183,10 +183,10 @@
 	  add</phrase>
         </textobject>
         <imageobject role="fo">
-         <imagedata format="PNG" fileref="add_2_addentry_file.png" width="60%"/>
+         <imagedata fileref="add_2_addentry_file.png" width="60%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="add_2_addentry_file.png" width="35%" format="PNG"/>
+         <imagedata fileref="add_2_addentry_file.png" width="35%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -203,10 +203,10 @@
         <textobject role="description"><phrase>Select capabilities</phrase>
         </textobject>
         <imageobject role="fo">
-         <imagedata format="PNG" fileref="add_2_addentry_network.png" width="50%"/>
+         <imagedata fileref="add_2_addentry_network.png" width="50%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata format="PNG" fileref="add_2_addentry_network.png" width="35%"/>
+         <imagedata fileref="add_2_addentry_network.png" width="35%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -223,10 +223,10 @@
         <textobject role="description"><phrase>Select capabilities</phrase>
         </textobject>
         <imageobject role="fo">
-         <imagedata format="PNG" fileref="add_2_addentry_capability.png" width="75%"/>
+         <imagedata fileref="add_2_addentry_capability.png" width="75%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata format="PNG" fileref="add_2_addentry_capability.png"/>
+         <imagedata fileref="add_2_addentry_capability.png"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -250,10 +250,10 @@
        <mediaobject>
         <textobject><phrase>enter subprofile name in popup window</phrase></textobject>
         <imageobject role="fo">
-         <imagedata fileref="add_2_addentry_hat.png" width="50%" format="PNG"/>
+         <imagedata fileref="add_2_addentry_hat.png" width="50%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="add_2_addentry_hat.png" format="PNG" width="60%"/>
+         <imagedata fileref="add_2_addentry_hat.png" width="60%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -325,10 +325,10 @@
 	panel</phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata format="PNG" fileref="sd_controlpanel_1.png" width="75%"/>
+     <imagedata fileref="sd_controlpanel_1.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata format="PNG" fileref="sd_controlpanel_1.png"/>
+     <imagedata fileref="sd_controlpanel_1.png"/>
     </imageobject>
    </mediaobject>
   </informalfigure>

--- a/l10n/sles/zh-cn/xml/apparmor_support.xml
+++ b/l10n/sles/zh-cn/xml/apparmor_support.xml
@@ -465,10 +465,10 @@ Profile /etc/apparmor.d/usr.sbin.squid failed to load
      <textobject><phrase>error message with hint for correcting the error</phrase>
       </textobject>
      <imageobject role="fo">
-      <imagedata fileref="aa_syncheck.png" width="60%" format="PNG"/>
+      <imagedata fileref="aa_syncheck.png" width="60%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="aa_syncheck.png" width="60%" format="PNG"/>
+      <imagedata fileref="aa_syncheck.png" width="60%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sles/zh-cn/xml/apps_ekiga.xml
+++ b/l10n/sles/zh-cn/xml/apps_ekiga.xml
@@ -170,10 +170,10 @@
    <title><productname>Ekiga</productname> 用户界面</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="ekiga_main.png" width="45%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="45%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ekiga_main.png" width="55%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="55%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/apps_evolution.xml
+++ b/l10n/sles/zh-cn/xml/apps_evolution.xml
@@ -733,10 +733,10 @@
    <title><productname>Evolution</productname> window</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" width="100%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" width="86%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="86%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/apps_firefox.xml
+++ b/l10n/sles/zh-cn/xml/apps_firefox.xml
@@ -29,7 +29,7 @@
   <note>
    <title>使用菜单栏</title>
    <para>
-    <productname>Firefox</productname> 的大多数功能都可通过三条横线按钮 (<inlinemediaobject><textobject role="description"><phrase>三条横线按钮</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject>) 访问，有些功能只能通过菜单栏访问。
+    <productname>Firefox</productname> 的大多数功能都可通过三条横线按钮 (<inlinemediaobject><textobject role="description"><phrase>三条横线按钮</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em"/></imageobject></inlinemediaobject>) 访问，有些功能只能通过菜单栏访问。
    </para>
    <para>
     <productname>Firefox</productname> 的菜单栏默认会隐藏起来。要暂时显示菜单栏，请按 <keycap function="alt"/>。菜单栏随后将一直显示，直到您单击浏览器窗口中的其他位置。

--- a/l10n/sles/zh-cn/xml/apps_gimp.xml
+++ b/l10n/sles/zh-cn/xml/apps_gimp.xml
@@ -125,10 +125,10 @@
     <title>工具箱</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="gimp-toolbox.png" width="35%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="35%"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="gimp-toolbox.png" width="30%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="30%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -547,10 +547,10 @@
        <title>基本颜色选择器对话框</title>
        <mediaobject>
         <imageobject role="html">
-         <imagedata fileref="gimp-color.png" width="70%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="70%"/>
         </imageobject>
         <imageobject role="fo">
-         <imagedata fileref="gimp-color.png" width="80%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="80%"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -719,10 +719,10 @@
    <title>打印对话框</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="gimp-print.png" width="75%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="75%"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="gimp-print.png" width="70%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/apps_libreoffice.xml
+++ b/l10n/sles/zh-cn/xml/apps_libreoffice.xml
@@ -492,10 +492,10 @@
    <title><guimenu>Writer</guimenu> 中的自定义对话框</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -647,10 +647,10 @@
    <title>选项窗口</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_options.png" width="95%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_options.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/apps_librevarious.xml
+++ b/l10n/sles/zh-cn/xml/apps_librevarious.xml
@@ -285,10 +285,10 @@
        <mediaobject>
         <textobject><phrase>Field selection</phrase></textobject>
         <imageobject role="fo">
-         <imagedata fileref="oo-wizard-base.png" width="90%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="90%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="oo-wizard-base.png" width="85%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="85%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>

--- a/l10n/sles/zh-cn/xml/apps_librewriter.xml
+++ b/l10n/sles/zh-cn/xml/apps_librewriter.xml
@@ -66,10 +66,10 @@
    <title>LibreOffice 向导</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo-wizard.png" width="100%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo-wizard.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -231,10 +231,10 @@
     <title>“样式”面板</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo-stylist.png" width="40%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="40%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo-stylist.png" width="50%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -641,10 +641,10 @@
     <title><guimenu>Writer</guimenu> 中的导航工具</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo_navigator.png" width="55%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo_navigator.png" width="45%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="45%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/zh-cn/xml/apps_totem.xml
+++ b/l10n/sles/zh-cn/xml/apps_totem.xml
@@ -59,10 +59,10 @@
    <title><guimenu>GNOME Videos</guimenu> 启动窗口</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -132,11 +132,11 @@
     <guimenu>弹出</guimenu> </menuchoice>。
    </para>
    <para>
-    要暂停正在播放的电影或歌曲，请单击 <inlinemediaobject><textobject role="description"><phrase>GNOME Videos 暂停</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_pause_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="totem_pause_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject> 按钮,或单击<menuchoice> <guimenu>电影</guimenu>
+    要暂停正在播放的电影或歌曲，请单击 <inlinemediaobject><textobject role="description"><phrase>GNOME Videos 暂停</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_pause_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="totem_pause_button-fallback.png" width="1em"/></imageobject></inlinemediaobject> 按钮,或单击<menuchoice> <guimenu>电影</guimenu>
     <guimenu>播放/暂停</guimenu> </menuchoice>。暂停电影或歌曲后，状态栏会显示<guimenu>已暂停</guimenu>以及当前电影或歌曲的已经过时间。
    </para>
    <para>
-    要继续播放电影或歌曲，请单击 <inlinemediaobject><textobject role="description"><phrase>GNOME Videos 播放</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_play_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="totem_play_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject>按钮,或单击<menuchoice> <guimenu>电影</guimenu>
+    要继续播放电影或歌曲，请单击 <inlinemediaobject><textobject role="description"><phrase>GNOME Videos 播放</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_play_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="totem_play_button-fallback.png" width="1em"/></imageobject></inlinemediaobject>按钮,或单击<menuchoice> <guimenu>电影</guimenu>
     <guimenu>播放/暂停</guimenu></menuchoice>。
    </para>
    <para>
@@ -223,10 +223,10 @@
     <title><guimenu>GNOME Videos</guimenu> 常规自选设置</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -268,10 +268,10 @@
     <title><guimenu>GNOME Videos</guimenu> 显示自选设置</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -307,10 +307,10 @@
     <title><guimenu>GNOME Videos</guimenu> 音频自选设置</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/zh-cn/xml/art_modules.xml
+++ b/l10n/sles/zh-cn/xml/art_modules.xml
@@ -961,10 +961,10 @@
         <phrase><guimenu>Add-On Product</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_addon_new.png" width="90%" format="PNG"/>
+        <imagedata fileref="yast2_addon_new.png" width="90%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_addon_new.png" width="80%" format="PNG"/>
+        <imagedata fileref="yast2_addon_new.png" width="80%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -1028,11 +1028,11 @@
         <phrase><guimenu>Installed Add-on Products</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="90%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="90%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="80%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="80%"/>
         
        </imageobject>
       </mediaobject>

--- a/l10n/sles/zh-cn/xml/art_raspberry-pi.xml
+++ b/l10n/sles/zh-cn/xml/art_raspberry-pi.xml
@@ -46,10 +46,10 @@
     <title>Raspberry Pi 3 B 型连接器 © Efa / English Wikipedia / CC BY-SA 3.0 概览</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="rpi-3b-overview-2.png" width="80%" format="PNG"/>
+      <imagedata fileref="rpi-3b-overview-2.png" width="80%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="rpi-3b-overview-2.png" width="80%" format="PNG"/>
+      <imagedata fileref="rpi-3b-overview-2.png" width="80%"/>
      </imageobject>
      <textobject><phrase>Overview of the Raspberry Pi 3 Model B connectors © Efa /
               English Wikipedia / CC BY-SA 3.0</phrase>
@@ -60,10 +60,10 @@
     <title>Raspberry Pi 3 B 型连接器 © Evan-Amos / own work / public domain 照片</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="rpi-3b-photo.png" width="80%" format="PNG"/>
+      <imagedata fileref="rpi-3b-photo.png" width="80%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="rpi-3b-photo.png" width="80%" format="PNG"/>
+      <imagedata fileref="rpi-3b-photo.png" width="80%"/>
      </imageobject>
      <textobject><phrase>Photo of the Raspberry Pi 3 Model B connectors © Evan-Amos
               / Own work / Public Domain</phrase>

--- a/l10n/sles/zh-cn/xml/art_virtualization-best-practices.xml
+++ b/l10n/sles/zh-cn/xml/art_virtualization-best-practices.xml
@@ -1593,10 +1593,10 @@ lazy refcounts: true</screen>
     <title>理解映像覆盖</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="qemu-img-overlay.png" width="95%" format="PNG"/>
+      <imagedata fileref="qemu-img-overlay.png" width="95%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="qemu-img-overlay.png" width="95%" format="PNG"/>
+      <imagedata fileref="qemu-img-overlay.png" width="95%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/zh-cn/xml/audit_components.xml
+++ b/l10n/sles/zh-cn/xml/audit_components.xml
@@ -153,7 +153,7 @@
    <title>Linux 审计组件简介</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="audit_components.png" width="75%" format="PNG"/>
+     <imagedata fileref="audit_components.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -1800,10 +1800,10 @@ Syscall Report
    <title>流程图 — 程序与系统调用之间的关系</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="audit_mkgraph.png" width="75%" format="PNG"/>
+     <imagedata fileref="audit_mkgraph.png" width="75%"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="audit_mkgraph.png" width="100%" format="PNG"/>
+     <imagedata fileref="audit_mkgraph.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -1838,10 +1838,10 @@ total  type
    <title>条形图 — 常见事件类型</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="audit_mkbar.png" width="75%" format="PNG"/>
+     <imagedata fileref="audit_mkbar.png" width="75%"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="audit_mkbar.png" width="100%" format="PNG"/>
+     <imagedata fileref="audit_mkbar.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/backup.xml
+++ b/l10n/sles/zh-cn/xml/backup.xml
@@ -20,10 +20,10 @@
  <mediaobject>
   <textobject><phrase>Backup application</phrase></textobject>
   <imageobject role="fo">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
   <imageobject role="html">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
  </mediaobject>
 </informalfigure>

--- a/l10n/sles/zh-cn/xml/chrony.xml
+++ b/l10n/sles/zh-cn/xml/chrony.xml
@@ -40,10 +40,10 @@
    <title>NTP 配置窗口</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="ntp_client.png" width="70%" format="PNG"/>
+     <imagedata fileref="ntp_client.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ntp_client.png" width="70%" format="PNG"/>
+     <imagedata fileref="ntp_client.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -103,10 +103,10 @@
     <title>添加时间服务器</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="ntp_client_serveradd.png" width="70%" format="PNG"/>
+      <imagedata fileref="ntp_client_serveradd.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="ntp_client_serveradd.png" width="70%" format="PNG"/>
+      <imagedata fileref="ntp_client_serveradd.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/zh-cn/xml/containers-basics.xml
+++ b/l10n/sles/zh-cn/xml/containers-basics.xml
@@ -70,10 +70,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="container-workflow.png" width="80%" format="PNG"/>
+     <imagedata fileref="container-workflow.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="container-workflow.png" width="100%" format="PNG"/>
+     <imagedata fileref="container-workflow.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -127,10 +127,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="container-image-layers.png" width="50%" format="PNG"/>
+     <imagedata fileref="container-image-layers.png" width="50%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="container-image-layers.png" width="100%" format="PNG"/>
+     <imagedata fileref="container-image-layers.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>

--- a/l10n/sles/zh-cn/xml/containers-docker-overview.xml
+++ b/l10n/sles/zh-cn/xml/containers-docker-overview.xml
@@ -86,7 +86,7 @@
    <title>Docker 开源引擎体系结构</title>
    <mediaobject>
     <imageobject>
-     <imagedata fileref="docker_architecture.png" format="PNG" width="70%"/>
+     <imagedata fileref="docker_architecture.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/containers-support.xml
+++ b/l10n/sles/zh-cn/xml/containers-support.xml
@@ -20,10 +20,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="container_support_matrix.png" width="100%" format="PNG"/>
+      <imagedata fileref="container_support_matrix.png" width="100%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="container_support_matrix.png" width="100%" format="PNG"/>
+      <imagedata fileref="container_support_matrix.png" width="100%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>
@@ -43,10 +43,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="container_non-sle_support.png" width="100%" format="PNG"/>
+      <imagedata fileref="container_non-sle_support.png" width="100%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="container_non-sle_support.png" width="100%" format="PNG"/>
+      <imagedata fileref="container_non-sle_support.png" width="100%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sles/zh-cn/xml/deployment_expert_partitioner_lvm.xml
+++ b/l10n/sles/zh-cn/xml/deployment_expert_partitioner_lvm.xml
@@ -88,10 +88,10 @@
    <title>创建卷组</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -108,10 +108,10 @@
    <title>逻辑卷管理</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/deployment_expert_partitioner_overview.xml
+++ b/l10n/sles/zh-cn/xml/deployment_expert_partitioner_overview.xml
@@ -24,10 +24,10 @@
   <title>YaST 分区程序</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -231,10 +231,10 @@
         <title>YaST 分区程序中的 Btrfs 子卷</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
         </mediaobject>
        </figure>

--- a/l10n/sles/zh-cn/xml/deployment_expert_partitioner_raid.xml
+++ b/l10n/sles/zh-cn/xml/deployment_expert_partitioner_raid.xml
@@ -56,10 +56,10 @@
    <title>RAID 分区</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/deployment_register.xml
+++ b/l10n/sles/zh-cn/xml/deployment_register.xml
@@ -80,11 +80,11 @@
         <phrase><guimenu>Registration</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -113,11 +113,11 @@
         <phrase><guimenu>Extension and Module Selection</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -143,11 +143,11 @@
         <phrase><guimenu>Installation Summary</guimenu> screen</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -212,11 +212,11 @@
         <phrase><guimenu>Extension and Module Selection</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%"/>
         
 
        </imageobject>
@@ -265,11 +265,11 @@
         <phrase><guimenu>Installed Add-on Products</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>

--- a/l10n/sles/zh-cn/xml/deployment_troubleshooting.xml
+++ b/l10n/sles/zh-cn/xml/deployment_troubleshooting.xml
@@ -160,10 +160,10 @@
    <title>美式键盘布局</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="keyboard_us.svg" width="75%" format="SVG"/>
+     <imagedata fileref="keyboard_us.svg" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="keyboard_us.png" width="75%" format="PNG"/>
+     <imagedata fileref="keyboard_us.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/gnome_accessibility.xml
+++ b/l10n/sles/zh-cn/xml/gnome_accessibility.xml
@@ -90,10 +90,10 @@
      <mediaobject>
       <textobject><phrase>On-screen keyboard</phrase></textobject>
       <imageobject role="fo">
-       <imagedata fileref="gnome_onscreen_kbd.png" width="95%" format="PNG"/>
+       <imagedata fileref="gnome_onscreen_kbd.png" width="95%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="gnome_onscreen_kbd.png" width="90%" format="PNG"/>
+       <imagedata fileref="gnome_onscreen_kbd.png" width="90%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/zh-cn/xml/gnome_crypto.xml
+++ b/l10n/sles/zh-cn/xml/gnome_crypto.xml
@@ -22,10 +22,10 @@
   <title><guimenu>口令和密钥</guimenu>主窗口</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sles/zh-cn/xml/gnome_custom.xml
+++ b/l10n/sles/zh-cn/xml/gnome_custom.xml
@@ -61,10 +61,10 @@
      <title>GNOME 背景设置</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="preferences_background.png" width="45%" format="PNG"/>
+        <imagedata fileref="preferences_background.png" width="45%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="preferences_background.png" width="45%" format="PNG"/>
+        <imagedata fileref="preferences_background.png" width="45%"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -148,10 +148,10 @@
    <title>键盘快捷键对话框</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_keyboard.png" width="100%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_keyboard.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -178,10 +178,10 @@
    <title>在 tweaks 中启用组合键</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -307,10 +307,10 @@
    <title><guimenu>鼠标和触摸板</guimenu>设置对话框</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -362,10 +362,10 @@
     <title>“单监视器设置”对话框</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="preferences_screen_single.png" width="100%" format="PNG"/>
+      <imagedata fileref="preferences_screen_single.png" width="100%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="preferences_screen_single.png" width="80%" format="PNG"/>
+      <imagedata fileref="preferences_screen_single.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -486,10 +486,10 @@
    <title>配置声音设置</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="sound_devices.png" width="100%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="sound_devices.png" width="80%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -515,10 +515,10 @@
      <title>默认应用程序</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="preferences_preferred_apps.png" width="100%" format="PNG"/>
+       <imagedata fileref="preferences_preferred_apps.png" width="100%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="preferences_preferred_apps.png" width="80%" format="PNG"/>
+       <imagedata fileref="preferences_preferred_apps.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/zh-cn/xml/gnome_networking.xml
+++ b/l10n/sles/zh-cn/xml/gnome_networking.xml
@@ -104,10 +104,10 @@
    <title>网络文件浏览器</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="network_browser.png" width="100%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="100%"/>
      </imageobject>
     <imageobject role="html">
-     <imagedata fileref="network_browser.png" width="90%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -256,10 +256,10 @@
       <mediaobject>
        <textobject><phrase>Sharing options</phrase></textobject>
        <imageobject role="fo">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/l10n/sles/zh-cn/xml/gnome_start.xml
+++ b/l10n/sles/zh-cn/xml/gnome_start.xml
@@ -37,11 +37,11 @@
    <title>默认 GNOME 登录屏幕</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata os="sles;sled" fileref="login_sled.png" width="90%" format="PNG"/>
+     <imagedata os="sles;sled" fileref="login_sled.png" width="90%"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata os="sles;sled" fileref="login_sled.png" width="75%" format="PNG"/>
+     <imagedata os="sles;sled" fileref="login_sled.png" width="75%"/>
      
     </imageobject>
    </mediaobject>
@@ -83,11 +83,11 @@
       <title>默认 GNOME 登录屏幕 - 会话类型</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="90%" format="PNG"/>
+        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="90%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="75%" format="PNG"/>
+        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="75%"/>
         
        </imageobject>
       </mediaobject>
@@ -197,10 +197,10 @@
    <title>GNOME 桌面及活动概览</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="desktop_sled_menu.png" width="95%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="desktop_sled_menu.png" width="90%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -245,10 +245,10 @@
      <title><guimenu>活动</guimenu>概览</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="desktop_activities_overview.png" width="95%" format="PNG"/>
+      <imagedata fileref="desktop_activities_overview.png" width="95%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="desktop_activities_overview.png" width="90%" format="PNG"/>
+      <imagedata fileref="desktop_activities_overview.png" width="90%"/>
      </imageobject>
     </mediaobject>
      </figure>
@@ -285,10 +285,10 @@
      <title><productname>Firefox</productname> 的<guimenu>应用程序</guimenu>菜单</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="desktop_app_menu_firefox.png" width="70%" format="PNG"/>
+       <imagedata fileref="desktop_app_menu_firefox.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="desktop_app_menu_firefox.png" width="70%" format="PNG"/>
+       <imagedata fileref="desktop_app_menu_firefox.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/zh-cn/xml/gnome_use.xml
+++ b/l10n/sles/zh-cn/xml/gnome_use.xml
@@ -26,10 +26,10 @@
    <title>文件管理器</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -573,10 +573,10 @@
     <textobject><phrase><productname>Evolution</productname></phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" format="PNG" width="100%"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" format="PNG" width="80%"/>
+     <imagedata fileref="evolution.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -673,10 +673,10 @@
    <title><productname>Archive manager</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -971,10 +971,10 @@
    <title><productname>Document viewer</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evince.png" format="PNG" width="90%"/>
+     <imagedata fileref="evince.png" width="90%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evince.png" format="PNG" width="78%"/>
+     <imagedata fileref="evince.png" width="78%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/grub2.xml
+++ b/l10n/sles/zh-cn/xml/grub2.xml
@@ -438,10 +438,10 @@
       <title>GRUB 2 引导编辑器</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="grub2_edit_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="grub2_edit_config.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="grub2_edit_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="grub2_edit_config.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </figure>

--- a/l10n/sles/zh-cn/xml/grub2_yast_i.xml
+++ b/l10n/sles/zh-cn/xml/grub2_yast_i.xml
@@ -93,10 +93,10 @@
     <title>引导代码选项</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%"/>
      </imageobject>
     </mediaobject>
   </figure>
@@ -215,10 +215,10 @@
     <title>引导加载程序选项</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_options.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_options.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_options.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_options.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -277,10 +277,10 @@
     <title>内核参数</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/zh-cn/xml/help_user.xml
+++ b/l10n/sles/zh-cn/xml/help_user.xml
@@ -61,10 +61,10 @@
    <title>帮助主窗口</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/journalctl.xml
+++ b/l10n/sles/zh-cn/xml/journalctl.xml
@@ -336,10 +336,10 @@ enabled</screen>
    <title>YaST systemd 日志</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_journal.png" width="80%" format="PNG"/>
+     <imagedata fileref="yast2_journal.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_journal.png" width="85%" format="PNG"/>
+     <imagedata fileref="yast2_journal.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/klp.xml
+++ b/l10n/sles/zh-cn/xml/klp.xml
@@ -64,10 +64,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="klp.png" width="80%" format="PNG"/>
+     <imagedata fileref="klp.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="klp.png" width="100%" format="PNG"/>
+     <imagedata fileref="klp.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>

--- a/l10n/sles/zh-cn/xml/kvm_virtualization_basics.xml
+++ b/l10n/sles/zh-cn/xml/kvm_virtualization_basics.xml
@@ -46,10 +46,10 @@
    <title>KVM 虚拟化体系结构</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="kvm_qemu.png" width="100%" format="PNG"/>
+     <imagedata fileref="kvm_qemu.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="kvm_qemu.png" width="100%" format="PNG"/>
+     <imagedata fileref="kvm_qemu.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/libvirt_configuration_gui.xml
+++ b/l10n/sles/zh-cn/xml/libvirt_configuration_gui.xml
@@ -18,10 +18,10 @@
   <title>VM Guest 的<guimenu>细节</guimenu>视图</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="libvirt_vmm_details.png" width="75%" format="PNG"/>
+    <imagedata fileref="libvirt_vmm_details.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="libvirt_vmm_details.png" width="75%" format="PNG"/>
+    <imagedata fileref="libvirt_vmm_details.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -53,10 +53,10 @@
     <title>概览细节</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="libvirt_vmm_overview.png" width="70%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_overview.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="libvirt_vmm_overview.png" width="70%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_overview.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -67,10 +67,10 @@
     <title>VM Guest 标题和说明</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="libvirt_vmm_desc.png" width="40%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_desc.png" width="40%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="libvirt_vmm_desc.png" width="40%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_desc.png" width="40%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -91,10 +91,10 @@
     <title>性能</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="libvirt_vmm_performance.png" width="70%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_performance.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="libvirt_vmm_performance.png" width="70%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_performance.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -109,10 +109,10 @@
     <title>统计图</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="libvirt_vmm_polling_charts.png" width="40%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_polling_charts.png" width="40%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="libvirt_vmm_polling_charts.png" width="40%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_polling_charts.png" width="40%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -127,10 +127,10 @@
     <title>处理器视图</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="libvirt_vmm_processor.png" width="70%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_processor.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="libvirt_vmm_processor.png" width="70%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_processor.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -166,10 +166,10 @@
     <title>内存视图</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="libvirt_vmm_memory.png" width="70%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_memory.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="libvirt_vmm_memory.png" width="70%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_memory.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -227,10 +227,10 @@
     <title>引导选项</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="libvirt_vmm_boot.png" width="70%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_boot.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="libvirt_vmm_boot.png" width="70%" format="PNG"/>
+      <imagedata fileref="libvirt_vmm_boot.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -262,10 +262,10 @@
      <title>添加新储存设备</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="libvirt_vmm_storage1.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_storage1.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="libvirt_vmm_storage1.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_storage1.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -345,10 +345,10 @@
      <title>添加新控制器</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="libvirt_vmm_controller.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_controller.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="libvirt_vmm_controller.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_controller.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -387,10 +387,10 @@
      <title>添加新网络接口</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="libvirt_vmm_network.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_network.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="libvirt_vmm_network.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_network.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -434,10 +434,10 @@
      <title>添加新输入设备</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="libvirt_vmm_input.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_input.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="libvirt_vmm_input.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_input.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -485,10 +485,10 @@
      <title>添加新视频设备</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="libvirt_vmm_video.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_video.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="libvirt_vmm_video.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_video.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -528,10 +528,10 @@
      <title>添加新 USB 重定向器</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="libvirt_vmm_usb_redirector.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_usb_redirector.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="libvirt_vmm_usb_redirector.png" width="70%" format="PNG"/>
+       <imagedata fileref="libvirt_vmm_usb_redirector.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -785,10 +785,10 @@
       <title>添加 PCI 设备</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="virt_add_pcidevice.png" width="75%" format="PNG"/>
+        <imagedata fileref="virt_add_pcidevice.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="virt_add_pcidevice.png" width="75%" format="PNG"/>
+        <imagedata fileref="virt_add_pcidevice.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -840,10 +840,10 @@
       <title>添加 USB 设备</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="virt_add_usbdevice.png" width="75%" format="PNG"/>
+        <imagedata fileref="virt_add_usbdevice.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="virt_add_usbdevice.png" width="75%" format="PNG"/>
+        <imagedata fileref="virt_add_usbdevice.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </figure>

--- a/l10n/sles/zh-cn/xml/libvirt_host.xml
+++ b/l10n/sles/zh-cn/xml/libvirt_host.xml
@@ -393,10 +393,10 @@ Connection successfully activated (master waiting for slaves) \
         <title>连接细节</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="libvirt_vmm_conndetails.png" width="45%" format="PNG"/>
+          <imagedata fileref="libvirt_vmm_conndetails.png" width="45%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="libvirt_vmm_conndetails.png" width="45%" format="PNG"/>
+          <imagedata fileref="libvirt_vmm_conndetails.png" width="45%"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -414,10 +414,10 @@ Connection successfully activated (master waiting for slaves) \
         <title>创建虚拟网络</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="libvirt_vmm_vnet_ipv4.png" width="45%" format="PNG"/>
+          <imagedata fileref="libvirt_vmm_vnet_ipv4.png" width="45%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="libvirt_vmm_vnet_ipv4.png" width="45%" format="PNG"/>
+          <imagedata fileref="libvirt_vmm_vnet_ipv4.png" width="45%"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -1221,10 +1221,10 @@ done</screen>
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="virt_virt-manager_storage.png" width="60%" format="PNG"/>
+      <imagedata fileref="virt_virt-manager_storage.png" width="60%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="virt_virt-manager_storage.png" width="60%" format="PNG"/>
+      <imagedata fileref="virt_virt-manager_storage.png" width="60%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>
@@ -1246,10 +1246,10 @@ done</screen>
       <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="virt_virt-manager_storage_add.png" width="60%" format="PNG"/>
+         <imagedata fileref="virt_virt-manager_storage_add.png" width="60%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="virt_virt-manager_storage_add.png" width="60%" format="PNG"/>
+         <imagedata fileref="virt_virt-manager_storage_add.png" width="60%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>

--- a/l10n/sles/zh-cn/xml/libvirt_managing.xml
+++ b/l10n/sles/zh-cn/xml/libvirt_managing.xml
@@ -525,10 +525,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="virt_vmm_snapshots_list.png" width="75%" format="PNG"/>
+      <imagedata fileref="virt_vmm_snapshots_list.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="virt_vmm_snapshots_list.png" width="75%" format="PNG"/>
+      <imagedata fileref="virt_vmm_snapshots_list.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sles/zh-cn/xml/net_basic.xml
+++ b/l10n/sles/zh-cn/xml/net_basic.xml
@@ -60,10 +60,10 @@
   <title>TCP/IP 的简化层模型</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata width="100%" fileref="net_basic_osi.svg" format="SVG"/>
+    <imagedata width="100%" fileref="net_basic_osi.svg"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata width="75%" fileref="net_basic_osi.png" format="PNG"/>
+    <imagedata width="75%" fileref="net_basic_osi.png"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -80,10 +80,10 @@
   <title>TCP/IP 以太网数据包</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata width="80%" fileref="net_basic_tcppacket.svg" format="SVG"/>
+    <imagedata width="80%" fileref="net_basic_tcppacket.svg"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata width="75%" fileref="net_basic_tcppacket.png" format="PNG"/>
+    <imagedata width="75%" fileref="net_basic_tcppacket.png"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sles/zh-cn/xml/net_bonding.xml
+++ b/l10n/sles/zh-cn/xml/net_bonding.xml
@@ -114,10 +114,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="bond_configuration.png" width="70%" format="PNG"/>
+      <imagedata fileref="bond_configuration.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="bond_configuration.png" width="65%" format="PNG"/>
+      <imagedata fileref="bond_configuration.png" width="65%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sles/zh-cn/xml/net_dhcp.xml
+++ b/l10n/sles/zh-cn/xml/net_dhcp.xml
@@ -86,10 +86,10 @@
       <title>DHCP 服务器：卡选择</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz1.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz1.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz1.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz1.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -102,10 +102,10 @@
       <title>DHCP 服务器：全局设置</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz2.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz2.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz2.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz2.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -118,10 +118,10 @@
       <title>DHCP 服务器：动态 DHCP</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz3.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz3.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz3.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz3.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -135,10 +135,10 @@
       <title>DHCP 服务器：启动</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_start.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_start.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_start.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_start.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -151,10 +151,10 @@
       <title>DHCP 服务器：主机管理</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_statdhcp.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_statdhcp.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_statdhcp.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_statdhcp.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -178,10 +178,10 @@
        <title>DHCP 服务器：Chroot Jail 和声明</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_chroot.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_chroot.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_chroot.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_chroot.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -197,10 +197,10 @@
        <title>DHCP 服务器：选择声明类型</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_newdec.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_newdec.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_newdec.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_newdec.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -216,10 +216,10 @@
        <title>DHCP 服务器：配置子网</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_sub.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_sub.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_sub.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_sub.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -235,10 +235,10 @@
        <title>DHCP 服务器：TSIG 配置</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_tsig.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_tsig.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_tsig.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_tsig.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -254,10 +254,10 @@
        <title>DHCP 服务器：动态 DNS 的接口配置</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_dyndns.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_dyndns.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_dyndns.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_dyndns.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -293,10 +293,10 @@
        <title>DHCP 服务器：网络接口和防火墙</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_fire.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_fire.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_fire.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_fire.png"/>
         </imageobject>
        </mediaobject>
       </figure>

--- a/l10n/sles/zh-cn/xml/net_dns.xml
+++ b/l10n/sles/zh-cn/xml/net_dns.xml
@@ -169,10 +169,10 @@
       <title>DNS 服务器安装：转发器设置</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dns_wiz_forw.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dns_wiz_forw.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dns_wiz_forw.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dns_wiz_forw.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -188,10 +188,10 @@
       <title>DNS 服务器安装：DNS 区域</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="72%" fileref="yast2_dns_wiz_zone.png" format="PNG"/>
+        <imagedata width="72%" fileref="yast2_dns_wiz_zone.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dns_wiz_zone.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dns_wiz_zone.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -204,10 +204,10 @@
       <title>DNS 服务器安装：完成向导</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="72%" fileref="yast2_dns_wiz_finish.png" format="PNG"/>
+        <imagedata width="72%" fileref="yast2_dns_wiz_finish.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dns_wiz_finish.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dns_wiz_finish.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -254,10 +254,10 @@
      <title>DNS 服务器：日志记录</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata width="75%" fileref="yast2_dns_def_logging.png" format="PNG"/>
+       <imagedata width="75%" fileref="yast2_dns_def_logging.png"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata width="75%" fileref="yast2_dns_def_logging.png" format="PNG"/>
+       <imagedata width="75%" fileref="yast2_dns_def_logging.png"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -318,10 +318,10 @@
      <title>DNS 服务器：区域编辑器（基本）</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata width="65%" fileref="yast2_dns_def_ddns.png" format="PNG"/>
+       <imagedata width="65%" fileref="yast2_dns_def_ddns.png"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata width="65%" fileref="yast2_dns_def_ddns.png" format="PNG"/>
+       <imagedata width="65%" fileref="yast2_dns_def_ddns.png"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -336,10 +336,10 @@
         <title>DNS 服务器：区域编辑器（NS 记录）</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata width="65%" fileref="yast2_dns_def_nsrec.png" format="PNG"/>
+          <imagedata width="65%" fileref="yast2_dns_def_nsrec.png"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata width="65%" fileref="yast2_dns_def_nsrec.png" format="PNG"/>
+          <imagedata width="65%" fileref="yast2_dns_def_nsrec.png"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -355,10 +355,10 @@
         <title>DNS 服务器：区域编辑器（MX 记录）</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata width="72%" fileref="yast2_dns_def_mxrec.png" format="PNG"/>
+          <imagedata width="72%" fileref="yast2_dns_def_mxrec.png"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata width="75%" fileref="yast2_dns_def_mxrec.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_mxrec.png"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -374,10 +374,10 @@
         <title>DNS 服务器：区域编辑器 (SOA)</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata width="75%" fileref="yast2_dns_def_soa.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_soa.png"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata width="75%" fileref="yast2_dns_def_soa.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_soa.png"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -418,10 +418,10 @@
         <title>添加主要区域记录</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="yast2_dns_revzone1.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone1.png" width="70%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="yast2_dns_revzone1.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone1.png" width="70%"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -434,10 +434,10 @@
         <title>添加反向区域</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="yast2_dns_revzone2.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone2.png" width="70%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="yast2_dns_revzone2.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone2.png" width="70%"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -450,10 +450,10 @@
         <title>添加反向记录</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="yast2_dns_revzone3.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone3.png" width="70%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="yast2_dns_revzone3.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone3.png" width="70%"/>
          </imageobject>
         </mediaobject>
        </figure>

--- a/l10n/sles/zh-cn/xml/net_samba.xml
+++ b/l10n/sles/zh-cn/xml/net_samba.xml
@@ -608,10 +608,10 @@ smbpasswd -a -m hostname</screen>
      <title>确定 Windows 域成员资格</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="ad_sambaclient.png" width="75%" format="PNG"/>
+       <imagedata fileref="ad_sambaclient.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="ad_sambaclient.png" format="PNG"/>
+       <imagedata fileref="ad_sambaclient.png"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -728,10 +728,10 @@ drwxrwxrwx. 2 root    root    0 Oct 24 22:31 subfolder
     <title>Windows 资源管理器<guimenu>高级属性</guimenu>对话框</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="samba_win_expl_advattr.png" width="75%" format="PNG"/>
+      <imagedata fileref="samba_win_expl_advattr.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="samba_win_expl_advattr.png" format="PNG"/>
+      <imagedata fileref="samba_win_expl_advattr.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -745,10 +745,10 @@ drwxrwxrwx. 2 root    root    0 Oct 24 22:31 subfolder
     <title>列有压缩文件的 Windows 资源管理器目录</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="samba_win_expl_view_compressed.png" width="75%" format="PNG"/>
+      <imagedata fileref="samba_win_expl_view_compressed.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="samba_win_expl_view_compressed.png" format="PNG"/>
+      <imagedata fileref="samba_win_expl_view_compressed.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -810,10 +810,10 @@ drwxrwxrwx. 2 root    root    0 Oct 24 22:31 subfolder
      <title>在启用快照的情况下添加新的 Samba 共享</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_samba_snapshot.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_samba_snapshot.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_samba_snapshot.png" format="PNG"/>
+       <imagedata fileref="yast2_samba_snapshot.png"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -824,10 +824,10 @@ drwxrwxrwx. 2 root    root    0 Oct 24 22:31 subfolder
      <title>Windows 资源管理器中的<guimenu>以前的版本</guimenu>选项卡</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="samba_winexpl_previous_versions.png" width="75%" format="PNG"/>
+       <imagedata fileref="samba_winexpl_previous_versions.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="samba_winexpl_previous_versions.png" format="PNG"/>
+       <imagedata fileref="samba_winexpl_previous_versions.png"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/zh-cn/xml/net_wicked.xml
+++ b/l10n/sles/zh-cn/xml/net_wicked.xml
@@ -79,10 +79,10 @@
     <title><literal>wicked</literal> 体系结构</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="wicked_scheme.png" format="PNG"/>
+      <imagedata fileref="wicked_scheme.png"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="wicked_scheme.png" format="PNG" width="80%"/>
+      <imagedata fileref="wicked_scheme.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/zh-cn/xml/net_yast.xml
+++ b/l10n/sles/zh-cn/xml/net_yast.xml
@@ -48,10 +48,10 @@
    <title>配置网络设置</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_net_icard.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_net_icard.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_net_icard.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_net_icard.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/network_scheme.xml
+++ b/l10n/sles/zh-cn/xml/network_scheme.xml
@@ -4,10 +4,10 @@
  <info>
   <mediaobject>
    <imageobject role="html">
-    <imagedata fileref="network_schema.png" width="100%" format="PNG"/>
+    <imagedata fileref="network_schema.png" width="100%"/>
    </imageobject>
    <imageobject role="pdf">
-    <imagedata fileref="network_schema.svg" width="100%" format="SVG"/>
+    <imagedata fileref="network_schema.svg" width="100%"/>
    </imageobject>
   </mediaobject>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -21,10 +21,10 @@
  <informalfigure>
   <mediaobject>
    <imageobject role="html">
-    <imagedata fileref="network_schema.png" width="100%" format="PNG"/>
+    <imagedata fileref="network_schema.png" width="100%"/>
    </imageobject>
    <imageobject role="pdf">
-    <imagedata fileref="network_schema.svg" width="100%" format="SVG"/>
+    <imagedata fileref="network_schema.svg" width="100%"/>
    </imageobject>
   </mediaobject>
  </informalfigure>

--- a/l10n/sles/zh-cn/xml/qemu_host_installation.xml
+++ b/l10n/sles/zh-cn/xml/qemu_host_installation.xml
@@ -48,10 +48,10 @@
      <title>安装 KVM 超级管理程序和工具</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_hypervisors.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_hypervisors.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_hypervisors.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_hypervisors.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -70,10 +70,10 @@
      <title>网桥</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_netbridge.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_netbridge.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_netbridge.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_netbridge.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/zh-cn/xml/qemu_running_vms_qemukvm.xml
+++ b/l10n/sles/zh-cn/xml/qemu_running_vms_qemukvm.xml
@@ -218,10 +218,10 @@
      <title>显示使用 SLES 作为 VM Guest 的 QEMU 窗口</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="qemu_win_sles.png" width="70%" format="PNG"/>
+       <imagedata fileref="qemu_win_sles.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="qemu_win_sles.png" width="70%" format="PNG"/>
+       <imagedata fileref="qemu_win_sles.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -1503,10 +1503,10 @@ sudo tunctl -d $tap<co xml:id="co-qemu-net-bridge-deltap"/></screen>
    <title>QEMU VNC 会话</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="qemu_sles_vnc.png" width="70%" format="PNG"/>
+     <imagedata fileref="qemu_sles_vnc.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="qemu_sles_vnc.png" width="70%" format="PNG"/>
+     <imagedata fileref="qemu_sles_vnc.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -1544,10 +1544,10 @@ Password: ****
     <title>Remmina 中的身份验证对话框</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="qemu_vnc_pwd.png" width="70%" format="PNG"/>
+      <imagedata fileref="qemu_vnc_pwd.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="qemu_vnc_pwd.png" width="70%" format="PNG"/>
+      <imagedata fileref="qemu_vnc_pwd.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/zh-cn/xml/rmt_install.xml
+++ b/l10n/sles/zh-cn/xml/rmt_install.xml
@@ -44,10 +44,10 @@
    <title>RMT 软件集</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="rmt_installation.png" width="70%" format="PNG"/>
+     <imagedata fileref="rmt_installation.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="rmt_installation.png" width="70%" format="PNG"/>
+     <imagedata fileref="rmt_installation.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/rmt_mirroring.xml
+++ b/l10n/sles/zh-cn/xml/rmt_mirroring.xml
@@ -75,10 +75,10 @@
      <textobject role="description"><phrase>眼睛图标</phrase>
      </textobject>
      <imageobject role="fo">
-      <imagedata fileref="scc_eye_icon.png" width="0.8em" format="SVG"/>
+      <imagedata fileref="scc_eye_icon.png" width="0.8em"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="scc_eye_icon.png" width="1em" format="PNG"/>
+      <imagedata fileref="scc_eye_icon.png" width="1em"/>
      </imageobject>
      </inlinemediaobject> 图标。
     </para>

--- a/l10n/sles/zh-cn/xml/rmt_overview.xml
+++ b/l10n/sles/zh-cn/xml/rmt_overview.xml
@@ -41,10 +41,10 @@
    <title>RMT</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="rmt_schema.png" width="70%" format="PNG"/>
+     <imagedata fileref="rmt_schema.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="rmt_schema.png" width="70%" format="PNG"/>
+     <imagedata fileref="rmt_schema.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/security_acls.xml
+++ b/l10n/sles/zh-cn/xml/security_acls.xml
@@ -310,10 +310,10 @@
     <title>最小 ACL：与权限位相比的 ACL 项</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="acls_map_mini.png" width="75%" format="PNG"/>
+      <imagedata fileref="acls_map_mini.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="acls_map_mini.png" width="75%" format="PNG"/>
+      <imagedata fileref="acls_map_mini.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -324,10 +324,10 @@
     <title>扩展 ACL：与权限位相比的 ACL 项</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="acls_map_ext.png" width="75%" format="PNG"/>
+      <imagedata fileref="acls_map_ext.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="acls_map_ext.png" width="75%" format="PNG"/>
+      <imagedata fileref="acls_map_ext.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/zh-cn/xml/security_ad_support.xml
+++ b/l10n/sles/zh-cn/xml/security_ad_support.xml
@@ -176,10 +176,10 @@
       <title>基于 Winbind 的 Active Directory 身份验证的纲要</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="sled10_ad_schema.svg" width="85%" format="SVG"/>
+        <imagedata fileref="sled10_ad_schema.svg" width="85%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="sled10_ad_schema.png" width="75%" format="PNG"/>
+        <imagedata fileref="sled10_ad_schema.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -542,10 +542,10 @@
       <title><guimenu>用户登录管理</guimenu>的主窗口</title>
       <mediaobject>
        <imageobject role="html">
-        <imagedata fileref="ad-overview.png" format="PNG"/>
+        <imagedata fileref="ad-overview.png"/>
        </imageobject>
        <imageobject role="fo">
-        <imagedata fileref="ad-overview.png" width="65%" format="PNG"/>
+        <imagedata fileref="ad-overview.png" width="65%"/>
        </imageobject>
        <textobject role="description">
         <phrase>
@@ -640,10 +640,10 @@
         <title>注册到域中</title>
         <mediaobject>
          <imageobject role="html">
-          <imagedata fileref="ad-enroll.png" format="PNG"/>
+          <imagedata fileref="ad-enroll.png"/>
          </imageobject>
          <imageobject role="fo">
-          <imagedata fileref="ad-enroll.png" width="60%" format="PNG"/>
+          <imagedata fileref="ad-enroll.png" width="60%"/>
          </imageobject>
          <textobject role="description">
           <phrase/>
@@ -666,10 +666,10 @@
       <title><guimenu>用户登录管理</guimenu>的配置窗口</title>
       <mediaobject>
        <imageobject role="html">
-        <imagedata fileref="ad-config.png" format="PNG"/>
+        <imagedata fileref="ad-config.png"/>
        </imageobject>
        <imageobject role="fo">
-        <imagedata fileref="ad-config.png" width="70%" format="PNG"/>
+        <imagedata fileref="ad-config.png" width="70%"/>
        </imageobject>
        <textobject role="description">
         <phrase/>
@@ -759,10 +759,10 @@
      <title>确定 Windows 域成员资格</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="ad_sambaclient.png" width="75%" format="PNG"/>
+       <imagedata fileref="ad_sambaclient.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="ad_sambaclient.png" width="75%" format="PNG"/>
+       <imagedata fileref="ad_sambaclient.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -805,10 +805,10 @@
      <title>提供管理员身份凭证</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="ad_join1.png" width="30%" format="PNG"/>
+       <imagedata fileref="ad_join1.png" width="30%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="ad_join1.png" width="30%" format="PNG"/>
+       <imagedata fileref="ad_join1.png" width="30%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/zh-cn/xml/security_cryptctl.xml
+++ b/l10n/sles/zh-cn/xml/security_cryptctl.xml
@@ -59,10 +59,10 @@
    <title>使用 <command>cryptctl</command> 检索密钥（不连接 KMIP 服务器的模式）</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="cryptctl-keyretrieval.png" format="PNG"/>
+     <imagedata fileref="cryptctl-keyretrieval.png"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="cryptctl-keyretrieval.svg" width="70%" format="SVG"/>
+     <imagedata fileref="cryptctl-keyretrieval.svg" width="70%"/>
     </imageobject>
     <textobject role="description">
      <phrase>The client asks the server for the disk decryption key, the server

--- a/l10n/sles/zh-cn/xml/security_firewall.xml
+++ b/l10n/sles/zh-cn/xml/security_firewall.xml
@@ -113,10 +113,10 @@
    <title>iptable：包的可能路径</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata width="75%" fileref="fire_tables.svg" format="SVG"/>
+     <imagedata width="75%" fileref="fire_tables.svg"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata width="65%" fileref="fire_tables.png" format="PNG"/>
+     <imagedata width="65%" fileref="fire_tables.png"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/security_kerberos.xml
+++ b/l10n/sles/zh-cn/xml/security_kerberos.xml
@@ -405,10 +405,10 @@
     <title>Kerberos 网络拓扑</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="network_kerb.png" width="73%" format="PNG"/>
+      <imagedata fileref="network_kerb.png" width="73%"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="network_kerb.svg" width="73%" format="SVG"/>
+      <imagedata fileref="network_kerb.svg" width="73%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/zh-cn/xml/security_ldap_directory_tree.xml
+++ b/l10n/sles/zh-cn/xml/security_ldap_directory_tree.xml
@@ -26,7 +26,7 @@
      <imagedata fileref="ldap_tree.svg" width="85%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ldap_tree.png" width="85%" format="PNG"/>
+     <imagedata fileref="ldap_tree.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/security_nis.xml
+++ b/l10n/sles/zh-cn/xml/security_nis.xml
@@ -63,11 +63,11 @@
       <title>NIS 服务器设置</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_nis1_no_nis_installed.png" width="75%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_nis1_no_nis_installed.png" width="75%" os="sles;sled"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_nis1_no_nis_installed.png" width="75%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_nis1_no_nis_installed.png" width="75%" os="sles;sled"/>
         
        </imageobject>
       </mediaobject>
@@ -109,11 +109,11 @@
         <title>主服务器设置</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="yast2_nis_master.png" width="75%" format="PNG" os="sles;sled"/>
+          <imagedata fileref="yast2_nis_master.png" width="75%" os="sles;sled"/>
           
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="yast2_nis_master.png" width="75%" format="PNG" os="sles;sled"/>
+          <imagedata fileref="yast2_nis_master.png" width="75%" os="sles;sled"/>
           
          </imageobject>
         </mediaobject>
@@ -130,11 +130,11 @@
         <title>更改 NIS 服务器目录并同步文件</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="yast2_inst_nisserver2.png" width="75%" format="PNG" os="sles;sled"/>
+          <imagedata fileref="yast2_inst_nisserver2.png" width="75%" os="sles;sled"/>
           
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="yast2_inst_nisserver2.png" width="75%" format="PNG" os="sles;sled"/>
+          <imagedata fileref="yast2_inst_nisserver2.png" width="75%" os="sles;sled"/>
           
          </imageobject>
         </mediaobject>
@@ -160,11 +160,11 @@
       <title>NIS 服务器映射设置</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_nis_maps.png" width="75%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_nis_maps.png" width="75%" os="sles;sled"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_nis_maps.png" width="75%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_nis_maps.png" width="75%" os="sles;sled"/>
         
        </imageobject>
       </mediaobject>
@@ -183,11 +183,11 @@
       <title>为 NIS 服务器设置请求权限</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_nis_hosts.png" width="75%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_nis_hosts.png" width="75%" os="sles;sled"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_nis_hosts.png" width="75%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_nis_hosts.png" width="75%" os="sles;sled"/>
         
        </imageobject>
       </mediaobject>
@@ -298,10 +298,10 @@
      <title>设置 NIS 服务器的域和地址</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_inst_nisclient.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_inst_nisclient.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_inst_nisclient.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_inst_nisclient.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/zh-cn/xml/security_spectre_meltdown_checker.xml
+++ b/l10n/sles/zh-cn/xml/security_spectre_meltdown_checker.xml
@@ -35,10 +35,10 @@
    <title>spectre-meltdown-checker 的输出</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="spectre-meltdown.png" width="80%" format="PNG"/>
+     <imagedata fileref="spectre-meltdown.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="spectre-meltdown.png" width="100%" format="PNG"/>
+     <imagedata fileref="spectre-meltdown.png" width="100%"/>
     </imageobject>
     <textobject role="description"><phrase>Partial output of spectre-meltdown-checker.sh</phrase>
     </textobject>

--- a/l10n/sles/zh-cn/xml/security_xca.xml
+++ b/l10n/sles/zh-cn/xml/security_xca.xml
@@ -34,10 +34,10 @@
  <title>创建新 XCA 数据库</title>
  <mediaobject>
   <imageobject role="html">
-   <imagedata fileref="sec-xca-2.png" width="80%" format="PNG"/>
+   <imagedata fileref="sec-xca-2.png" width="80%"/>
   </imageobject>
   <imageobject role="fo">
-   <imagedata fileref="sec-xca-2.png" width="80%" format="PNG"/>
+   <imagedata fileref="sec-xca-2.png" width="80%"/>
   </imageobject>
   <textobject role="description">
    <phrase>Create a new XCA database</phrase>

--- a/l10n/sles/zh-cn/xml/security_yast2_security.xml
+++ b/l10n/sles/zh-cn/xml/security_yast2_security.xml
@@ -56,10 +56,10 @@
    <title>YaST 安全和强化中心：安全概览</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata width="75%" fileref="yast2_security_overview.png" format="PNG"/>
+     <imagedata width="75%" fileref="yast2_security_overview.png"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_security_overview.png" format="PNG"/>
+     <imagedata fileref="yast2_security_overview.png"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/sle_update_upgrading.xml
+++ b/l10n/sles/zh-cn/xml/sle_update_upgrading.xml
@@ -72,11 +72,11 @@
    <title>支持的升级路径概述</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="100%" format="PNG"/>
+     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="100%"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="80%" format="PNG"/>
+     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="80%"/>
      
     </imageobject>
    </mediaobject>

--- a/l10n/sles/zh-cn/xml/snapper.xml
+++ b/l10n/sles/zh-cn/xml/snapper.xml
@@ -417,10 +417,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_list.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_list.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_list.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_list.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -432,10 +432,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_changes.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_changes.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_changes.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_changes.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -447,10 +447,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_diff.png" width="65%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_diff.png" width="65%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_diff.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_diff.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -462,10 +462,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_restore.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_restore.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_restore.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_restore.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -827,10 +827,10 @@ single | 4 |     |         |                       |
     <title>引导加载程序：快照</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="boot_snapshots.png" width="75%" format="PNG"/>
+      <imagedata fileref="boot_snapshots.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="boot_snapshots.png" width="75%" format="PNG"/>
+      <imagedata fileref="boot_snapshots.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/zh-cn/xml/storage_fcoe.xml
+++ b/l10n/sles/zh-cn/xml/storage_fcoe.xml
@@ -14,10 +14,10 @@
   <title>开放式以太网光纤通道 SAN</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="fcoe_san_a.svg" width="80%" format="SVG"/>
+    <imagedata fileref="fcoe_san_a.svg" width="80%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="fcoe_san_a.png" width="100%" format="PNG"/>
+    <imagedata fileref="fcoe_san_a.png" width="100%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -61,10 +61,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="fcoe_inst_disk_activation_a.png" width="80%" format="PNG"/>
+     <imagedata fileref="fcoe_inst_disk_activation_a.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="fcoe_inst_disk_activation_a.png" width="10%" format="PNG"/>
+     <imagedata fileref="fcoe_inst_disk_activation_a.png" width="10%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -108,10 +108,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="fcoe_services_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="fcoe_services_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="fcoe_services_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="fcoe_services_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -149,10 +149,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="fcoe_notconfig_interface_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="fcoe_notconfig_interface_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="fcoe_notconfig_interface_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="fcoe_notconfig_interface_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -243,10 +243,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="fcoe_configtab_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="fcoe_configtab_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="fcoe_configtab_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="fcoe_configtab_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/zh-cn/xml/storage_filesystems.xml
+++ b/l10n/sles/zh-cn/xml/storage_filesystems.xml
@@ -1043,10 +1043,10 @@ inode_ratio = 8192</screen>
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="ext4_inode_yast_a.png" width="60%" format="PNG"/>
+        <imagedata fileref="ext4_inode_yast_a.png" width="60%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="ext4_inode_yast_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="ext4_inode_yast_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/l10n/sles/zh-cn/xml/storage_iscsi.xml
+++ b/l10n/sles/zh-cn/xml/storage_iscsi.xml
@@ -14,10 +14,10 @@
   <title>使用 iSNS 服务器的 iSCSI SAN</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="iscsi_san_a.svg" width="80%" format="SVG"/>
+    <imagedata fileref="iscsi_san_a.svg" width="80%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="iscsi_san_a.png" width="100%" format="PNG"/>
+    <imagedata fileref="iscsi_san_a.png" width="100%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -94,10 +94,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="lio_service_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="lio_service_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="lio_service_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="lio_service_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -184,10 +184,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="lio_global_noauth_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="lio_global_noauth_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="lio_global_noauth_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="lio_global_noauth_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -263,10 +263,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="lio_targets_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="lio_targets_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="lio_targets_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="lio_targets_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -313,10 +313,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="lio_target_client_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="lio_target_client_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="lio_target_client_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="lio_target_client_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -623,10 +623,10 @@
       <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="iscsi_init_service_a.png" width="80%" format="PNG"/>
+         <imagedata fileref="iscsi_init_service_a.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="iscsi_init_service_a.png" width="100%" format="PNG"/>
+         <imagedata fileref="iscsi_init_service_a.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>

--- a/l10n/sles/zh-cn/xml/storage_isns.xml
+++ b/l10n/sles/zh-cn/xml/storage_isns.xml
@@ -37,10 +37,10 @@
    <title>iSNS 发现域</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="isns_a.png" width="80%" format="PNG"/>
+     <imagedata fileref="isns_a.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="isns_a.png" width="100%" format="PNG"/>
+     <imagedata fileref="isns_a.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -138,10 +138,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="isns_config_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="isns_config_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="isns_config_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="isns_config_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -252,10 +252,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="isns_discdomains_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="isns_discdomains_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="isns_discdomains_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="isns_discdomains_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -296,10 +296,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="isns_iscsinodes_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="isns_iscsinodes_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="isns_iscsinodes_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="isns_iscsinodes_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/l10n/sles/zh-cn/xml/storage_lvm.xml
+++ b/l10n/sles/zh-cn/xml/storage_lvm.xml
@@ -33,10 +33,10 @@
    <title>物理分区与 LVM</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="lvm.svg" width="80%" format="SVG"/>
+     <imagedata fileref="lvm.svg" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="lvm.png" width="100%" format="PNG"/>
+     <imagedata fileref="lvm.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -160,10 +160,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm4_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm4_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm4_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm4_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -227,10 +227,10 @@
      <title>名为 DATA 的卷组中的物理卷</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm5_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm5_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm5_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm5_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -307,10 +307,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm9_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm9_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm9_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm9_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -325,10 +325,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm10_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm10_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm10_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm10_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -340,10 +340,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm11_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm11_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm11_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm11_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -575,10 +575,10 @@ root's password:
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm8_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm8_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm8_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm8_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -653,10 +653,10 @@ root's password:
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm12_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm12_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm12_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm12_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/zh-cn/xml/storage_nfs.xml
+++ b/l10n/sles/zh-cn/xml/storage_nfs.xml
@@ -144,11 +144,11 @@
       <title>NFS 服务器配置工具</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_inst_nfsserver1.png" width="75%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_inst_nfsserver1.png" width="75%" os="sles;sled"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_inst_nfsserver1.png" width="75%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_inst_nfsserver1.png" width="75%" os="sles;sled"/>
         
        </imageobject>
       </mediaobject>

--- a/l10n/sles/zh-cn/xml/storage_raid.xml
+++ b/l10n/sles/zh-cn/xml/storage_raid.xml
@@ -227,10 +227,10 @@
      <title>RAID 5 配置示例</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_raid3_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_raid3_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_raid3_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_raid3_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/zh-cn/xml/storage_raid10.xml
+++ b/l10n/sles/zh-cn/xml/storage_raid10.xml
@@ -726,10 +726,10 @@ ARRAY /dev/md2 UUID=<replaceable>UUID</replaceable></screen>
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="raid10_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="raid10_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="raid10_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="raid10_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -780,10 +780,10 @@ ARRAY /dev/md2 UUID=<replaceable>UUID</replaceable></screen>
        <informalfigure>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="raid10_classify_a.png" width="80%" format="PNG"/>
+          <imagedata fileref="raid10_classify_a.png" width="80%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="raid10_classify_a.png" width="100%" format="PNG"/>
+          <imagedata fileref="raid10_classify_a.png" width="100%"/>
          </imageobject>
         </mediaobject>
        </informalfigure>

--- a/l10n/sles/zh-cn/xml/storage_raidroot.xml
+++ b/l10n/sles/zh-cn/xml/storage_raidroot.xml
@@ -123,10 +123,10 @@
       <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install2_a.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install2_a.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install2_a.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install2_a.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -155,10 +155,10 @@
       <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install3_a.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install3_a.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install3_a.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install3_a.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -178,10 +178,10 @@
      <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install_editraid.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_editraid.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install_editraid.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_editraid.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -198,10 +198,10 @@
       <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install_filesystem.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_filesystem.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install_filesystem.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_filesystem.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -221,10 +221,10 @@
    	<informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install_swap.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_swap.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install_swap.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_swap.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -236,10 +236,10 @@
     <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install_boot.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_boot.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install_boot.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_boot.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -247,10 +247,10 @@
     <informalfigure>
       <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="raid_yast_install3_b.png" width="70%" format="PNG"/>
+       <imagedata fileref="raid_yast_install3_b.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="raid_yast_install3_b.png" width="70%" format="PNG"/>
+       <imagedata fileref="raid_yast_install3_b.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/zh-cn/xml/systemd.xml
+++ b/l10n/sles/zh-cn/xml/systemd.xml
@@ -1046,10 +1046,10 @@ Startup finished in 2666ms (kernel) + 21961ms (userspace) = 24628ms</screen>
        <informalfigure>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="systemd_startup.svg" width="75%" format="SVG"/>
+          <imagedata fileref="systemd_startup.svg" width="75%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="systemd_startup.png" width="75%" format="PNG"/>
+          <imagedata fileref="systemd_startup.png" width="75%"/>
          </imageobject>
         </mediaobject>
        </informalfigure>
@@ -1132,10 +1132,10 @@ WantedBy=multi-user.target<co xml:id="co-service-wrapper-target"/></screen>
    <title>服务管理器</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_runlevel.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_runlevel.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_runlevel.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_runlevel.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/tuning_kexec.xml
+++ b/l10n/sles/zh-cn/xml/tuning_kexec.xml
@@ -609,10 +609,10 @@ KDUMP_NET_TIMEOUT=30</screen>
     <title>YaST Kdump 模块：启动页</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_kdump_startup.png" width="60%" format="PNG"/>
+      <imagedata fileref="yast2_kdump_startup.png" width="60%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_kdump_startup.png" width="70%" format="PNG"/>
+      <imagedata fileref="yast2_kdump_startup.png" width="70%"/>
      </imageobject>
      <textobject><phrase>
         Screenshot of the YaST Kdump Module

--- a/l10n/sles/zh-cn/xml/tuning_multikernel.xml
+++ b/l10n/sles/zh-cn/xml/tuning_multikernel.xml
@@ -236,10 +236,10 @@
      <title>YaST 软件管理器：多版本视图</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_sw_multiversion.png" width="90%" format="PNG"/>
+       <imagedata fileref="yast2_sw_multiversion.png" width="90%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_sw_multiversion.png" width="90%" format="PNG"/>
+       <imagedata fileref="yast2_sw_multiversion.png" width="90%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/zh-cn/xml/tuning_power.xml
+++ b/l10n/sles/zh-cn/xml/tuning_power.xml
@@ -440,10 +440,10 @@ CPU | C0   | Cx   | Freq || POLL | C1   | C2   | C3
    <title>处于交互模式的 powerTOP</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="powertop_ncurses.png" width="75%" format="PNG"/>
+     <imagedata fileref="powertop_ncurses.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="powertop_ncurses.png" width="75%" format="PNG"/>
+     <imagedata fileref="powertop_ncurses.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -470,10 +470,10 @@ powerreport-20200108-104431.html
    <title>HTML powerTOP 报告</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="powertop_html.png" width="75%" format="PNG"/>
+     <imagedata fileref="powertop_html.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="powertop_html.png" width="75%" format="PNG"/>
+     <imagedata fileref="powertop_html.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/uefi.xml
+++ b/l10n/sles/zh-cn/xml/uefi.xml
@@ -83,10 +83,10 @@
      <title>安全引导支持</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/zh-cn/xml/updater_gnome.xml
+++ b/l10n/sles/zh-cn/xml/updater_gnome.xml
@@ -25,11 +25,11 @@
   <mediaobject>
    <imageobject role="fo">
     
-    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%" format="PNG"/>
+    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
     
-    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%" format="PNG"/>
+    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -47,10 +47,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="gupdater_updates.png" width="75%" format="PNG"/>
+      <imagedata fileref="gupdater_updates.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="gupdater_updates.png" width="75%" format="PNG"/>
+      <imagedata fileref="gupdater_updates.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sles/zh-cn/xml/updater_gnome_sw.xml
+++ b/l10n/sles/zh-cn/xml/updater_gnome_sw.xml
@@ -42,10 +42,10 @@
   <title><guimenu>GNOME Software</guimenu> — <guimenu>更新</guimenu>视图</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="gnome-software-updates.png" width="75%" format="PNG"/>
+    <imagedata fileref="gnome-software-updates.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="gnome-software-updates.png" width="75%" format="PNG"/>
+    <imagedata fileref="gnome-software-updates.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sles/zh-cn/xml/utilities.xml
+++ b/l10n/sles/zh-cn/xml/utilities.xml
@@ -2674,10 +2674,10 @@ LINE2:free_memory#FF0000 \
      <title>使用 RRDtool 创建的示例图表</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata width="75%" fileref="rrdtool_graph1.png" format="PNG"/>
+       <imagedata width="75%" fileref="rrdtool_graph1.png"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata width="55%" fileref="rrdtool_graph1.png" format="PNG"/>
+       <imagedata width="55%" fileref="rrdtool_graph1.png"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/zh-cn/xml/vnc.xml
+++ b/l10n/sles/zh-cn/xml/vnc.xml
@@ -56,10 +56,10 @@
      <textobject role="description"><phrase>vncviewer asking for connection details</phrase>
      </textobject>
      <imageobject role="html">
-      <imagedata fileref="vnc_connect.png" format="PNG"/>
+      <imagedata fileref="vnc_connect.png"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="vnc_connect.png" format="PNG"/>
+      <imagedata fileref="vnc_connect.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -99,10 +99,10 @@
     <title>Remmina 的主窗口</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -114,16 +114,16 @@
   <sect2 xml:id="vnc-remmina-addnew">
    <title>添加远程会话</title>
    <para>
-    要添加和保存新远程会话，请单击主窗口右上方的 <inlinemediaobject><textobject role="description"><phrase>添加新会话</phrase></textobject><imageobject role="fo"><imagedata fileref="remmina_plus.png" width="1.2em" format="PNG"/></imageobject><imageobject role="html"><imagedata fileref="remmina_plus.png" width="1.2em" format="PNG"/></imageobject></inlinemediaobject>。<guimenu>远程桌面首选项</guimenu>窗口即会打开。
+    要添加和保存新远程会话，请单击主窗口右上方的 <inlinemediaobject><textobject role="description"><phrase>添加新会话</phrase></textobject><imageobject role="fo"><imagedata fileref="remmina_plus.png" width="1.2em"/></imageobject><imageobject role="html"><imagedata fileref="remmina_plus.png" width="1.2em"/></imageobject></inlinemediaobject>。<guimenu>远程桌面首选项</guimenu>窗口即会打开。
    </para>
    <figure>
     <title>远程桌面首选项</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina_session_details.png" width="80%" format="PNG"/>
+      <imagedata fileref="remmina_session_details.png" width="80%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina_session_details.png" width="80%" format="PNG"/>
+      <imagedata fileref="remmina_session_details.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -203,10 +203,10 @@
      <title>快速启动</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="remmina_quickstart.png" width="40%" format="PNG"/>
+       <imagedata fileref="remmina_quickstart.png" width="40%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="remmina_quickstart.png" width="40%" format="PNG"/>
+       <imagedata fileref="remmina_quickstart.png" width="40%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -229,10 +229,10 @@
      <title>正在查看远程会话的 Remmina</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>
+       <imagedata fileref="remmina_sle15inside.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>
+       <imagedata fileref="remmina_sle15inside.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -267,10 +267,10 @@
     <title>读取配置文件的路径</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina_status.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina_status.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina_status.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina_status.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -332,10 +332,10 @@
    <title>远程管理</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="vnc_nosession.png" width="70%" format="PNG"/>
+     <imagedata fileref="vnc_nosession.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="vnc_nosession.png" width="70%" format="PNG"/>
+     <imagedata fileref="vnc_nosession.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -561,10 +561,10 @@ WINDOWMANAGER=icewm vncserver -geometry 1024x768</screen>
      <title>VNC 会话设置</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="vncmanager_session.png" width="85%" format="PNG"/>
+       <imagedata fileref="vncmanager_session.png" width="85%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="vncmanager_session.png" width="85%" format="PNG"/>
+       <imagedata fileref="vncmanager_session.png" width="85%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -649,10 +649,10 @@ WINDOWMANAGER=icewm vncserver -geometry 1024x768</screen>
      <title>加入永久 VNC 会话</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="vncmanager_whether.png" width="80%" format="PNG"/>
+       <imagedata fileref="vncmanager_whether.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="vncmanager_whether.png" width="80%" format="PNG"/>
+       <imagedata fileref="vncmanager_whether.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/zh-cn/xml/vt_tools.xml
+++ b/l10n/sles/zh-cn/xml/vt_tools.xml
@@ -103,10 +103,10 @@ mercury.example.com</screen>
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="virt_virt-manager.png" width="80%" format="PNG"/>
+        <imagedata fileref="virt_virt-manager.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="virt_virt-manager.png" width="80%" format="PNG"/>
+        <imagedata fileref="virt_virt-manager.png" width="80%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -143,10 +143,10 @@ mercury.example.com</screen>
      <informalfigure pgwide="0">
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_vm.png" width="56%" format="PNG"/>
+        <imagedata fileref="yast2_vm.png" width="56%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_vm.png" width="56%" format="PNG"/>
+        <imagedata fileref="yast2_vm.png" width="56%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/l10n/sles/zh-cn/xml/xen_administrating.xml
+++ b/l10n/sles/zh-cn/xml/xen_administrating.xml
@@ -25,10 +25,10 @@
    <title>引导加载器设置</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="xen_bootloader.png" width="80%" format="PNG"/>
+     <imagedata fileref="xen_bootloader.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="xen_bootloader.png" width="80%" format="PNG"/>
+     <imagedata fileref="xen_bootloader.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/xen_virtualization_basics.xml
+++ b/l10n/sles/zh-cn/xml/xen_virtualization_basics.xml
@@ -105,10 +105,10 @@
    <title>Xen 虚拟化体系结构</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="xen_master_fong_a.png" width="100%" format="PNG"/>
+     <imagedata fileref="xen_master_fong_a.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="xen_master_fong_a.png" width="100%" format="PNG"/>
+     <imagedata fileref="xen_master_fong_a.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/yast2_ftp.xml
+++ b/l10n/sles/zh-cn/xml/yast2_ftp.xml
@@ -67,10 +67,10 @@
    <title>FTP 服务器配置 — 启动</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_ftp-start-up.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_ftp-start-up.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_ftp-start-up.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_ftp-start-up.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/yast2_lang.xml
+++ b/l10n/sles/zh-cn/xml/yast2_lang.xml
@@ -91,10 +91,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_language.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_language.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_language.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_language.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>
@@ -225,10 +225,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_timezone.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_timezone.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_timezone.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_timezone.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -306,10 +306,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_timezone_ntp.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_timezone_ntp.png" width="75%"/>
       </imageobject>
       <imageobject role="pdf">
-       <imagedata fileref="yast2_timezone_ntp.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_timezone_ntp.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/zh-cn/xml/yast2_ncurses.xml
+++ b/l10n/sles/zh-cn/xml/yast2_ncurses.xml
@@ -15,10 +15,10 @@
   <title>文本模式下的 YaST 主窗口</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="yast2_ncurses_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="yast2_ncurses_main.png" width="70%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="yast2_ncurses_main.png" width="75%" format="PNG"/>
+    <imagedata fileref="yast2_ncurses_main.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -99,10 +99,10 @@
    <title>软件安装模块</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_ncurses_inst.png" width="70%" format="PNG"/>
+     <imagedata fileref="yast2_ncurses_inst.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_ncurses_inst.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_ncurses_inst.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-cn/xml/yast2_sw.xml
+++ b/l10n/sles/zh-cn/xml/yast2_sw.xml
@@ -152,10 +152,10 @@
      <phrase><guimenu>YaST</guimenu> software manager screen</phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_sw_manager.png" width="70%" format="PNG"/>
+     <imagedata fileref="yast2_sw_manager.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_sw_manager.png" width="65%" format="PNG"/>
+     <imagedata fileref="yast2_sw_manager.png" width="65%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -477,10 +477,10 @@
     <title>软件管理器的冲突管理</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_package_conflict.png" width="70%" format="PNG"/>
+      <imagedata fileref="yast2_package_conflict.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_package_conflict.png" width="65%" format="PNG"/>
+      <imagedata fileref="yast2_package_conflict.png" width="65%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/zh-cn/xml/yast2_sw_repo.xml
+++ b/l10n/sles/zh-cn/xml/yast2_sw_repo.xml
@@ -52,10 +52,10 @@
      <title>添加软件源</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_addon_new.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_addon_new.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_addon_new.png" width="65%" format="PNG"/>
+       <imagedata fileref="yast2_addon_new.png" width="65%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/zh-cn/xml/yast2_userman.xml
+++ b/l10n/sles/zh-cn/xml/yast2_userman.xml
@@ -22,11 +22,11 @@
    <title>YaST 用户和组管理</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_users_main_qt.png" width="90%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_users_main_qt.png" width="90%" os="sles;sled"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_users_main_qt.png" width="70%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_users_main_qt.png" width="70%" os="sles;sled"/>
      
     </imageobject>
    </mediaobject>
@@ -388,11 +388,11 @@
      <informalfigure os="sles;sled">
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_users_quota_qt.png" width="80%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_users_quota_qt.png" width="80%" os="sles;sled"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_users_quota_qt.png" width="70%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_users_quota_qt.png" width="70%" os="sles;sled"/>
         
        </imageobject>
       </mediaobject>
@@ -558,11 +558,11 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_groups_edit_qt.png" width="80%" format="PNG" os="sles;sled"/>
+       <imagedata fileref="yast2_groups_edit_qt.png" width="80%" os="sles;sled"/>
        
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_groups_edit_qt.png" width="75%" format="PNG" os="sles;sled"/>
+       <imagedata fileref="yast2_groups_edit_qt.png" width="75%" os="sles;sled"/>
        
       </imageobject>
      </mediaobject>

--- a/l10n/sles/zh-cn/xml/yast2_you.xml
+++ b/l10n/sles/zh-cn/xml/yast2_you.xml
@@ -73,11 +73,11 @@
    <title>YaST 联机更新</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_you.png" width="75%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_you.png" width="75%" os="sles;sled"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_you.png" width="75%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_you.png" width="75%" os="sles;sled"/>
      
     </imageobject>
    </mediaobject>
@@ -204,10 +204,10 @@
    <title>查看已撤回的补丁和历史记录</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_retracted_patches.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_retracted_patches.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_retracted_patches.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_retracted_patches.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>  
@@ -245,10 +245,10 @@
    <title>YaST 联机更新配置</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_autoupdate.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_autoupdate.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_autoupdate.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_autoupdate.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-tw/xml/adm_support.xml
+++ b/l10n/sles/zh-tw/xml/adm_support.xml
@@ -135,10 +135,10 @@ CPU Load Average:         7 (3%) with 2 CPUs
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_support_main.png" width="70%" format="PNG"/>
+        <imagedata fileref="yast2_support_main.png" width="70%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_support_main.png" width="60%" format="PNG"/>
+        <imagedata fileref="yast2_support_main.png" width="60%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -176,10 +176,10 @@ CPU Load Average:         7 (3%) with 2 CPUs
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_support_conf.png" width="90%" format="PNG"/>
+        <imagedata fileref="yast2_support_conf.png" width="90%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_support_conf.png" width="80%" format="PNG"/>
+        <imagedata fileref="yast2_support_conf.png" width="80%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -740,10 +740,10 @@ Creating Tar Ball
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_support_conf_upload.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_support_conf_upload.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_support_conf_upload.png" width="60%" format="PNG"/>
+       <imagedata fileref="yast2_support_conf_upload.png" width="60%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/zh-tw/xml/apache2_yast_i.xml
+++ b/l10n/sles/zh-tw/xml/apache2_yast_i.xml
@@ -45,10 +45,10 @@
     <title>HTTP 伺服器精靈：預設主機</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_apache_wizard3.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_apache_wizard3.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_apache_wizard3.png" format="PNG"/>
+      <imagedata fileref="yast2_apache_wizard3.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -154,10 +154,10 @@
     <title>HTTP 伺服器精靈：摘要</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_apache_wizard5.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_apache_wizard5.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_apache_wizard5.png" format="PNG"/>
+      <imagedata fileref="yast2_apache_wizard5.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -181,10 +181,10 @@
     <title>HTTP 伺服器組態：監聽連接埠和位址</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_apache_config_listen.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_apache_config_listen.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_apache_config_listen.png" format="PNG"/>
+      <imagedata fileref="yast2_apache_config_listen.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -198,10 +198,10 @@
     <title>HTTP 伺服器組態：伺服器模組</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata width="75%" fileref="yast2_apache_config_modules.png" format="PNG"/>
+      <imagedata width="75%" fileref="yast2_apache_config_modules.png"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_apache_config_modules.png" format="PNG"/>
+      <imagedata fileref="yast2_apache_config_modules.png"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/zh-tw/xml/apps_ekiga.xml
+++ b/l10n/sles/zh-tw/xml/apps_ekiga.xml
@@ -170,10 +170,10 @@
    <title><productname>Ekiga</productname> 使用者介面</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="ekiga_main.png" width="45%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="45%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ekiga_main.png" width="55%" format="PNG"/>
+     <imagedata fileref="ekiga_main.png" width="55%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-tw/xml/apps_evolution.xml
+++ b/l10n/sles/zh-tw/xml/apps_evolution.xml
@@ -733,10 +733,10 @@
    <title><productname>Evolution</productname> window</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" width="100%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" width="86%" format="PNG"/>
+     <imagedata fileref="evolution.png" width="86%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-tw/xml/apps_firefox.xml
+++ b/l10n/sles/zh-tw/xml/apps_firefox.xml
@@ -29,7 +29,7 @@
   <note>
    <title>使用選單列</title>
    <para>
-    <productname>Firefox</productname> 的大多數功能都可透過三條橫線按鈕 (<inlinemediaobject><textobject role="description"><phrase>三條橫線按鈕</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject>) 存取，有些功能只能透過選單列存取。
+    <productname>Firefox</productname> 的大多數功能都可透過三條橫線按鈕 (<inlinemediaobject><textobject role="description"><phrase>三條橫線按鈕</phrase></textobject><imageobject role="fo"><imagedata fileref="hamburger_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="hamburger_button-fallback.png" width="1em"/></imageobject></inlinemediaobject>) 存取，有些功能只能透過選單列存取。
    </para>
    <para>
     <productname>Firefox</productname> 的選單列預設會隱藏起來。若要暫時顯示選單列，請按 <keycap function="alt"/>。選單列隨後將一直顯示，直至您按一下瀏覽器視窗中的其他位置。

--- a/l10n/sles/zh-tw/xml/apps_gimp.xml
+++ b/l10n/sles/zh-tw/xml/apps_gimp.xml
@@ -125,10 +125,10 @@
     <title>工具箱</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="gimp-toolbox.png" width="35%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="35%"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="gimp-toolbox.png" width="30%" format="PNG"/>
+      <imagedata fileref="gimp-toolbox.png" width="30%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -547,10 +547,10 @@
        <title>基本色彩選擇器對話方塊</title>
        <mediaobject>
         <imageobject role="html">
-         <imagedata fileref="gimp-color.png" width="70%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="70%"/>
         </imageobject>
         <imageobject role="fo">
-         <imagedata fileref="gimp-color.png" width="80%" format="PNG"/>
+         <imagedata fileref="gimp-color.png" width="80%"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -719,10 +719,10 @@
    <title>列印對話方塊</title>
    <mediaobject>
     <imageobject role="html">
-     <imagedata fileref="gimp-print.png" width="75%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="75%"/>
     </imageobject>
     <imageobject role="fo">
-     <imagedata fileref="gimp-print.png" width="70%" format="PNG"/>
+     <imagedata fileref="gimp-print.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-tw/xml/apps_libreoffice.xml
+++ b/l10n/sles/zh-tw/xml/apps_libreoffice.xml
@@ -492,10 +492,10 @@
    <title><guimenu>Writer</guimenu> 中的自訂對話方塊</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_customize_main.png" width="80%" format="PNG"/>
+     <imagedata fileref="oo_customize_main.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -647,10 +647,10 @@
    <title>選項視窗</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo_options.png" width="95%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo_options.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo_options.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-tw/xml/apps_librevarious.xml
+++ b/l10n/sles/zh-tw/xml/apps_librevarious.xml
@@ -285,10 +285,10 @@
        <mediaobject>
         <textobject><phrase>Field selection</phrase></textobject>
         <imageobject role="fo">
-         <imagedata fileref="oo-wizard-base.png" width="90%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="90%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="oo-wizard-base.png" width="85%" format="PNG"/>
+         <imagedata fileref="oo-wizard-base.png" width="85%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>

--- a/l10n/sles/zh-tw/xml/apps_librewriter.xml
+++ b/l10n/sles/zh-tw/xml/apps_librewriter.xml
@@ -66,10 +66,10 @@
    <title>LibreOffice 精靈</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="oo-wizard.png" width="100%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="oo-wizard.png" width="85%" format="PNG"/>
+     <imagedata fileref="oo-wizard.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -231,10 +231,10 @@
     <title>「樣式」面板</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo-stylist.png" width="40%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="40%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo-stylist.png" width="50%" format="PNG"/>
+      <imagedata fileref="oo-stylist.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -641,10 +641,10 @@
     <title><guimenu>Writer</guimenu> 中的助手工具</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="oo_navigator.png" width="55%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="oo_navigator.png" width="45%" format="PNG"/>
+      <imagedata fileref="oo_navigator.png" width="45%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/zh-tw/xml/apps_totem.xml
+++ b/l10n/sles/zh-tw/xml/apps_totem.xml
@@ -59,10 +59,10 @@
    <title><guimenu>GNOME Videos</guimenu> 啟動視窗</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="totem_a.png" width="75%" format="PNG"/>
+     <imagedata fileref="totem_a.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -132,11 +132,11 @@
     <guimenu>退出</guimenu> </menuchoice>。
    </para>
    <para>
-    若要暫停正在播放的影片或曲目，請按一下 <inlinemediaobject><textobject role="description"><phrase>GNOME Videos 暫停</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_pause_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="totem_pause_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject> 按鈕,或按一下<menuchoice> <guimenu>影片</guimenu>
+    若要暫停正在播放的影片或曲目，請按一下 <inlinemediaobject><textobject role="description"><phrase>GNOME Videos 暫停</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_pause_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="totem_pause_button-fallback.png" width="1em"/></imageobject></inlinemediaobject> 按鈕,或按一下<menuchoice> <guimenu>影片</guimenu>
     <guimenu>播放/暫停</guimenu> </menuchoice>。暫停影片或曲目後，狀態列會顯示<guimenu>已暫停</guimenu>和目前影片或曲目已播放的時間。
    </para>
    <para>
-    若要繼續播放影片或曲目，請按一下 <inlinemediaobject><textobject role="description"><phrase>GNOME Videos 播放</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_play_button.svg" width="0.8em" format="SVG"/></imageobject><imageobject role="html"><imagedata fileref="totem_play_button-fallback.png" width="1em" format="PNG"/></imageobject></inlinemediaobject> 按鈕,或按一下<menuchoice> <guimenu>影片</guimenu>
+    若要繼續播放影片或曲目，請按一下 <inlinemediaobject><textobject role="description"><phrase>GNOME Videos 播放</phrase></textobject><imageobject role="fo"><imagedata fileref="totem_play_button.svg" width="0.8em"/></imageobject><imageobject role="html"><imagedata fileref="totem_play_button-fallback.png" width="1em"/></imageobject></inlinemediaobject> 按鈕,或按一下<menuchoice> <guimenu>影片</guimenu>
     <guimenu>播放/暫停</guimenu></menuchoice>。
    </para>
    <para>
@@ -223,10 +223,10 @@
     <title><guimenu>GNOME Videos</guimenu> 一般偏好設定</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_general.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_general.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -268,10 +268,10 @@
     <title><guimenu>GNOME Videos</guimenu> 顯示偏好設定</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_display.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_display.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -307,10 +307,10 @@
     <title><guimenu>GNOME Videos</guimenu> 音效偏好設定</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="totem_audio.png" width="55%" format="PNG"/>
+      <imagedata fileref="totem_audio.png" width="55%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/zh-tw/xml/backup.xml
+++ b/l10n/sles/zh-tw/xml/backup.xml
@@ -20,10 +20,10 @@
  <mediaobject>
   <textobject><phrase>Backup application</phrase></textobject>
   <imageobject role="fo">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
   <imageobject role="html">
-   <imagedata fileref="gnome_backup.png" width="75%" format="png"/>
+   <imagedata fileref="gnome_backup.png" width="75%"/>
   </imageobject>
  </mediaobject>
 </informalfigure>

--- a/l10n/sles/zh-tw/xml/chrony.xml
+++ b/l10n/sles/zh-tw/xml/chrony.xml
@@ -40,10 +40,10 @@
    <title>NTP 組態視窗</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="ntp_client.png" width="70%" format="PNG"/>
+     <imagedata fileref="ntp_client.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="ntp_client.png" width="70%" format="PNG"/>
+     <imagedata fileref="ntp_client.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -103,10 +103,10 @@
     <title>新增時間伺服器</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="ntp_client_serveradd.png" width="70%" format="PNG"/>
+      <imagedata fileref="ntp_client_serveradd.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="ntp_client_serveradd.png" width="70%" format="PNG"/>
+      <imagedata fileref="ntp_client_serveradd.png" width="70%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/zh-tw/xml/deployment_expert_partitioner_lvm.xml
+++ b/l10n/sles/zh-tw/xml/deployment_expert_partitioner_lvm.xml
@@ -88,10 +88,10 @@
    <title>建立磁碟區群組</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_add_vg.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_add_vg.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -108,10 +108,10 @@
    <title>邏輯磁碟區管理</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_volume_management.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_volume_management.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-tw/xml/deployment_expert_partitioner_overview.xml
+++ b/l10n/sles/zh-tw/xml/deployment_expert_partitioner_overview.xml
@@ -24,10 +24,10 @@
   <title>YaST 磁碟分割程式</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="install_partitioner_expert.png" width="75%" format="PNG"/>
+    <imagedata fileref="install_partitioner_expert.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -231,10 +231,10 @@
         <title>YaST 磁碟分割程式中的 Btrfs 子磁碟區</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%" format="PNG"/>
+          <imagedata fileref="install_partitioner_btrfs_subvolumes.png" width="75%"/>
          </imageobject>
         </mediaobject>
        </figure>

--- a/l10n/sles/zh-tw/xml/deployment_expert_partitioner_raid.xml
+++ b/l10n/sles/zh-tw/xml/deployment_expert_partitioner_raid.xml
@@ -56,10 +56,10 @@
    <title>RAID 分割區</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="install_partitioner_raid.png" width="75%" format="PNG"/>
+     <imagedata fileref="install_partitioner_raid.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-tw/xml/deployment_register.xml
+++ b/l10n/sles/zh-tw/xml/deployment_register.xml
@@ -80,11 +80,11 @@
         <phrase><guimenu>Registration</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_register_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -113,11 +113,11 @@
         <phrase><guimenu>Extension and Module Selection</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -143,11 +143,11 @@
         <phrase><guimenu>Installation Summary</guimenu> screen</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_install_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>
@@ -212,11 +212,11 @@
         <phrase><guimenu>Extension and Module Selection</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_extension_list_sles.png" width="100%"/>
         
 
        </imageobject>
@@ -265,11 +265,11 @@
         <phrase><guimenu>Installed Add-on Products</guimenu> dialog</phrase>
        </textobject>
        <imageobject role="fo">
-        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="75%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="75%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="100%" format="png"/>
+        <imagedata os="sles;slemicro" fileref="yast2_addon_installed_sles.png" width="100%"/>
         
        </imageobject>
       </mediaobject>

--- a/l10n/sles/zh-tw/xml/deployment_troubleshooting.xml
+++ b/l10n/sles/zh-tw/xml/deployment_troubleshooting.xml
@@ -160,10 +160,10 @@
    <title>美式鍵盤配置</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="keyboard_us.svg" width="75%" format="SVG"/>
+     <imagedata fileref="keyboard_us.svg" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="keyboard_us.png" width="75%" format="PNG"/>
+     <imagedata fileref="keyboard_us.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-tw/xml/gnome_accessibility.xml
+++ b/l10n/sles/zh-tw/xml/gnome_accessibility.xml
@@ -90,10 +90,10 @@
      <mediaobject>
       <textobject><phrase>On-screen keyboard</phrase></textobject>
       <imageobject role="fo">
-       <imagedata fileref="gnome_onscreen_kbd.png" width="95%" format="PNG"/>
+       <imagedata fileref="gnome_onscreen_kbd.png" width="95%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="gnome_onscreen_kbd.png" width="90%" format="PNG"/>
+       <imagedata fileref="gnome_onscreen_kbd.png" width="90%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/zh-tw/xml/gnome_crypto.xml
+++ b/l10n/sles/zh-tw/xml/gnome_crypto.xml
@@ -22,10 +22,10 @@
   <title><guimenu>密碼及金鑰</guimenu>主視窗</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="seahorse_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="seahorse_main.png" width="70%"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sles/zh-tw/xml/gnome_custom.xml
+++ b/l10n/sles/zh-tw/xml/gnome_custom.xml
@@ -61,10 +61,10 @@
      <title>GNOME 背景設定</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="preferences_background.png" width="45%" format="PNG"/>
+        <imagedata fileref="preferences_background.png" width="45%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="preferences_background.png" width="45%" format="PNG"/>
+        <imagedata fileref="preferences_background.png" width="45%"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -148,10 +148,10 @@
    <title>鍵盤快速鍵對話方塊</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_keyboard.png" width="100%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_keyboard.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_keyboard.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -178,10 +178,10 @@
    <title>在 tweaks 中啟用按鍵組合</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="tweaks-compose.png" width="80%" format="PNG"/>
+     <imagedata fileref="tweaks-compose.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -307,10 +307,10 @@
    <title><guimenu>滑鼠和觸控板</guimenu>設定對話方塊</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="preferences_mouse.png" width="80%" format="PNG"/>
+     <imagedata fileref="preferences_mouse.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -362,10 +362,10 @@
     <title>「單監視器設定」對話方塊</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="preferences_screen_single.png" width="100%" format="PNG"/>
+      <imagedata fileref="preferences_screen_single.png" width="100%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="preferences_screen_single.png" width="80%" format="PNG"/>
+      <imagedata fileref="preferences_screen_single.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -486,10 +486,10 @@
    <title>組態音效設定</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="sound_devices.png" width="100%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="sound_devices.png" width="80%" format="PNG"/>
+     <imagedata fileref="sound_devices.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -515,10 +515,10 @@
      <title>預設應用程式</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="preferences_preferred_apps.png" width="100%" format="PNG"/>
+       <imagedata fileref="preferences_preferred_apps.png" width="100%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="preferences_preferred_apps.png" width="80%" format="PNG"/>
+       <imagedata fileref="preferences_preferred_apps.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/zh-tw/xml/gnome_networking.xml
+++ b/l10n/sles/zh-tw/xml/gnome_networking.xml
@@ -104,10 +104,10 @@
    <title>網路檔案瀏覽器</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="network_browser.png" width="100%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="100%"/>
      </imageobject>
     <imageobject role="html">
-     <imagedata fileref="network_browser.png" width="90%" format="PNG"/>
+     <imagedata fileref="network_browser.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -256,10 +256,10 @@
       <mediaobject>
        <textobject><phrase>Sharing options</phrase></textobject>
        <imageobject role="fo">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="folder_sharing_1_a.png" width="85%" format="PNG"/>
+        <imagedata fileref="folder_sharing_1_a.png" width="85%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/l10n/sles/zh-tw/xml/gnome_start.xml
+++ b/l10n/sles/zh-tw/xml/gnome_start.xml
@@ -37,11 +37,11 @@
    <title>預設 GNOME 登入畫面</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata os="sles;sled" fileref="login_sled.png" width="90%" format="PNG"/>
+     <imagedata os="sles;sled" fileref="login_sled.png" width="90%"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata os="sles;sled" fileref="login_sled.png" width="75%" format="PNG"/>
+     <imagedata os="sles;sled" fileref="login_sled.png" width="75%"/>
      
     </imageobject>
    </mediaobject>
@@ -83,11 +83,11 @@
       <title>預設 GNOME 登入畫面 - 工作階段類型</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="90%" format="PNG"/>
+        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="90%"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="75%" format="PNG"/>
+        <imagedata os="sles;sled" fileref="login_sessiontype_sle.png" width="75%"/>
         
        </imageobject>
       </mediaobject>
@@ -197,10 +197,10 @@
    <title>GNOME 桌面及活動綜覽</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="desktop_sled_menu.png" width="95%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="95%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="desktop_sled_menu.png" width="90%" format="PNG"/>
+     <imagedata fileref="desktop_sled_menu.png" width="90%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -245,10 +245,10 @@
      <title><guimenu>活動</guimenu>綜覽</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="desktop_activities_overview.png" width="95%" format="PNG"/>
+      <imagedata fileref="desktop_activities_overview.png" width="95%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="desktop_activities_overview.png" width="90%" format="PNG"/>
+      <imagedata fileref="desktop_activities_overview.png" width="90%"/>
      </imageobject>
     </mediaobject>
      </figure>
@@ -285,10 +285,10 @@
      <title><productname>Firefox</productname> 的<guimenu>應用程式</guimenu>功能表</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="desktop_app_menu_firefox.png" width="70%" format="PNG"/>
+       <imagedata fileref="desktop_app_menu_firefox.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="desktop_app_menu_firefox.png" width="70%" format="PNG"/>
+       <imagedata fileref="desktop_app_menu_firefox.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/zh-tw/xml/gnome_use.xml
+++ b/l10n/sles/zh-tw/xml/gnome_use.xml
@@ -26,10 +26,10 @@
    <title>檔案管理員</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="nautilus.png" format="PNG" width="75%"/>
+     <imagedata fileref="nautilus.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -573,10 +573,10 @@
     <textobject><phrase><productname>Evolution</productname></phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata fileref="evolution.png" format="PNG" width="100%"/>
+     <imagedata fileref="evolution.png" width="100%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evolution.png" format="PNG" width="80%"/>
+     <imagedata fileref="evolution.png" width="80%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -673,10 +673,10 @@
    <title><productname>Archive manager</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="file_roller.png" format="PNG" width="70%"/>
+     <imagedata fileref="file_roller.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -971,10 +971,10 @@
    <title><productname>Document viewer</productname></title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="evince.png" format="PNG" width="90%"/>
+     <imagedata fileref="evince.png" width="90%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="evince.png" format="PNG" width="78%"/>
+     <imagedata fileref="evince.png" width="78%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-tw/xml/grub2.xml
+++ b/l10n/sles/zh-tw/xml/grub2.xml
@@ -438,10 +438,10 @@
       <title>GRUB 2 開機編輯器</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="grub2_edit_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="grub2_edit_config.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="grub2_edit_config.png" width="75%" format="PNG"/>
+        <imagedata fileref="grub2_edit_config.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </figure>

--- a/l10n/sles/zh-tw/xml/grub2_yast_i.xml
+++ b/l10n/sles/zh-tw/xml/grub2_yast_i.xml
@@ -93,10 +93,10 @@
     <title>開機代碼選項</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_boot_code.png" width="75%"/>
      </imageobject>
     </mediaobject>
   </figure>
@@ -215,10 +215,10 @@
     <title>開機載入程式選項</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_options.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_options.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_options.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_options.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -277,10 +277,10 @@
     <title>核心參數</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_bootloader_kernel_parameters.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/zh-tw/xml/help_user.xml
+++ b/l10n/sles/zh-tw/xml/help_user.xml
@@ -61,10 +61,10 @@
    <title>說明的主視窗</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="gnome_yelp_main.png" width="70%" format="PNG"/>
+     <imagedata fileref="gnome_yelp_main.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-tw/xml/journalctl.xml
+++ b/l10n/sles/zh-tw/xml/journalctl.xml
@@ -336,10 +336,10 @@ enabled</screen>
    <title>YaST systemd 日誌</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_journal.png" width="80%" format="PNG"/>
+     <imagedata fileref="yast2_journal.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_journal.png" width="85%" format="PNG"/>
+     <imagedata fileref="yast2_journal.png" width="85%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-tw/xml/klp.xml
+++ b/l10n/sles/zh-tw/xml/klp.xml
@@ -64,10 +64,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="klp.png" width="80%" format="PNG"/>
+     <imagedata fileref="klp.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="klp.png" width="100%" format="PNG"/>
+     <imagedata fileref="klp.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>

--- a/l10n/sles/zh-tw/xml/net_basic.xml
+++ b/l10n/sles/zh-tw/xml/net_basic.xml
@@ -60,10 +60,10 @@
   <title>TCP/IP 的簡化層模型</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata width="100%" fileref="net_basic_osi.svg" format="SVG"/>
+    <imagedata width="100%" fileref="net_basic_osi.svg"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata width="75%" fileref="net_basic_osi.png" format="PNG"/>
+    <imagedata width="75%" fileref="net_basic_osi.png"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -80,10 +80,10 @@
   <title>TCP/IP 乙太網路封包</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata width="80%" fileref="net_basic_tcppacket.svg" format="SVG"/>
+    <imagedata width="80%" fileref="net_basic_tcppacket.svg"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata width="75%" fileref="net_basic_tcppacket.png" format="PNG"/>
+    <imagedata width="75%" fileref="net_basic_tcppacket.png"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sles/zh-tw/xml/net_bonding.xml
+++ b/l10n/sles/zh-tw/xml/net_bonding.xml
@@ -114,10 +114,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="bond_configuration.png" width="70%" format="PNG"/>
+      <imagedata fileref="bond_configuration.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="bond_configuration.png" width="65%" format="PNG"/>
+      <imagedata fileref="bond_configuration.png" width="65%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sles/zh-tw/xml/net_dhcp.xml
+++ b/l10n/sles/zh-tw/xml/net_dhcp.xml
@@ -86,10 +86,10 @@
       <title>DHCP 伺服器：介面卡選項</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz1.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz1.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz1.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz1.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -102,10 +102,10 @@
       <title>DHCP 伺服器：全域設定</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz2.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz2.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz2.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz2.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -118,10 +118,10 @@
       <title>DHCP 伺服器：動態 DHCP</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz3.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz3.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_wiz3.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_wiz3.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -135,10 +135,10 @@
       <title>DHCP 伺服器：啟動</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_start.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_start.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_start.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_start.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -151,10 +151,10 @@
       <title>DHCP 伺服器：主機管理</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dhcp_statdhcp.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_statdhcp.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dhcp_statdhcp.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dhcp_statdhcp.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -178,10 +178,10 @@
        <title>DHCP 伺服器：Chroot Jail 和宣告</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_chroot.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_chroot.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_chroot.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_chroot.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -197,10 +197,10 @@
        <title>DHCP 伺服器：選取宣告類型</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_newdec.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_newdec.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_newdec.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_newdec.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -216,10 +216,10 @@
        <title>DHCP 伺服器：設定子網路</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_sub.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_sub.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_sub.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_sub.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -235,10 +235,10 @@
        <title>DHCP 伺服器：TSIG 組態</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_tsig.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_tsig.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_tsig.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_tsig.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -254,10 +254,10 @@
        <title>DHCP 伺服器：動態 DNS 的介面組態</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_dyndns.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_dyndns.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_dyndns.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_dyndns.png"/>
         </imageobject>
        </mediaobject>
       </figure>
@@ -293,10 +293,10 @@
        <title>DHCP 伺服器：網路介面和防火牆</title>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata width="75%" fileref="yast2_dhcp_fire.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_fire.png"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata width="75%" fileref="yast2_dhcp_fire.png" format="PNG"/>
+         <imagedata width="75%" fileref="yast2_dhcp_fire.png"/>
         </imageobject>
        </mediaobject>
       </figure>

--- a/l10n/sles/zh-tw/xml/net_dns.xml
+++ b/l10n/sles/zh-tw/xml/net_dns.xml
@@ -169,10 +169,10 @@
       <title>DNS 伺服器安裝：轉遞者設定</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="75%" fileref="yast2_dns_wiz_forw.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dns_wiz_forw.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dns_wiz_forw.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dns_wiz_forw.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -188,10 +188,10 @@
       <title>DNS 伺服器安裝：DNS 區域</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="72%" fileref="yast2_dns_wiz_zone.png" format="PNG"/>
+        <imagedata width="72%" fileref="yast2_dns_wiz_zone.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dns_wiz_zone.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dns_wiz_zone.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -204,10 +204,10 @@
       <title>DNS 伺服器安裝：完成精靈</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata width="72%" fileref="yast2_dns_wiz_finish.png" format="PNG"/>
+        <imagedata width="72%" fileref="yast2_dns_wiz_finish.png"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata width="75%" fileref="yast2_dns_wiz_finish.png" format="PNG"/>
+        <imagedata width="75%" fileref="yast2_dns_wiz_finish.png"/>
        </imageobject>
       </mediaobject>
      </figure>
@@ -254,10 +254,10 @@
      <title>DNS 伺服器：記錄</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata width="75%" fileref="yast2_dns_def_logging.png" format="PNG"/>
+       <imagedata width="75%" fileref="yast2_dns_def_logging.png"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata width="75%" fileref="yast2_dns_def_logging.png" format="PNG"/>
+       <imagedata width="75%" fileref="yast2_dns_def_logging.png"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -318,10 +318,10 @@
      <title>DNS 伺服器：區域編輯器 (基本)</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata width="65%" fileref="yast2_dns_def_ddns.png" format="PNG"/>
+       <imagedata width="65%" fileref="yast2_dns_def_ddns.png"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata width="65%" fileref="yast2_dns_def_ddns.png" format="PNG"/>
+       <imagedata width="65%" fileref="yast2_dns_def_ddns.png"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -336,10 +336,10 @@
         <title>DNS 伺服器：區域編輯器 (NS 記錄)</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata width="65%" fileref="yast2_dns_def_nsrec.png" format="PNG"/>
+          <imagedata width="65%" fileref="yast2_dns_def_nsrec.png"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata width="65%" fileref="yast2_dns_def_nsrec.png" format="PNG"/>
+          <imagedata width="65%" fileref="yast2_dns_def_nsrec.png"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -355,10 +355,10 @@
         <title>DNS 伺服器：區域編輯器 (MX 記錄)</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata width="72%" fileref="yast2_dns_def_mxrec.png" format="PNG"/>
+          <imagedata width="72%" fileref="yast2_dns_def_mxrec.png"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata width="75%" fileref="yast2_dns_def_mxrec.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_mxrec.png"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -374,10 +374,10 @@
         <title>DNS 伺服器：區域編輯器 (SOA)</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata width="75%" fileref="yast2_dns_def_soa.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_soa.png"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata width="75%" fileref="yast2_dns_def_soa.png" format="PNG"/>
+          <imagedata width="75%" fileref="yast2_dns_def_soa.png"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -418,10 +418,10 @@
         <title>新增主要區域記錄</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="yast2_dns_revzone1.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone1.png" width="70%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="yast2_dns_revzone1.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone1.png" width="70%"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -434,10 +434,10 @@
         <title>新增反向區域</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="yast2_dns_revzone2.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone2.png" width="70%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="yast2_dns_revzone2.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone2.png" width="70%"/>
          </imageobject>
         </mediaobject>
        </figure>
@@ -450,10 +450,10 @@
         <title>新增反向記錄</title>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="yast2_dns_revzone3.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone3.png" width="70%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="yast2_dns_revzone3.png" width="70%" format="PNG"/>
+          <imagedata fileref="yast2_dns_revzone3.png" width="70%"/>
          </imageobject>
         </mediaobject>
        </figure>

--- a/l10n/sles/zh-tw/xml/net_samba.xml
+++ b/l10n/sles/zh-tw/xml/net_samba.xml
@@ -608,10 +608,10 @@ smbpasswd -a -m hostname</screen>
      <title>確定 Windows 網域成員資格</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="ad_sambaclient.png" width="75%" format="PNG"/>
+       <imagedata fileref="ad_sambaclient.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="ad_sambaclient.png" format="PNG"/>
+       <imagedata fileref="ad_sambaclient.png"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -728,10 +728,10 @@ drwxrwxrwx. 2 root    root    0 Oct 24 22:31 subfolder
     <title>Windows 檔案總管<guimenu>進階屬性</guimenu>對話方塊</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="samba_win_expl_advattr.png" width="75%" format="PNG"/>
+      <imagedata fileref="samba_win_expl_advattr.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="samba_win_expl_advattr.png" format="PNG"/>
+      <imagedata fileref="samba_win_expl_advattr.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -745,10 +745,10 @@ drwxrwxrwx. 2 root    root    0 Oct 24 22:31 subfolder
     <title>列有壓縮檔案的 Windows 檔案總管目錄</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="samba_win_expl_view_compressed.png" width="75%" format="PNG"/>
+      <imagedata fileref="samba_win_expl_view_compressed.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="samba_win_expl_view_compressed.png" format="PNG"/>
+      <imagedata fileref="samba_win_expl_view_compressed.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -810,10 +810,10 @@ drwxrwxrwx. 2 root    root    0 Oct 24 22:31 subfolder
      <title>在啟用快照的情況下新增新的 Samba 共用</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_samba_snapshot.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_samba_snapshot.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_samba_snapshot.png" format="PNG"/>
+       <imagedata fileref="yast2_samba_snapshot.png"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -824,10 +824,10 @@ drwxrwxrwx. 2 root    root    0 Oct 24 22:31 subfolder
      <title>Windows 檔案總管中的<guimenu>以前的版本</guimenu>索引標籤</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="samba_winexpl_previous_versions.png" width="75%" format="PNG"/>
+       <imagedata fileref="samba_winexpl_previous_versions.png" width="75%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="samba_winexpl_previous_versions.png" format="PNG"/>
+       <imagedata fileref="samba_winexpl_previous_versions.png"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/zh-tw/xml/net_wicked.xml
+++ b/l10n/sles/zh-tw/xml/net_wicked.xml
@@ -79,10 +79,10 @@
     <title><literal>wicked</literal> 架構</title>
     <mediaobject>
      <imageobject role="html">
-      <imagedata fileref="wicked_scheme.png" format="PNG"/>
+      <imagedata fileref="wicked_scheme.png"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="wicked_scheme.png" format="PNG" width="80%"/>
+      <imagedata fileref="wicked_scheme.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/zh-tw/xml/net_yast.xml
+++ b/l10n/sles/zh-tw/xml/net_yast.xml
@@ -48,10 +48,10 @@
    <title>組態網路設定</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_net_icard.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_net_icard.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_net_icard.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_net_icard.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-tw/xml/network_scheme.xml
+++ b/l10n/sles/zh-tw/xml/network_scheme.xml
@@ -4,10 +4,10 @@
  <info>
   <mediaobject>
    <imageobject role="html">
-    <imagedata fileref="network_schema.png" width="100%" format="PNG"/>
+    <imagedata fileref="network_schema.png" width="100%"/>
    </imageobject>
    <imageobject role="pdf">
-    <imagedata fileref="network_schema.svg" width="100%" format="SVG"/>
+    <imagedata fileref="network_schema.svg" width="100%"/>
    </imageobject>
   </mediaobject>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -21,10 +21,10 @@
  <informalfigure>
   <mediaobject>
    <imageobject role="html">
-    <imagedata fileref="network_schema.png" width="100%" format="PNG"/>
+    <imagedata fileref="network_schema.png" width="100%"/>
    </imageobject>
    <imageobject role="pdf">
-    <imagedata fileref="network_schema.svg" width="100%" format="SVG"/>
+    <imagedata fileref="network_schema.svg" width="100%"/>
    </imageobject>
   </mediaobject>
  </informalfigure>

--- a/l10n/sles/zh-tw/xml/sle_update_upgrading.xml
+++ b/l10n/sles/zh-tw/xml/sle_update_upgrading.xml
@@ -72,11 +72,11 @@
    <title>支援的升級路徑綜覽</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="100%" format="PNG"/>
+     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="100%"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="80%" format="PNG"/>
+     <imagedata os="sles" fileref="upgrade-paths_sles.png" width="80%"/>
      
     </imageobject>
    </mediaobject>

--- a/l10n/sles/zh-tw/xml/snapper.xml
+++ b/l10n/sles/zh-tw/xml/snapper.xml
@@ -417,10 +417,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_list.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_list.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_list.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_list.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -432,10 +432,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_changes.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_changes.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_changes.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_changes.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -447,10 +447,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_diff.png" width="65%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_diff.png" width="65%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_diff.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_diff.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -462,10 +462,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="snapper_yast2_restore.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_restore.png" width="75%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="snapper_yast2_restore.png" width="75%" format="PNG"/>
+        <imagedata fileref="snapper_yast2_restore.png" width="75%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -827,10 +827,10 @@ single | 4 |     |         |                       |
     <title>開機載入程式：快照</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="boot_snapshots.png" width="75%" format="PNG"/>
+      <imagedata fileref="boot_snapshots.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="boot_snapshots.png" width="75%" format="PNG"/>
+      <imagedata fileref="boot_snapshots.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/zh-tw/xml/storage_fcoe.xml
+++ b/l10n/sles/zh-tw/xml/storage_fcoe.xml
@@ -14,10 +14,10 @@
   <title>開放式乙太網路光纖通道 SAN</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="fcoe_san_a.svg" width="80%" format="SVG"/>
+    <imagedata fileref="fcoe_san_a.svg" width="80%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="fcoe_san_a.png" width="100%" format="PNG"/>
+    <imagedata fileref="fcoe_san_a.png" width="100%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -61,10 +61,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="fcoe_inst_disk_activation_a.png" width="80%" format="PNG"/>
+     <imagedata fileref="fcoe_inst_disk_activation_a.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="fcoe_inst_disk_activation_a.png" width="10%" format="PNG"/>
+     <imagedata fileref="fcoe_inst_disk_activation_a.png" width="10%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -108,10 +108,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="fcoe_services_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="fcoe_services_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="fcoe_services_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="fcoe_services_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -149,10 +149,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="fcoe_notconfig_interface_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="fcoe_notconfig_interface_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="fcoe_notconfig_interface_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="fcoe_notconfig_interface_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -243,10 +243,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="fcoe_configtab_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="fcoe_configtab_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="fcoe_configtab_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="fcoe_configtab_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/zh-tw/xml/storage_filesystems.xml
+++ b/l10n/sles/zh-tw/xml/storage_filesystems.xml
@@ -1043,10 +1043,10 @@ inode_ratio = 8192</screen>
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="ext4_inode_yast_a.png" width="60%" format="PNG"/>
+        <imagedata fileref="ext4_inode_yast_a.png" width="60%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="ext4_inode_yast_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="ext4_inode_yast_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/l10n/sles/zh-tw/xml/storage_iscsi.xml
+++ b/l10n/sles/zh-tw/xml/storage_iscsi.xml
@@ -14,10 +14,10 @@
   <title>配有 iSNS 伺服器的 iSCSI SAN</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="iscsi_san_a.svg" width="80%" format="SVG"/>
+    <imagedata fileref="iscsi_san_a.svg" width="80%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="iscsi_san_a.png" width="100%" format="PNG"/>
+    <imagedata fileref="iscsi_san_a.png" width="100%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -94,10 +94,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="lio_service_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="lio_service_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="lio_service_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="lio_service_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -184,10 +184,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="lio_global_noauth_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="lio_global_noauth_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="lio_global_noauth_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="lio_global_noauth_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -263,10 +263,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="lio_targets_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="lio_targets_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="lio_targets_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="lio_targets_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -313,10 +313,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="lio_target_client_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="lio_target_client_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="lio_target_client_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="lio_target_client_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -623,10 +623,10 @@
       <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="iscsi_init_service_a.png" width="80%" format="PNG"/>
+         <imagedata fileref="iscsi_init_service_a.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="iscsi_init_service_a.png" width="100%" format="PNG"/>
+         <imagedata fileref="iscsi_init_service_a.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>

--- a/l10n/sles/zh-tw/xml/storage_isns.xml
+++ b/l10n/sles/zh-tw/xml/storage_isns.xml
@@ -37,10 +37,10 @@
    <title>iSNS 探查網域</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="isns_a.png" width="80%" format="PNG"/>
+     <imagedata fileref="isns_a.png" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="isns_a.png" width="100%" format="PNG"/>
+     <imagedata fileref="isns_a.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -138,10 +138,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="isns_config_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="isns_config_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="isns_config_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="isns_config_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -252,10 +252,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="isns_discdomains_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="isns_discdomains_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="isns_discdomains_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="isns_discdomains_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -296,10 +296,10 @@
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="isns_iscsinodes_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="isns_iscsinodes_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="isns_iscsinodes_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="isns_iscsinodes_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>

--- a/l10n/sles/zh-tw/xml/storage_lvm.xml
+++ b/l10n/sles/zh-tw/xml/storage_lvm.xml
@@ -33,10 +33,10 @@
    <title>實體分割與 LVM</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="lvm.svg" width="80%" format="SVG"/>
+     <imagedata fileref="lvm.svg" width="80%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="lvm.png" width="100%" format="PNG"/>
+     <imagedata fileref="lvm.png" width="100%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -160,10 +160,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm4_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm4_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm4_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm4_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -227,10 +227,10 @@
      <title>名為 DATA 的磁碟區群組中的實體磁碟區</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm5_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm5_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm5_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm5_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -307,10 +307,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm9_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm9_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm9_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm9_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -325,10 +325,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm10_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm10_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm10_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm10_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -340,10 +340,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm11_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm11_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm11_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm11_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -575,10 +575,10 @@ root's password:
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm8_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm8_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm8_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm8_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>
@@ -653,10 +653,10 @@ root's password:
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_lvm12_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_lvm12_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_lvm12_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_lvm12_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/zh-tw/xml/storage_nfs.xml
+++ b/l10n/sles/zh-tw/xml/storage_nfs.xml
@@ -144,11 +144,11 @@
       <title>NFS 伺服器組態工具</title>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_inst_nfsserver1.png" width="75%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_inst_nfsserver1.png" width="75%" os="sles;sled"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_inst_nfsserver1.png" width="75%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_inst_nfsserver1.png" width="75%" os="sles;sled"/>
         
        </imageobject>
       </mediaobject>

--- a/l10n/sles/zh-tw/xml/storage_raid.xml
+++ b/l10n/sles/zh-tw/xml/storage_raid.xml
@@ -227,10 +227,10 @@
      <title>RAID 5 組態範例</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_raid3_a.png" width="80%" format="PNG"/>
+       <imagedata fileref="yast2_raid3_a.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_raid3_a.png" width="100%" format="PNG"/>
+       <imagedata fileref="yast2_raid3_a.png" width="100%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/zh-tw/xml/storage_raid10.xml
+++ b/l10n/sles/zh-tw/xml/storage_raid10.xml
@@ -726,10 +726,10 @@ ARRAY /dev/md2 UUID=<replaceable>UUID</replaceable></screen>
      <informalfigure>
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="raid10_a.png" width="80%" format="PNG"/>
+        <imagedata fileref="raid10_a.png" width="80%"/>
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="raid10_a.png" width="100%" format="PNG"/>
+        <imagedata fileref="raid10_a.png" width="100%"/>
        </imageobject>
       </mediaobject>
      </informalfigure>
@@ -780,10 +780,10 @@ ARRAY /dev/md2 UUID=<replaceable>UUID</replaceable></screen>
        <informalfigure>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="raid10_classify_a.png" width="80%" format="PNG"/>
+          <imagedata fileref="raid10_classify_a.png" width="80%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="raid10_classify_a.png" width="100%" format="PNG"/>
+          <imagedata fileref="raid10_classify_a.png" width="100%"/>
          </imageobject>
         </mediaobject>
        </informalfigure>

--- a/l10n/sles/zh-tw/xml/storage_raidroot.xml
+++ b/l10n/sles/zh-tw/xml/storage_raidroot.xml
@@ -123,10 +123,10 @@
       <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install2_a.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install2_a.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install2_a.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install2_a.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -155,10 +155,10 @@
       <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install3_a.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install3_a.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install3_a.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install3_a.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -178,10 +178,10 @@
      <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install_editraid.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_editraid.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install_editraid.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_editraid.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -198,10 +198,10 @@
       <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install_filesystem.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_filesystem.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install_filesystem.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_filesystem.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -221,10 +221,10 @@
    	<informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install_swap.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_swap.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install_swap.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_swap.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -236,10 +236,10 @@
     <informalfigure>
        <mediaobject>
         <imageobject role="fo">
-         <imagedata fileref="raid_yast_install_boot.png" width="80%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_boot.png" width="80%"/>
         </imageobject>
         <imageobject role="html">
-         <imagedata fileref="raid_yast_install_boot.png" width="100%" format="PNG"/>
+         <imagedata fileref="raid_yast_install_boot.png" width="100%"/>
         </imageobject>
        </mediaobject>
       </informalfigure>
@@ -247,10 +247,10 @@
     <informalfigure>
       <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="raid_yast_install3_b.png" width="70%" format="PNG"/>
+       <imagedata fileref="raid_yast_install3_b.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="raid_yast_install3_b.png" width="70%" format="PNG"/>
+       <imagedata fileref="raid_yast_install3_b.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/zh-tw/xml/systemd.xml
+++ b/l10n/sles/zh-tw/xml/systemd.xml
@@ -1051,10 +1051,10 @@ Startup finished in 2666ms (kernel) + 21961ms (userspace) = 24628ms</screen>
        <informalfigure>
         <mediaobject>
          <imageobject role="fo">
-          <imagedata fileref="systemd_startup.svg" width="75%" format="SVG"/>
+          <imagedata fileref="systemd_startup.svg" width="75%"/>
          </imageobject>
          <imageobject role="html">
-          <imagedata fileref="systemd_startup.png" width="75%" format="PNG"/>
+          <imagedata fileref="systemd_startup.png" width="75%"/>
          </imageobject>
         </mediaobject>
        </informalfigure>
@@ -1137,10 +1137,10 @@ WantedBy=multi-user.target<co xml:id="co-service-wrapper-target"/></screen>
    <title>服務管理員</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_runlevel.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_runlevel.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_runlevel.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_runlevel.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-tw/xml/tuning_multikernel.xml
+++ b/l10n/sles/zh-tw/xml/tuning_multikernel.xml
@@ -236,10 +236,10 @@
      <title>YaST 軟體管理員：多版本檢視</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_sw_multiversion.png" width="90%" format="PNG"/>
+       <imagedata fileref="yast2_sw_multiversion.png" width="90%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_sw_multiversion.png" width="90%" format="PNG"/>
+       <imagedata fileref="yast2_sw_multiversion.png" width="90%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/zh-tw/xml/uefi.xml
+++ b/l10n/sles/zh-tw/xml/uefi.xml
@@ -83,10 +83,10 @@
      <title>安全開機支援</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_bootloader_boot_code_efi.png" width="70%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/zh-tw/xml/updater_gnome.xml
+++ b/l10n/sles/zh-tw/xml/updater_gnome.xml
@@ -25,11 +25,11 @@
   <mediaobject>
    <imageobject role="fo">
     
-    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%" format="PNG"/>
+    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
     
-    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%" format="PNG"/>
+    <imagedata os="sles;sled" fileref="gnome_update_notification_desktop.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -47,10 +47,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="gupdater_updates.png" width="75%" format="PNG"/>
+      <imagedata fileref="gupdater_updates.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="gupdater_updates.png" width="75%" format="PNG"/>
+      <imagedata fileref="gupdater_updates.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>

--- a/l10n/sles/zh-tw/xml/updater_gnome_sw.xml
+++ b/l10n/sles/zh-tw/xml/updater_gnome_sw.xml
@@ -42,10 +42,10 @@
   <title><guimenu>GNOME Software</guimenu> — <guimenu>更新</guimenu>檢視</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="gnome-software-updates.png" width="75%" format="PNG"/>
+    <imagedata fileref="gnome-software-updates.png" width="75%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="gnome-software-updates.png" width="75%" format="PNG"/>
+    <imagedata fileref="gnome-software-updates.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>

--- a/l10n/sles/zh-tw/xml/vnc.xml
+++ b/l10n/sles/zh-tw/xml/vnc.xml
@@ -56,10 +56,10 @@
      <textobject role="description"><phrase>vncviewer asking for connection details</phrase>
      </textobject>
      <imageobject role="html">
-      <imagedata fileref="vnc_connect.png" format="PNG"/>
+      <imagedata fileref="vnc_connect.png"/>
      </imageobject>
      <imageobject role="fo">
-      <imagedata fileref="vnc_connect.png" format="PNG"/>
+      <imagedata fileref="vnc_connect.png"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -99,10 +99,10 @@
     <title>Remmina 的主視窗</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -114,16 +114,16 @@
   <sect2 xml:id="vnc-remmina-addnew">
    <title>新增遠端工作階段</title>
    <para>
-    若要新增和儲存新的遠端工作階段，請按一下主視窗右上方的 <inlinemediaobject><textobject role="description"><phrase>新增新工作階段</phrase></textobject><imageobject role="fo"><imagedata fileref="remmina_plus.png" width="1.2em" format="PNG"/></imageobject><imageobject role="html"><imagedata fileref="remmina_plus.png" width="1.2em" format="PNG"/></imageobject></inlinemediaobject>。<guimenu>遠端桌面優先設定</guimenu>視窗即會開啟。
+    若要新增和儲存新的遠端工作階段，請按一下主視窗右上方的 <inlinemediaobject><textobject role="description"><phrase>新增新工作階段</phrase></textobject><imageobject role="fo"><imagedata fileref="remmina_plus.png" width="1.2em"/></imageobject><imageobject role="html"><imagedata fileref="remmina_plus.png" width="1.2em"/></imageobject></inlinemediaobject>。<guimenu>遠端桌面優先設定</guimenu>視窗即會開啟。
    </para>
    <figure>
     <title>遠端桌面優先設定</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina_session_details.png" width="80%" format="PNG"/>
+      <imagedata fileref="remmina_session_details.png" width="80%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina_session_details.png" width="80%" format="PNG"/>
+      <imagedata fileref="remmina_session_details.png" width="80%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -203,10 +203,10 @@
      <title>快速啟動</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="remmina_quickstart.png" width="40%" format="PNG"/>
+       <imagedata fileref="remmina_quickstart.png" width="40%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="remmina_quickstart.png" width="40%" format="PNG"/>
+       <imagedata fileref="remmina_quickstart.png" width="40%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -229,10 +229,10 @@
      <title>正在檢視遠端工作階段的 Remmina</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>
+       <imagedata fileref="remmina_sle15inside.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="remmina_sle15inside.png" width="80%" format="PNG"/>
+       <imagedata fileref="remmina_sle15inside.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -267,10 +267,10 @@
     <title>讀取設定檔的路徑</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="remmina_status.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina_status.png" width="50%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="remmina_status.png" width="50%" format="PNG"/>
+      <imagedata fileref="remmina_status.png" width="50%"/>
      </imageobject>
     </mediaobject>
    </figure>
@@ -332,10 +332,10 @@
    <title>遠端管理</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="vnc_nosession.png" width="70%" format="PNG"/>
+     <imagedata fileref="vnc_nosession.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="vnc_nosession.png" width="70%" format="PNG"/>
+     <imagedata fileref="vnc_nosession.png" width="70%"/>
     </imageobject>
    </mediaobject>
   </figure>
@@ -561,10 +561,10 @@ WINDOWMANAGER=icewm vncserver -geometry 1024x768</screen>
      <title>VNC 工作階段設定</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="vncmanager_session.png" width="85%" format="PNG"/>
+       <imagedata fileref="vncmanager_session.png" width="85%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="vncmanager_session.png" width="85%" format="PNG"/>
+       <imagedata fileref="vncmanager_session.png" width="85%"/>
       </imageobject>
      </mediaobject>
     </figure>
@@ -649,10 +649,10 @@ WINDOWMANAGER=icewm vncserver -geometry 1024x768</screen>
      <title>加入永久 VNC 工作階段</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="vncmanager_whether.png" width="80%" format="PNG"/>
+       <imagedata fileref="vncmanager_whether.png" width="80%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="vncmanager_whether.png" width="80%" format="PNG"/>
+       <imagedata fileref="vncmanager_whether.png" width="80%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/zh-tw/xml/yast2_ftp.xml
+++ b/l10n/sles/zh-tw/xml/yast2_ftp.xml
@@ -67,10 +67,10 @@
    <title>FTP 伺服器組態 — 啟動</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_ftp-start-up.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_ftp-start-up.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_ftp-start-up.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_ftp-start-up.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-tw/xml/yast2_lang.xml
+++ b/l10n/sles/zh-tw/xml/yast2_lang.xml
@@ -91,10 +91,10 @@
    <informalfigure>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_language.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_language.png" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_language.png" width="75%" format="PNG"/>
+      <imagedata fileref="yast2_language.png" width="75%"/>
      </imageobject>
     </mediaobject>
    </informalfigure>
@@ -225,10 +225,10 @@
   <informalfigure>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_timezone.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_timezone.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_timezone.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_timezone.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -306,10 +306,10 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_timezone_ntp.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_timezone_ntp.png" width="75%"/>
       </imageobject>
       <imageobject role="pdf">
-       <imagedata fileref="yast2_timezone_ntp.png" width="75%" format="PNG"/>
+       <imagedata fileref="yast2_timezone_ntp.png" width="75%"/>
       </imageobject>
      </mediaobject>
     </informalfigure>

--- a/l10n/sles/zh-tw/xml/yast2_ncurses.xml
+++ b/l10n/sles/zh-tw/xml/yast2_ncurses.xml
@@ -15,10 +15,10 @@
   <title>文字模式下的 YaST 主視窗</title>
   <mediaobject>
    <imageobject role="fo">
-    <imagedata fileref="yast2_ncurses_main.png" width="70%" format="PNG"/>
+    <imagedata fileref="yast2_ncurses_main.png" width="70%"/>
    </imageobject>
    <imageobject role="html">
-    <imagedata fileref="yast2_ncurses_main.png" width="75%" format="PNG"/>
+    <imagedata fileref="yast2_ncurses_main.png" width="75%"/>
    </imageobject>
   </mediaobject>
  </figure>
@@ -99,10 +99,10 @@
    <title>軟體安裝模組</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_ncurses_inst.png" width="70%" format="PNG"/>
+     <imagedata fileref="yast2_ncurses_inst.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_ncurses_inst.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_ncurses_inst.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>

--- a/l10n/sles/zh-tw/xml/yast2_sw.xml
+++ b/l10n/sles/zh-tw/xml/yast2_sw.xml
@@ -152,10 +152,10 @@
      <phrase><guimenu>YaST</guimenu> software manager screen</phrase>
     </textobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_sw_manager.png" width="70%" format="PNG"/>
+     <imagedata fileref="yast2_sw_manager.png" width="70%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_sw_manager.png" width="65%" format="PNG"/>
+     <imagedata fileref="yast2_sw_manager.png" width="65%"/>
     </imageobject>
    </mediaobject>
   </informalfigure>
@@ -477,10 +477,10 @@
     <title>軟體管理員的衝突管理</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="yast2_package_conflict.png" width="70%" format="PNG"/>
+      <imagedata fileref="yast2_package_conflict.png" width="70%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="yast2_package_conflict.png" width="65%" format="PNG"/>
+      <imagedata fileref="yast2_package_conflict.png" width="65%"/>
      </imageobject>
     </mediaobject>
    </figure>

--- a/l10n/sles/zh-tw/xml/yast2_sw_repo.xml
+++ b/l10n/sles/zh-tw/xml/yast2_sw_repo.xml
@@ -52,10 +52,10 @@
      <title>新增軟體儲存庫</title>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_addon_new.png" width="70%" format="PNG"/>
+       <imagedata fileref="yast2_addon_new.png" width="70%"/>
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_addon_new.png" width="65%" format="PNG"/>
+       <imagedata fileref="yast2_addon_new.png" width="65%"/>
       </imageobject>
      </mediaobject>
     </figure>

--- a/l10n/sles/zh-tw/xml/yast2_userman.xml
+++ b/l10n/sles/zh-tw/xml/yast2_userman.xml
@@ -22,11 +22,11 @@
    <title>YaST 使用者及群組管理</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_users_main_qt.png" width="90%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_users_main_qt.png" width="90%" os="sles;sled"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_users_main_qt.png" width="70%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_users_main_qt.png" width="70%" os="sles;sled"/>
      
     </imageobject>
    </mediaobject>
@@ -388,11 +388,11 @@
      <informalfigure os="sles;sled">
       <mediaobject>
        <imageobject role="fo">
-        <imagedata fileref="yast2_users_quota_qt.png" width="80%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_users_quota_qt.png" width="80%" os="sles;sled"/>
         
        </imageobject>
        <imageobject role="html">
-        <imagedata fileref="yast2_users_quota_qt.png" width="70%" format="PNG" os="sles;sled"/>
+        <imagedata fileref="yast2_users_quota_qt.png" width="70%" os="sles;sled"/>
         
        </imageobject>
       </mediaobject>
@@ -558,11 +558,11 @@
     <informalfigure>
      <mediaobject>
       <imageobject role="fo">
-       <imagedata fileref="yast2_groups_edit_qt.png" width="80%" format="PNG" os="sles;sled"/>
+       <imagedata fileref="yast2_groups_edit_qt.png" width="80%" os="sles;sled"/>
        
       </imageobject>
       <imageobject role="html">
-       <imagedata fileref="yast2_groups_edit_qt.png" width="75%" format="PNG" os="sles;sled"/>
+       <imagedata fileref="yast2_groups_edit_qt.png" width="75%" os="sles;sled"/>
        
       </imageobject>
      </mediaobject>

--- a/l10n/sles/zh-tw/xml/yast2_you.xml
+++ b/l10n/sles/zh-tw/xml/yast2_you.xml
@@ -73,11 +73,11 @@
    <title>YaST 線上更新</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_you.png" width="75%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_you.png" width="75%" os="sles;sled"/>
      
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_you.png" width="75%" format="PNG" os="sles;sled"/>
+     <imagedata fileref="yast2_you.png" width="75%" os="sles;sled"/>
      
     </imageobject>
    </mediaobject>
@@ -204,10 +204,10 @@
    <title>檢視已收回的修補程式和歷程</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_retracted_patches.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_retracted_patches.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_retracted_patches.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_retracted_patches.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>  
@@ -245,10 +245,10 @@
    <title>YaST 線上更新組態</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="yast2_autoupdate.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_autoupdate.png" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="yast2_autoupdate.png" width="75%" format="PNG"/>
+     <imagedata fileref="yast2_autoupdate.png" width="75%"/>
     </imageobject>
    </mediaobject>
   </figure>


### PR DESCRIPTION
### PR creator: Description

We decided in our SLE sync call on 2022-09-26 to remove the `format` attribute from `<imagedata/>`. For l10n directory.

**This change only changes real files, NOT links**!


### PR creator: Are there any relevant issues/feature requests?

* DOCTEAM-584
* #1372


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 SP0
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4

- [ ] all necessary backports are done
