### PR TITLE
SLE-25081 add gTile

### DIFF
--- a/xml/gnome_custom.xml
+++ b/xml/gnome_custom.xml
@@ -645,6 +645,164 @@ commented out the screen. Texts taken from GNOME help.
     <xref linkend="sec-gnome-settings-hardware-screen-single"/>.
    </para>
   </sect2>
+ <sect2>
+  <title>Managing tiling windows on <productname>Wayland</productname></title>
+  <para>
+   If you are running &productname; on <productname>Wayland</productname> and
+   you want to have your windows arranged next to each other, it is recommended
+   to use the <productname>gTile</productname> extension.
+   <productname>gTile</productname> lets you re-arrange windows based on a
+   configurable grid scheme.  For example, you can launch six terminals, and 
+   have your terminals arranged in 3 rows and 2 columns, so that they use the
+   whole desktop area.
+  </para>
+  <para>
+   For more information about <productname>gTile</productname> and to download
+   the extension, refer to
+   <link xlink:href="https://extensions.gnome.org/extension/28/gtile/">.
+   </link>
+  </para>
+  <sect3>
+   <title>Installing <productname>gTile</productname> extension</title>
+   <procedure>
+    <title>Installing for a single user</title>
+    <step>
+     <para>
+     Download the extension from
+     <link xlink:href="https://extensions.gnome.org/extension/28/gtile/"></link>.
+     </para>
+     <remark>jufa 2022-10-31: as I don't see the On/Off button, I haven't
+      included this step here. Check, if it it now the Install button instead</remark>
+     <para>
+      The extension is stored to
+      <filename>~/.local/share/gnome-shell/extensions</filename> and activated
+      automatically.
+     </para>
+    </step>
+    <step>
+     <para>
+      Go to your &gnome; desktop. The <productname>gTile</productname> icon is
+      now shown in the right corner of the top bar.
+     </para>
+    </step>
+   </procedure>
+   <procedure>
+    <title>Installing from the command line</title>
+    <step>
+     <para>
+      Go to
+      <link xlink:href="https://extensions.gnome.org/extension/28/gtile/"></link>
+      and select the your <guimenu>Shell version</guimenu> and the
+      <guimenu>Extension version</guimenu> from the drop-down lists.
+     </para>
+     <para>
+      The extension is downloaded as <filename>.zip</filename> file.
+     </para>
+    </step>
+    <step>
+     <para>
+     In your command line, enter the following command
+     <command>gnome-extensions install <replaceable>FILENAME</replaceable>
+     </command>.
+     </para>
+    </step>
+    <step>
+     <para>
+      Go to your &gnome; desktop. The <productname>gTile</productname> icon is
+      now shown in the right corner of the top bar.
+     </para>
+    </step>
+   </procedure>
+   <note>
+    <title>System installation</title>
+    <para>
+     For a system installation, refer to
+     <link xlink:href="https://help.gnome.org/admin/system-admin-guide/stable/software.html.en#extension"></link>.
+    </para>
+   </note>
+  </sect3>
+  <sect3>
+   <title>Working with the <productname>gTile</productname> extension</title>
+   <procedure>
+    <title>Arranging the windows</title>
+    <step>
+    <para>
+     To open <productname>gTile</productname> for the currently focused window,
+     press
+     <keycombo><keycap function="meta"></keycap><keycap function="enter"></keycap></keycombo>.
+    </para>
+    </step>
+    <step>
+     <para>
+      To set the number of columns in which the windows will be arranged, press
+      a number key.
+     </para>
+    </step>
+    <step>
+     <para>
+      To automatically tile the windows according to the <guimenu>Autotile Main
+       window sizes</guimenu> setting, press the <keycap>M</keycap> key.
+      By default, the first time you press the <keycap>M</keycap> key, it will
+      make the current window use half the screen, and all other windows
+      to be tiled in a column on the other half of the screen. You can
+      press <keycap>M</keycap> repeatedly, to cycle between variants. This is
+      helpful to keep a big main window, and a number of smaller secondary
+      windows.
+     </para>
+    </step>
+    <step>
+     <para>
+      To move the current window to within the pre-defined tiling of the screen,
+      use the arrow keys.
+     </para>
+     <para>
+      To shrink or grow the number of tiles, use
+      <keycap function="shift"></keycap> and an arrow key.
+     </para>
+    </step>
+    <step>
+     <para>
+      To snap a window to the edges of the neighbor windows and the desktop,
+      press
+      <keycombo><keycap function="control"></keycap><keycap function="alt"></keycap><keycap>S</keycap></keycombo>.
+     </para>
+    </step>
+    <step>
+     <para>
+      To close the <productname>gTile</productname> window, press
+      <keycap function="escape"></keycap>.
+     </para>
+    </step>
+   </procedure>
+   <procedure>
+    <title>Advanced configuration</title>
+    <step>
+     <para>
+      To open the <productname>gTile</productname> settings, run the following
+      command:
+      <command>gnome-extensions-app</command>.
+     </para>
+    </step>
+    <step>
+     <para>
+      Select <productname>gTile</productname> and click on
+      <guimenu>Settings</guimenu>.
+     </para>
+    </step>
+    <step>
+     <para>
+      Define a preset and hotkey to easily switch between frequently used
+      window layouts.
+     </para>
+     <para>
+      For more details on how to configure the <productname>gTile</productname>
+      extension, refer to
+      <link xlink:href="https://github.com/gTile/gTile"></link>.
+     </para>
+    </step>
+   </procedure>
+  </sect3>
+ </sect2>
  </sect1>
 
  <sect1 xml:id="sec-gnome-settings-hardware-audio">


### PR DESCRIPTION
Description of how to install and use the gTile extension for window management added.

* jsc#SLE-25081


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
