### PR TITLE
#PED-1582 mv folder evolution

### DIFF
--- a/xml/apps_evolution.xml
+++ b/xml/apps_evolution.xml
@@ -1117,6 +1117,15 @@
       Moves the folder to another location.
      </para>
     </formalpara>
+    <note>
+     <para>
+      By default, the user is asked to confirm before a folder is moved to
+      another place.
+      If this is not the case, refer to 
+      <link xlink:href="https://www.suse.com/support/kb/doc/?id=000020878"/>
+      to reset the settings.
+     </para>
+    </note>
     <formalpara>
      <title><guimenu>Delete</guimenu>:</title>
      <para>


### PR DESCRIPTION
### PR creator: Description

Add link to TID about how to fix behaviour in Evolution when moving a folder.


### PR creator: Are there any relevant issues/feature requests?

* jsc#PED-1582


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
