### PR TITLE
Security Guide: comment FIPS chapter for now

### DIFF
--- a/xml/book_security.xml
+++ b/xml/book_security.xml
@@ -77,7 +77,7 @@
   <xi:include href="security_vpnserver.xml"/>
   <xi:include href="security_xca.xml"/>
   <xi:include href="security_sysctl.xml"/>
-  <xi:include href="security_fips.xml"/>
+  <!--<xi:include href="security_fips.xml"/>-->
   </part>
 
  <part xml:id="part-apparmor">


### PR DESCRIPTION
### PR creator: Description

Temporarily remove the FIPS chapter from the Security Guide.


### PR creator: Are there any relevant issues/feature requests?

Based on input by Cert team (mail from 2022-10-12)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
