### PR TITLE
Added warning about conflicting time-sync services (bsc#1182393)

### DIFF
--- a/xml/chrony.xml
+++ b/xml/chrony.xml
@@ -47,8 +47,8 @@
   runtime.
  </para>
  <para>
-  Starting with &productname;&nbsp;15.2, the &yast; module for NTP client 
-  configuration configures the systemd-timer instead of the cron daemon 
+  Starting with &productname;&nbsp;15.2, the &yast; module for NTP client
+  configuration configures the systemd-timer instead of the cron daemon
   to execute &chrony;, when it is not configured to run as a daemon.
  </para>
  <note os="sled;osuse">
@@ -63,7 +63,7 @@
   <para>
    The NTP daemon (&chronyd;) coming with the <systemitem>chrony</systemitem>
    package is preset to use the local computer hardware clock as a time
-   reference.  The precision of a hardware clock heavily depends on its time
+   reference. The precision of a hardware clock heavily depends on its time
    source. For example, an atomic clock or GPS receiver is a very precise time
    source, while a common RTC chip is not a reliable time source.  &yast;
    simplifies the configuration of an NTP client.
@@ -253,6 +253,19 @@
   </para>
 
 <screen>systemctl enable chronyd.service</screen>
+  <warning>
+   <title>Conflicting <systemitem class="daemon">yast-timesync.service</systemitem> service</title>
+   <para>
+    Apart from the <systemitem class="daemon">chronyd.service</systemitem>
+    service, &productnameshort; includes the <systemitem
+    class="daemon">yast-timesync.service</systemitem> as well. <systemitem
+    class="daemon">yast-timesync.service</systemitem> is triggered by a timer
+    every 5 minutes and runs &chronyd; with the <option>-q</option> option to
+    set the system time and exit. Because only one instance of &chronyd; can be
+    running at any given time, do not enable or start both &chronyd; related
+    services at the same time.
+   </para>
+  </warning>
  </sect1>
  <sect1 xml:id="ntp-chronyc">
   <title>Configure &chronyd; at runtime using &chronyc;</title>

--- a/xml/chrony.xml
+++ b/xml/chrony.xml
@@ -63,9 +63,9 @@
   <para>
    The NTP daemon (&chronyd;) coming with the <systemitem>chrony</systemitem>
    package is preset to use the local computer hardware clock as a time
-   reference. The precision of a hardware clock heavily depends on its time
+   reference. The precision of the hardware clock heavily depends on its time
    source. For example, an atomic clock or GPS receiver is a very precise time
-   source, while a common RTC chip is not a reliable time source.  &yast;
+   source, while a common RTC chip is not a reliable time source. &yast;
    simplifies the configuration of an NTP client.
   </para>
 
@@ -256,13 +256,13 @@
   <warning>
    <title>Conflicting <systemitem class="daemon">yast-timesync.service</systemitem> service</title>
    <para>
-    Apart from the <systemitem class="daemon">chronyd.service</systemitem>
-    service, &productnameshort; includes the <systemitem
-    class="daemon">yast-timesync.service</systemitem> as well. <systemitem
+    In addition to the <systemitem class="daemon">chronyd.service</systemitem>
+    service, &productnameshort; includes <systemitem
+    class="daemon">yast-timesync.service</systemitem>. <systemitem
     class="daemon">yast-timesync.service</systemitem> is triggered by a timer
     every 5 minutes and runs &chronyd; with the <option>-q</option> option to
     set the system time and exit. Because only one instance of &chronyd; can be
-    running at any given time, do not enable or start both &chronyd; related
+    running at any given time, do not enable or start both &chronyd;-related
     services at the same time.
    </para>
   </warning>


### PR DESCRIPTION
### PR creator: Description

There are 2 conflicting time sync systemd services, this update warns about not enabling both of them.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1182393


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
