### PR TITLE
The pattern name for cockpit is named microos_cockpit instead microos-cockpit

### DIFF
--- a/xml/art_admin_slemicro_cockpit.xml
+++ b/xml/art_admin_slemicro_cockpit.xml
@@ -101,7 +101,7 @@
    described below. You can also use the following command in case Cockpit is not
    installed on your system.
   </para>
-<screen>&prompt.root;transactional-update pkg install -t pattern microos-cockpit</screen>
+<screen>&prompt.root;transactional-update pkg install -t pattern microos_cockpit</screen>
   <para>
    Reboot your machine to switch to the latest snapshot.
   </para>


### PR DESCRIPTION
…


All the patterns for microos contain underscores instead of dashes, it might be good to update all the documents if its not the case for the rest in microos documentation.

```
zypper search -t pattern microos
Loading repository data...
Reading installed packages...

S | Name                    | Summary                               | Type
--+-------------------------+---------------------------------------+--------
  | microos_apparmor        | Apparmor Support                      | pattern
  | microos_base            | openSUSE MicroOS                      | pattern
  | microos_base_microdnf   | openSUSE MicroOS using Micro DNF      | pattern
  | microos_base_packagekit | openSUSE MicroOS using PackageKit     | pattern
  | microos_base_zypper     | openSUSE MicroOS using Zypper         | pattern
  | microos_cloud           | Support for Cloud                     | pattern
  | microos_cockpit         | Web based remote system managemet     | pattern
  | microos_gnome_desktop   | MicroOS GNOME Desktop                 | pattern
  | microos_hardware        | Hardware Support                      | pattern
  | microos_ima_evm         | IMA/EVM Support                       | pattern
  | microos_kde_desktop     | MicroOS KDE Plasma Desktop            | pattern
  | microos_ra_agent        | Remote Attestation (Agent) Support    | pattern
  | microos_ra_verifier     | Remote Attestation (Verifier) Support | pattern
  | microos_selinux         | SELinux Support                       | pattern
  | microos_sssd_ldap       | LDAP client                           | pattern
```

