### PR TITLE
Depl. Guide: add info about deviceautoconfig (bsc#1188066)

### DIFF
--- a/xml/deployment_prep_zseries_prep_io_auto_config.xml
+++ b/xml/deployment_prep_zseries_prep_io_auto_config.xml
@@ -42,8 +42,40 @@ packagenames etc.)in all zSeries documents, because they are trademarks:
  </note>
 
  <para>
-  Auto-configuration can be disabled by using the
-  <option>rd.zdev=no-auto</option> kernel parameter.
+  In <command>linuxrc</command>, the <parameter>DeviceAutoConfig</parameter> parameter
+  controls the use of I/O device auto-configuration data for &zseries; systems.
+ </para>
+ <variablelist>
+   <varlistentry>
+    <term>DeviceAutoConfig=0</term>
+    <listitem>
+     <para>
+      If set to <literal>0</literal>, auto-configuration is disabled.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>DeviceAutoConfig=1</term>
+    <listitem>
+     <para>
+      If set to <literal>1</literal>, existing auto-config data are applied.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>DeviceAutoConfig=2 (default)</term>
+    <listitem>
+     <para>If set to <literal>2</literal> (the default), a dialog is shown if
+      auto-config data are present. The user is asked whether to apply them.
+     </para>
+    </listitem>
+   </varlistentry>
+ </variablelist>
+
+ <para>
+  If device auto-config is disabled by the user, the kernel parameter
+  <parameter>rd.zdev=no-auto</parameter> is added to the boot options of
+  the target system.
  </para>
 
  <para>


### PR DESCRIPTION
### PR creator: Description

Add missing info about the DeviceAutoConfig parameter for IBM Z systems.

### PR creator: Are there any relevant issues/feature requests?

* bsc#1188066



### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
