### PR TITLE
correction: pattern for FIPS modules in SLE 15 SP3

### DIFF
--- a/xml/security_fips.xml
+++ b/xml/security_fips.xml
@@ -112,7 +112,7 @@
   <title>Installing FIPS</title>
   <para>
     It is best to install the
-    <package>patterns-server-enterprise-fips</package> pattern on a new
+    <package>patterns-base-fips</package> pattern on a new
     installation. Then, after the installation is complete, enable FIPS mode
     by running the steps in <xref linkend="sec-fips-enable"/>.
   </para>


### PR DESCRIPTION
### PR creator: Description

The correct pattern name for the FIPS configuration is patttern-base-fips instead of pattern-server-enterprise-fips

### PR creator: Are there any relevant issues/feature requests?

* bsc#1204981

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
