### PR TITLE
Remove broken link to Microfocus

### DIFF
--- a/xml/adm_support.xml
+++ b/xml/adm_support.xml
@@ -2219,14 +2219,12 @@ vsftpd yast2 yast2-ftp-server
      Basic Server Health Check with Supportconfig.
     </para>
    </listitem>
-   <!--
    <listitem>
     <para>
-     <link xlink:href="https://community.microfocus.com/t5/GroupWise-Tips-Information/Create-Your-Own-Supportconfig-Plugin/ta-p/1783289"/>&mdash;Create
+     <link xlink:href="https://community.microfocus.com/img/gw/groupwise/w/groupwise/34308/create-your-own-supportconfig-plugin"/>&mdash;Create
      Your Own Supportconfig Plugin.
     </para>
    </listitem>
-   -->
    <listitem>
     <para>
      <link xlink:href="https://www.suse.com/c/blog/creating-a-central-supportconfig-repository/"/>&mdash;Creating

--- a/xml/adm_support.xml
+++ b/xml/adm_support.xml
@@ -2219,12 +2219,14 @@ vsftpd yast2 yast2-ftp-server
      Basic Server Health Check with Supportconfig.
     </para>
    </listitem>
+   <!--
    <listitem>
     <para>
      <link xlink:href="https://community.microfocus.com/t5/GroupWise-Tips-Information/Create-Your-Own-Supportconfig-Plugin/ta-p/1783289"/>&mdash;Create
      Your Own Supportconfig Plugin.
     </para>
    </listitem>
+   -->
    <listitem>
     <para>
      <link xlink:href="https://www.suse.com/c/blog/creating-a-central-supportconfig-repository/"/>&mdash;Creating


### PR DESCRIPTION
### PR creator: Description

Reported by ContentKing.

The reported link doesn't exist anymore and should be removed or replaced. This was the old link:

    https://community.microfocus.com/t5/GroupWise-Tips-Information/Create-Your-Own-Supportconfig-Plugin/ta-p/1783289

A quick search revealed it is maybe here:

    https://community.microfocus.com/img/gw/groupwise/w/groupwise/34308/create-your-own-supportconfig-plugin


To whom it may concern: please make sure to

* backport it to the other branches and
* if possible, apply the patch to the l10n directories


### PR creator: Are there any relevant issues/feature requests?

n/a

### PR creator: Which product versions do the changes apply to?

The following release contains the broken link. Maybe it would be feasible to distribute the load.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 SP0
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4
- SLE Micro
  - [x] SLE Micro 5.2
  - [x] SLE Micro 5.1
  - [x] SLE Micro 5.0

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
