### PR TITLE
Remove <indexterm> from localized docs

### DIFF
--- a/l10n/sles/de-de/xml/64bit_issues.xml
+++ b/l10n/sles/de-de/xml/64bit_issues.xml
@@ -6,8 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary> 64-Bit-Linux</primary></indexterm> 
+ </info>
  <para>
   <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> ist für <phrase os="sles">verschiedene</phrase> 64-Bit-Plattformen verfügbar. Das bedeutet jedoch nicht unbedingt, dass alle enthaltenen Anwendungen bereits auf 64-Bit-Plattformen portiert wurden. <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> unterstützt die Verwendung von 32-Bit-Anwendungen in einer 64-Bit-Systemumgebung. Dieses Kapitel bietet einen kurzen Überblick darüber, wie diese Unterstützung auf <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>-64-Bit-Plattformen implementiert ist.
  </para>
@@ -25,11 +24,7 @@
 
 
  <sect1 xml:id="sec-64bit-runt">
-  <title>Laufzeitunterstützung</title><indexterm>
-
-  <primary> 64-Bit-Linux</primary>
-
-  <secondary> Laufzeitunterstützung</secondary></indexterm> 
+  <title>Laufzeitunterstützung</title>
 
   <important>
    <title>Konflikte zwischen Anwendungsversionen</title>
@@ -58,11 +53,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-64bit-kernel">
-  <title>Kernel-Spezifikationen</title><indexterm>
-
-  <primary> 64-Bit-Linux</primary>
-
-  <secondary> Kernel-Spezifikationen</secondary></indexterm> 
+  <title>Kernel-Spezifikationen</title>
 
   <para>
    Die 64-Bit-Kernel für AMD64/Intel 64<phrase os="sles">, IBM POWER und IBM Z </phrase> bieten sowohl eine 64-Bit- als auch eine 32-Bit-Kernel-ABI (binäre Anwendungsschnittstelle). Letztere ist mit der ABI für den entsprechenden 32-Bit-Kernel identisch. Das bedeutet, dass die 32-Bit-Anwendung mit dem 64-Bit-Kernel auf die gleiche Weise kommunizieren kann wie mit dem 32-Bit-Kernel.

--- a/l10n/sles/de-de/xml/aarch64_inst_problem.xml
+++ b/l10n/sles/de-de/xml/aarch64_inst_problem.xml
@@ -7,9 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary> Problemlösung</primary></indexterm> 
+ </info>
 
  <para>
   Vor der Bereitstellung wird <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> umfangreichen Tests unterzogen. Dennoch treten gelegentlich Probleme beim Start oder bei der Installation auf.

--- a/l10n/sles/de-de/xml/adm_shell.xml
+++ b/l10n/sles/de-de/xml/adm_shell.xml
@@ -13,10 +13,7 @@
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
  </info>
-<indexterm>
- <primary>Shell</primary></indexterm><indexterm>
- <primary>Bash</primary>
- <see>Shell</see></indexterm>
+
  <sect1 xml:id="sec-adm-whatistheshell">
   <title>Was ist <quote>die Shell</quote>?</title>
 
@@ -27,9 +24,7 @@
   </para>
 
   <sect2 xml:id="sec-adm-configfiles">
-   <title>Die Bash-Konfigurationsdateien</title><indexterm>
-   <primary> Konfigurationsdateien</primary>
-   <see> Bash</see></indexterm> 
+   <title>Die Bash-Konfigurationsdateien</title>
    <para>
     Eine Shell lässt sich aufrufen als:
    </para>
@@ -243,9 +238,7 @@
   <xi:include href="fs_structure_i.xml"/>
  </sect1>
  <sect1 xml:id="sec-adm-shellscripts">
-  <title>Schreiben von Shell-Skripten</title><indexterm>
-
-  <primary> Shell-Skripten</primary></indexterm> 
+  <title>Schreiben von Shell-Skripten</title>
 
   <para>
    Shell-Skripte bieten eine bequeme Möglichkeit, die verschiedensten Aufgaben zu erledigen: Erfassen von Daten, Suche nach einem Wort oder Begriff in einem Text und andere nützliche Dinge. Das folgende Beispiel zeigt ein kleines Shell-Skript, das einen Text druckt:
@@ -259,9 +252,7 @@ echo "Hello World" <co xml:id="co-adm-shell-echo"/></screen>
    <calloutlist>
     <callout arearefs="co-adm-shell-shebang">
      <para>
-      Die erste Zeile beginnt mit dem <emphasis>Shebang</emphasis> <indexterm>
-      <primary>  Shebang</primary>
-      </indexterm> -Zeichen (<literal>#!</literal>), das darauf hinweist, dass es sich bei dieser Datei um ein Skript handelt. Das Skript wird mit dem Interpreter ausgeführt, der nach dem Shebang angegeben ist, in diesem Fall mit <command>/bin/sh</command>.
+      Die erste Zeile beginnt mit dem <emphasis>Shebang</emphasis>  -Zeichen (<literal>#!</literal>), das darauf hinweist, dass es sich bei dieser Datei um ein Skript handelt. Das Skript wird mit dem Interpreter ausgeführt, der nach dem Shebang angegeben ist, in diesem Fall mit <command>/bin/sh</command>.
      </para>
     </callout>
     <callout arearefs="co-adm-shell-comment">
@@ -411,9 +402,7 @@ echo "Hello World" <co xml:id="co-adm-shell-echo"/></screen>
 <screen>find / -name "foo*" 2&gt;/dev/null</screen>
  </sect1>
  <sect1 xml:id="sec-adm-alias">
-  <title>Verwenden von Aliassen</title><indexterm>
-
-  <primary>aliases</primary></indexterm>
+  <title>Verwenden von Aliassen</title>
 
   <para>
    Ein Alias ist ein Definitionskürzel für einen oder mehrere Kommandos. Die Syntax für einen Alias lautet:

--- a/l10n/sles/de-de/xml/adm_support.xml
+++ b/l10n/sles/de-de/xml/adm_support.xml
@@ -22,9 +22,7 @@
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
  </info>
-<indexterm>
- <primary>Support</primary></indexterm><indexterm>
- <primary>Systeminformationen</primary></indexterm>
+
  <sect1 xml:id="sec-admsupport-hostinfo">
   <title>Anzeigen aktueller Systeminformationen</title>
 

--- a/l10n/sles/de-de/xml/apache2.xml
+++ b/l10n/sles/de-de/xml/apache2.xml
@@ -11,14 +11,9 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm class="startofrange" xml:id="idx-apache2">
- <primary> Apache</primary></indexterm> 
+ </info>
  <sect1 xml:id="sec-apache2-quickstart">
-  <title>Kurzanleitung</title><indexterm>
-
-  <primary> Apache</primary>
-
-  <secondary> Schnelleinführung</secondary></indexterm> 
+  <title>Kurzanleitung</title>
 
   <para>
    In diesem Abschnitt finden Sie Informationen zum schnellen Einrichten und Starten von Apache. Zur Installation und Konfiguration von Apache müssen Sie <systemitem class="username">root</systemitem>-Benutzer sein.
@@ -54,9 +49,7 @@
   </sect2>
 
   <sect2 xml:id="sec-apache2-quickstart-installation">
-   <title>Installation</title><indexterm>
-   <primary> Apache</primary>
-   <secondary> installieren</secondary></indexterm> 
+   <title>Installation</title>
    <para>
     Apache ist in der Standardinstallation von <phrase role="productname"><phrase os="sles"> SUSE Linux Enterprise Server</phrase></phrase> nicht enthalten. Zum Installieren von Apache mit einer vordefinierten Standardkonfiguration <quote/> gehen Sie wie folgt vor:
    </para>
@@ -129,11 +122,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-apache2-configuration">
-  <title>Konfigurieren von Apache</title><indexterm>
-
-  <primary> Apache</primary>
-
-  <secondary> konfigurieren</secondary></indexterm> 
+  <title>Konfigurieren von Apache</title>
 
   <para>
    <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> bietet zwei Konfigurationsoptionen:
@@ -167,10 +156,7 @@
   </important>
 
   <sect2 xml:id="sec-apache2-configuration-manually-configfiles">
-   <title>Apache-Konfigurationsdateien</title><indexterm>
-   <primary> Apache </primary>
-   <secondary> konfigurieren </secondary>
-   <tertiary> Dateien</tertiary></indexterm> 
+   <title>Apache-Konfigurationsdateien</title>
    <para>
     Dieser Abschnitt enthält eine Übersicht über die Apache-Konfigurationsdateien. Wenn Sie die Konfiguration mit YaST vornehmen, müssen Sie diese Dateien nicht bearbeiten. Die Informationen können jedoch nützlich sein, wenn Sie später auf die manuelle Konfiguration umstellen möchten.
    </para>
@@ -362,18 +348,12 @@
   </sect2>
 
   <sect2 xml:id="sec-apache2-configuration-manually">
-   <title>Manuelle Konfiguration von Apache</title><indexterm class="startofrange" xml:id="idx-apache2-configuration-manually">
-   <primary> Apache </primary>
-   <secondary> konfigurieren </secondary>
-   <tertiary> manuell</tertiary></indexterm> 
+   <title>Manuelle Konfiguration von Apache</title>
    <para>
     Wenn Sie den Apache-Webserver manuell konfigurieren möchten, müssen Sie die Klartext-Konfigurationsdateien als <systemitem class="username">root</systemitem>-Benutzer bearbeiten.
    </para>
    <sect3 xml:id="sec-apache2-configuration-manually-vhost">
-    <title>Virtuelle Hostkonfiguration</title><indexterm>
-    <primary> Apache</primary>
-    <secondary> konfigurieren</secondary>
-    <tertiary> virtueller Host</tertiary></indexterm> 
+    <title>Virtuelle Hostkonfiguration</title>
     <para>
      <emphasis>Virtueller Host</emphasis> bezieht sich auf die Fähigkeit von Apache, mehrere URI (Universal Resource Identifiers) vom gleichen physischen Computer aus bedienen zu können. In anderen Worten: Mehrere Domänen wie www.beispiel.com und www.beispiel.net können von einem einzigen Webserver auf einem physischen Computer ausgeführt werden.
     </para>
@@ -558,7 +538,7 @@ Allow from all</screen>
   Require all granted
   &lt;/Directory&gt;
 &lt;/VirtualHost&gt;</screen>
-     </example><indexterm class="endofrange" startref="idx-apache2-configuration-manually"/>
+     </example>
     </sect4>
    </sect3>
   </sect2>
@@ -570,15 +550,7 @@ Allow from all</screen>
 
  </sect1>
  <sect1 xml:id="sec-apache2-start-stop">
-  <title>Starten und Beenden von Apache</title><indexterm>
-
-  <primary>Apache</primary>
-
-  <secondary>Starten</secondary></indexterm><indexterm>
-
-  <primary>Apache</primary>
-
-  <secondary>Beenden</secondary></indexterm>
+  <title>Starten und Beenden von Apache</title>
 
   <remark>taroth 2014-02-11: @file-maintainer: please give the following a
  thorough check - so far I only replaced the rc* commands by the systemctl
@@ -707,11 +679,7 @@ Allow from all</screen>
   </tip>
  </sect1>
  <sect1 xml:id="sec-apache2-modules">
-  <title>Installieren, Aktivieren und Konfigurieren von Modulen</title><indexterm class="startofrange" xml:id="idx-apache2-modules">
-
-  <primary> Apache</primary>
-
-  <secondary> Module</secondary></indexterm> 
+  <title>Installieren, Aktivieren und Konfigurieren von Modulen</title>
 
   <para>
    Die Apache-Software ist modular aufgebaut. Alle Funktionen außer einigen Kernaufgaben werden von Modulen durchgeführt Dies geht sogar so weit, dass selbst HTTP durch ein Modul verarbeitet wird (<systemitem>http_core</systemitem>).
@@ -761,10 +729,7 @@ Allow from all</screen>
   </variablelist>
 
   <sect2 xml:id="sec-apache2-modules-installing">
-   <title>Installieren von Modulen</title><indexterm>
-   <primary> Apache </primary>
-   <secondary> Module </secondary>
-   <tertiary> installieren</tertiary></indexterm> 
+   <title>Installieren von Modulen</title>
    <para>
     Wenn Sie die in <xref linkend="sec-apache2-quickstart-installation"/> beschriebene Standardinstallation vorgenommen haben, sind folgende Module bereits installiert: alle Basis- und Erweiterungsmodule, das Multiprocessing-Modul Prefork MPM sowie das externe Modul <systemitem>mod_python</systemitem>.
    </para>
@@ -790,10 +755,7 @@ Allow from all</screen>
   </sect2>
 
   <sect2 xml:id="sec-apache2-modules-base-extension">
-   <title>Basis- und Erweiterungsmodule</title><indexterm>
-   <primary> Apache </primary>
-   <secondary> Module </secondary>
-   <tertiary> verfügbar</tertiary></indexterm> 
+   <title>Basis- und Erweiterungsmodule</title>
    <para>
     Alle Basis- und Erweiterungsmodule werden ausführlich in der Apache-Dokumentation beschrieben. An dieser Stelle gehen wir daher nur kurz auf die wichtigsten Module ein. Informationen zu den einzelnen Modulen erhalten Sie auch unter <link xlink:href="http://httpd.apache.org/docs/2.4/mod/">http://httpd.apache.org/docs/2.4/mod/</link>.
    </para>
@@ -1010,10 +972,7 @@ Allow from all</screen>
   </sect2>
 
   <sect2 xml:id="sec-apache2-modules-mpm">
-   <title>Multiprocessing-Module</title><indexterm>
-   <primary> Apache </primary>
-   <secondary> Module </secondary>
-   <tertiary> Multiprocessing</tertiary></indexterm> 
+   <title>Multiprocessing-Module</title>
    <para>
     <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> bietet zwei Multiprocessing-Module (MPMs) für Apache:
    </para>
@@ -1062,10 +1021,7 @@ Allow from all</screen>
   </sect2>
 
   <sect2 xml:id="sec-apache2-modules-external">
-   <title>Externe Module</title><indexterm>
-   <primary> Apache </primary>
-   <secondary> Module </secondary>
-   <tertiary> externe</tertiary></indexterm> 
+   <title>Externe Module</title>
    <para>
     Nachfolgend finden Sie eine Liste aller externen Module, die mit <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> ausgeliefert werden. Die Dokumentation zu den einzelnen Modulen finden Sie in den jeweils genannten Verzeichnissen.
    </para>
@@ -1157,10 +1113,7 @@ Allow from all</screen>
   </sect2>
 
   <sect2 xml:id="sec-apache2-modules-building-modules">
-   <title>Kompilieren von Modulen</title><indexterm>
-   <primary> Apache</primary>
-   <secondary> Module </secondary>
-   <tertiary> erstellen</tertiary></indexterm> 
+   <title>Kompilieren von Modulen</title>
    <para>
     Apache kann von erfahrenen Benutzern durch selbst entwickelte Module erweitert werden. Für die Entwicklung eigener Apache-Module und für die Kompilierung von Drittanbieter-Modulen sind neben dem Paket <systemitem>apache2-devel</systemitem> auch die entsprechenden Entwicklungstools erforderlich. <systemitem>apache2-devel</systemitem> enthält unter anderem die <command>apxs2</command>-Tools, die zur Kompilierung von Apache-Erweiterungsmodulen erforderlich sind.
    </para>
@@ -1194,15 +1147,11 @@ Allow from all</screen>
 apxs2 -cia <replaceable>MODULE</replaceable>.c</screen>
    <para>
     wobei das Modul mit <option>-c</option> kompiliert, mit <option>-i</option> installiert und mit <option>-a</option> aktiviert wird. Alle weiteren Optionen von <command>apxs2</command> werden auf der man-Seite <systemitem>apxs2(1)</systemitem> beschrieben.
-   </para><indexterm class="endofrange" startref="idx-apache2-modules"/>
+   </para>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-apache2-cgi">
-  <title>Aktivieren von CGI-Skripten</title><indexterm>
-
-  <primary>Apache</primary>
-
-  <secondary> CGI-Skripte</secondary></indexterm>
+  <title>Aktivieren von CGI-Skripten</title>
 
   <para>
    Die Common Gateway Interface (CGI) von Apache ermöglicht die Erstellung dynamischer Inhalte mit Programmen bzw. sogenannten CGI-Skripten. CGI-Skripten können in jeder beliebigen Programmiersprache geschrieben sein. In der Regel werden aber die Skriptsprachen Perl oder PHP verwendet.
@@ -1306,11 +1255,7 @@ apxs2 -cia <replaceable>MODULE</replaceable>.c</screen>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-apache2-ssl">
-  <title>Einrichten eines sicheren Webservers mit SSL</title><indexterm class="startofrange" xml:id="idx-apache2-ssl">
-
-  <primary> Apache</primary>
-
-  <secondary> SSL</secondary></indexterm> 
+  <title>Einrichten eines sicheren Webservers mit SSL</title>
 
   <para>
    Wenn sensible Daten wie Kreditkarteninformationen zwischen Webserver und Client übertragen werden, ist eine sichere, verschlüsselte Verbindung mit Authentifizierung wünschenswert. <systemitem>mod_ssl</systemitem> bietet mittels der Protokolle Secure Sockets Layer (SSL) und Transport Layer Security (TLS) eine sichere Verschlüsselung für die HTTP-Kommunikation zwischen einem Client und dem Webserver. Wenn Sie SSL/TLS verwenden, wird zwischen dem Webserver und dem Client eine private Verbindung eingerichtet. Die Datenintegrität bleibt dadurch gewährleistet und Client und Server können sich gegenseitig authentifizieren.
@@ -1329,10 +1274,7 @@ apxs2 -cia <replaceable>MODULE</replaceable>.c</screen>
   </para>
 
   <sect2 xml:id="sec-apache2-ssl-certificate">
-   <title>Erstellen eines SSL-Zertifikats</title><indexterm>
-   <primary> Apache</primary>
-   <secondary> SSL</secondary>
-   <tertiary> SSL-Zertifikat erstellen</tertiary></indexterm> 
+   <title>Erstellen eines SSL-Zertifikats</title>
    <para>
     Wenn Sie SSL/TLS mit dem Webserver einsetzen möchten, müssen Sie ein SSL-Zertifikat erstellen. Dieses Zertifikat ist für die Autorisierung zwischen Webserver und Client erforderlich, damit beide Endpunkte jeweils die Identität des anderen Endpunkts überprüfen können. Zum Nachweis der Zertifikatintegrität muss das Zertifikat von einer Organisation signiert sein, der jeder der beteiligten Benutzer vertraut.
    </para>
@@ -1537,10 +1479,7 @@ sudo cp new.cert.key /etc/apache2/ssl.key/server.key</screen>
   </sect2>
 
   <sect2 xml:id="sec-apache2-ssl-configuration">
-   <title>Konfigurieren von Apache mit SSL</title><indexterm>
-   <primary> Apache</primary>
-   <secondary> SSL</secondary>
-   <tertiary> Apache mit SSL konfigurieren</tertiary></indexterm> 
+   <title>Konfigurieren von Apache mit SSL</title>
    <para>
     Port 443 ist auf dem Webserver der Standardport für SSL- und TLS-Anforderungen. Zwischen einem <quote>normalen</quote> Apache-Webserver, der Port 80 überwacht, und einem SSL/TLS-aktivierten Apache-Server, der Port 443 überwacht, kommt es zu keinen Konflikten. In der Tat kann die gleiche Apache-Instanz sowohl HTTP als auch HTTPS ausführen. In der Regel verteilen separate virtuelle Hosts die Anforderungen für Port 80 und Port 443 an separate virtuelle Server.
    </para>
@@ -1608,7 +1547,7 @@ sudo cp new.cert.key /etc/apache2/ssl.key/server.key</screen>
      <para>
       Wenn in der Serverkonfiguration <literal>off</literal> festgelegt ist, verhält sich der Server wie ohne SNI-Unterstützung. SSL-Anforderungen werden durch den <emphasis>ersten</emphasis> (für Port 443) definierten virtuellen Host bearbeitet.
      </para>
-    </important><indexterm class="endofrange" startref="idx-apache2-ssl"/>
+    </important>
    </sect3>
   </sect2>
  </sect1>
@@ -1779,11 +1718,7 @@ apachectl start</screen>
   </itemizedlist>
  </sect1>
  <sect1 xml:id="sec-apache2-security">
-  <title>Vermeiden von Sicherheitsproblemen</title><indexterm>
-
-  <primary> Apache</primary>
-
-  <secondary> Sicherheit</secondary></indexterm> 
+  <title>Vermeiden von Sicherheitsproblemen</title>
 
   <para>
    Ein dem öffentlichen Internet ausgesetzter Webserver erfordert ständige Wartungs- und Verwaltungsarbeiten. Sicherheitsprobleme, verursacht durch die Software wie auch durch versehentliche Fehlkonfigurationen, sind kaum zu vermeiden. Im Folgenden einige Tipps zur Verbesserung der Sicherheit.
@@ -1857,11 +1792,7 @@ apachectl start</screen>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-apache2-troubleeshooting">
-  <title>Fehlerbehebung</title><indexterm>
-
-  <primary>Apache</primary>
-
-  <secondary> Fehlersuche</secondary></indexterm>
+  <title>Fehlerbehebung</title>
 
   <para>
    Wenn sich Apache nicht starten lässt, eine Webseite nicht angezeigt werden kann oder Benutzer keine Verbindung zum Webserver herstellen können, müssen Sie die Ursache des Problems herausfinden. Im Folgenden werden einige nützliche Ressourcen vorgestellt, die Ihnen bei der Fehlersuche behilflich sein können:
@@ -2010,7 +1941,7 @@ apachectl start</screen>
    <title>Verschiedene Informationsquellen</title>
    <para>
     Wenn Sie in <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> Probleme mit Apache haben, werfen Sie einen Blick in die technische Informationssuche unter <link xlink:href="http://www.suse.com/support"/>. Die Entstehungsgeschichte von Apache finden Sie unter <link xlink:href="http://httpd.apache.org/ABOUT_APACHE.html"/>. Auf dieser Seite erfahren Sie auch, weshalb dieser Server Apache genannt wird.
-   </para><indexterm class="endofrange" startref="idx-apache2"/>
+   </para>
   </sect2>
  </sect1>
 </chapter>

--- a/l10n/sles/de-de/xml/apache2_yast_i.xml
+++ b/l10n/sles/de-de/xml/apache2_yast_i.xml
@@ -6,10 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm class="startofrange" xml:id="idx-apache2-configuration-yast">
- <primary>Apache</primary>
- <secondary> konfigurieren</secondary>
- <tertiary> YaST</tertiary></indexterm>
+ </info>
  <para>
   Zur Konfiguration des Webservers mit YaST starten Sie YaST, und wählen Sie <menuchoice> <guimenu>Netwerkdienste</guimenu> <guimenu>HTTP-Server</guimenu> </menuchoice>. Wenn Sie dieses Modul zum ersten Mal starten, wird der <guimenu>HTTP-Server-Assistent</guimenu> geöffnet und sie werden aufgefordert, einige grundlegende Entscheidungen zur Verwaltung des Servers zu treffen. Nach Fertigstellung des Assistenten wird das Dialogfeld <guimenu>HTTP-Server-Konfiguration</guimenu> geöffnet, sobald Sie das <guimenu>HTTP-Server</guimenu>-Modul aufrufen. Weitere Informationen finden Sie unter <xref linkend="sec-apache2-configuration-yast-server-configuration"/>.
  </para>
@@ -221,7 +218,7 @@
    <title>Haupthost oder Hosts</title>
    <para>
     Diese Dialogfelder sind mit den bereits beschriebenen identisch. in <xref linkend="sec-apache2-configuration-yast-wizard-default-host"/> und <xref linkend="sec-apache2-configuration-yast-wizard-virtual-hosts"/> beschriebenen Dialogfeldern.
-   </para><indexterm class="endofrange" startref="idx-apache2-configuration-yast"/>
+   </para>
   </sect4>
  </sect3>
 </sect2>

--- a/l10n/sles/de-de/xml/apps_brasero.xml
+++ b/l10n/sles/de-de/xml/apps_brasero.xml
@@ -15,26 +15,9 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-brasero" class="startofrange">
- <primary> Brasero</primary></indexterm> 
+ </info>
  <sect1 xml:id="sec-brasero-creating">
-  <title>Erstellen einer Daten-CD oder -DVD</title><indexterm>
-
-  <primary>CDs</primary>
-
-  <secondary>Erstellung</secondary>
-
-  <tertiary>Daten</tertiary></indexterm><indexterm>
-
-  <primary>K3b</primary>
-
-  <secondary>Daten-CDs</secondary></indexterm><indexterm>
-
-  <primary>DVDs</primary>
-
-  <secondary>Erstellung</secondary>
-
-  <tertiary>Daten</tertiary></indexterm>
+  <title>Erstellen einer Daten-CD oder -DVD</title>
 
   <para>
    Wenn Sie Brasero zum ersten Mal gestartet haben, wird das Hauptfenster so angezeigt wie in <xref linkend="fig-brasero-main" xrefstyle="select:label nopage"/> dargestellt. 
@@ -116,17 +99,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-brasero-creatingaudiocd">
-  <title>Erstellen einer Audio-CD</title><indexterm>
-
-  <primary> CDs</primary>
-
-  <secondary> Erstellung</secondary>
-
-  <tertiary> Audio</tertiary></indexterm><indexterm>
-
-  <primary>   Brasero</primary>
-
-  <secondary> Audio-CDs</secondary></indexterm> 
+  <title>Erstellen einer Audio-CD</title>
 
   <para>
    Es gibt keine wesentlichen Unterschiede zwischen dem Erstellen einer Audio-CD und dem Erstellen einer Daten-CD. Führen Sie dazu die folgenden Schritte aus:
@@ -168,19 +141,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-brasero-copying">
-  <title>Kopieren einer CD oder DVD</title><indexterm>
-
-  <primary>CDs</primary>
-
-  <secondary>Kopieren</secondary></indexterm><indexterm>
-
-  <primary>Brasero</primary>
-
-  <secondary>Kopieren von CDs</secondary></indexterm><indexterm>
-
-  <primary>DVDs</primary>
-
-  <secondary>Kopieren</secondary></indexterm>
+  <title>Kopieren einer CD oder DVD</title>
 
   <para>
    Führen Sie zum Kopieren einer CD oder DVD die folgenden Schritte aus:
@@ -216,15 +177,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-gnome-writingiso">
-  <title>Schreiben von ISO-Abbildern</title><indexterm>
-
-  <primary>CDs</primary>
-
-  <secondary> ISO-Images</secondary></indexterm><indexterm>
-
-  <primary> DVDs</primary>
-
-  <secondary> ISO-Images</secondary></indexterm>
+  <title>Schreiben von ISO-Abbildern</title>
 
   <para>
    Wenn Sie bereits ein ISO-Abbild besitzen, klicken Sie auf <guimenu>Burn image</guimenu> (Abbild brennen) oder wählen Sie <menuchoice> <guimenu>Project</guimenu> <guimenu>(Projekt) New Project</guimenu>
@@ -232,11 +185,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-brasero-multisession">
-  <title>Erstellen einer Multisession-CD oder -DVD</title><indexterm>
-
-  <primary> CDs</primary>
-
-  <secondary> Multisession</secondary></indexterm> 
+  <title>Erstellen einer Multisession-CD oder -DVD</title>
 
   <para>
    Bei Multisession-Discs können Daten in mehreren Brennvorgängen geschrieben werden. Das bietet sich z. B. für Backups an, die kleiner sind als das Medium. Sie können bei jedem neuen Brennvorgang eine weitere Backup-Datei hinzufügen. Das Interessante hierbei ist, dass Sie nicht auf Daten-CDs oder -DVDs beschränkt sind. Bei einer Multisession-Disc können Sie auch Audiodateien hinzufügen.
@@ -274,6 +223,6 @@
 
   <para>
    Weitere Informationen zu Brasero finden Sie unter <link xlink:href="https://wiki.gnome.org/Apps/Brasero"/>.
-  </para><indexterm class="endofrange" startref="idx-brasero"/>
+  </para>
  </sect1>
 </chapter>

--- a/l10n/sles/de-de/xml/apps_ekiga.xml
+++ b/l10n/sles/de-de/xml/apps_ekiga.xml
@@ -11,12 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-voip" class="startofrange">
- <primary>Voice-over-IP</primary></indexterm><indexterm>
- <primary>Anwendungen</primary>
- <secondary>Netzwerk</secondary>
- <tertiary>Ekiga</tertiary></indexterm><indexterm xml:id="idx-ekiga" class="startofrange">
- <primary>Ekiga</primary></indexterm>
+ </info>
  <note>
   <title>Keine Installation von Ekiga</title>
   <para>
@@ -387,11 +382,7 @@
   </table>
  </sect1>
  <sect1 xml:id="sec-ekiga-firstcall">
-  <title>Tätigen eines Anrufs</title><indexterm>
-
-  <primary> Anrufen mit</primary>
-
-  <secondary> Ekiga</secondary></indexterm> 
+  <title>Tätigen eines Anrufs</title>
 
   <para>
    Sobald Ekiga ordnungsgemäß konfiguriert wurde, ist das Telefonieren ganz leicht.
@@ -531,8 +522,7 @@
   </para>
 
   <para>
-   Wenn Sie ein privates Telefonnetz einrichten wollen, könnte die <literal>PBX</literal>-Software Asterisk <link xlink:href="http://www.asterisk.org/"/> für Sie von Interesse sein. Weitere Informationen finden Sie unter <link xlink:href="http://www.voip-info.org/wiki-Asterisk"/>. <indexterm startref="idx-ekiga" class="endofrange"/>
-   <indexterm startref="idx-voip" class="endofrange"/>
+   Wenn Sie ein privates Telefonnetz einrichten wollen, könnte die <literal>PBX</literal>-Software Asterisk <link xlink:href="http://www.asterisk.org/"/> für Sie von Interesse sein. Weitere Informationen finden Sie unter <link xlink:href="http://www.voip-info.org/wiki-Asterisk"/>.
   </para>
  </sect1>
 </chapter>

--- a/l10n/sles/de-de/xml/apps_firefox.xml
+++ b/l10n/sles/de-de/xml/apps_firefox.xml
@@ -11,13 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm class="startofrange" xml:id="idx-firefox">
- <primary>Firefox</primary></indexterm><indexterm class="startofrange" xml:id="idx-browsers-firefox">
- <primary>Webbrowser</primary>
- <secondary>Firefox</secondary></indexterm><indexterm>
- <primary>Anwendungen</primary>
- <secondary>Netzwerk</secondary>
- <tertiary>Firefox</tertiary></indexterm>
+ </info>
  <sect1 xml:id="sec-firefox-start">
   <title>Starten von Firefox</title>
 
@@ -27,11 +21,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-firefox-navigating">
-  <title>Navigieren im Internet</title><indexterm>
-
-  <primary> Firefox</primary>
-
-  <secondary> Navigieren</secondary></indexterm> 
+  <title>Navigieren im Internet</title>
 
   <para>
    Firefox ist in Aussehen und Verhalten mit anderen Browsern zu vergleichen. Siehe <xref linkend="fig-firefox-main"/>. Oben im Fenster befinden sich die Adressleiste, in die Sie die Webadresse eingeben können, und die Suchleiste. Die Lesezeichen-Symbolleiste bietet Lesezeichen für einen schnellen Zugriff. Weitere Informationen zu den einzelnen Funktionen von Firefox erhalten Sie im Menü <guimenu>Hilfe</guimenu>.
@@ -72,9 +62,7 @@
   </figure>
 
   <sect2 xml:id="sec-firefox-locationbar">
-   <title>Die Adressleiste</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> Adressleiste</secondary></indexterm> 
+   <title>Die Adressleiste</title>
    <para>
     Wenn Sie Text in die Adressleiste eingeben, wird ein Dropdown-Feld mit AutoVervollständigen-Optionen geöffnet. Hier werden alle bisher eingegebenen Adressen und Lesezeichen angezeigt, die die eingegebenen Zeichen enthalten. Passende Texte werden hervorgehoben. Am Kopf der Liste werden die am häufigsten und zuletzt besuchten Adressen aufgeführt.
    </para>
@@ -87,9 +75,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-zoom">
-   <title>Zoomen</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> Zoom</secondary></indexterm> 
+   <title>Zoomen</title>
    <para>
     Firefox bietet zwei Zoom-Optionen: Seitenzoom, die Standardoption, und Textzoom. Mit dem Seitenzoom wird die gesamte Seite mit all ihren Elementen, einschließlich der Grafiken, vergrößert, während mithilfe des Textzooms nur die Textgröße verändert wird.
    </para>
@@ -102,11 +88,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-tabbedbrowsing">
-   <title>Tabbed Browsing</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary>Tabs</secondary></indexterm><indexterm>
-   <primary>Firefox</primary>
-   <secondary>Suchen über Tabs</secondary></indexterm>
+   <title>Tabbed Browsing</title>
    <para>
     Mithilfe der Registernavigation („Tabbed browsing“) können Sie mehrere Websites in einem einzelnen Fenster laden. Über die Registerkarten oben im Fenster wechseln Sie zwischen den geöffneten Seiten. Wenn Sie häufig mehrere Webseiten gleichzeitig verwenden, wird der Wechsel zwischen diesen Seiten durch Tabbed Browsing noch einfacher. 
    </para>
@@ -153,9 +135,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-sidebar">
-   <title>Verwenden der Sidebar</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> Sidebar</secondary></indexterm> 
+   <title>Verwenden der Sidebar</title>
    <para>
     Auf der linken Seite des Browserfensters können Sie Lesezeichen und die Browser-Chronik anzeigen. Durch Erweiterungen lassen sich der Sidebar weitere Funktionen hinzufügen. Zum Einblenden der Sidebar klicken Sie in der Menüleiste auf <menuchoice> <guimenu>Ansicht</guimenu>
     <guimenu>Sidebar</guimenu> </menuchoice> und wählen Sie den gewünschten Inhalt aus.
@@ -170,13 +150,7 @@
   </para>
 
   <sect2 xml:id="sec-firefox-searchengine">
-   <title>Informationssuche im Web</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> Suche mit</secondary></indexterm><indexterm>
-   <primary>   Firefox</primary>
-   <secondary> Suchleiste</secondary></indexterm><indexterm>
-   <primary>   Firefox</primary>
-   <secondary> Websuche</secondary></indexterm> 
+   <title>Informationssuche im Web</title>
    <para>
     Firefox hat eine Suchleiste, in der Sie auf verschiedene Suchmaschinen wie Google, Yahoo oder Amazon zugreifen können. Möchten Sie sich zum Beispiel mithilfe der aktuellen Suchmaschine über SUSE informieren, dann klicken Sie in die Suchleiste, geben Sie <literal>SUSE</literal> ein und drücken Sie die <keycap function="enter"/>. Das Suchergebnis wird im Firefox-Fenster angezeigt. 
    </para>
@@ -231,9 +205,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-searchengine-smartkeywords">
-    <title>Hinzufügen von Schlüsselwörtern für Online-Suchen</title><indexterm>
-    <primary>Firefox</primary>
-    <secondary> Schlüsselwörter</secondary></indexterm>
+    <title>Hinzufügen von Schlüsselwörtern für Online-Suchen</title>
     <para>
      Mit Firefox können Sie eigene <emphasis>Schlüsselwörter</emphasis> festlegen: Abkürzungen, die als URL-Kürzel für eine bestimmte Suchmaschine verwendet werden sollen. Wenn Sie <literal>ws</literal> beispielsweise als Schlüsselwort für die Suche in Wikipedia festgelegt haben, können Sie <literal>ws <replaceable>SUCHBEGRIFF</replaceable></literal> in die Adressleiste eingeben und so in Wikipedia nach <replaceable>SUCHBEGRIFF</replaceable> suchen.
     </para>
@@ -275,26 +247,18 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-findinfo-page">
-   <title>Suche auf der aktuellen Seite</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> Auf Seite suchen</secondary></indexterm> 
+   <title>Suche auf der aktuellen Seite</title>
    <para>
     Für die Suche innerhalb einer Webseite klicken Sie in der Menüleiste auf <menuchoice>
     <guimenu>Bearbeiten</guimenu> <guimenu>Suchen</guimenu> </menuchoice>  oder drücken Sie <keycombo> <keycap function="control"/> <keycap>  F</keycap> </keycombo>. Die Such-Symbolleiste wird geöffnet. Normalerweise wird sie am unteren Fensterrand angezeigt. Geben Sie Ihre Abfrage in das Textfeld ein. Firefox sucht bereits nach dem ersten Vorkommen des gesuchten Ausdrucks, während Sie tippen. Weitere Vorkommen des Ausdrucks werden gesucht, wenn Sie auf <keycap>F3</keycap> drücken oder in der Such-Symbolleiste auf die Schaltfläche <guimenu>Next</guimenu> (Abwärts) klicken. Klicken Sie auf die Schaltfläche <guimenu>Alle hervorheben</guimenu>, um alle Vorkommen des Ausdrucks hervorzuheben. Wenn Sie die Option <guimenu>Match Case</guimenu> (Groß-/Kleinschreibung) aktivieren, wird bei der Suche auf die Groß-/Kleinschreibung geachtet.
-   </para><indexterm>
-   <primary> Firefox</primary>
-   <secondary> Schnellsuche</secondary></indexterm> 
+   </para>
    <para>
     Firefox bietet auch zwei Optionen zur Schnellsuche. Klicken Sie auf einer Webseite an die Stelle, an der Sie mit der Suche beginnen möchten, und geben Sie <keycap>/</keycap> gefolgt vom Suchbegriff ein. Das erste Vorkommen des Suchbegriffs wird hervorgehoben, während Sie tippen. Drücken Sie <keycap>F3</keycap>, um das nächste Vorkommen zu suchen. Es ist auch möglich, die Schnellsuche auf Links einzugrenzen. Diese Suchoption ist durch Eingabe von <keycap>'</keycap> verfügbar.
    </para>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-firefox-bookmarks">
-  <title>Verwalten von Lesezeichen</title><indexterm>
-
-  <primary> Firefox</primary>
-
-  <secondary> Lesezeichen</secondary></indexterm> 
+  <title>Verwalten von Lesezeichen</title>
 
   <para>
    Lesezeichen sind eine komfortable Methode, die Links häufig besuchter Webseiten zu speichern, um später schnell darauf zurückzugreifen. In Firefox können Sie jedoch nicht nur durch einfaches Klicken ganz leicht neue Lesezeichen hinzufügen, sondern auch eine große Sammlung von Lesezeichen auf verschiedene Arten verwalten. Sie können Lesezeichen in Ordner sortieren, mit Schlagwörtern versehen oder mithilfe von intelligenten Lesezeichenordnern filtern.
@@ -313,13 +277,7 @@
   </para>
 
   <sect2 xml:id="sec-firefox-bookmarks-organise">
-   <title>Verwalten von Lesezeichen</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary>Lesezeichen</secondary>
-   <tertiary>verwalten</tertiary></indexterm><indexterm>
-   <primary>Firefox</primary>
-   <secondary>Lesezeichen</secondary>
-   <tertiary>Bibliothek</tertiary></indexterm>
+   <title>Verwalten von Lesezeichen</title>
    <para>
     In der <guimenu>Library</guimenu> (Bibliothek) können Sie die Eigenschaften (Name und Adresse) der einzelnen Lesezeichen verwalten und die Lesezeichen in Ordner und Abschnitte einteilen. Eine Abbildung der Bibliothek sehen Sie in <xref linkend="fig-firefox-library"/>.
    </para>
@@ -400,10 +358,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-tags">
-   <title>Kennungen</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> Lesezeichen</secondary>
-   <tertiary> Schlagwörter</tertiary></indexterm> 
+   <title>Kennungen</title>
    <para>
     Schlagwörter bieten eine praktische Möglichkeit, Lesezeichen in verschiedene Kategorien zu unterteilen. Lesezeichen können mit beliebig vielen Schlagwörtern versehen werden. Wenn Sie beispielsweise auf alle Websites zugreifen möchten, denen das Schlagwort <literal>suse</literal> zugewiesen wurde, geben Sie in die Adressleiste <literal>suse</literal> ein. Für jedes Schlagwort wird automatisch ein Eintrag im Ordner <systemitem>Kürzlich verwendete Schlagwörter</systemitem> in der Bibliothek angelegt. Sie können einen Eintrag für ein Schlagwort per Drag &amp; Drop in die Lesezeichen-Symbolleiste ziehen, sodass er schnell und einfach aufgerufen werden kann.
    </para>
@@ -413,13 +368,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-imexport">
-   <title>Importieren und Exportieren von Lesezeichen</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary>Lesezeichen</secondary>
-   <tertiary>Importieren</tertiary></indexterm><indexterm>
-   <primary>Firefox</primary>
-   <secondary>Lesezeichen</secondary>
-   <tertiary>Exportieren</tertiary></indexterm>
+   <title>Importieren und Exportieren von Lesezeichen</title>
 
    <para>
     Zum Importieren von Lesezeichen aus einem anderen Browser oder aus einer Datei im HTML-Format öffnen Sie die Bibliothek. Klicken Sie hierzu in der Menüleiste auf <menuchoice>
@@ -436,10 +385,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-live">
-   <title>Dynamische Lesezeichen</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> Lesezeichen</secondary>
-   <tertiary> Dynamische Lesezeichen</tertiary></indexterm> 
+   <title>Dynamische Lesezeichen</title>
    <para>
     Live-Lesezeichen zeigen Nachrichtenschlagzeilen im Lesezeichen-Menü an, mit denen Sie auf dem neuesten Stand bleiben. Auf diese Weise erhalten Sie auf einen Blick die neuesten Informationen von Ihren bevorzugten Websites. Dynamische Lesezeichen werden automatisch aktualisiert. Dieses Format wird von vielen Websites und Blogs unterstützt. 
    </para>
@@ -450,20 +396,14 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-smart">
-   <title>Intelligente Lesezeichenordner</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> Lesezeichen</secondary>
-   <tertiary> Intelligente Lesezeichen</tertiary></indexterm> 
+   <title>Intelligente Lesezeichenordner</title>
    <para>
     Intelligente Lesezeichenordner sind virtuelle Lesezeichen-Ordner, die dynamisch aktualisiert werden. Es gibt drei Arten von intelligenten Lesezeichenordnern: Die <guimenu>meistbesuchten</guimenu> Links befinden sich in der Lesezeichen-Symbolleiste. Die <guimenu>kürzlich als Lesezeichen gesetzten</guimenu> Links und die <guimenu>kürzlich verwendeten Schlagwörter</guimenu> sind im Lesezeichenmenü verfügbar.
    </para>
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-toolbar">
-   <title>Die Lesezeichen-Symbolleiste</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> Lesezeichen</secondary>
-   <tertiary> Symbolleiste</tertiary></indexterm> 
+   <title>Die Lesezeichen-Symbolleiste</title>
    <para>
     Die <literal>Lesezeichen-Symbolleiste</literal> wird unterhalb der Adressleiste angezeigt. Sie haben darüber schnellen Zugriff auf Ihre Lesezeichen. Hier können Sie Lesezeichen direkt hinzufügen, organisieren und bearbeiten. Standardmäßig befindet sich in der <literal>Lesezeichen-Symbolleiste</literal> ein vordefinierter Satz von Lesezeichen, die in verschiedenen Ordnern organisiert sind (siehe <xref linkend="fig-firefox-main"/>).
    </para>
@@ -476,15 +416,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-firefox-downloadmanager">
-  <title>Verwenden des Download-Managers</title><indexterm>
-
-  <primary> Firefox</primary>
-
-  <secondary> Download-Manager</secondary></indexterm><indexterm>
-
-  <primary>   Download-Manager</primary>
-
-  <secondary> Firefox </secondary></indexterm> 
+  <title>Verwenden des Download-Managers</title>
 
   <para>
    Mit dem Download-Manager können Sie Ihre aktuellen und früheren Downloads verfolgen. Mit <menuchoice>
@@ -504,20 +436,14 @@
   </tip>
  </sect1>
  <sect1 xml:id="sec-firefox-security">
-  <title>Sicherheit</title><indexterm>
-
-  <primary> Firefox</primary>
-
-  <secondary> Sicherheit</secondary></indexterm> 
+  <title>Sicherheit</title>
 
   <para>
    Da das Browsen im Internet immer riskanter wird, bietet Firefox zahlreiche Maßnahmen, um das Browsen sicherer zu machen. Firefox prüft automatisch, ob Sie auf eine Site zugreifen, die dafür bekannt ist, schädliche Software (Malware) zu verbreiten, oder ob es sich um eine Site handelt, die bekanntermaßen wichtige Daten stiehlt (Phishing), und verhindert dann den Zugriff auf solche Sites. Anhand der Instant Website ID kann die Legitimität einer Website überprüft werden und ein Passwort-Manager sowie die Popup-Sperre sorgen für zusätzliche Sicherheit. Im privaten Modus können Sie im Internet surfen, ohne dass Firefox Daten auf dem Computer aufzeichnet.
   </para>
 
   <sect2 xml:id="sec-firefox-security-instant-id">
-   <title>Instant Website ID</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> Website-ID</secondary></indexterm> 
+   <title>Instant Website ID</title>
    <para>
     In Firefox können Sie die Identität einer Webseite mit nur einem Blick überprüfen. Das Symbol in der Adressleiste neben der Adresse gibt an, welche Identitätsdaten verfügbar sind und ob die Datenübertragung verschlüsselt ist:
    </para>
@@ -630,11 +556,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-firefox-customizing">
-  <title>Anpassen von Firefox</title><indexterm>
-
-  <primary> Firefox</primary>
-
-  <secondary> konfigurieren</secondary></indexterm> 
+  <title>Anpassen von Firefox</title>
 
   <para>
    Firefox ist vielseitig anpassbar. 
@@ -663,9 +585,7 @@
   </para>
 
   <sect2 xml:id="sec-firefox-preferences">
-   <title>Einstellungen</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> Einstellungen</secondary></indexterm> 
+   <title>Einstellungen</title>
    <para>
     Firefox bietet zahlreiche Konfigurationsoptionen. Klicken Sie hierzu in der Menüleiste auf <menuchoice> <guimenu>Bearbeiten</guimenu>
     <guimenu>Einstellungen</guimenu> </menuchoice>. Die einzelnen Optionen sind in der Online-Hilfe detailliert beschrieben, die Sie über das Fragezeichensymbol im Dialogfeld öffnen können.
@@ -682,9 +602,7 @@
     </mediaobject>
    </figure>
    <sect3 xml:id="sec-firefox-preferences-sessions">
-    <title>Sitzungsverwaltung</title><indexterm>
-    <primary> Firefox</primary>
-    <secondary> Sitzungsverwaltung</secondary></indexterm> 
+    <title>Sitzungsverwaltung</title>
     <para>
      Sitzungen (Fenster und Tabs) werden von Firefox standardmäßig nur nach einem Absturz oder nach einem Neustart aufgrund einer Erweiterung automatisch wiederhergestellt. Der Browser kann jedoch so konfiguriert werden, dass bei jedem Start eine Sitzung wiederhergestellt wird. Öffnen Sie hierzu das Dialogfeld „Einstellungen“ gemäß <xref linkend="sec-firefox-preferences"/> und wechseln Sie zur Kategorie <guimenu>Allgemein</guimenu>. Stellen Sie die Option <guimenu>Wenn Firefox gestartet wird:</guimenu> auf <guimenu>Fenster und Tabs der letzten Sitzung anzeigen</guimenu> ein.
     </para>
@@ -695,17 +613,13 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-preferences-language">
-    <title>Spracheinstellungen für Websites</title><indexterm>
-    <primary> Firefox</primary>
-    <secondary> Sprache</secondary></indexterm> 
+    <title>Spracheinstellungen für Websites</title>
     <para>
      Beim Senden einer Anfrage an einen Webserver sendet der Browser stets die Information mit, welche Sprachen vom Benutzer bevorzugt werden. Websites, die in mehreren Sprachen verfügbar sind (und für die Auswertung dieses Sprachparameters konfiguriert wurden), zeigen dann ihre Seiten in der vom Browser angeforderten Sprache an. In <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> ist die bevorzugte Sprache für die Verwendung der Desktop-Sprache vorkonfiguriert. Zum Ändern dieser Einstellung öffnen Sie das Fenster <guimenu>Einstellungen</guimenu> gemäß <xref linkend="sec-firefox-preferences"/>, wechseln Sie zur Kategorie <guimenu>Inhalt</guimenu>, klicken Sie auf <guimenu>Wählen</guimenu> und legen Sie die gewünschte Sprache fest.
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-preferences-spelling">
-    <title>Rechtschreibprüfung</title><indexterm>
-    <primary> Firefox</primary>
-    <secondary> Rechtschreibprüfung</secondary></indexterm> 
+    <title>Rechtschreibprüfung</title>
     <para>
      Standardmäßig wird in Firefox für Eingaben in mehrzeilige Textfelder eine Rechtschreibprüfung ausgeführt. Falsch geschriebene Wörter werden rot unterstrichen. Zum Korrigieren eines Worts klicken Sie mit der rechten Maustaste darauf, und wählen Sie im Kontextmenü die richtige Schreibweise aus. Wenn das Wort richtig ist, können Sie es auch dem Wörterbuch hinzufügen.
     </para>
@@ -716,13 +630,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-extensions">
-   <title>Add-Ons</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary>Add-ons</secondary></indexterm><indexterm>
-   <primary>Firefox</primary>
-   <secondary>Erweiterungen</secondary></indexterm><indexterm>
-   <primary>Firefox</primary>
-   <secondary>Themes</secondary></indexterm>
+   <title>Add-Ons</title>
    <para>
     Mithilfe von Erweiterungen können Sie Firefox an Ihre Bedürfnisse anpassen. Erweiterungen verändern das Erscheinungsbild von Firefox, optimieren die vorhandenen Funktionen und bringen neue Funktionen mit. Es stehen beispielsweise Erweiterungen zur Auswahl, mit denen Sie den Download-Manager optimieren, den Wetterbericht abrufen oder Web-Musikwiedergabeprogramme steuern können. Andere Erweiterungen fungieren als Unterstützung für Web-Entwickler oder blockieren Inhalte wie Werbung oder Skripte, wodurch die Sicherheit erhöht wird.
    </para>
@@ -733,10 +641,7 @@
     Wenn Ihnen das normale Erscheinungsbild von Firefox nicht zusagt, können Sie ein neues <emphasis>Design</emphasis> installieren. Designs ändern lediglich das Aussehen des Browsers und haben keine Auswirkung auf seine Funktionen.
    </para>
    <sect3 xml:id="sec-firefox-extensions-install">
-    <title>Installieren von Add-Ons</title><indexterm>
-    <primary> Firefox</primary>
-    <secondary> Add-Ons</secondary>
-    <tertiary> Installieren</tertiary></indexterm> 
+    <title>Installieren von Add-Ons</title>
     <para>
      Starten Sie zum Hinzufügen einer Erweiterung oder eines Themes den Add-on-Manager mit <menuchoice>
      <guimenu>Extras</guimenu> <guimenu>Add-ons</guimenu> </menuchoice>. Auf der Registerkarte <guimenu>Add-ons herunterladen</guimenu> im Add-on-Manager werden entweder einige empfohlene Add-ons oder die Ergebnisse Ihrer letzten Suche angezeigt.
@@ -761,10 +666,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-extensions-manage">
-    <title>Verwalten von Add-Ons</title><indexterm>
-    <primary> Firefox</primary>
-    <secondary> Add-Ons</secondary>
-    <tertiary> Verwalten</tertiary></indexterm> 
+    <title>Verwalten von Add-Ons</title>
     <para>
      Der Add-On-Manager bietet auch eine praktische Oberfläche zum Verwalten von Erweiterungen, Themen und Plugins. <guimenu>Erweiterungen</guimenu> können aktiviert, deaktiviert oder deinstalliert werden. Wenn eine Erweiterung konfigurierbar ist, können Sie über die Schaltfläche <guimenu>Preferences</guimenu> (Einstellungen) auf deren Konfigurationsoptionen zugreifen. Auf dem Karteireiter <guimenu>Erscheinungsbild</guimenu> können Sie ein Thema <guimenu>deinstallieren</guimenu> oder ein anderes Thema aktivieren, indem Sie auf <guimenu>Aktivieren</guimenu> klicken. Ausstehende Erweiterungen und Thema-Installationen sind ebenfalls aufgelistet. Klicken Sie auf <guimenu>Cancel</guimenu> (Abbrechen), um die Installation zu stoppen. Obwohl Sie als Benutzer keine <guimenu>Plugins</guimenu> installieren können, können Sie diese über den Add-On-Manager deaktivieren oder aktivieren.
     </para>
@@ -777,15 +679,7 @@
 
  </sect1>
  <sect1 xml:id="sec-firefox-printing">
-  <title>Drucken aus Firefox</title><indexterm>
-
-  <primary>Firefox</primary>
-
-  <secondary>Drucken</secondary></indexterm><indexterm>
-
-  <primary>Drucken</primary>
-
-  <secondary>Firefox</secondary></indexterm>
+  <title>Drucken aus Firefox</title>
 
   <para>
    Vor dem tatsächlichen Drucken einer Webseite können Sie die Druckvorschaufunktion verwenden, um zu steuern, wie die gedruckte Seite auszusehen hat. Klicken Sie in der Menüleiste auf <menuchoice> <guimenu>Datei</guimenu> <guimenu>Druckvorschau</guimenu>
@@ -821,6 +715,6 @@
    </member>
    <member><emphasis>Tastaturkürzel</emphasis>: <link xlink:href="http://support.mozilla.org/kb/Keyboard+shortcuts"/>
    </member>
-  </simplelist><indexterm startref="idx-firefox" class="endofrange"/><indexterm class="endofrange" startref="idx-browsers-firefox"/>
+  </simplelist>
  </sect1>
 </chapter>

--- a/l10n/sles/de-de/xml/apps_gimp.xml
+++ b/l10n/sles/de-de/xml/apps_gimp.xml
@@ -11,26 +11,12 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-gimp" class="startofrange">
- <primary>GIMP</primary></indexterm><indexterm xml:id="idx-graphics-editing" class="startofrange">
- <primary>Grafiken</primary>
- <secondary>Bearbeiten</secondary></indexterm><indexterm>
- <primary>Anwendungen</primary>
- <secondary>Grafiken</secondary>
- <tertiary>GIMP</tertiary></indexterm>
+ </info>
  <para>
   GIMP ist ein sehr komplexes Programm. In diesem Kapitel werden daher nur einige Funktionen, Werkzeuge und Menüoptionen erläutert. In <xref linkend="sec-gimp-moreinfo"/> erhalten Sie Hinweise auf weitere Informationsquellen über das Programm.
  </para>
  <sect1 xml:id="sec-gimp-graphics">
-  <title>Grafikformate</title><indexterm>
-
-  <primary>Grafiken</primary>
-
-  <secondary>Pixel</secondary></indexterm><indexterm>
-
-  <primary>Grafiken</primary>
-
-  <secondary>Vektor</secondary></indexterm>
+  <title>Grafikformate</title>
 
   <para>
    Es gibt zwei Arten von digitalen Grafiken: Raster- und Vektorgrafiken. GIMP dient zur Arbeit mit Rastergrafiken, die am häufigsten für Digitalfotos und gescannte Bilder verwendet werden.
@@ -87,11 +73,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-gimp-starting">
-  <title>Starten von GIMP</title><indexterm>
-
-  <primary> GIMP</primary>
-
-  <secondary> Starten</secondary></indexterm> 
+  <title>Starten von GIMP</title>
 
   <para>
    Zum Starten von GIMP wählen Sie <menuchoice><guimenu>Anwendungen</guimenu>
@@ -129,10 +111,7 @@
     Im Menü <guimenu>Datei</guimenu> finden sich die Standard-Dateivorgänge wie <guimenu>Neu</guimenu>, <guimenu>Öffnen</guimenu>, <guimenu>Speichern</guimenu>, <guimenu>Drucken</guimenu> und <guimenu>Schließen</guimenu>. Mit <guimenu>Beenden</guimenu> wird die Anwendung beendet.
    </para>
    <para>
-    <indexterm>
-    <primary>GIMP</primary>
-    <secondary> Ansichten</secondary>
-    </indexterm>  Mit den Elementen im Menü <guimenu>View</guimenu> (Ansicht) steuern Sie die Anzeige des Bilds und des Bildfensters. <guimenu>New View</guimenu> (Neue Ansicht) öffnet ein zweites Fenster, in dem das aktuelle Bild angezeigt wird. Die in einer Ansicht vorgenommenen Änderungen werden auch in allen anderen Fenstern angezeigt. Das Arbeiten mit unterschiedlichen Ansichten ist hilfreich, um beispielsweise einen Bildausschnitt für die Bearbeitung zu vergrößern, während das komplette Bild in einer anderen Ansicht zu sehen ist. Mit <guimenu>Zoom</guimenu> können Sie die Vergrößerungsstufe des aktuellen Fensters anpassen. Bei Auswahl von <guimenu>Fit Image in Window</guimenu> (Bild an Fenster anpassen) wird die Größe des Bildfensters exakt an das aktuelle Bild angepasst.
+      Mit den Elementen im Menü <guimenu>View</guimenu> (Ansicht) steuern Sie die Anzeige des Bilds und des Bildfensters. <guimenu>New View</guimenu> (Neue Ansicht) öffnet ein zweites Fenster, in dem das aktuelle Bild angezeigt wird. Die in einer Ansicht vorgenommenen Änderungen werden auch in allen anderen Fenstern angezeigt. Das Arbeiten mit unterschiedlichen Ansichten ist hilfreich, um beispielsweise einen Bildausschnitt für die Bearbeitung zu vergrößern, während das komplette Bild in einer anderen Ansicht zu sehen ist. Mit <guimenu>Zoom</guimenu> können Sie die Vergrößerungsstufe des aktuellen Fensters anpassen. Bei Auswahl von <guimenu>Fit Image in Window</guimenu> (Bild an Fenster anpassen) wird die Größe des Bildfensters exakt an das aktuelle Bild angepasst.
    </para>
   </sect2>
 
@@ -185,9 +164,7 @@
   </para>
 
   <sect2 xml:id="sec-gimp-getstart-creating">
-   <title>Erstellen eines neuen Bilds</title><indexterm>
-   <primary> GIMP</primary>
-   <secondary> Bilder erstellen</secondary></indexterm> 
+   <title>Erstellen eines neuen Bilds</title>
    <procedure>
     <step>
      <para>
@@ -198,9 +175,7 @@
     <step>
      <para>
       Auf Wunsch können Sie eine vordefinierte Einstellung, eine so genannte Vorlage (<guimenu>Template</guimenu>) auswählen. 
-     </para><indexterm>
-     <primary> GIMP</primary>
-     <secondary> Vorlagen</secondary></indexterm> 
+     </para>
      <note>
       <title>Benutzerdefinierte Vorlagen</title>
       <para>
@@ -238,9 +213,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-getstart-open">
-   <title>Öffnen eines vorhandenen Bilds</title><indexterm>
-   <primary> GIMP</primary>
-   <secondary> Bilder öffnen</secondary></indexterm> 
+   <title>Öffnen eines vorhandenen Bilds</title>
    <para>
     Zum Öffnen eines vorhandenen Bilds wählen Sie <menuchoice> <guimenu>File</guimenu>
     <guimenu>(Datei) Open</guimenu></menuchoice> (Öffnen).
@@ -251,11 +224,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gimp-saving">
-  <title>Speichern und Exportieren von Bildern</title><indexterm>
-
-  <primary> GIMP</primary>
-
-  <secondary> Bilder speichern</secondary></indexterm> 
+  <title>Speichern und Exportieren von Bildern</title>
 
   <para>
    In GIMP wird zwischen dem Speichern und dem Exportieren von Bildern unterschieden.
@@ -287,10 +256,7 @@
 
 
    <varlistentry>
-    <term>JPEG<indexterm>
-     <primary> Dateien</primary>
-     <secondary> Formate</secondary>
-     <tertiary> JPG</tertiary></indexterm> 
+    <term>JPEG 
     </term>
     <listitem>
      <para>
@@ -299,10 +265,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>GIF<indexterm>
-     <primary> Dateien</primary>
-     <secondary> Formate</secondary>
-     <tertiary> GIF</tertiary></indexterm> 
+    <term>GIF 
     </term>
     <listitem>
      <para>
@@ -311,10 +274,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>PNG<indexterm>
-     <primary> Dateien</primary>
-     <secondary> Formate</secondary>
-     <tertiary> PNG</tertiary></indexterm> 
+    <term>PNG 
     </term>
     <listitem>
      <para>
@@ -325,20 +285,14 @@
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-gimp-basics">
-  <title>Bearbeiten von Bildern</title><indexterm xml:id="idx-gimp-editing-images" class="startofrange">
-
-  <primary> GIMP</primary>
-
-  <secondary> Bilder bearbeiten</secondary></indexterm> 
+  <title>Bearbeiten von Bildern</title>
 
   <para>
    GIMP bietet verschiedene Werkzeuge, mit denen sich Bilder ändern lassen. Nachfolgend werden diejenigen Funktionen beschrieben, die für weniger umfangreiche Bearbeitungen am interessantesten sind.
   </para>
 
   <sect2 xml:id="sec-gimp-basics-size">
-   <title>Ändern der Größe eines Bilds</title><indexterm xml:id="idx-graphics-resizing" class="startofrange">
-   <primary> Grafiken</primary>
-   <secondary> Größe ändern</secondary></indexterm> 
+   <title>Ändern der Größe eines Bilds</title>
    <para>
     Die Größe eines gescannten Bilds oder einer von der Kamera geladenen digitalen Fotografie muss häufig angepasst werden, damit das Bild auf einer Webseite angezeigt oder gedruckt werden kann. Das Verkleinern von Bildern ist kein Problem: Sie werden entweder auf das gewünschte Format skaliert oder entsprechend zugeschnitten. 
    </para>
@@ -346,9 +300,7 @@
     Das Vergrößern von Bildern ist dagegen problematischer. Aufgrund der Eigenschaften von Rastergrafiken kann ein Bild nicht ohne Qualitätsverlust vergrößert werden. Vor dem Skalieren oder Zuschneiden sollten Sie daher immer eine Kopie des Originalbilds erstellen.
    </para>
    <sect3 xml:id="sec-gimp-basics-size-cropping">
-    <title>Zuschneiden eines Bilds</title><indexterm>
-    <primary> GIMP</primary>
-    <secondary> Zuschneiden</secondary></indexterm> 
+    <title>Zuschneiden eines Bilds</title>
     <procedure>
      <step>
       <para>
@@ -374,9 +326,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-size-scaling">
-    <title>Skalieren eines Bilds</title><indexterm>
-    <primary> GIMP</primary>
-    <secondary> Bilder skalieren</secondary></indexterm> 
+    <title>Skalieren eines Bilds</title>
     <procedure>
      <step>
       <para>
@@ -427,14 +377,12 @@
        Klicken Sie abschließend auf <guimenu>Resize</guimenu> (Größe ändern).
       </para>
      </step>
-    </procedure><indexterm startref="idx-graphics-resizing" class="endofrange"/>
+    </procedure>
    </sect3>
   </sect2>
 
   <sect2 xml:id="sec-gimp-basics-select">
-   <title>Auswählen von Bildausschnitten</title><indexterm xml:id="idx-gimp-selecting" class="startofrange">
-   <primary> GIMP</primary>
-   <secondary> Auswählen</secondary></indexterm> 
+   <title>Auswählen von Bildausschnitten</title>
    <para>
     Oft müssen nur bestimmte Ausschnitte eines Bilds bearbeitet werden. Hierzu muss der zu bearbeitende Teil des Bilds ausgewählt werden. Bildausschnitte können mit den Auswahlwerkzeugen der Werkzeugsammlung, mit der Schnellmaske oder durch Kombination verschiedener Optionen ausgewählt werden. Auswahlen können mit den Funktionen unter <guimenu>Select</guimenu> (Auswählen) auch geändert werden. Eine Auswahl wird durch eine gestrichelte Linie, die <emphasis>Markierungslinie</emphasis>, gekennzeichnet.
    </para>
@@ -543,9 +491,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-select-quickmask">
-    <title>Verwenden der Schnellmaske</title><indexterm>
-    <primary> GIMP</primary>
-    <secondary> Schnellmaske</secondary></indexterm> 
+    <title>Verwenden der Schnellmaske</title>
     <para>
      Mit der Schnellmaske können Sie Bildbereiche mithilfe der Malwerkzeuge auswählen. Es empfiehlt sich, zuvor mit dem Werkzeug <guimenu>Scissors</guimenu> (Schere) oder <guimenu>Free Select</guimenu> (Freihandauswahl) eine grobe Vorauswahl zu treffen. Verwenden Sie dann die <guimenu>Quick Mask</guimenu> (Schnellmaske):
     </para>
@@ -577,7 +523,7 @@
        Mit dem Symbol unten links im Bildfenster kehren Sie abschließend zur normalen Auswahlansicht zurück. Die Auswahl wird dann mit den „laufenden Ameisen“ angezeigt.
       </para>
      </step>
-    </procedure><indexterm startref="idx-gimp-selecting" class="endofrange"/>
+    </procedure>
    </sect3>
   </sect2>
 
@@ -590,9 +536,7 @@
     Bei vielen Werkzeugen wird neben dem Pfeil ein Symbol des aktuellen Werkzeugs angezeigt. Für Malwerkzeuge erscheint ein Umriss der aktuellen Pinselform, damit Sie exakt sehen, wo Sie im Bild malen und wie groß der gemalte Bereich ist.
    </para>
    <sect3 xml:id="sec-gimp-basics-color-selecting">
-    <title>Farben einstellen</title><indexterm>
-    <primary> GIMP</primary>
-    <secondary> Farben</secondary></indexterm> 
+    <title>Farben einstellen</title>
     <para>
      Die GIMP-Werkzeugsammlung enthält stets zwei Farbpaletten. Die Vordergrundfarbe wird von den Malwerkzeugen verwendet. Die Hintergrundfarbe kommt deutlich seltener zum Einsatz, kann jedoch schnell und einfach als Vordergrundfarbe festgelegt werden.
     </para>
@@ -650,9 +594,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-color-text">
-    <title>Hinzufügen von Text</title><indexterm>
-    <primary> GIMP</primary>
-    <secondary> Text</secondary></indexterm> 
+    <title>Hinzufügen von Text</title>
     <para>
      Mit dem Textwerkzeug fügen Sie Text ein. Legen Sie die gewünschte Schriftart und die Texteigenschaften in den Werkzeugoptionen fest. Klicken Sie in das Bild und beginnen Sie mit der Texteingabe.
     </para>
@@ -661,9 +603,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-color-clone">
-    <title>Retuschieren von Bildern – Das Clone-Werkzeug</title><indexterm>
-    <primary> GIMP</primary>
-    <secondary> Bilder retuschieren</secondary></indexterm> 
+    <title>Retuschieren von Bildern – Das Clone-Werkzeug</title>
     <para>
      Mit dem Klonwerkzeug lassen sich Bilder perfekt retuschieren. Sie können damit einen Bildbereich mit den Informationen eines anderen Bildbereichs übermalen. Statt den Informationen eines Bildbereichs können auch die Informationen eines Musters übernommen werden.
     </para>
@@ -680,9 +620,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-basics-levels">
-   <title>Anpassen der Farbebenen</title><indexterm>
-   <primary> GIMP</primary>
-   <secondary> Ebenen</secondary></indexterm> 
+   <title>Anpassen der Farbebenen</title>
    <para>
     Für optimale Druck- oder Anzeigeergebnisse müssen Bilder häufig ein wenig angepasst werden. 
    </para>
@@ -713,9 +651,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-basics-undo">
-   <title>Korrigieren von Fehlern</title><indexterm>
-   <primary> GIMP</primary>
-   <secondary> Rückgängig</secondary></indexterm> 
+   <title>Korrigieren von Fehlern</title>
    <para>
     Die meisten Änderungen in GIMP können rückgängig gemacht werden. Wenn Sie einen Änderungsverlauf anzeigen möchten, verwenden Sie das Dialogfeld „Undo“ (Rückgängig machen) im Standardfensterlayout. Sie können den Verlauf auch im Menü des Bildfensters mit der Optionsfolge <menuchoice>
     <guimenu>Windows (Fenster)</guimenu> <guimenu>Dockable Dialogs (Andockbare Dialogfelder)</guimenu>
@@ -732,9 +668,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-advanced-layers">
-   <title>Schichten</title><indexterm>
-   <primary> GIMP</primary>
-   <secondary> Schichten</secondary></indexterm> 
+   <title>Schichten</title>
    <para>
     Schichten sind in GIMP ein sehr wichtiges Kompositionsmittel. Wenn Sie einzelne Teile eines Bilds in verschiedenen Schichten erstellen, können Sie diese Teile ändern, verschieben oder löschen, ohne die restlichen Bildbereiche zu beeinflussen. 
    </para>
@@ -747,9 +681,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-advanced-modes">
-   <title>Bildmodi</title><indexterm>
-   <primary> GIMP</primary>
-   <secondary> Bildmodi</secondary></indexterm> 
+   <title>Bildmodi</title>
    <para>
     GIMP bietet drei Bildmodi:
    </para>
@@ -776,24 +708,14 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-advanced-effects">
-   <title>Spezialeffekte</title><indexterm>
-   <primary> GIMP</primary>
-   <secondary> Effekte</secondary></indexterm> 
+   <title>Spezialeffekte</title>
    <para>
     GIMP bietet eine große Auswahl an Filtern und Skripten für die Bildoptimierung, für Spezialeffekte und für künstlerische Manipulationen. Sie stehen unter <guimenu>Filters</guimenu> (Filter) zur Verfügung. Durch Experimentieren finden Sie am besten heraus, was Sie alles damit machen können.
-   </para><indexterm startref="idx-gimp-editing-images" class="endofrange"/>
+   </para>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gimp-printing">
-  <title>Drucken von Bildern</title><indexterm>
-
-  <primary>GIMP</primary>
-
-  <secondary>Drucken</secondary></indexterm><indexterm>
-
-  <primary>Drucken</primary>
-
-  <secondary>GIMP</secondary></indexterm>
+  <title>Drucken von Bildern</title>
 
   <para>
    Wählen Sie zum Drucken einer Datei aus dem Bildmenü <menuchoice> <guimenu>File (Datei)</guimenu>
@@ -866,6 +788,6 @@
      Es gibt ein ganzes IRC-Netzwerk, das GIMP und der GNOME-Desktopumgebung gewidmet ist – GIMPNet. Sie können über Ihren bevorzugten IRC-Client eine Verbindung mit GIMPNet herstellen, indem Sie als Server <literal>irc.gimp.org</literal> angeben. Der Kanal <literal>#gimp-users</literal> ist der richtige Ort, um Fragen zur Verwendung von GIMP zu stellen. Wenn Sie die Diskussionen von Entwicklern mitverfolgen möchten, müssen Sie den Kanal <literal>#gimp</literal> abonnieren.
     </para>
    </listitem>
-  </itemizedlist><indexterm class="endofrange" startref="idx-gimp"/><indexterm class="endofrange" startref="idx-graphics-editing"/>
+  </itemizedlist>
  </sect1>
 </chapter>

--- a/l10n/sles/de-de/xml/autofs.xml
+++ b/l10n/sles/de-de/xml/autofs.xml
@@ -11,8 +11,7 @@
     Das Programm <systemitem>autofs</systemitem> hängt automatisch festgelegte Verzeichnisse bedarfsweise ein. Das Programm beruht auf einem Kernel-Modul, das für hohe Effizienz sorgt, und kann sowohl lokale Verzeichnisse als auch Netzwerkfreigaben verwalten. Diese automatischen Einhängepunkte werden nur dann eingehängt, wenn auf sie zugegriffen wird; nach einem bestimmten Zeitraum ohne Aktivität werden sie wieder ausgehängt. Dieses bedarfsweise Verfahren spart Bandweite und bewirkt höhere Leistungen als das statische Einhängen mit <filename>/etc/fstab</filename>. <systemitem>autofs</systemitem> ist das Steuerungsskript und <command>automount</command> das Kommando (der Daemon), mit dem das automatische Einhängen ausgeführt wird.
    </para>
   </abstract>
- </info><indexterm>
- <primary>AutoFS</primary></indexterm>
+ </info>
  <sect1 xml:id="sec-autofs-installation">
   <title>Installation</title>
 

--- a/l10n/sles/de-de/xml/common_intro_available_doc_i.xml
+++ b/l10n/sles/de-de/xml/common_intro_available_doc_i.xml
@@ -9,13 +9,7 @@
    </dm:bugtracker>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary> Hilfe</primary>
-
- <secondary> SUSE-Handbücher</secondary></indexterm><indexterm>
-
- <primary>   SUSE-Handbücher</primary></indexterm> 
+ </info>
 
  <note>
   <title>Online-Dokumentation und neueste Aktualisierungen</title>

--- a/l10n/sles/de-de/xml/fs_structure_i.xml
+++ b/l10n/sles/de-de/xml/fs_structure_i.xml
@@ -6,9 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary> Verzeichnisstruktur</primary>
- <secondary>  </secondary></indexterm>
+ </info>
  <para>
   Die folgende Tabelle bietet eine kurze Übersicht über die wichtigsten Verzeichnisse der höheren Ebene auf einem Linux-System. Ausführlichere Informationen über die Verzeichnisse und wichtige Unterverzeichnisse erhalten Sie in der folgenden Liste.
  </para>
@@ -244,9 +242,7 @@
  </para>
  <variablelist>
   <varlistentry>
-   <term><filename>/bin</filename><indexterm>
-    <primary>Verzeichnisse</primary>
-    <secondary>/bin</secondary></indexterm>
+   <term><filename>/bin</filename>
    </term>
    <listitem>
     <para>
@@ -255,9 +251,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/boot </filename><indexterm>
-    <primary>Verzeichnisse</primary>
-    <secondary>/boot</secondary></indexterm>
+   <term><filename>/boot </filename>
    </term>
    <listitem>
     <para>
@@ -266,9 +260,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/dev</filename><indexterm>
-    <primary>Verzeichnisse</primary>
-    <secondary>/dev </secondary></indexterm>
+   <term><filename>/dev</filename>
    </term>
    <listitem>
     <para>
@@ -277,9 +269,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/etc</filename><indexterm>
-    <primary>Verzeichnisse</primary>
-    <secondary>/etc </secondary></indexterm>
+   <term><filename>/etc</filename>
    </term>
    <listitem>
     <para>
@@ -288,9 +278,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/home/<replaceable>BENUTZERNAME</replaceable></filename><indexterm>
-    <primary>directories</primary>
-    <secondary>/home</secondary></indexterm>
+   <term><filename>/home/<replaceable>BENUTZERNAME</replaceable></filename>
    </term>
    <listitem>
     <para>
@@ -305,9 +293,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/lib</filename><indexterm>
-    <primary>Verzeichnisse</primary>
-    <secondary>/lib</secondary></indexterm>
+   <term><filename>/lib</filename>
    </term>
    <listitem>
     <para>
@@ -316,9 +302,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/media</filename><indexterm>
-    <primary>Verzeichnisse </primary>
-    <secondary>/media</secondary></indexterm>
+   <term><filename>/media</filename>
    </term>
    <listitem>
     <para>
@@ -329,9 +313,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/mnt</filename><indexterm>
-    <primary>Verzeichnisse </primary>
-    <secondary>/mnt</secondary></indexterm>
+   <term><filename>/mnt</filename>
    </term>
    <listitem>
     <para>
@@ -340,9 +322,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/opt</filename><indexterm>
-    <primary>Verzeichnisse </primary>
-    <secondary>/opt</secondary></indexterm>
+   <term><filename>/opt</filename>
    </term>
    <listitem>
     <para>
@@ -351,9 +331,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/root</filename><indexterm>
-    <primary>Verzeichnisse </primary>
-    <secondary>/root</secondary></indexterm>
+   <term><filename>/root</filename>
    </term>
    <listitem>
     <para>
@@ -362,9 +340,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/run</filename><indexterm>
-    <primary> Verzeichnisse</primary>
-    <secondary> /run</secondary></indexterm>
+   <term><filename>/run</filename>
    </term>
    <listitem>
     <para>
@@ -373,9 +349,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/sbin</filename><indexterm>
-    <primary>Verzeichnisse </primary>
-    <secondary>/sbin</secondary></indexterm>
+   <term><filename>/sbin</filename>
    </term>
    <listitem>
     <para>
@@ -384,9 +358,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/srv</filename><indexterm>
-    <primary>Verzeichnisse </primary>
-    <secondary>/srv</secondary></indexterm>
+   <term><filename>/srv</filename>
    </term>
    <listitem>
     <para>
@@ -395,9 +367,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/tmp</filename><indexterm>
-    <primary>Verzeichnisse </primary>
-    <secondary>/tmp</secondary></indexterm>
+   <term><filename>/tmp</filename>
    </term>
    <listitem>
     <para>
@@ -412,9 +382,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/usr</filename><indexterm>
-    <primary>Verzeichnisse </primary>
-    <secondary>/usr</secondary></indexterm>
+   <term><filename>/usr</filename>
    </term>
    <listitem>
     <para>
@@ -465,9 +433,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/var</filename><indexterm>
-    <primary>Verzeichnisse </primary>
-    <secondary>/var</secondary></indexterm>
+   <term><filename>/var</filename>
    </term>
    <listitem>
     <para>

--- a/l10n/sles/de-de/xml/fuse.xml
+++ b/l10n/sles/de-de/xml/fuse.xml
@@ -12,15 +12,10 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary> FUSE</primary></indexterm> 
+ </info>
 
  <sect1 xml:id="sec-fuse-config">
-  <title>Konfigurieren von FUSE</title><indexterm>
-
-  <primary> FUSE</primary>
-
-  <secondary> Konfigurieren</secondary></indexterm> 
+  <title>Konfigurieren von FUSE</title>
 
   <para>
    Bevor Sie FUSE installieren können, müssen Sie das Paket <systemitem class="resource">fuse</systemitem> installieren. Abhängig vom gewünschten Dateisystem benötigen Sie zusätzliche Plugins, die in verschiedenen Paketen verfügbar sind. 
@@ -31,13 +26,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-fuse-ntfs">
-  <title>Einhängen einer NTFS-Partition</title><indexterm>
-
-  <primary> FUSE</primary>
-
-  <secondary> ntfs-3g</secondary></indexterm><indexterm>
-
-  <primary>   ntfs-3g</primary></indexterm> 
+  <title>Einhängen einer NTFS-Partition</title>
 
   <para>
    NTFS (<emphasis>New Technology File System</emphasis>) ist das Standard-Dateisystem von Windows. Unter normalen Umständen ist ein nicht privilegierter Benutzer nicht in der Lage, NTFS-Blockgeräte über die externe FUSE-Bibliothek einzuhängen. Für das nachfolgende Verfahren zum Einhängen einer Windows-Partition sind daher Root-Berechtigungen erforderlich.

--- a/l10n/sles/de-de/xml/grub2.xml
+++ b/l10n/sles/de-de/xml/grub2.xml
@@ -11,10 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>Booten</primary>
- <secondary>GRUB 2</secondary></indexterm><indexterm>
- <primary>GRUB 2</primary></indexterm>
+ </info>
  <sect1 xml:id="sec-grub2-new-features">
   <title>Hauptunterschiede zwischen GRUB Legacy und GRUB 2</title>
 
@@ -67,9 +64,7 @@
    <varlistentry>
     <term><filename>/boot/grub2/grub.cfg</filename>
     </term>
-    <listitem><indexterm>
-     <primary>GRUB 2</primary>
-     <secondary> grub.cfg</secondary></indexterm>
+    <listitem>
      <para>
       Diese Datei enthält die Konfiguration der Menüpunkte in GRUB 2. Die Datei ersetzt die Datei <filename>menu.lst</filename> in GRUB Legacy. <filename>grub.cfg</filename> sollte nicht bearbeitet werden. Die Datei wird automatisch durch das Kommando <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command> generiert.
      </para>
@@ -78,9 +73,7 @@
    <varlistentry>
     <term><filename>/boot/grub2/custom.cfg</filename>
     </term>
-    <listitem><indexterm>
-     <primary>GRUB 2</primary>
-     <secondary> custom.cfg</secondary></indexterm>
+    <listitem>
      <para>
       Diese optionale Datei wird beim Booten direkt aus <filename>grub.cfg</filename> erzeugt. Hiermit können Sie benutzerdefinierte Einträge in das Bootmenü aufnehmen. Ab <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> werden diese Einträge auch geparst, wenn <command>grub-once</command> verwendet wird.
      </para>
@@ -89,9 +82,7 @@
    <varlistentry>
     <term><filename>/etc/default/grub</filename>
     </term>
-    <listitem><indexterm>
-     <primary>GRUB 2</primary>
-     <secondary> /etc/default/grub</secondary></indexterm>
+    <listitem>
      <para>
       Diese Datei steuert die Benutzereinstellungen für GRUB 2 und enthält in der Regel zusätzliche Umgebungseinstellungen, beispielsweise Hintergründe und Themen.
      </para>
@@ -100,9 +91,7 @@
    <varlistentry>
     <term>Skripte unter <filename>/etc/grub.d/</filename>
     </term>
-    <listitem><indexterm>
-     <primary>GRUB 2</primary>
-     <secondary> /etc/grub.d/</secondary></indexterm>
+    <listitem>
      <para>
       Die Skripte in diesem Verzeichnis werden bei Ausführung des Kommandos <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command> gelesen. Die zugehörigen Anweisungen werden in die Hauptkonfigurationsdatei <filename>/boot/grub/grub.cfg</filename> integriert.
      </para>
@@ -111,9 +100,7 @@
    <varlistentry xml:id="vle-grub2-sysconfig">
     <term><filename>/etc/sysconfig/bootloader</filename>
     </term>
-    <listitem><indexterm>
-     <primary>GRUB 2</primary>
-     <secondary> sysconfig/bootloader</secondary></indexterm>
+    <listitem>
      <para>
       Diese Konfigurationsdatei enthält einige Grundeinstellungen wie den Bootloader-Typ oder ob die UEFI Secure Boot-Unterstützung aktiviert werden soll.
      </para>
@@ -142,13 +129,7 @@
   </note>
 
   <sect2 xml:id="sec-grub2-cfg">
-   <title>Die Datei <filename>/boot/grub2/grub.cfg</filename></title><indexterm>
-   <primary>Konfigurationsdateien</primary>
-   <secondary>grub.cfg</secondary></indexterm><indexterm>
-   <primary>GRUB 2</primary>
-   <secondary>Bootmenü</secondary></indexterm><indexterm>
-   <primary>GRUB 2</primary>
-   <secondary>grub.cfg</secondary></indexterm>
+   <title>Die Datei <filename>/boot/grub2/grub.cfg</filename></title>
    <para>
     Hinter dem grafischen Eröffnungsbildschirm mit dem Bootmenü steht die GRUB 2-Konfigurationsdatei <filename>/boot/grub2/grub.cfg</filename>, die alle Informationen zu allen Partitionen oder Betriebssystemen enthält, die über das Menü gebootet werden können.
    </para>
@@ -161,11 +142,7 @@
   </sect2>
 
   <sect2 xml:id="sec-grub2-etc-default-grub">
-   <title>Die Datei <filename>/etc/default/grub</filename></title><indexterm>
-   <primary>Konfigurationsdateien</primary>
-   <secondary> /etc/default/grub</secondary></indexterm><indexterm>
-   <primary> GRUB 2</primary>
-   <secondary> /etc/default/grub</secondary></indexterm>
+   <title>Die Datei <filename>/etc/default/grub</filename></title>
    <para>
     Hier finden Sie allgemeinere Optionen für GRUB 2, beispielsweise den Zeitraum, über den das Menü angezeigt wird, oder das standardmäßig zu bootende Betriebssystem. Mit dem folgenden Kommando erhalten Sie eine Liste aller verfügbaren Optionen:
    </para>
@@ -422,9 +399,7 @@
   </sect2>
 
   <sect2 xml:id="sec-grub2-map">
-   <title>Zuordnung von BIOS-Laufwerken und Linux-Geräten</title><indexterm>
-   <primary>GRUB 2</primary>
-   <secondary> device.map</secondary></indexterm>
+   <title>Zuordnung von BIOS-Laufwerken und Linux-Geräten</title>
    <para>
     In GRUB Legacy wurden die Linux-Geräte mithilfe der Konfigurationsdatei <filename>device.map</filename>aus den Nummern der BIOS-Laufwerke abgeleitet. Die Zuordnung von BIOS-Laufwerken und Linux-Geräten ist jedoch nicht in jedem Fall fehlerfrei erkennbar. Wenn Sie beispielsweise die Reihenfolge der IDE- und SCSI-Laufwerke in der BIOS-Konfiguration vertauschen, entsteht in GRUB Legacy eine falsche Reihenfolge.
    </para>
@@ -440,9 +415,7 @@
   </sect2>
 
   <sect2 xml:id="sec-grub2-menu-change">
-   <title>Ändern von Menüeinträgen während des Bootvorgangs</title><indexterm>
-   <primary>GRUB 2</primary>
-   <secondary> Menüeditor</secondary></indexterm>
+   <title>Ändern von Menüeinträgen während des Bootvorgangs</title>
    <para>
     Das direkte Bearbeiten von Menüeinträgen eröffnet einen Ausweg, wenn das System aufgrund einer fehlerhaften Konfiguration nicht mehr gebootet werden kann. Hiermit können Sie außerdem neue Einstellungen testen, ohne die bestehende Systemkonfiguration ändern zu müssen.
    </para>
@@ -518,9 +491,7 @@
   </sect2>
 
   <sect2 xml:id="sec-grub2-password">
-   <title>Festlegen eines Bootpassworts</title><indexterm>
-   <primary>GRUB 2</primary>
-   <secondary> Bootpasswort</secondary></indexterm>
+   <title>Festlegen eines Bootpassworts</title>
    <para>
     GRUB 2 unterstützt schon vor dem Booten des Betriebssystems den Zugriff auf Dateisysteme. Dies bedeutet, dass Benutzer ohne root-Berechtigungen auf Dateien des Linux-Systems zugreifen können, auf die sie nach dem Booten keinen Zugriff haben. Um diese Zugriffe oder das Booten bestimmter Menüeinträge zu verhindern, können Sie ein Bootpasswort festlegen.
    </para>

--- a/l10n/sles/de-de/xml/help_admin.xml
+++ b/l10n/sles/de-de/xml/help_admin.xml
@@ -6,10 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>Hilfe</primary></indexterm><indexterm>
- <primary>Dokumentation</primary>
- <see>Hilfe</see></indexterm>
+ </info>
  <para>
   Im Lieferumfang von <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> sind verschiedene Informationen und Dokumentationen enthalten, viele davon bereits in Ihr installiertes System integriert.
  </para>
@@ -32,9 +29,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>Desktop-Hilfezentren<indexterm>
-    <primary> Hilfe</primary>
-    <secondary> Hilfezentrum</secondary></indexterm> 
+   <term>Desktop-Hilfezentren 
    </term>
    <listitem>
     <para>
@@ -55,10 +50,7 @@
   <title>Dokumentationsverzeichnis</title>
 
   <para>
-   <indexterm>
-   <primary>Hilfe</primary>
-   <secondary> /usr/share/doc</secondary>
-   </indexterm>  Das traditionelle Verzeichnis zum Suchen von Dokumentationen in Ihrem installierten Linux-System finden Sie unter <filename>/usr/share/doc</filename>. Das Verzeichnis enthält normalerweise Informationen zu den auf Ihrem System installierten Paketen sowie Versionshinweise, Handbücher usw.
+     Das traditionelle Verzeichnis zum Suchen von Dokumentationen in Ihrem installierten Linux-System finden Sie unter <filename>/usr/share/doc</filename>. Das Verzeichnis enthält normalerweise Informationen zu den auf Ihrem System installierten Paketen sowie Versionshinweise, Handbücher usw.
   </para>
 
   <note>
@@ -71,12 +63,7 @@
   <sect2 xml:id="sec-help-onboard-docdir-manual">
    <title>SUSE-Handbücher</title>
    <para>
-    <indexterm>
-    <primary>Hilfe</primary>
-    <secondary> SUSE-Handbücher</secondary>
-    </indexterm> <indexterm>
-    <primary>   SUSE-Handbücher</primary>
-    </indexterm>  Wir bieten unsere Handbücher im HTML- und PDF-Format in verschiedenen Sprachen an. Im Unterverzeichnis <filename>Handbuch</filename> finden Sie HTML-Versionen der meisten für Ihr Produkt verfügbaren SUSE-Handbücher. Eine Übersicht über sämtliche für Ihr Produkt verfügbare Dokumentation finden Sie im Vorwort der Handbücher.
+       Wir bieten unsere Handbücher im HTML- und PDF-Format in verschiedenen Sprachen an. Im Unterverzeichnis <filename>Handbuch</filename> finden Sie HTML-Versionen der meisten für Ihr Produkt verfügbaren SUSE-Handbücher. Eine Übersicht über sämtliche für Ihr Produkt verfügbare Dokumentation finden Sie im Vorwort der Handbücher.
    </para>
    <para>
     Wenn mehr als eine Sprache installiert ist, enthält <filename>/usr/share/doc/manual</filename> möglicherweise verschiedene Sprachversionen der Handbücher. Die HTML-Versionen der SUSE-Handbücher stehen auch in der Hilfe an beiden Desktops zur Verfügung. Informationen zum Speicherort der PDF- und HTML-Versionen des Handbuchs auf Ihrem Installationsmedium finden Sie in den Versionshinweisen zu <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>. Sie stehen auf Ihrem installierten System unter <filename>/usr/share/doc/release-notes/</filename> oder online auf Ihrer produktspezifischen Webseite unter <link os="sles;sled" xlink:href="http://www.suse.com/releasenotes/"/> zur Verfügung.
@@ -87,10 +74,7 @@
   <sect2 xml:id="sec-help-onboard-docdir-pkg">
    <title>Dokumentation zu den einzelnen Paketen</title>
    <para>
-    <indexterm>
-    <primary>Hilfe</primary>
-    <secondary> Dokumentation zu Paketen</secondary>
-    </indexterm>  Im Verzeichnis <filename>packages</filename> befindet sich die Dokumentation zu den auf Ihrem System installierten Software-Paketen. Für jedes Paket wird das entsprechende Unterverzeichnis <filename>/usr/share/doc/packages/<replaceable>Paketname</replaceable></filename> erstellt. Es enthält README-Dateien für das Paket und manchmal Beispiele, Konfigurationsdateien und zusätzliche Skripten. In der folgenden Liste werden die typischen Dateien vorgestellt, die unter <filename>/usr/share/doc/packages</filename> zu finden sind. Diese Einträge sind nicht obligatorisch, und viele Pakete enthalten möglicherweise nur einige davon. 
+      Im Verzeichnis <filename>packages</filename> befindet sich die Dokumentation zu den auf Ihrem System installierten Software-Paketen. Für jedes Paket wird das entsprechende Unterverzeichnis <filename>/usr/share/doc/packages/<replaceable>Paketname</replaceable></filename> erstellt. Es enthält README-Dateien für das Paket und manchmal Beispiele, Konfigurationsdateien und zusätzliche Skripten. In der folgenden Liste werden die typischen Dateien vorgestellt, die unter <filename>/usr/share/doc/packages</filename> zu finden sind. Diese Einträge sind nicht obligatorisch, und viele Pakete enthalten möglicherweise nur einige davon. 
    </para>
    <variablelist>
     <varlistentry>
@@ -191,11 +175,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-help-onboard-manpages">
-  <title>man-Seiten</title><indexterm>
-
-  <primary> Hilfe</primary>
-
-  <secondary> man-Seiten</secondary></indexterm> 
+  <title>man-Seiten</title>
 
   <para>
    man-Seiten sind ein wichtiger Teil des Linux-Hilfesystems. Sie erklären die Verwendung der einzelnen Befehle und deren Optionen und Parameter. Sie greifen auf man-Seiten mit dem Befehl <command>man</command> gefolgt vom Namen des jeweiligen Befehls zu, z. B. <command>man ls</command>.
@@ -340,22 +320,14 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-help-onboard-infopages">
-  <title>Infoseiten</title><indexterm>
-
-  <primary> Hilfe</primary>
-
-  <secondary> Infoseiten</secondary></indexterm> 
+  <title>Infoseiten</title>
 
   <para>
    Eine weitere wichtige Informationsquelle sind Infoseiten. Diese sind im Allgemeinen ausführlicher als man-Seiten. Hier finden Sie nicht nur die Kommandozeilenoptionen, sondern manchmal sogar ganze Lernprogramme oder Referenzdokumentation. Die Infoseite für einen bestimmten Befehl zeigen Sie an, indem Sie <command>info</command> gefolgt vom Namen des Befehls eingeben, z. B. <command>info ls</command>. Infoseiten werden direkt in der Shell in einem Viewer angezeigt, in dem Sie zwischen den verschiedenen Abschnitten, so genannten <quote>Knoten, navigieren können</quote>. Mit <keycap function="space"/> blättern Sie vorwärts und mit <keycap function="backspace"/> zurück. Innerhalb eines Knotens können Sie auch mit <keycap function="pageup"/> und <keycap function="pagedown"/> navigieren, jedoch gelangen Sie nur mit <keycap function="space"/> und <keycap function="backspace"/> zum vorherigen bzw. nächsten Knoten. Drücken Sie <keycap>Q</keycap>, um den Anzeigemodus zu beenden. Nicht für jedes Kommando gibt es eine Infoseite und umgekehrt.
   </para>
  </sect1>
  <sect1 xml:id="sec-help-online">
-  <title>Online-Ressourcen</title><indexterm>
-
-  <primary>Hilfe</primary>
-
-  <secondary> Online-Dokumentation</secondary></indexterm>
+  <title>Online-Ressourcen</title>
 
   <para>
    Zusätzlich zu den Online-Versionen der SUSE-Handbücher, die unter <filename>/usr/share/doc</filename> installiert sind, können Sie auch auf die produktspezifischen Handbücher und Dokumentationen im Internet zugreifen. Eine Übersicht über alle Dokumentationen für <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> erhalten Sie auf der produktspezifischen Dokumentations-Website unter <phrase os="sles;sled"><link xlink:href="http://www.suse.com/doc/"/></phrase>.

--- a/l10n/sles/de-de/xml/help_user.xml
+++ b/l10n/sles/de-de/xml/help_user.xml
@@ -12,16 +12,11 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-help">
- <primary>Hilfe</primary></indexterm><indexterm>
- <primary>Dokumentation</primary>
- <see>Hilfe</see></indexterm>
+ </info>
 
  <variablelist>
   <varlistentry>
-   <term>Desktop-Hilfezentren<indexterm>
-    <primary> Hilfe</primary>
-    <secondary> Hilfezentrum</secondary></indexterm> 
+   <term>Desktop-Hilfezentren 
    </term>
    <listitem>
     <para>
@@ -56,11 +51,7 @@
   </varlistentry>
  </variablelist>
  <sect1 xml:id="sec-help-onboard-yelp">
-  <title>Verwenden der GNOME-Hilfe</title><indexterm>
-
-  <primary>Hilfe</primary>
-
-  <secondary> Hilfe</secondary></indexterm>
+  <title>Verwenden der GNOME-Hilfe</title>
 
   <para>
    Um die Hilfe direkt aus einer Anwendung zu starten, klicken Sie am GNOME-Desktop entweder auf die Schaltfläche <guimenu>Hilfe</guimenu>, oder drücken Sie <keycap>F1</keycap>. Mit beiden Optionen gelangen Sie direkt zur Dokumentation der Anwendung in der Hilfe. Sie können die Hilfe jedoch auch öffnen, indem Sie ein Terminalfenster öffnen und <command>yelp</command> eingeben. Alternativ klicken Sie im Hauptmenü auf <menuchoice><guimenu>Anwendungen</guimenu>
@@ -91,9 +82,7 @@
   <title>Weitere Hilferessourcen</title>
 
   <para>
-   <indexterm>
-   <primary>Hilfe</primary>
-   <secondary> Online-Dokumentation</secondary> </indexterm>  Zusätzlich zu den SUSE-Handbüchern, die unter <filename>/usr/share/doc</filename> installiert sind, können Sie auch auf die produktspezifischen Handbücher und Dokumentationen im Internet zugreifen. Eine Übersicht über alle Dokumentationen für <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> erhalten Sie auf der produktspezifischen Dokumentations-Website unter <link os="sles;sled" xlink:href="https://documentation.suse.com/"/>.
+     Zusätzlich zu den SUSE-Handbüchern, die unter <filename>/usr/share/doc</filename> installiert sind, können Sie auch auf die produktspezifischen Handbücher und Dokumentationen im Internet zugreifen. Eine Übersicht über alle Dokumentationen für <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> erhalten Sie auf der produktspezifischen Dokumentations-Website unter <link os="sles;sled" xlink:href="https://documentation.suse.com/"/>.
   </para>
 
   <para>
@@ -141,29 +130,20 @@
   </para>
 
   <sect2 xml:id="sec-help-more-tldp">
-   <title>Das Linux-Dokumentationsprojekt</title><indexterm>
-   <primary> TLDP</primary></indexterm><indexterm>
-   <primary>   Hilfe</primary>
-   <secondary> Linux-Dokumentationsprojekt (TLDP)</secondary></indexterm> 
+   <title>Das Linux-Dokumentationsprojekt</title>
    <para>
     Das Linux-Dokumentationsprojekt (TLDP) ist eine auf freiwilliger Mitarbeit beruhende Gemeinschaftsinitiative zur Erarbeitung von Linux-Dokumentationen und Veröffentlichungen zu verwandten Themen (siehe <link xlink:href="http://www.tldp.org"/>). Sie finden dort durchaus Anleitungen, die auch für Anfänger geeignet sind, doch hauptsächlich richten sich die Dokumente an erfahrene Benutzer, zum Beispiel an professionelle Systemadministratoren. Das Projekt veröffentlicht HOWTOs (Verfahrensbeschreibungen), FAQs (Antworten zu häufigen Fragen) sowie ausführliche Handbücher und stellt diese unter einer kostenlosen Lizenz zur Verfügung. Ein Teil der TLDP-Dokumentation ist auch unter <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> verfügbar.
    </para>
 
 
    <sect3 xml:id="sec-helpmore-tldp-faq">
-    <title>Häufig gestellte Fragen</title><indexterm>
-    <primary> help</primary>
-    <secondary> TLDP</secondary>
-    <tertiary> FAQs</tertiary></indexterm> 
+    <title>Häufig gestellte Fragen</title>
     <para>
      FAQs (Antworten zu häufigen Fragen) beinhalten bestimmte Fragestellungen und deren Antworten. FAQs wurden ursprünglich in Usenet Newsgroups eingeführt, um zu vermeiden, dass immer wieder die gleichen grundlegenden Fragen gestellt werden.
     </para>
    </sect3>
    <sect3 xml:id="sec-helpmore-tldp-guides">
-    <title>Tutoren</title><indexterm>
-    <primary> help</primary>
-    <secondary> TLDP</secondary>
-    <tertiary> Guides</tertiary></indexterm> 
+    <title>Tutoren</title>
     <para>
      Handbücher und Guides für verschiedene Themen oder Programme finden Sie unter <link xlink:href="http://www.tldp.org/guides.html"/>. Dort finden Sie Handbücher von <citetitle>Bash Guide for Beginners</citetitle> (Bash-Anleitungen für Anfänger) und der <citetitle>Linux Filesystem Hierarchy</citetitle> (Linux-Dateisystemhierarchie) bis hin zum <citetitle>Linux Administrator's Security Guide</citetitle> (Sicherheitshandbuch für Linux-Administratoren). Grundsätzlich sind Handbücher ausführlicher und umfassender als HOWTOs oder FAQs. und werden von Fachleuten für erfahrene Benutzer geschrieben. 
     </para>
@@ -175,9 +155,7 @@
 
 
   <sect2 xml:id="sec-help-more-wikipedia">
-   <title>Wikipedia: Die kostenlose Online-Enzyklopädie</title><indexterm>
-   <primary> Hilfe</primary>
-   <secondary> Wikipedia</secondary></indexterm>
+   <title>Wikipedia: Die kostenlose Online-Enzyklopädie</title>
    <remark>Translators: Translate the link http://en.wikipedia.org into your language: Replace "en"
     with your ISO language code.</remark> 
    <para>
@@ -186,11 +164,7 @@
   </sect2>
 
   <sect2 xml:id="sec-help-more-standards">
-   <title>Standards und Spezifikationen</title><indexterm>
-   <primary>Hilfe</primary>
-   <secondary>Standards</secondary></indexterm><indexterm>
-   <primary>Hilfe</primary>
-   <secondary>Spezifikationen</secondary></indexterm>
+   <title>Standards und Spezifikationen</title>
    <para>
     Informationen zu Standards und Spezifikationen werden von verschiedenen Organisationen zur Verfügung gestellt.
    </para>

--- a/l10n/sles/de-de/xml/lvm.xml
+++ b/l10n/sles/de-de/xml/lvm.xml
@@ -7,19 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>YaST</primary>
-
- <secondary>LVM</secondary></indexterm><indexterm>
-
- <primary>LVM</primary>
-
- <secondary>YaST</secondary></indexterm><indexterm>
-
- <primary>Logical Volume Manager</primary>
-
- <see>LVM</see></indexterm>
+ </info>
 
  <para>
   In diesem Abschnitt werden die Schritte erläutert, die bei der LVM-Konfiguration ausgeführt werden müssen. <phrase os="sles">Allgemeine Informationen zum Logical Volume Manager finden Sie im <xref linkend="sec-lvm-explained"/>.</phrase>

--- a/l10n/sles/de-de/xml/mobile.xml
+++ b/l10n/sles/de-de/xml/mobile.xml
@@ -11,36 +11,16 @@
     Die mobile Computernutzung wird meist mit Notebooks, PDAs, Mobiltelefonen (und dem Datenaustausch zwischen diesen Geräten) in Verbindung gebracht. An Notebooks oder Desktop-Systeme können aber auch mobile Hardware-Komponenten, wie externe Festplatten, Flash-Laufwerke und Digitalkameras, angeschlossen sein. Ebenso zählen zahlreiche Software-Komponenten zu den Bestandteilen mobiler Computerszenarien und einige Anwendungen sind sogar speziell für die mobile Verwendung vorgesehen.
    </para>
   </abstract>
- </info><indexterm xml:id="idx-mobility" class="startofrange">
- <primary>Mobilität</primary></indexterm>
+ </info>
  <sect1 xml:id="sec-mobile-nbook">
-  <title>Notebooks</title><indexterm class="startofrange" xml:id="idx-notebook">
-
-  <primary>Notebooks</primary></indexterm><indexterm>
-
-  <primary>Notebooks</primary>
-
-  <secondary>Hardware</secondary></indexterm><indexterm>
-
-  <primary>Notebooks</primary>
-
-  <secondary>PCMCIA</secondary></indexterm><indexterm>
-
-  <primary>PCMCIA</primary></indexterm><indexterm>
-
-  <primary>Mobilität</primary>
-
-  <secondary>Notebooks</secondary></indexterm>
+  <title>Notebooks</title>
 
   <para>
    Die Hardware von Notebooks unterscheidet sich von der eines normalen Desktopsystems. Dies liegt daran, dass Kriterien wie Austauschbarkeit, Platzanforderungen und Energieverbrauch berücksichtigt werden müssen. Die Hersteller von mobiler Hardware haben Standardschnittstellen wie PCMCIA (Personal Computer Memory Card International Association), Mini PCI und Mini PCIe entwickelt, die zur Erweiterung der Hardware von Laptops verwendet werden können. Dieser Standard bezieht sich auf Speicherkarten, Netzwerkschnittstellenkarten und externe Festplatten.
   </para>
 
   <sect2 xml:id="sec-mobile-powerm">
-   <title>Energieeinsparung</title><indexterm>
-   <primary> Notebooks</primary>
-   <secondary> Energieverwaltung</secondary></indexterm><indexterm>
-   <primary>   Energieverwaltung</primary></indexterm> 
+   <title>Energieeinsparung</title>
    <para>
     Durch die Integration von energieoptimierten Systemkomponenten bei der Herstellung von Notebooks erhöht sich die Eignung der Geräte für die Verwendung ohne Zugang zum Stromnetz. Ihr Beitrag zur Energieeinsparung ist mindestens so wichtig wie der des Betriebssystems. <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> unterstützt verschiedene Methoden, die den Energieverbrauch eines Notebooks steuern und sich bei Akkubetrieb auf die Betriebsdauer auswirken. In der folgenden Liste werden die Möglichkeiten zur Energieeinsparung in absteigender Reihenfolge ihrer Wirksamkeit angegeben:
    </para>
@@ -77,8 +57,7 @@
   </sect2>
 
   <sect2 xml:id="sec-mobile-nbook-change">
-   <title>Integration in unterschiedlichen Betriebsumgebungen</title><indexterm>
-   <primary>Laptops</primary></indexterm>
+   <title>Integration in unterschiedlichen Betriebsumgebungen</title>
    <para>
     Ihr System muss sich an unterschiedliche Betriebsumgebungen anpassen können, wenn es für mobile Computernutzung verwendet werden soll. Viele Dienste hängen von der Umgebung ab und die zugrunde liegenden Clients müssen neu konfiguriert werden. <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> übernimmt diese Aufgabe für Sie.
    </para>
@@ -138,12 +117,7 @@
      <term>NetworkManager</term>
      <listitem>
       <para>
-       <indexterm>
-       <primary>NetworkManager</primary>
-       </indexterm> <indexterm>
-       <primary>NotebooksNetworkManager</primary>
-       <secondary> Der NetworkManager wurde speziell für die mobile Verbindung von Notebooks mit Netzwerken entwickelt. </secondary>
-       </indexterm> NetworkManager bietet die Möglichkeit, einfach und automatisch zwischen Netzwerkumgebungen oder unterschiedlichen Netzwerktypen, wie mobiles Breitband (GPRS, EDGE oder 3G), WLAN und Ethernet zu wechseln. NetworkManager unterstützt die WEP- und WPA-PSK-Verschlüsselung in drahtlosen LANs. Auch DFÜ-Verbindungen werden unterstützt. Der GNOME-Desktop bietet ein Frontend für NetworkManager. Weitere Informationen finden Sie unter <xref linkend="sec-nm-configure"/>.
+         NetworkManager bietet die Möglichkeit, einfach und automatisch zwischen Netzwerkumgebungen oder unterschiedlichen Netzwerktypen, wie mobiles Breitband (GPRS, EDGE oder 3G), WLAN und Ethernet zu wechseln. NetworkManager unterstützt die WEP- und WPA-PSK-Verschlüsselung in drahtlosen LANs. Auch DFÜ-Verbindungen werden unterstützt. Der GNOME-Desktop bietet ein Frontend für NetworkManager. Weitere Informationen finden Sie unter <xref linkend="sec-nm-configure"/>.
       </para>
       <table>
        <title>Anwendungsbeispiele für den NetworkManager</title>
@@ -229,12 +203,7 @@
      <term>SLP</term>
      <listitem>
       <para>
-       <indexterm>
-       <primary>Notebooks</primary>
-       <secondary> SLP</secondary>
-       </indexterm> <indexterm>
-       <primary>   SLP</primary>
-       </indexterm>  Das Service Location Protocol (SLP) vereinfacht die Verbindung eines Notebooks mit einem bestehenden Netzwerk. Ohne SLP benötigt der Administrator eines Notebooks normalerweise detaillierte Kenntnisse über die im Netzwerk verfügbaren Dienste. SLP sendet die Verfügbarkeit eines bestimmten Diensttyps an alle Clients in einem lokalen Netzwerk. Anwendungen, die SLP unterstützen, können die von SLP weitergeleiteten Informationen verarbeiten und automatisch konfiguriert werden. SLP kann auch zur Installation eines Systems verwendet werden und minimiert dabei den Aufwand bei der Suche nach einer geeigneten Installationsquelle. <phrase os="sles;osuse"> Weitere Informationen zu SLP finden Sie unter <xref linkend="cha-slp"/>.</phrase>
+          Das Service Location Protocol (SLP) vereinfacht die Verbindung eines Notebooks mit einem bestehenden Netzwerk. Ohne SLP benötigt der Administrator eines Notebooks normalerweise detaillierte Kenntnisse über die im Netzwerk verfügbaren Dienste. SLP sendet die Verfügbarkeit eines bestimmten Diensttyps an alle Clients in einem lokalen Netzwerk. Anwendungen, die SLP unterstützen, können die von SLP weitergeleiteten Informationen verarbeiten und automatisch konfiguriert werden. SLP kann auch zur Installation eines Systems verwendet werden und minimiert dabei den Aufwand bei der Suche nach einer geeigneten Installationsquelle. <phrase os="sles;osuse"> Weitere Informationen zu SLP finden Sie unter <xref linkend="cha-slp"/>.</phrase>
       </para>
      </listitem>
     </varlistentry>
@@ -247,8 +216,7 @@
     Bei der mobilen Nutzung gibt es verschiedene Aufgabenbereiche, die von dedizierter Software abgedeckt werden: Systemüberwachung (insbesondere der Ladezustand des Akkus), Datensynchronisierung sowie drahtlose Kommunikation mit angeschlossenen Geräten und dem Internet. In den folgenden Abschnitten werden die wichtigsten Anwendungen behandelt, die <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> für jede Aufgabe bietet.
    </para>
    <sect3 xml:id="sec-mobile-nbook-soft-mon">
-    <title>Systemüberwachung</title><indexterm>
-    <primary> Systemüberwachung</primary></indexterm> 
+    <title>Systemüberwachung</title>
     <para>
      <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> umfasst zwei Werkzeuge zur Systemüberwachung:
     </para>
@@ -257,12 +225,7 @@
       <term>Energieverwaltung</term>
       <listitem>
        <para>
-        <indexterm>
-        <primary>Systemüberwachung</primary>
-        <secondary> Energieverwaltung</secondary>
-        </indexterm> <indexterm>
-        <primary>   Power-Management</primary>
-        </indexterm> <guimenu> Power-Management</guimenu> ist eine Anwendung für die Einstellung der mit der Energieeinsparung zusammenhängenden Verhaltensweisen des GNOME-Desktops. Diese Anwendung finden Sie in der Regel unter <menuchoice><guimenu>Rechner</guimenu> <guimenu>Kontrollzentrum</guimenu> <guimenu>System</guimenu> <guimenu>Power-Management</guimenu></menuchoice>.
+          <guimenu> Power-Management</guimenu> ist eine Anwendung für die Einstellung der mit der Energieeinsparung zusammenhängenden Verhaltensweisen des GNOME-Desktops. Diese Anwendung finden Sie in der Regel unter <menuchoice><guimenu>Rechner</guimenu> <guimenu>Kontrollzentrum</guimenu> <guimenu>System</guimenu> <guimenu>Power-Management</guimenu></menuchoice>.
        </para>
       </listitem>
      </varlistentry>
@@ -270,10 +233,7 @@
       <term>Systemmonitor</term>
       <listitem>
        <para>
-        <indexterm>
-        <primary>Systemüberwachung</primary>
-        <secondary> Systemmonitor</secondary>
-        </indexterm>  Der <guimenu>Systemmonitor</guimenu> fasst messbare Systemparameter in einer Überwachungsumgebung zusammen. Die Informationen werden standardmäßig auf drei Karteireitern ausgegeben. <guimenu>Processes</guimenu> (Prozesse) enthält detaillierte Informationen zu den aktuell ausgeführten Prozessen, wie CPU-Last, Speicherauslastung oder Prozess-ID und Priorität. Die Präsentation und Filterung der erfassten Daten kann angepasst werden – um einen neuen Typ von Prozessinformationen hinzuzufügen, klicken Sie mit der linken Maustaste auf die Kopfzeile der Tabelle, und wählen Sie die Spalte aus, die Sie zur Ansicht hinzufügen oder daraus ausblenden möchten. Es ist auch möglich, verschiedene Systemparameter auf verschiedenen Datenseiten zu überwachen oder die Daten von mehreren Computern parallel über das Netzwerk zu sammeln. Auf dem Karteireiter <guimenu>Ressourcen</guimenu> wird die CPU-, Arbeitsspeicher- und Netzwerkauslastung grafisch dargestellt, und der Karteireiter <guimenu>Dateisystem</guimenu> enthält eine Liste aller Partitionen und ihrer Nutzung.
+          Der <guimenu>Systemmonitor</guimenu> fasst messbare Systemparameter in einer Überwachungsumgebung zusammen. Die Informationen werden standardmäßig auf drei Karteireitern ausgegeben. <guimenu>Processes</guimenu> (Prozesse) enthält detaillierte Informationen zu den aktuell ausgeführten Prozessen, wie CPU-Last, Speicherauslastung oder Prozess-ID und Priorität. Die Präsentation und Filterung der erfassten Daten kann angepasst werden – um einen neuen Typ von Prozessinformationen hinzuzufügen, klicken Sie mit der linken Maustaste auf die Kopfzeile der Tabelle, und wählen Sie die Spalte aus, die Sie zur Ansicht hinzufügen oder daraus ausblenden möchten. Es ist auch möglich, verschiedene Systemparameter auf verschiedenen Datenseiten zu überwachen oder die Daten von mehreren Computern parallel über das Netzwerk zu sammeln. Auf dem Karteireiter <guimenu>Ressourcen</guimenu> wird die CPU-, Arbeitsspeicher- und Netzwerkauslastung grafisch dargestellt, und der Karteireiter <guimenu>Dateisystem</guimenu> enthält eine Liste aller Partitionen und ihrer Nutzung.
        </para>
       </listitem>
      </varlistentry>
@@ -289,13 +249,7 @@
       <term>Synchronisieren von E-Mail</term>
       <listitem>
        <para>
-        <indexterm>
-        <primary>Synchronisieren von Daten</primary>
-        <secondary> E-Mail</secondary>
-        </indexterm> <indexterm>
-        <primary>   E-Mail</primary>
-        <secondary> synchronisieren</secondary>
-        </indexterm>  Verwenden eines IMAP-Kontos zum Speichern der E-Mails im Firmennetzwerk. Greifen Sie dann auf die E-Mails vom Arbeitsplatzrechner aus über einen beliebigen, nicht verbundenen IMAP-fähigen E-Mail-Client wie Mozilla Thunderbird oder Evolution zu, wie im <xref linkend="book-gnomeuser"/> beschrieben. Der E-Mail-Client muss so konfiguriert sein, dass für <literal>Gesendete Nachrichten</literal> immer derselbe Ordner aufgerufen wird.  Dadurch wird gewährleistet, dass nach Abschluss der Synchronisierung alle Nachrichten mit den zugehörigen Statusinformationen verfügbar sind. Verwenden Sie zum Senden von Nachrichten einen im Mail-Client implementierten SMTP-Server anstatt des systemweiten MTA-Postfix oder Sendmail, um zuverlässige Rückmeldungen über nicht gesendete Mail zu erhalten.
+           Verwenden eines IMAP-Kontos zum Speichern der E-Mails im Firmennetzwerk. Greifen Sie dann auf die E-Mails vom Arbeitsplatzrechner aus über einen beliebigen, nicht verbundenen IMAP-fähigen E-Mail-Client wie Mozilla Thunderbird oder Evolution zu, wie im <xref linkend="book-gnomeuser"/> beschrieben. Der E-Mail-Client muss so konfiguriert sein, dass für <literal>Gesendete Nachrichten</literal> immer derselbe Ordner aufgerufen wird.  Dadurch wird gewährleistet, dass nach Abschluss der Synchronisierung alle Nachrichten mit den zugehörigen Statusinformationen verfügbar sind. Verwenden Sie zum Senden von Nachrichten einen im Mail-Client implementierten SMTP-Server anstatt des systemweiten MTA-Postfix oder Sendmail, um zuverlässige Rückmeldungen über nicht gesendete Mail zu erhalten.
        </para>
       </listitem>
      </varlistentry>
@@ -303,18 +257,14 @@
       <term>Synchronisieren von Dateien und Verzeichnissen</term>
       <listitem>
        <para>
-        <indexterm>
-        <primary>Synchronisieren von Daten</primary>
-        </indexterm> Es gibt mehrere Dienstprogramme, die sich für die Synchronisierung von Daten zwischen Notebook und Arbeitsstation eignen. Am meisten verwendet wird ein Kommandozeilen-Tool namens <command>rsync</command>. Weitere Informationen hierzu finden Sie auf dessen man-Seite <command>man 1 rsync</command>).
+         Es gibt mehrere Dienstprogramme, die sich für die Synchronisierung von Daten zwischen Notebook und Arbeitsstation eignen. Am meisten verwendet wird ein Kommandozeilen-Tool namens <command>rsync</command>. Weitere Informationen hierzu finden Sie auf dessen man-Seite <command>man 1 rsync</command>).
        </para>
       </listitem>
      </varlistentry>
     </variablelist>
    </sect3>
    <sect3 xml:id="sec-mobile-nbook-soft-wifi">
-    <title>Drahtlose Kommunikation: WLAN</title><indexterm>
-    <primary>Netzwerke</primary>
-    <secondary> WLAN</secondary></indexterm>
+    <title>Drahtlose Kommunikation: WLAN</title>
     <para>
      WLAN weist unter diesen drahtlosen Technologien die größte Reichweite auf und ist daher das einzige System, das für den Betrieb großer und zuweilen sogar räumlich getrennter Netzwerke geeignet ist. Einzelne Computer können untereinander eine Verbindung herstellen und so ein unabhängiges drahtloses Netzwerk bilden oder auf das Internet zugreifen. Als <emphasis>Zugriffspunkte</emphasis> bezeichnete Geräte können als Basisstationen für WLAN-fähige Geräte und als Zwischengeräte für den Zugriff auf das Internet fungieren. Ein mobiler Benutzer kann zwischen verschiedenen Zugriffspunkten umschalten, je nachdem, welcher Zugriffspunkt die beste Verbindung aufweist. Wie bei der Mobiltelefonie steht WLAN-Benutzern ein großes Netzwerk zur Verfügung, ohne dass sie für den Zugriff an einen bestimmten Standort gebunden sind.
     </para>
@@ -579,34 +529,19 @@
    <sect3 xml:id="sec-mobile-nbook-soft-bluetooth">
     <title>Drahtlose Kommunikation: Bluetooth</title>
     <para>
-     <indexterm>
-     <primary>Netzwerke</primary>
-     <secondary> Bluetooth</secondary>
-     </indexterm> <indexterm>
-     <primary>   Bluetooth</primary>
-     </indexterm>  Bluetooth weist das breiteste Anwendungsspektrum von allen drahtlosen Technologien auf. Es kann, ebenso wie IrDA, für die Kommunikation zwischen Computern (Notebooks) und PDAs oder Mobiltelefonen verwendet werden. Außerdem kann es zur Verbindung mehrerer Computer innerhalb des zulässigen Bereichs verwendet werden. Des Weiteren wird Bluetooth zum Anschluss drahtloser Systemkomponenten, beispielsweise Tastatur oder Maus, verwendet. Die Reichweite dieser Technologie reicht jedoch nicht aus, um entfernte Systeme über ein Netzwerk zu verbinden. WLAN ist die optimale Technologie für die Kommunikation durch physische Hindernisse, wie Wände.
+        Bluetooth weist das breiteste Anwendungsspektrum von allen drahtlosen Technologien auf. Es kann, ebenso wie IrDA, für die Kommunikation zwischen Computern (Notebooks) und PDAs oder Mobiltelefonen verwendet werden. Außerdem kann es zur Verbindung mehrerer Computer innerhalb des zulässigen Bereichs verwendet werden. Des Weiteren wird Bluetooth zum Anschluss drahtloser Systemkomponenten, beispielsweise Tastatur oder Maus, verwendet. Die Reichweite dieser Technologie reicht jedoch nicht aus, um entfernte Systeme über ein Netzwerk zu verbinden. WLAN ist die optimale Technologie für die Kommunikation durch physische Hindernisse, wie Wände.
     </para>
    </sect3>
    <sect3 xml:id="sec-mobile-nbook-soft-irda">
     <title>Drahtlose Kommunikation: IrDA</title>
     <para>
-     <indexterm>
-     <primary>Netzwerke</primary>
-     <secondary> IrDA</secondary>
-     </indexterm> <indexterm>
-     <primary>   IrDA</primary>
-     </indexterm>  IrDA ist die drahtlose Technologie mit der kürzesten Reichweite. Beide Kommunikationspartner müssen sich in Sichtweite voneinander befinden. Hindernisse, wie Wände, können nicht überwunden werden. Eine mögliche Anwendung von IrDA ist die Übertragung einer Datei von einem Notebook auf ein Mobiltelefon. Die kurze Entfernung zwischen Notebook und Mobiltelefon wird mit IrDa überbrückt. Die Langstreckenübertragung der Datei an den Empfänger erfolgt über das mobile Netzwerk. Ein weiterer Anwendungsbereich von IrDA ist die drahtlose Übertragung von Druckaufträgen im Büro.
+        IrDA ist die drahtlose Technologie mit der kürzesten Reichweite. Beide Kommunikationspartner müssen sich in Sichtweite voneinander befinden. Hindernisse, wie Wände, können nicht überwunden werden. Eine mögliche Anwendung von IrDA ist die Übertragung einer Datei von einem Notebook auf ein Mobiltelefon. Die kurze Entfernung zwischen Notebook und Mobiltelefon wird mit IrDa überbrückt. Die Langstreckenübertragung der Datei an den Empfänger erfolgt über das mobile Netzwerk. Ein weiterer Anwendungsbereich von IrDA ist die drahtlose Übertragung von Druckaufträgen im Büro.
     </para>
    </sect3>
   </sect2>
 
   <sect2 xml:id="sec-mobile-nbook-sec">
-   <title>Datensicherheit</title><indexterm>
-   <primary> Mobilität</primary>
-   <secondary> Datensicherheit</secondary></indexterm><indexterm>
-   <primary>   Sicherheit</primary>
-   <secondary> verschlüsseltes Dateisystem</secondary></indexterm><indexterm>
-   <primary>   Datensicherheit</primary></indexterm> 
+   <title>Datensicherheit</title>
    <para>
     Idealerweise schützen Sie die Daten auf Ihrem Notebook mehrfach gegen unbefugten Zugriff. Mögliche Sicherheitsmaßnahmen können in folgenden Bereichen ergriffen werden:
    </para>
@@ -649,43 +584,11 @@
       </para>
      </listitem>
     </varlistentry>
-   </variablelist><indexterm class="endofrange" startref="idx-notebook"/>
+   </variablelist>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-mobile-hw">
-  <title>Mobile Hardware</title><indexterm>
-
-  <primary>Mobilität</primary>
-
-  <secondary>USB</secondary></indexterm><indexterm>
-
-  <primary>Mobilität</primary>
-
-  <secondary>FireWire (IEEE 1394)</secondary></indexterm><indexterm>
-
-  <primary>FireWire (IEEE 1394)</primary>
-
-  <secondary>Festplatten</secondary></indexterm><indexterm>
-
-  <primary>USB</primary>
-
-  <secondary>Festplatten</secondary></indexterm><indexterm>
-
-  <primary>USB</primary>
-
-  <secondary>Flash-Laufwerke</secondary></indexterm><indexterm>
-
-  <primary>Flash-Laufwerke</primary></indexterm><indexterm>
-
-  <primary>Mobilität</primary>
-
-  <secondary>externe Festplatten</secondary></indexterm><indexterm>
-
-  <primary>Mobilität</primary>
-
-  <secondary>Digitalkameras</secondary></indexterm><indexterm>
-
-  <primary>Digitalkameras</primary></indexterm>
+  <title>Mobile Hardware</title>
 
   <para>
    <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> unterstützt die automatische Erkennung mobiler Speichergeräte über FireWire (IEEE 1394) oder USB. Der Ausdruck <emphasis>mobiles Speichergerät</emphasis> bezieht sich auf jegliche Arten von FireWire- oder USB-Festplatten, Flash-Laufwerken oder Digitalkameras. Alle Geräte werden automatisch erkannt und konfiguriert, wenn sie mit dem System über die entsprechende Schnittstelle verbunden werden. Der Dateimanager in GNOME ermöglicht die flexible Handhabung von mobilen Hardwaregeräten. Zum sicheren Aushängen dieser Medien verwenden Sie die GNOME-Funktion <guimenu>Unmount Volume</guimenu> (Volumen aushängen) im Dateimanager. Weitere Informationen finden Sie unter <xref linkend="book-gnomeuser"/>.
@@ -717,19 +620,7 @@
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-mobile-comm">
-  <title>Mobilgeräte (Smartphones und Tablets)</title><indexterm>
-
-  <primary>Mobilität</primary>
-
-  <secondary>Smartphones</secondary></indexterm><indexterm>
-
-  <primary>Mobilität</primary>
-
-  <secondary>Tablets</secondary></indexterm><indexterm>
-
-  <primary>Smartphones</primary></indexterm><indexterm>
-
-  <primary>Tablets</primary></indexterm>
+  <title>Mobilgeräte (Smartphones und Tablets)</title>
 
   <para>
    Ein Desktop-System oder ein Laptop kann mit Mobilgeräten über Bluetooth, WLAN oder eine direkte USB-Verbindung kommunizieren. Die Auswahl der Verbindungsmethode ist abhängig vom Modell des Mobilgeräts und von Ihren jeweiligen Anforderungen. Wenn Sie ein Mobilgerät über USB mit einem Desktop-System oder einem Laptop verbinden, können Sie mit dem Gerät in der Regel ebenso wie mit herkömmlichem externem Speicher arbeiten. Über eine Bluetooth- oder WLAN-Verbindung können Sie direkt vom Desktop-System oder Laptop aus mit dem Mobilgerät interagieren und seine Funktionen steuern. Es stehen verschiedene grafische Open-Source-Oberflächen für die Steuerung des verbundenen Geräts zur Auswahl (insbesondere <link xlink:href="https://community.kde.org/KDEConnect">KDE Connect</link> und <link xlink:href="https://extensions.gnome.org/extension/1319/gsconnect/">GSConnect</link>).

--- a/l10n/sles/de-de/xml/net_config_files.xml
+++ b/l10n/sles/de-de/xml/net_config_files.xml
@@ -7,10 +7,7 @@
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
  </info>
-<indexterm>
- <primary> Konfigurationsdateien</primary></indexterm><indexterm xml:id="idx-networks-configuration-files" class="startofrange">
- <primary>   Netzwerke</primary>
- <secondary> Konfigurationsdateien</secondary></indexterm> 
+ 
  <para>
   Dieser Abschnitt bietet einen Überblick über die Netzwerkkonfigurationsdateien und erklärt ihren Zweck sowie das verwendete Format.
  </para>
@@ -82,21 +79,13 @@ MACVLAN_DEVICE='eth0'
   <para>
    Informationen zu <filename>ifcfg.template</filename> finden Sie unter <xref linkend="sec-basicnet-manconf-files-config-etc"/>.
   </para>
-<indexterm>
-  <primary> Konfigurationsdateien</primary>
-  <secondary> ifcfg-*</secondary></indexterm> 
+ 
   <para arch="zseries" os="sles">
    IBM Z unterstützt USB nicht. Die Namen der Schnittstellendateien und Netzwerkaliasse enthalten IBM Z-spezifische Elemente wie <literal>qeth</literal>.
   </para>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-config-etc">
-  <title><filename>/etc/sysconfig/network/config</filename>, <filename>/etc/sysconfig/network/dhcp</filename> und <filename>/etc/sysconfig/network/wireless</filename></title><indexterm>
-  <primary> Konfigurationsdateien</primary>
-  <secondary> Netzwerk</secondary></indexterm><indexterm>
-  <primary>   Konfigurationsdateien</primary>
-  <secondary> dhcp</secondary></indexterm><indexterm>
-  <primary>   Konfigurationsdateien</primary>
-  <secondary> wireless</secondary></indexterm> 
+  <title><filename>/etc/sysconfig/network/config</filename>, <filename>/etc/sysconfig/network/dhcp</filename> und <filename>/etc/sysconfig/network/wireless</filename></title>
   <para>
    Die Datei <filename>config</filename> enthält allgemeine Einstellungen für das Verhalten von <command>ifup</command>, <command>ifdown</command> und <command>ifstatus</command>. <filename>dhcp</filename> enthält DHCP-Einstellungen und <filename>wireless</filename> Einstellungen für Wireless-LAN-Karten. Die Variablen in allen drei Konfigurationsdateien sind kommentiert. Einige der Variablen von <filename>/etc/sysconfig/network/config</filename> können auch in <filename>ifcfg-*</filename>-Dateien verwendet werden, wo sie eine höhere Priorität erhalten. Die Datei <filename>/etc/sysconfig/network/ifcfg.template</filename> listet Variablen auf, die mit einer Reichweite pro Schnittstelle angegeben werden können. Jedoch sind die meisten <filename>/etc/sysconfig/network/config</filename>-Variablen global und lassen sich in ifcfg-Dateien nicht überschreiben. Beispielsweise sind die Variablen <systemitem>NETWORKMANAGER</systemitem> oder <systemitem>NETCONFIG_*</systemitem> global.
   </para>
@@ -115,19 +104,9 @@ MACVLAN_DEVICE='eth0'
 
  <sect3 xml:id="sec-basicnet-manconf-files-routes">
   <title><filename>/etc/sysconfig/network/routes</filename> und <filename>/etc/sysconfig/network/ifroute-*</filename></title>
-<indexterm xml:id="idx-routing" class="startofrange">
-  <primary>Routing</primary></indexterm><indexterm>
-  <primary>Routing</primary>
-  <secondary>Routen</secondary></indexterm><indexterm>
-  <primary>Konfigurationsdateien</primary>
-  <secondary>Routen</secondary></indexterm><indexterm>
-  <primary>Konfigurieren</primary>
-  <secondary>Routing</secondary></indexterm>
+
   <para>
-   Das statische Routing von TCP/IP-Paketen wird mit den Dateien <filename>/etc/sysconfig/network/routes</filename> und <filename>/etc/sysconfig/network/ifroute-*</filename> bestimmt. Alle statischen Routen, die für verschiedene Systemaufgaben benötigt werden, können in <filename>/etc/sysconfig/network/routes</filename> angegeben werden: Routen zu einem Host, Routen zu einem Host über Gateways und Routen zu einem Netzwerk. Definieren Sie für jede Schnittstelle, die individuelles Routing benötigt, eine zusätzliche Konfigurationsdatei: <filename>/etc/sysconfig/network/ifroute-*</filename>. Ersetzen Sie das Platzhalterzeichen (<literal>*</literal>) durch den Namen der Schnittstelle. Die folgenden Einträge werden in die Routing-Konfigurationsdatei aufgenommen: <indexterm>
-   <primary> Routing</primary>
-   <secondary> statisch</secondary>
-   </indexterm>
+   Das statische Routing von TCP/IP-Paketen wird mit den Dateien <filename>/etc/sysconfig/network/routes</filename> und <filename>/etc/sysconfig/network/ifroute-*</filename> bestimmt. Alle statischen Routen, die für verschiedene Systemaufgaben benötigt werden, können in <filename>/etc/sysconfig/network/routes</filename> angegeben werden: Routen zu einem Host, Routen zu einem Host über Gateways und Routen zu einem Netzwerk. Definieren Sie für jede Schnittstelle, die individuelles Routing benötigt, eine zusätzliche Konfigurationsdatei: <filename>/etc/sysconfig/network/ifroute-*</filename>. Ersetzen Sie das Platzhalterzeichen (<literal>*</literal>) durch den Namen der Schnittstelle. Die folgenden Einträge werden in die Routing-Konfigurationsdatei aufgenommen: 
   </para>
 <screen># Destination     Gateway           Netmask            Interface  Options</screen>
 
@@ -170,21 +149,13 @@ default           204.127.235.41    0.0.0.0            eth0
 # Destination     [Gateway]                -           Interface
 2001:DB8:100::/64 -                        -           eth0
 2001:DB8:100::/32 fe80::216:3eff:fe6d:c042 -           eth0</screen>
-  </example><indexterm class="endofrange" startref="idx-routing"/>
+  </example>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-resolv">
   <title><filename>/etc/resolv.conf</filename></title>
-<indexterm>
-  <primary> Konfigurationsdateien</primary>
-  <secondary> resolv.conf</secondary></indexterm> 
+ 
   <para>
-   In <filename>/etc/resolv.conf</filename> wird die Domäne angegeben, zu der der Host gehört (Schlüsselwort <systemitem>search</systemitem>). Mit der Option <systemitem>search</systemitem> können Sie bis zu sechs Domänen mit insgesamt 256 Zeichen angeben. Bei der Auflösung eines Namens, der nicht voll qualifiziert ist, wird versucht, einen solchen zu generieren, indem die einzelnen <systemitem>search</systemitem>-Einträge angehängt werden. Mit der Option <systemitem>nameserver</systemitem> können Sie bis zu drei Nameserver angeben (jeweils in einer eigenen Zeile). Kommentare sind mit einer Raute (<literal>#</literal>) oder einem Semikolon (<literal>;</literal>) gekennzeichnet. Ein Beispiel finden Sie in <xref linkend="dat-netz-etc-resolv-conf"/>. <indexterm>
-   <primary>DNS</primary>
-   <secondary>Domänen</secondary>
-   </indexterm> <indexterm>
-   <primary>DNS</primary>
-   <secondary>Namenserver</secondary>
-   </indexterm>
+   In <filename>/etc/resolv.conf</filename> wird die Domäne angegeben, zu der der Host gehört (Schlüsselwort <systemitem>search</systemitem>). Mit der Option <systemitem>search</systemitem> können Sie bis zu sechs Domänen mit insgesamt 256 Zeichen angeben. Bei der Auflösung eines Namens, der nicht voll qualifiziert ist, wird versucht, einen solchen zu generieren, indem die einzelnen <systemitem>search</systemitem>-Einträge angehängt werden. Mit der Option <systemitem>nameserver</systemitem> können Sie bis zu drei Nameserver angeben (jeweils in einer eigenen Zeile). Kommentare sind mit einer Raute (<literal>#</literal>) oder einem Semikolon (<literal>;</literal>) gekennzeichnet. Ein Beispiel finden Sie in <xref linkend="dat-netz-etc-resolv-conf"/>.  
   </para>
   <para>
    Jedoch darf <filename>/etc/resolv.conf</filename> nicht manuell bearbeitet werden. Stattdessen wird es vom Skript <command>netconfig</command> generiert. Um die statische DNS-Konfiguration ohne YaST zu definieren, bearbeiten Sie die entsprechenden Variablen in der Datei <filename>/etc/sysconfig/network/config</filename> manuell:
@@ -307,9 +278,7 @@ nameserver 192.168.1.116</screen>
 
  <sect3 xml:id="sec-basicnet-manconf-hosts">
   <title><filename>/etc/hosts</filename></title>
-<indexterm>
-  <primary> Konfigurationsdateien</primary>
-  <secondary> Hosts</secondary></indexterm> 
+ 
   <para>
    In dieser Datei werden, wie in <xref linkend="dat-netz-etc-hosts"/> gezeigt, IP-Adressen zu Hostnamen zugewiesen. Wenn kein Namenserver implementiert ist, müssen alle Hosts, für die IP-Verbindungen eingerichtet werden sollen, hier aufgeführt sein. Geben Sie für jeden Host in die Datei eine Zeile ein, die aus der IP-Adresse, dem voll qualifizierten Hostnamen und dem Hostnamen besteht. Die IP-Adresse muss am Anfang der Zeile stehen und die Einträge müssen durch Leerzeichen und Tabulatoren getrennt werden. Kommentaren wird immer das <literal>#</literal>-Zeichen vorangestellt.
   </para>
@@ -321,9 +290,7 @@ nameserver 192.168.1.116</screen>
   </example>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-networks">
-  <title><filename>/etc/networks</filename></title><indexterm>
-  <primary> Konfigurationsdateien</primary>
-  <secondary>Netzwerke</secondary></indexterm> 
+  <title><filename>/etc/networks</filename></title>
   <para>
    Hier werden Netzwerknamen in Netzwerkadressen umgesetzt. Das Format ähnelt dem der <filename>hosts</filename>-Datei, jedoch stehen hier die Netzwerknamen vor den Adressen. Weitere Informationen hierzu finden Sie unter <xref linkend="dat-netz-networks"/>.
   </para>
@@ -334,9 +301,7 @@ localnet     192.168.0.0</screen>
   </example>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-host">
-  <title><filename>/etc/host.conf</filename></title><indexterm>
-  <primary> Konfigurationsdateien</primary>
-  <secondary> host.conf</secondary></indexterm> 
+  <title><filename>/etc/host.conf</filename></title>
   <para>
    Das Auflösen von Namen, d. h. das Übersetzen von Host- bzw. Netzwerknamen über die <emphasis>resolver</emphasis>-Bibliothek, wird durch diese Datei gesteuert. Diese Datei wird nur für Programme verwendet, die mit libc4 oder libc5 gelinkt sind. Weitere Informationen zu aktuellen glibc-Programmen finden Sie in den Einstellungen in <filename>/etc/nsswitch.conf</filename>. Jeder Parameter muss immer auf einer separaten Zeile eingegeben werden. Kommentare werden durch ein <literal>#</literal>-Zeichen eingeleitet. Die verfügbaren Parameter sind in <xref linkend="tab-netz-param-hostconf"/> aufgeführt. Ein Beispiel für <filename>/etc/host.conf</filename> wird in <xref linkend="dat-netz-etc-hostconf"/> gezeigt.
   </para>
@@ -434,13 +399,9 @@ multi on</screen>
   </example>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-nsswitch">
-  <title><filename>/etc/nsswitch.conf</filename></title><indexterm>
-  <primary> Konfigurationsdateien</primary>
-  <secondary> nsswitch.conf</secondary></indexterm> 
+  <title><filename>/etc/nsswitch.conf</filename></title>
   <para>
-   Mit der GNU C Library 2.0 wurde <emphasis>Name Service Switch</emphasis> (NSS) eingeführt. Weitere Informationen hierzu finden Sie auf der man-Seite für <systemitem>nsswitch.conf(5)</systemitem> und im Dokument <emphasis>The GNU C Library Reference Manual. </emphasis> <indexterm>
-   <primary>NSS</primary>
-   </indexterm>
+   Mit der GNU C Library 2.0 wurde <emphasis>Name Service Switch</emphasis> (NSS) eingeführt. Weitere Informationen hierzu finden Sie auf der man-Seite für <systemitem>nsswitch.conf(5)</systemitem> und im Dokument <emphasis>The GNU C Library Reference Manual. </emphasis> 
   </para>
   <para>
    In der Datei <filename>/etc/nsswitch.conf</filename> wird festgelegt, in welcher Reihenfolge bestimmte Informationen abgefragt werden. Ein Beispiel für <filename>nsswitch.conf</filename> ist in <xref linkend="dat-netz-nsswitchconf"/> dargestellt. Kommentaren werden <literal>#</literal>-Zeichen vorangestellt. Der Eintrag unter der <filename>hosts</filename>-Datenbank bedeutet, dass Anfragen über DNS an <filename>/etc/hosts</filename> (<option>files</option>) gehen <phrase os="sles;osuse">(siehe <xref linkend="cha-dns"/>)</phrase>.
@@ -468,10 +429,7 @@ shadow:     compat
 </screen>
   </example>
   <para>
-   Die über NSS verfügbaren <quote>Datenbanken</quote> sind in <xref linkend="tab-netz-nnswitch-db"/> aufgelistet. <indexterm>
-   <primary>NSS</primary>
-   <secondary>Datenbanken</secondary>
-   </indexterm> Die Konfigurationsoptionen für NSS-Datenbanken sind in <xref linkend="tab-netz-nnswitch-conf"/> aufgelistet.
+   Die über NSS verfügbaren <quote>Datenbanken</quote> sind in <xref linkend="tab-netz-nnswitch-db"/> aufgelistet.  Die Konfigurationsoptionen für NSS-Datenbanken sind in <xref linkend="tab-netz-nnswitch-conf"/> aufgelistet.
   </para>
   <table xml:id="tab-netz-nnswitch-db">
    <title>Über /etc/nsswitch.conf verfügbare Datenbanken</title>
@@ -706,9 +664,7 @@ shadow:     compat
   </table>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-nscd">
-  <title><filename>/etc/nscd.conf</filename></title><indexterm>
-  <primary> Konfigurationsdateien</primary>
-  <secondary>nscd.conf</secondary></indexterm> 
+  <title><filename>/etc/nscd.conf</filename></title>
   <para>
    Mit dieser Datei wird nscd (Name Service Cache Daemon) konfiguriert. Weitere Informationen hierzu finden Sie auf den man-Seiten <systemitem>nscd(8)</systemitem> und <systemitem>nscd.conf(5)</systemitem>. Standardmäßig werden die Systemeinträge von <option>passwd</option>, <option>groups</option> und <option>hosts</option> von nscd gecacht. Dies ist für die Leistung von Verzeichnisdiensten wie NIS and LDAP wichtig, denn andernfalls muss für jeden Zugriff auf Namen, Gruppen oder Hosts die Netzwerkverbindung verwendet werden.
    
@@ -720,12 +676,10 @@ shadow:     compat
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-hostname">
   <title><filename>/etc/HOSTNAME </filename></title>
-<indexterm>
-  <primary> Konfigurationsdateien</primary>
-  <secondary> HOSTNAME</secondary></indexterm> 
+ 
   <para>
    <filename>/etc/HOSTNAME</filename> enthält den vollständigen Hostnamen (FQHN). Der vollständige Hostname besteht aus dem eigentlichen Hostnamen und der Domäne. Die Datei darf nur eine einzige Zeile enthalten (in der der Hostname angegeben ist). Diese Angabe wird beim Booten des Rechners gelesen.
   </para>
-<indexterm class="endofrange" startref="idx-networks-configuration-files"/>
+
  </sect3>
 </sect2>

--- a/l10n/sles/de-de/xml/net_dhcp.xml
+++ b/l10n/sles/de-de/xml/net_dhcp.xml
@@ -13,12 +13,7 @@
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
  </info>
-<indexterm class="startofrange" xml:id="idx-DHCP">
- <primary>DHCP</primary></indexterm><indexterm>
- <primary>Netzwerke</primary>
- <secondary>DHCP</secondary></indexterm><indexterm>
- <primary>IP-Adressen</primary>
- <secondary>Dynamische Zuweisung</secondary></indexterm>
+
  <tip arch="zseries" os="sles">
   <title>IBM Z: Unterstützung für DHCP</title>
   <para>
@@ -40,15 +35,7 @@
  <sect1 xml:id="sec-dhcp-yast">
   <title>Konfigurieren eines DHCP-Servers mit YaST</title>
 
-<indexterm>
 
-  <primary>YaST</primary>
-
-  <secondary> DHCP</secondary></indexterm><indexterm>
-
-  <primary> DHCP</primary>
-
-  <secondary> Konfigurieren mit YaST</secondary></indexterm>
 
   <para>
    Zur Installation eines DNS-Servers starten Sie YaST, und wählen Sie <menuchoice><guimenu>Software</guimenu> <guimenu>Software installieren oder löschen</guimenu></menuchoice>. Wählen Sie <menuchoice><guimenu>Filter</guimenu>
@@ -292,39 +279,20 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-dhcp-soft">
-  <title>DHCP-Softwarepakete</title><indexterm>
-
-  <primary> DHCP</primary>
-
-  <secondary> Pakete</secondary></indexterm> 
+  <title>DHCP-Softwarepakete</title>
 
   <para>
    Sowohl der DHCP-Server als auch die DHCP-Clients stehen für <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> zur Verfügung. Der vom Internet Systems Consortium (ISC) herausgegebene DHCP-Server <systemitem class="daemon">dhcpd</systemitem> stellt die Serverfunktionalität zur Verfügung. Auf der Clientseite befinden sich <systemitem>dhcp-client</systemitem> (ebenfalls von ISC) sowie Werkzeuge aus dem <systemitem>wicked</systemitem>-Paket.
   </para>
 
   <para>
-   Standardmäßig werden die <systemitem>wicked</systemitem>-Werkzeuge mit den Diensten <systemitem>wicked-dhcp4</systemitem> und <systemitem>wicked-dhcp6</systemitem> installiert. Beide Services werden automatisch bei jedem Booten des Systems gestartet und übernehmen die Überwachung auf einem DHCP-Server. Sie kommen ohne eine Konfigurationsdatei aus und funktionieren im Normalfall ohne weitere Konfiguration. Für komplexere Situationen greifen Sie auf <systemitem>dhcp-client</systemitem> von ISC zurück, das sich über die Konfigurationsdateien <filename>/etc/dhclient.conf</filename> und <filename>/etc/dhclient6.conf</filename> steuern lässt. <indexterm>
-   <primary>Konfigurationsdateien</primary>
-   <secondary> dhclient.conf</secondary>
-   </indexterm>
+   Standardmäßig werden die <systemitem>wicked</systemitem>-Werkzeuge mit den Diensten <systemitem>wicked-dhcp4</systemitem> und <systemitem>wicked-dhcp6</systemitem> installiert. Beide Services werden automatisch bei jedem Booten des Systems gestartet und übernehmen die Überwachung auf einem DHCP-Server. Sie kommen ohne eine Konfigurationsdatei aus und funktionieren im Normalfall ohne weitere Konfiguration. Für komplexere Situationen greifen Sie auf <systemitem>dhcp-client</systemitem> von ISC zurück, das sich über die Konfigurationsdateien <filename>/etc/dhclient.conf</filename> und <filename>/etc/dhclient6.conf</filename> steuern lässt. 
   </para>
  </sect1>
  <sect1 xml:id="sec-dhcp-server">
   <title>Der DHCP-Server dhcpd</title>
 
-<indexterm>
 
-  <primary>Konfigurationsdateien</primary>
-
-  <secondary>dhcpd.conf</secondary></indexterm><indexterm class="startofrange" xml:id="idx-dhcp-server">
-
-  <primary>DHCP</primary>
-
-  <secondary>Server</secondary></indexterm><indexterm class="startofrange" xml:id="idx-dhcp-dhcpd">
-
-  <primary>DHCP</primary>
-
-  <secondary>dhcpd</secondary></indexterm>
 
   <para>
    Das Kernstück des DHCP-Systems ist der dhcpd-Daemon. Dieser Server <emphasis>least</emphasis> Adressen und überwacht deren Nutzung gemäß den Vorgaben in der Konfigurationsdatei <filename>/etc/dhcpd.conf</filename>. Über die dort definierten Parameter und Werte stehen dem Systemadministrator eine Vielzahl von Möglichkeiten zur Verfügung, das Verhalten des Programms anforderungsgemäß zu beeinflussen. Sehen Sie sich die einfache Beispieldatei <filename>/etc/dhcpd.conf</filename> in <xref linkend="dat-dhcp-conf"/> an.
@@ -400,12 +368,10 @@ subnet 192.168.2.0 netmask 255.255.255.0
 
   <para>
    Auf einem <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise</phrase></phrase>-Standardsystem wird der DHCP-Daemon aus Sicherheitsgründen in einer chroot-Umgebung gestartet. Damit der Daemon die Konfigurationsdateien finden kann, müssen diese in die chroot-Umgebung kopiert werden. In der Regel müssen Sie dazu nur den Befehl <command>systemctl start dhcpd</command> eingeben und die Dateien werden automatisch kopiert.
-  </para><indexterm class="endofrange" startref="idx-dhcp-server"/><indexterm class="endofrange" startref="idx-dhcp-dhcpd"/>
+  </para>
 
   <sect2 xml:id="sec-dhcp-statip">
-   <title>Clients mit statischen IP-Adressen</title><indexterm>
-   <primary> DHCP</primary>
-   <secondary> Zuweisung statischer Adressen</secondary></indexterm> 
+   <title>Clients mit statischen IP-Adressen</title>
    <para>
     DHCP lässt sich auch verwenden, um einem bestimmten Client eine vordefinierte statische Adresse zuzuweisen. Solche expliziten Adresszuweisungen haben Vorrang vor dynamischen Adressen aus dem Pool. Im Unterschied zu den dynamischen verfallen die statischen Adressinformationen nie, z. B. wenn nicht mehr genügend freie Adressen zur Verfügung stehen und deshalb eine Neuverteilung unter den Clients erforderlich ist.
    </para>
@@ -476,6 +442,6 @@ fixed-address 192.168.2.100;
 
   <para>
    Weitere Informationen zu DHCP finden Sie auf der Website des <emphasis>Internet Systems Consortium</emphasis> (<link xlink:href="https://www.isc.org/dhcp/"/>). Weitere Informationen finden Sie zudem auf den man-Seiten <option>dhcpd</option>, <option>dhcpd.conf</option>, <option>dhcpd.leases</option> und <option>dhcp-options</option>.
-  </para><indexterm class="endofrange" startref="idx-DHCP"/>
+  </para>
  </sect1>
 </chapter>

--- a/l10n/sles/de-de/xml/net_dns.xml
+++ b/l10n/sles/de-de/xml/net_dns.xml
@@ -16,21 +16,9 @@
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
  </info>
-<indexterm>
- <primary>Domain Name System</primary>
- <see>DNS</see></indexterm><indexterm>
- <primary>DNS</primary>
- <secondary>Konfigurieren</secondary></indexterm><indexterm>
- <primary>Konfigurieren</primary>
- <secondary>DNS</secondary></indexterm><indexterm>
- <primary>Namenserver</primary>
- <see>DNS</see></indexterm>
+
  <sect1 xml:id="sec-dns-basic">
-  <title> DNS-Terminologie </title><indexterm>
-
-  <primary> DNS</primary>
-
-  <secondary>-Terminologie</secondary></indexterm> 
+  <title> DNS-Terminologie </title>
 
   <variablelist>
    <varlistentry>
@@ -489,25 +477,11 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-dns-bind">
-  <title>Starten des BIND-Nameservers</title><indexterm xml:id="idx-DNS-BIND" class="startofrange">
-
-  <primary>DNS</primary>
-
-  <secondary>BIND</secondary></indexterm><indexterm xml:id="idx-BIND" class="startofrange">
-
-  <primary>BIND</primary></indexterm>
+  <title>Starten des BIND-Nameservers</title>
 
   <para>
    Bei <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase>-Systemen ist der Namenserver BIND (<emphasis>Berkeley Internet Name Domain</emphasis>) vorkonfiguriert, sodass er problemlos unmittelbar nach der Installation gestartet werden kann. Wenn Sie bereits über eine funktionierende Internetverbindung verfügen und <systemitem class="ipaddress">127.0.0.1</systemitem> als Namenserveradresse für <systemitem class="domainname">localhost</systemitem> in <filename>/etc/resolv.conf</filename> eingegeben haben, verfügen Sie normalerweise bereits über eine funktionierende Namenauflösung, ohne dass Ihnen der DNS des Anbieters bekannt sein muss. BIND führt die Namenauflösung über den Root-Namenserver durch. Dies ist ein wesentlich langsamerer Prozess. Normalerweise sollte der DNS des Anbieters zusammen mit der zugehörigen IP-Adresse in die Konfigurationsdatei <filename>/etc/named.conf</filename> unter <systemitem>forwarders</systemitem> eingegeben werden, um eine effektive und sichere Namenauflösung zu gewährleisten. Wenn dies so weit funktioniert, wird der Namenserver als reiner <emphasis>Nur-Cache</emphasis>-Namenserver ausgeführt. Nur wenn Sie seine eigenen Zonen konfigurieren, wird er ein richtiger DNS. Ein einfaches Beispiel zur Veranschaulichung finden Sie unter <filename>/usr/share/doc/packages/bind/config</filename>.
-  </para><indexterm>
-
-  <primary> Konfigurationsdateien</primary>
-
-  <secondary> resolv.conf</secondary></indexterm><indexterm>
-
-  <primary>   Konfigurationsdateien</primary>
-
-  <secondary> named.conf</secondary></indexterm> 
+  </para>
 
   <tip>
    <title>Automatische Anpassung der Namenserverinformationen</title>
@@ -524,25 +498,10 @@
    Starten Sie den Nameserver mit dem Befehl <command>systemctl start named</command> als <systemitem class="username">root</systemitem>. Prüfen Sie mit <command>systemctl status named</command>, ob der Nameserverprozess „named“ ordnungsgemäß gestartet wurde. Testen Sie den Nameserver umgehend auf dem lokalen System mit den Programmen <command>host</command> oder <command>dig</command>. Sie sollten <systemitem class="domainname">localhost</systemitem> als Standardserver mit der Adresse <systemitem class="ipaddress">127.0.0.1</systemitem> zurückgeben. Ist dies nicht der Fall, enthält <filename>/etc/resolv.conf</filename> vermutlich einen falschen Nameservereintrag oder die Datei ist nicht vorhanden. Geben Sie beim ersten Test <command>host</command> <option>127.0.0.1</option> ein. Dieser Eintrag sollte immer funktionieren. Wenn Sie eine Fehlermeldung erhalten, überprüfen Sie mit <command>systemctl status named</command>, ob der Server tatsächlich ausgeführt wird. Wenn der Nameserver nicht startet oder sich ungewöhnlich verhält, prüfen Sie die Ausgabe von <command>journalctl -e</command>.
   </para>
 
-<indexterm>
 
-  <primary>Protokolldateien</primary>
-
-  <secondary>Meldungen</secondary></indexterm><indexterm>
-
-  <primary>DNS</primary>
-
-  <secondary>Starten</secondary></indexterm><indexterm>
-
-  <primary>DNS</primary>
-
-  <secondary>Fehlersuche</secondary></indexterm>
 
   <para>
-   Um den Namenserver des Anbieters (oder einen bereits in Ihrem Netzwerk ausgeführten Server) als Forwarder zu verwenden, geben Sie die entsprechende IP-Adresse(n) im Abschnitt <systemitem>options</systemitem> unter <systemitem>forwarders</systemitem> ein. Bei den Adressen in <xref linkend="ex-forward"/> handelt es sich lediglich um Beispiele. Passen Sie diese Einträge an Ihr eigenes Setup an. <indexterm>
-   <primary>DNS</primary>
-   <secondary> Weiterleiten</secondary>
-   </indexterm>
+   Um den Namenserver des Anbieters (oder einen bereits in Ihrem Netzwerk ausgeführten Server) als Forwarder zu verwenden, geben Sie die entsprechende IP-Adresse(n) im Abschnitt <systemitem>options</systemitem> unter <systemitem>forwarders</systemitem> ein. Bei den Adressen in <xref linkend="ex-forward"/> handelt es sich lediglich um Beispiele. Passen Sie diese Einträge an Ihr eigenes Setup an. 
   </para>
 
   <example xml:id="ex-forward">
@@ -563,11 +522,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-dns-named">
-  <title>Die Konfigurationsdatei /etc/named.conf</title><indexterm xml:id="idx-configuration-files-named-conf" class="startofrange">
-
-  <primary> Konfigurationsdateien</primary>
-
-  <secondary>named.conf</secondary></indexterm> 
+  <title>Die Konfigurationsdatei /etc/named.conf</title>
 
   <para>
    Alle Einstellungen für den BIND-Namenserver selbst sind in der Datei <filename>/etc/named.conf</filename> gespeichert. Die Zonendaten für die zu bearbeitenden Domänen, die aus Hostnamen, IP-Adressen usw. bestehen, sind jedoch in gesonderten Dateien im Verzeichnis <filename>/var/lib/named</filename> gespeichert. Einzelheiten hierzu werden weiter unten beschrieben.
@@ -602,9 +557,7 @@ zone "." in {
   </example>
 
   <sect2 xml:id="sec-dns-named-options">
-   <title>Wichtige Konfigurationsoptionen</title><indexterm>
-   <primary> DNS</primary>
-   <secondary> Optionen</secondary></indexterm> 
+   <title>Wichtige Konfigurationsoptionen</title>
    <variablelist>
     <varlistentry>
      <term>directory "<replaceable>DATEINAME</replaceable>";</term>
@@ -632,9 +585,7 @@ zone "." in {
     </varlistentry>
     <varlistentry>
      <term>listen-on port 53 { 127.0.0.1; <replaceable>IP-ADRESSE</replaceable>; };</term>
-     <listitem><indexterm>
-      <primary>Ports</primary>
-      <secondary>53</secondary></indexterm>
+     <listitem>
       <para>
        Informiert BIND darüber, an welchen Netzwerkschnittstellen und Ports Client-Abfragen akzeptiert werden sollen. <literal>port 53</literal> muss nicht explizit angegeben werden, da <literal>53</literal> der Standardport ist. Geben Sie <literal>127.0.0.1</literal> ein, um Anforderungen vom lokalen Host zuzulassen. Wenn Sie diesen Eintrag ganz auslassen, werden standardmäßig alle Schnittstellen verwendet.
       </para>
@@ -719,9 +670,7 @@ zone "." in {
   </sect2>
 
   <sect2 xml:id="sec-dns-named-log">
-   <title>Protokollierung</title><indexterm>
-   <primary> DNS</primary>
-   <secondary> Protokollieren</secondary></indexterm> 
+   <title>Protokollierung</title>
    <para>
     Der Umfang, die Art und Weise und der Ort der Protokollierung kann in BIND extensiv konfiguriert werden. Normalerweise sollten die Standardeinstellungen ausreichen. In <xref linkend="ex-no-log"/> sehen Sie die einfachste Form eines solchen Eintrags, bei dem jegliche Protokollierung unterdrückt wird.
    </para>
@@ -810,13 +759,7 @@ zone "." in {
   </sect2>
  </sect1>
  <sect1 xml:id="sec-dns-zonefile">
-  <title>Zonendateien</title><indexterm>
-
-  <primary> DNS</primary>
-
-  <secondary> Zonen</secondary>
-
-  <tertiary> Dateien</tertiary></indexterm> 
+  <title>Zonendateien</title>
 
   <para>
    Zwei Arten von Zonendateien sind erforderlich. Eine Art ordnet IP-Adressen Hostnamen zu, die andere stellt Hostnamen für IP-Adressen bereit.
@@ -994,10 +937,7 @@ pluto     AAAA 2345:00D2:DA11::1234:5678:9ABC:DEF0</screen>
 
 
   <para>
-   Die Pseudodomäne <literal>in-addr.arpa</literal> wird für Reverse-Lookups zur Auflösung von IP-Adressen in Hostnamen verwendet. Sie wird in umgekehrter Notation an den Netzwerk-Teil der Adresse angehängt. <systemitem class="ipaddress">192.168</systemitem> wird also in <systemitem>168.192.in-addr.arpa</systemitem> aufgelöst. Weitere Informationen hierzu finden Sie unter <xref linkend="dat-arpa"/>. <indexterm>
-   <primary>DNS</primary>
-   <secondary> Reverse-Lookup</secondary>
-   </indexterm>
+   Die Pseudodomäne <literal>in-addr.arpa</literal> wird für Reverse-Lookups zur Auflösung von IP-Adressen in Hostnamen verwendet. Sie wird in umgekehrter Notation an den Netzwerk-Teil der Adresse angehängt. <systemitem class="ipaddress">192.168</systemitem> wird also in <systemitem>168.192.in-addr.arpa</systemitem> aufgelöst. Weitere Informationen hierzu finden Sie unter <xref linkend="dat-arpa"/>. 
   </para>
 
 
@@ -1064,9 +1004,7 @@ pluto     AAAA 2345:00D2:DA11::1234:5678:9ABC:DEF0</screen>
   </variablelist>
 
   <para>
-   Normalerweise sollten Zonentransfers zwischen verschiedenen Versionen von BIND problemlos möglich sein. <indexterm class="endofrange" startref="idx-DNS-BIND"/>
-   <indexterm class="endofrange" startref="idx-BIND"/>
-   <indexterm class="endofrange" startref="idx-configuration-files-named-conf"/>
+   Normalerweise sollten Zonentransfers zwischen verschiedenen Versionen von BIND problemlos möglich sein.
 
   </para>
  </sect1>

--- a/l10n/sles/de-de/xml/net_samba.xml
+++ b/l10n/sles/de-de/xml/net_samba.xml
@@ -11,16 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-Samba" class="startofrange">
- <primary>Samba</primary></indexterm><indexterm>
- <primary>SMB</primary>
- <see>Samba</see></indexterm><indexterm>
- <primary>macOS</primary>
- <secondary>Dateien freigeben</secondary></indexterm><indexterm>
- <primary>Windows</primary>
- <secondary>Dateien freigeben</secondary></indexterm><indexterm>
- <primary>Linux</primary>
- <secondary>Dateien für andere Betriebssysteme freigeben</secondary></indexterm>
+ </info>
  <sect1 xml:id="sec-samba-term">
   <title>Terminologie</title>
 
@@ -33,18 +24,7 @@
     <term>SMB-Protokoll</term>
     <listitem>
      <para>
-      <indexterm>
-      <primary>Samba</primary>
-      <secondary> SMB</secondary>
-      </indexterm> <indexterm>
-      <primary>   protocols</primary>
-      <secondary> SMB</secondary>
-      </indexterm> <indexterm>
-      <primary>   smbd</primary>
-      </indexterm>  Samba verwendet das SMB-Protokoll (Server Message Block), das auf den <phrase role="productname">NetBIOS</phrase>-Diensten basiert. Microsoft veröffentlichte das Protokoll, damit auch andere Softwarehersteller Anbindungen an ein Microsoft-Domänennetzwerk einrichten konnten. Samba setzt das SMB- auf das TCP/IP-Protokoll auf. Entsprechend muss auf allen Clients das TCP/IP-Protokoll installiert sein. <indexterm>
-      <primary>Samba</primary>
-      <secondary> TCP/IP und</secondary>
-      </indexterm>
+          Samba verwendet das SMB-Protokoll (Server Message Block), das auf den <phrase role="productname">NetBIOS</phrase>-Diensten basiert. Microsoft veröffentlichte das Protokoll, damit auch andere Softwarehersteller Anbindungen an ein Microsoft-Domänennetzwerk einrichten konnten. Samba setzt das SMB- auf das TCP/IP-Protokoll auf. Entsprechend muss auf allen Clients das TCP/IP-Protokoll installiert sein. 
      </para>
      <tip arch="zseries" os="sles">
       <title>IBM Z: Unterstützung für NetBIOS</title>
@@ -58,13 +38,7 @@
     <term>CIFS-Protokoll</term>
     <listitem>
      <para>
-      <indexterm>
-      <primary>Samba</primary>
-      <secondary> CIFS</secondary>
-      </indexterm> <indexterm>
-      <primary>   Protokolle</primary>
-      <secondary> CIFS</secondary>
-      </indexterm>  Das CIFS-Protokoll (Common Internet File System) ist ein weiteres von Samba unterstütztes Protokoll. CIFS definiert ein Standardprotokoll für den Fernzugriff auf Dateisysteme über das Netzwerk, das Benutzergruppen die netzwerkweite Zusammenarbeit und gemeinsame Dokumentbenutzung ermöglicht.
+         Das CIFS-Protokoll (Common Internet File System) ist ein weiteres von Samba unterstütztes Protokoll. CIFS definiert ein Standardprotokoll für den Fernzugriff auf Dateisysteme über das Netzwerk, das Benutzergruppen die netzwerkweite Zusammenarbeit und gemeinsame Dokumentbenutzung ermöglicht.
      </para>
     </listitem>
    </varlistentry>
@@ -72,22 +46,16 @@
     <term>NetBIOS</term>
     <listitem>
      <para>
-      <indexterm>
-      <primary> NetBIOS</primary>
-      </indexterm>  NetBIOS ist eine Softwareschnittstelle (API) für die Kommunikation zwischen Computern, die einen Name Service bereitstellen. Mit diesem Dienst können die an das Netzwerk angeschlossenen Computer Namen für sich reservieren. Nach dieser Reservierung können die Computer anhand ihrer Namen adressiert werden. Für die Überprüfung der Namen gibt es keine zentrale Instanz. Jeder Computer im Netzwerk kann beliebig viele Namen reservieren, solange die Namen noch nicht Gebrauch sind. Die NetBIOS-Schnittstelle kann in unterschiedlichen Netzwerkarchitekturen implementiert werden. Eine Implementierung, die relativ eng mit der Netzwerkhardware arbeitet, ist <phrase role="productname">NetBEUI</phrase> (häufig auch als <phrase role="productname">NetBIOS</phrase> bezeichnet). Mit NetBIOS implementierte Netzwerkprotokolle sind IPX (NetBIOS über TCP/IP) von Novell und TCP/IP.
+        NetBIOS ist eine Softwareschnittstelle (API) für die Kommunikation zwischen Computern, die einen Name Service bereitstellen. Mit diesem Dienst können die an das Netzwerk angeschlossenen Computer Namen für sich reservieren. Nach dieser Reservierung können die Computer anhand ihrer Namen adressiert werden. Für die Überprüfung der Namen gibt es keine zentrale Instanz. Jeder Computer im Netzwerk kann beliebig viele Namen reservieren, solange die Namen noch nicht Gebrauch sind. Die NetBIOS-Schnittstelle kann in unterschiedlichen Netzwerkarchitekturen implementiert werden. Eine Implementierung, die relativ eng mit der Netzwerkhardware arbeitet, ist <phrase role="productname">NetBEUI</phrase> (häufig auch als <phrase role="productname">NetBIOS</phrase> bezeichnet). Mit NetBIOS implementierte Netzwerkprotokolle sind IPX (NetBIOS über TCP/IP) von Novell und TCP/IP.
      </para>
      <para>
       Die per TCP/IP übermittelten NetBIOS-Namen haben nichts mit den in der Datei <filename>/etc/hosts</filename> oder per DNS vergebenen Namen zu tun. NetBIOS ist ein eigener, vollständig unabhängiger Namensraum. Es empfiehlt sich jedoch, für eine einfachere Administration NetBIOS-Namen zu vergeben, die den jeweiligen DNS-Hostnamen entsprechen, oder DNS nativ zu verwenden. Für einen Samba-Server ist dies die Voreinstellung.
-     </para><indexterm>
-     <primary>Samba </primary>
-     <secondary>Namen</secondary></indexterm>
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>Samba-Server</term>
-    <listitem><indexterm>
-     <primary>Samba</primary>
-     <secondary>-Server</secondary></indexterm>
+    <listitem>
      <para>
       Samba-Server stellt SMB/CIFS-Dienste sowie NetBIOS over IP-Namensdienste für Clients zur Verfügung. Für Linux gibt es drei Dämonen für Samba-Server: smbd für SMB/CIFS-Dienste, nmbd für Naming Services und winbind für Authentifizierung.
      </para>
@@ -95,9 +63,7 @@
    </varlistentry>
    <varlistentry>
     <term>Samba-Client</term>
-    <listitem><indexterm xml:id="idx-Samba-clients" class="startofrange">
-     <primary> Samba</primary>
-     <secondary> Clients</secondary></indexterm> 
+    <listitem> 
      <para>
       Der Samba-Client ist ein System, das Samba-Dienste von einem Samba-Server über das SMB-Protokoll nutzt. Das Samba-Protokoll wird von gängigen Betriebssystemen wie Windows und MacOS unterstützt. Auf den Computern muss das TCP/IP-Protokoll installiert sein. Für die verschiedenen UNIX-Versionen stellt Samba einen Client zur Verfügung. Für Linux gibt es zudem ein Dateisystem-Kernel-Modul für SMB, das die Integration von SMB-Ressourcen auf Linux-Systemebene ermöglicht. Sie brauchen für den Samba-Client keinen Dämon auszuführen.
      </para>
@@ -107,16 +73,7 @@
     <term>Freigaben</term>
     <listitem>
      <para>
-      <indexterm>
-      <primary> Samba</primary>
-      <secondary> Freigaben</secondary>
-      </indexterm> SMB-Server stellen den Clients Ressourcen in Form von Freigaben (Shares) zur Verfügung. Freigaben sind Drucker und Verzeichnisse mit ihren Unterverzeichnissen auf dem Server. Eine Freigabe wird unter einem eigenen Namen exportiert und kann von Clients unter diesem Namen angesprochen werden. Der Freigabename kann frei vergeben werden. Er muss nicht dem Namen des exportierten Verzeichnisses entsprechen. Ebenso wird einem Drucker ein Name zugeordnet. Clients können mit diesem Namen auf den Drucker zugreifen. <indexterm>
-      <primary> Drucken</primary>
-      <secondary> Samba</secondary>
-      </indexterm> <indexterm>
-      <primary>   Samba</primary>
-      <secondary> Drucker</secondary>
-      </indexterm> <indexterm class="endofrange" startref="idx-Samba-clients"/>
+       SMB-Server stellen den Clients Ressourcen in Form von Freigaben (Shares) zur Verfügung. Freigaben sind Drucker und Verzeichnisse mit ihren Unterverzeichnissen auf dem Server. Eine Freigabe wird unter einem eigenen Namen exportiert und kann von Clients unter diesem Namen angesprochen werden. Der Freigabename kann frei vergeben werden. Er muss nicht dem Namen des exportierten Verzeichnisses entsprechen. Ebenso wird einem Drucker ein Name zugeordnet. Clients können mit diesem Namen auf den Drucker zugreifen.
      </para>
     </listitem>
    </varlistentry>
@@ -124,10 +81,7 @@
     <term>DC</term>
     <listitem>
      <para>
-      <indexterm>
-      <primary>Samba</primary>
-      <secondary> DC</secondary>
-      </indexterm>  Ein Domänencontroller (DC) ist ein Server, der Konten in der Domäne verwaltet. Zur Datenreplikation stehen zusätzliche Domain Controller in einer Domäne zur Verfügung.
+        Ein Domänencontroller (DC) ist ein Server, der Konten in der Domäne verwaltet. Zur Datenreplikation stehen zusätzliche Domain Controller in einer Domäne zur Verfügung.
      </para>
     </listitem>
    </varlistentry>
@@ -156,34 +110,10 @@
    <para>
     <systemitem>winbind</systemitem> ist ein unabhängiger Dienst und wird als solcher auch als einzelnes <systemitem>samba-winbind</systemitem>-Paket angeboten.
    </para>
-  </tip><indexterm>
-
-  <primary>Samba</primary>
-
-  <secondary>Starten</secondary></indexterm><indexterm>
-
-  <primary>Samba</primary>
-
-  <secondary>Stoppen</secondary></indexterm>
+  </tip>
  </sect1>
  <sect1 xml:id="sec-samba-serv-inst">
-  <title>Konfigurieren eines Samba-Servers</title><indexterm>
-
-  <primary>Samba</primary>
-
-  <secondary>Installieren</secondary></indexterm><indexterm>
-
-  <primary>Samba</primary>
-
-  <secondary>Server</secondary></indexterm><indexterm>
-
-  <primary>Samba</primary>
-
-  <secondary>Konfigurieren</secondary></indexterm><indexterm>
-
-  <primary>Konfigurieren</primary>
-
-  <secondary>Samba</secondary></indexterm>
+  <title>Konfigurieren eines Samba-Servers</title>
 
   <para os="sles;osuse">
    Es gibt zwei Möglichkeiten, Samba-Server in <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> zu konfigurieren: mit YaST oder manuell. Bei der manuellen Konfiguration können Sie mehr Details einstellen, allerdings müssen Sie ohne den Komfort der Bedienoberfläche von YaST zurechtkommen.
@@ -288,16 +218,7 @@
   <sect2 xml:id="sec-samba-serv-inst-manual" os="sles;osuse">
    <title>Manuelles Konfigurieren des Servers</title>
    <para>
-    <indexterm>
-    <primary>Samba</primary>
-    <secondary> Konfigurieren</secondary>
-    </indexterm> <indexterm>
-    <primary>   Konfigurieren</primary>
-    <secondary> Samba</secondary>
-    </indexterm> <indexterm>
-    <primary>   Konfigurationsdateien</primary>
-    <secondary> smb.conf</secondary>
-    </indexterm>  Wenn Sie Samba als Server verwenden möchten, installieren Sie <systemitem class="resource">samba</systemitem>. Die Hauptkonfigurationsdatei für Samba ist <filename>/etc/samba/smb.conf</filename>. Diese Datei kann in zwei logische Bereiche aufgeteilt werden. Der Abschnitt <literal>[global]</literal> enthält die zentralen und globalen Einstellungen. Die folgenden Abschnitte enthalten die einzelnen Datei- und Druckerfreigaben:
+        Wenn Sie Samba als Server verwenden möchten, installieren Sie <systemitem class="resource">samba</systemitem>. Die Hauptkonfigurationsdatei für Samba ist <filename>/etc/samba/smb.conf</filename>. Diese Datei kann in zwei logische Bereiche aufgeteilt werden. Der Abschnitt <literal>[global]</literal> enthält die zentralen und globalen Einstellungen. Die folgenden Abschnitte enthalten die einzelnen Datei- und Druckerfreigaben:
    </para>
    <itemizedlist mark="bullet" spacing="normal">
     <listitem>
@@ -380,9 +301,7 @@
     </variablelist>
    </sect3>
    <sect3 xml:id="sec-samba-smb-conf-shares">
-    <title>Freigaben</title><indexterm>
-    <primary> Samba</primary>
-    <secondary> Freigaben</secondary></indexterm> 
+    <title>Freigaben</title>
     <para>
      In den folgenden Beispielen werden einerseits das CD-ROM-Laufwerk und andererseits die Verzeichnisse der Nutzer (<literal>homes</literal>) für SMB-Clients freigegeben.
     </para>
@@ -498,13 +417,7 @@
     </warning>
    </sect3>
    <sect3 xml:id="sec-samba-rechte">
-    <title>Sicherheitsstufen (Security Levels)</title><indexterm xml:id="idx-Samba-security" class="startofrange">
-    <primary>Samba</primary>
-    <secondary>Sicherheit</secondary></indexterm><indexterm>
-    <primary>Sicherheit</primary>
-    <secondary>Samba</secondary></indexterm><indexterm>
-    <primary>Samba</primary>
-    <secondary>Berechtigungen</secondary></indexterm>
+    <title>Sicherheitsstufen (Security Levels)</title>
     <para>
      Jeder Zugriff auf eine Freigabe kann für mehr Sicherheit durch ein Passwort geschützt werden. SMB bietet die folgenden Möglichkeiten zur Überprüfung von Berechtigungen:
     </para>
@@ -540,31 +453,19 @@
     </para>
     <para>
      Weitere Informationen zu diesem Thema finden Sie im Samba 3-HOWTO. Wenn sich mehrere Server auf einem System befinden, beachten Sie die Optionen <option>interfaces</option> und <option>bind interfaces only</option>.
-    </para><indexterm class="endofrange" startref="idx-Samba-security"/>
+    </para>
    </sect3>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-samba-client-inst">
-  <title>Konfigurieren der Clients</title><indexterm>
-
-  <primary> Samba</primary>
-
-  <secondary> Clients</secondary></indexterm> 
+  <title>Konfigurieren der Clients</title>
 
   <para>
    Clients können auf den Samba-Server nur über TCP/IP zugreifen. NetBEUI oder NetBIOS über IPX können mit Samba nicht verwendet werden.
   </para>
 
   <sect2 xml:id="sec-samba-client-inst-yast">
-   <title>Konfigurieren eines Samba-Clients mit YaST</title><indexterm>
-   <primary>YaST</primary>
-   <secondary>Samba</secondary>
-   <tertiary>Clients</tertiary></indexterm><indexterm>
-   <primary>Samba</primary>
-   <secondary>Clients</secondary></indexterm><indexterm>
-   <primary>Konfigurieren</primary>
-   <secondary>Samba</secondary>
-   <tertiary>Clients</tertiary></indexterm>
+   <title>Konfigurieren eines Samba-Clients mit YaST</title>
    <para>
     Konfigurieren Sie einen Samba-Client, um auf Ressourcen (Dateien oder Drucker) auf dem Samba- oder Windows-Server zuzugreifen. Geben Sie im Dialogfeld <menuchoice> <guimenu>Netzwerkdienste</guimenu>
     <guimenu>Windows-Domänenmitgliedschaft</guimenu></menuchoice> die NT- oder Active Directory-Domäne oder -Arbeitsgruppe an. Wenn Sie <guimenu>Zusätzlich SMB-Informationen für Linux-Authentifizierung verwenden</guimenu> aktivieren, erfolgt die Benutzerauthentifizierung über den Samba, NT- oder Kerberos-Server.
@@ -578,11 +479,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-samba-anmeld-serv">
-  <title>Samba als Anmeldeserver</title><indexterm>
-
-  <primary> Samba</primary>
-
-  <secondary> Anmelden</secondary></indexterm> 
+  <title>Samba als Anmeldeserver</title>
 
   <para>
    In Netzwerken, in denen sich überwiegend Windows-Clients befinden, ist es oft wünschenswert, dass sich Benutzer nur mit einem gültigen Konto und zugehörigem Passwort anmelden dürfen. In einem Windows-basierten Netzwerk wird diese Aufgabe von einem Primary Domain Controller (PDC) übernommen. Sie können einen Windows NT-Server verwenden, der als PDC konfiguriert ist; diese Aufgabe kann aber auch mithilfe eines Samba-Servers ausgeführt werden. Es müssen Einträge im Abschnitt <literal>[global]</literal> von <filename>smb.conf</filename> vorgenommen werden. Diese werden in <xref linkend="dat-samba-smb-conf-dom"/> beschrieben.
@@ -601,11 +498,7 @@
   </para>
 
 <screen>useradd hostname\$
-smbpasswd -a -m hostname</screen><indexterm>
-
-  <primary> commands</primary>
-
-  <secondary> smbpasswd</secondary></indexterm> 
+smbpasswd -a -m hostname</screen> 
 
   <para>
    Mit dem Befehl <command>useradd</command> wird ein Dollarzeichen hinzugefügt. Der Befehl <command>smbpasswd</command> fügt dieses bei der Verwendung des Parameters <option>-m</option> automatisch hinzu. In der kommentierten Beispielkonfiguration (<filename>/usr/share/doc/packages/Samba/examples/smb.conf.SuSE</filename>) sind Einstellungen enthalten, die diese Aufgabe automatisieren.
@@ -1076,14 +969,11 @@ No shadow copies found in system.</screen>
 
   <para>
    Die Dokumentation zu Samba ist im Paket <systemitem>samba-doc</systemitem> enthalten, das standardmäßig nicht installiert wird. Installieren Sie das Paket mit <command>zypper install samba-doc</command>. Wenn Samba installiert ist, können Sie in die Kommandozeile <command>apropos</command>
-   <option>samba</option> eingeben und einige man-Seiten aufrufen. Alternativ dazu finden Sie im Verzeichnis <filename>/usr/share/doc/packages/samba</filename> weitere Online-Dokumentationen und Beispiele. Eine kommentierte Beispielkonfiguration (<filename>smb.conf.SuSE</filename>) finden Sie im Unterverzeichnis <filename>examples</filename>. Auch in der Datei <filename>/usr/share/doc/packages/samba/README.SUSE</filename> finden Sie zusätzliche Informationen zu Samba. <indexterm>
-   <primary>Konfigurationsdateien</primary>
-   <secondary> smb.conf</secondary>
-   </indexterm>
+   <option>samba</option> eingeben und einige man-Seiten aufrufen. Alternativ dazu finden Sie im Verzeichnis <filename>/usr/share/doc/packages/samba</filename> weitere Online-Dokumentationen und Beispiele. Eine kommentierte Beispielkonfiguration (<filename>smb.conf.SuSE</filename>) finden Sie im Unterverzeichnis <filename>examples</filename>. Auch in der Datei <filename>/usr/share/doc/packages/samba/README.SUSE</filename> finden Sie zusätzliche Informationen zu Samba. 
   </para>
 
   <para>
    Das Samba-Team stellt in Samba HOWTO (siehe <link xlink:href="https://wiki.samba.org"/>) einen Abschnitt zur Fehlerbehebung zur Verfügung. In Teil V ist außerdem eine ausführliche Anleitung zum Überprüfen der Konfiguration enthalten. 
-  </para><indexterm class="endofrange" startref="idx-Samba"/>
+  </para>
  </sect1>
 </chapter>

--- a/l10n/sles/de-de/xml/net_slp.xml
+++ b/l10n/sles/de-de/xml/net_slp.xml
@@ -11,14 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>Netzwerke</primary>
- <secondary>SLP</secondary></indexterm><indexterm>
- <primary>Service Location Protocol</primary>
- <see>SLP</see></indexterm><indexterm>
- <primary>SLP</primary></indexterm><indexterm>
- <primary>Protokolle</primary>
- <secondary>SLP</secondary></indexterm>
+ </info>
  <para>
   <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> unterstützt die Installation von per SLP bekannt gegebenen Installationsquellen und beinhaltet viele Systemdienste mit integrierter Unterstützung für SLP. Nutzen Sie SLP, um vernetzten Clients zentrale Funktionen wie Installationsserver, YOU-Server, Dateiserver oder Druckserver auf Ihrem System zur Verfügung zu stellen. Dienste mit SLP-Unterstützung sind beispielsweise login, ntp, openldap2, postfix, rpasswd, rsyncd, saned, sshd (über fish), vnc und ypserv.
  </para>

--- a/l10n/sles/de-de/xml/net_yast.xml
+++ b/l10n/sles/de-de/xml/net_yast.xml
@@ -9,15 +9,7 @@
   </dm:docmanager>
  </info>
 
-<indexterm xml:id="idx-networks-integrating" class="startofrange">
 
- <primary>Netzwerke </primary>
-
- <secondary>konfigurieren </secondary></indexterm><indexterm>
-
- <primary>Karten </primary>
-
- <secondary>Netzwerk</secondary></indexterm>
 
  <para>
   Unter Linux gibt es viele unterstützte Netzwerktypen. Die meisten verwenden unterschiedliche Gerätenamen und die Konfigurationsdateien sind im Dateisystem an unterschiedlichen Speicherorten verteilt. Einen detaillierten Überblick über die Aspekte der manuellen Netzwerkkonfiguration finden Sie in <xref linkend="sec-basicnet-manconf"/>.
@@ -37,13 +29,7 @@
 
  <sect2 xml:id="sec-basicnet-yast-netcard">
   <title>Konfigurieren der Netzwerkkarte mit YaST</title>
-<indexterm>
-  <primary>Karten</primary>
-  <secondary>Netzwerk</secondary></indexterm><indexterm>
-  <primary>Netzwerke</primary>
-  <secondary>YaST</secondary></indexterm><indexterm>
-  <primary>YaST</primary>
-  <secondary>Netzwerkkarte</secondary></indexterm><indexterm/>
+
   <para>
    Zur Konfiguration verkabelter oder drahtloser Netzwerkkarten in YaST wählen Sie <menuchoice> <guimenu>System</guimenu> <guimenu>Netzwerkeinstellungen</guimenu>
    </menuchoice>. Nach dem Öffnen des Moduls zeigt YaST das Dialogfeld <guimenu>Netzwerkeinstellungen</guimenu> mit den vier Karteireitern <guimenu>Globale Optionen</guimenu>, <guimenu>Übersicht</guimenu>, <guimenu>Hostname/DNS</guimenu> und <guimenu>Routing</guimenu> an.
@@ -107,10 +93,7 @@
    </para>
    <sect4 xml:id="sec-basicnet-yast-change-address">
     <title>IP-Adressen konfigurieren</title>
-<indexterm>
-    <primary> Netzwerke</primary>
-    <secondary> YaST</secondary>
-    <tertiary> IP-Adresse</tertiary></indexterm> 
+ 
     <para>
      Die IP-Adresse der Netzwerkkarte oder die Art der Festlegung dieser IP-Adresse kann auf dem Karteireiter <guimenu>Adresse</guimenu> im Dialogfeld <guimenu>Einrichten der Netzwerkkarte</guimenu> festgelegt werden. Die Adressen IPv4 und IPv6 werden unterstützt. Für die Netzwerkkarte können die Einstellungen <guimenu>Keine IP-Adresse</guimenu> (nützlich für eingebundene Geräte), <guimenu>Statisch zugewiesene IP-Adresse</guimenu> (IPv4 oder IPv6) oder <guimenu>Dynamische Adresse</guimenu> über <guimenu>DHCP</guimenu> und/oder <guimenu>Zeroconf</guimenu> zugewiesen werden.
     </para>
@@ -181,13 +164,7 @@
     </para>
    </sect4>
    <sect4 xml:id="sec-basicnet-yast-configure-addresses">
-    <title>Konfigurieren von mehreren Adressen</title><indexterm>
-    <primary>networks</primary>
-    <secondary>YaST</secondary>
-    <tertiary>Alias</tertiary></indexterm><indexterm>
-    <primary>Netzwerke</primary>
-    <secondary>YaST</secondary>
-    <tertiary>Adressen</tertiary></indexterm>
+    <title>Konfigurieren von mehreren Adressen</title>
     <para>
      Ein Netzwerkgerät kann mehrere IP-Adressen haben.
     </para>
@@ -287,10 +264,7 @@
    </sect4>
    <sect4 xml:id="sec-basicnet-yast-change-start">
     <title>Aktivieren des Netzwerkgeräts</title>
-<indexterm>
-    <primary> Netzwerke</primary>
-    <secondary> YaST</secondary>
-    <tertiary> Aktivieren</tertiary></indexterm> 
+ 
     <para>
      Wenn Sie die Methode mit <command>wicked</command> verwenden, können Sie Ihr Gerät so konfigurieren, dass es wahlweise beim Systemstart, beim Anschließen des Kabels, beim Erkennen der Karte, manuell oder nie startet. Wenn Sie den Gerätestart ändern möchten, gehen Sie wie folgt vor:
     </para>
@@ -503,10 +477,7 @@
    </procedure>
   </sect3>
   <sect3 xml:id="sec-basicnet-yast-change-host">
-   <title>Konfigurieren des Hostnamens und des DNS</title><indexterm>
-   <primary>Netzwerke</primary>
-   <secondary> YaST</secondary>
-   <tertiary> Hostname</tertiary></indexterm>
+   <title>Konfigurieren des Hostnamens und des DNS</title>
    <para>
     Wenn Sie die Netzwerkkonfiguration während der Installation noch nicht geändert haben und die Ethernet-Karte bereits verfügbar war, wurde automatisch ein Hostname für Ihren Rechner erstellt, und DHCP wurde aktiviert. Dasselbe gilt für die Namensservicedaten, die Ihr Host für die Integration in eine Netzwerkumgebung benötigt. Wenn DHCP für eine Konfiguration der Netzwerkadresse verwendet wird, wird die Liste der Domain Name Server automatisch mit den entsprechenden Daten versorgt. Falls eine statische Konfiguration vorgezogen wird, legen Sie diese Werte manuell fest.
    </para>
@@ -593,10 +564,7 @@ yast dns edit nameserver3=192.168.1.118</screen>
 
   <sect3 xml:id="sec-basicnet-yast-change-route">
    <title>Konfigurieren des Routings</title>
-<indexterm>
-   <primary> Netzwerke</primary>
-   <secondary> YaST</secondary>
-   <tertiary> Gateway</tertiary></indexterm> 
+ 
    <para>
     Damit Ihre Maschine mit anderen Maschinen und Netzwerken kommuniziert, müssen Routing-Daten festgelegt werden. Dann nimmt der Netzwerkverkehr den korrekten Weg. Wird DHCP verwendet, werden diese Daten automatisch angegeben. Wird eine statische Konfiguration verwendet, müssen Sie die Daten manuell angeben.
    </para>

--- a/l10n/sles/de-de/xml/nm.xml
+++ b/l10n/sles/de-de/xml/nm.xml
@@ -6,10 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>Internet</primary>
- <secondary>Herstellen der Verbindung</secondary></indexterm><indexterm>
- <primary>NetworkManager</primary></indexterm>
+ </info>
  <para>
   NetworkManager ist die ideale Lösung für Notebooks und andere portable Computer. Es unterstützt die neuesten Verschlüsselungstypen und Standards für Netzwerkverbindungen, einschließlich Verbindungen zu Netzwerken, die nach 802.1X geschützt sind. 802.1X ist die <quote>anschlussbasierte Netzwerkzugriffssteuerung des IEEE-Standards für lokale und innerstädtische Netzwerke</quote>. Wenn Sie viel unterwegs sind und NetworkManager verwenden, brauchen Sie keine Gedanken mehr an die Konfiguration von Netzwerkschnittstellen und den Wechsel zwischen verkabelten und drahtlosen Netzwerken zu verschwenden.  NetworkManager kann automatisch eine Verbindung zu bekannten drahtlosen Netzwerken aufbauen oder mehrere Netzwerkverbindungen parallel verwalten – die schnellste Verbindung wird in diesem Fall als Standard verwendet. Darüber hinaus können Sie zwischen verfügbaren Netzwerken manuell wechseln und Ihre Netzwerkverbindung über ein Miniprogramm im Systemabschnitt der Kontrollleiste verwalten.
 
@@ -38,11 +35,7 @@
   </itemizedlist>
  </sect1>
  <sect1 xml:id="sec-nm-activate">
-  <title>Aktivieren oder Deaktivieren von NetworkManager</title><indexterm>
-
-  <primary> NetworkManager</primary>
-
-  <secondary> Aktivieren</secondary></indexterm>
+  <title>Aktivieren oder Deaktivieren von NetworkManager</title>
 
   <para>
    Auf Notebook-Computern ist NetworkManager standardmäßig aktiviert. Es lässt sich jedoch jederzeit im YaST-Modul „Netzwerkeinstellungen“ aktivieren oder deaktivieren.
@@ -110,11 +103,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-nm-configure">
-  <title>Konfigurieren von Netzwerkverbindungen</title><indexterm>
-
-  <primary> NetworkManager</primary>
-
-  <secondary> Konfigurieren</secondary></indexterm>
+  <title>Konfigurieren von Netzwerkverbindungen</title>
 
   <para>
    Konfigurieren Sie nach der Aktivierung von NetworkManager in YaST Ihre Netzwerkverbindungen mit dem NetworkManager-Frontend, das in GNOME verfügbar ist. Hier sehen Sie Registerkarten für alle Arten von Netzwerkverbindungen, z. B. verkabelte, drahtlose, mobile Breitband-, DSL- und VPN-Verbindungen. 
@@ -318,10 +307,7 @@
   </sect2>
 
   <sect2 xml:id="sec-nm-vpn">
-   <title>NetworkManager und VPN</title><indexterm>
-   <primary>NetworkManager</primary>
-   <secondary>VPN</secondary></indexterm><indexterm>
-   <primary>VPN</primary></indexterm>
+   <title>NetworkManager und VPN</title>
    <para>
     NetworkManager unterstützt verschiedene Technologien für virtuelle private Netzwerke (VPN). Für jede Technologie bietet <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> ein Basispaket mit generischer Unterstützung für NetworkManager. Zusätzlich müssen Sie auch das entsprechende Desktop-spezifische Paket für Ihr Miniprogramm installieren.
    </para>
@@ -517,11 +503,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-nm-security">
-  <title>NetworkManager und Sicherheit</title><indexterm>
-
-  <primary> NetworkManager</primary>
-
-  <secondary> Sicherheit</secondary></indexterm>
+  <title>NetworkManager und Sicherheit</title>
 
   <para>
    Der NetworkManager unterscheidet zwischen zwei Typen von drahtlosen Verbindungen: verbürgte und unverbürgte Verbindungen. Eine verbürgte Verbindung ist jedes Netzwerk, das Sie in der Vergangenheit explizit ausgewählt haben. Alle anderen sind unverbürgt. Verbürgte Verbindungen werden anhand des Namens und der MAC-Adresse des Zugriffspunkts identifiziert. Durch Verwendung der MAC-Adresse wird sichergestellt, dass Sie keinen anderen Zugriffspunkt mit dem Namen Ihrer verbürgten Verbindung verwenden können.
@@ -651,11 +633,7 @@
   </qandaset>
  </sect1>
  <sect1 xml:id="sec-nm-trouble">
-  <title>Fehlersuche</title><indexterm>
-
-  <primary> NetworkManager</primary>
-
-  <secondary> Fehlersuche</secondary></indexterm>
+  <title>Fehlersuche</title>
 
   <para>
    Es können Verbindungsprobleme auftreten. Bei NetworkManager sind unter anderem die Probleme bekannt, dass das Miniprogramm nicht startet oder eine VPN-Option fehlt. Die Methoden zum Lösen und Verhindern dieser Probleme hängen vom verwendeten Werkzeug ab.

--- a/l10n/sles/de-de/xml/pcmcia_apm.xml
+++ b/l10n/sles/de-de/xml/pcmcia_apm.xml
@@ -39,9 +39,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Tiefschlaf (Suspend to Disk)<indexterm>
-     <primary>Energieverwaltung</primary>
-     <secondary>Tiefschlaf</secondary></indexterm> 
+    <term>Tiefschlaf (Suspend to Disk) 
     </term>
     <listitem>
      <para>
@@ -55,9 +53,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>Akku-Überwachung<indexterm>
-     <primary>Energieverwaltung</primary>
-     <secondary>Akku-Überwachung</secondary></indexterm> 
+    <term>Akku-Überwachung 
     </term>
     <listitem>
      <para>
@@ -84,11 +80,7 @@
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-pmanage-acpi">
-  <title>Advanced Configuration &amp; Power Interface (ACPI)</title><indexterm xml:id="idx-power-management-ACPI" class="startofrange">
-
-  <primary> Energieverwaltung</primary>
-
-  <secondary> ACPI</secondary></indexterm> 
+  <title>Advanced Configuration &amp; Power Interface (ACPI)</title>
 
   <para>
    Die ACPI (erweiterte Konfigurations- und Energieschnittstelle) wurde entwickelt, um dem Betriebssystem die Einrichtung und Steuerung der einzelnen Hardware-Komponenten zu ermöglichen. ACPI löst sowohl Power-Management Plug and Play (PnP) als auch Advanced Power Management (APM) ab. Diese Schnittstelle bietet Informationen zu Akku, Netzteil, Temperatur, Ventilator und Systemereignissen wie <quote>Deckel schließen</quote> oder <quote>Akku-Ladezustand niedrig</quote>.
@@ -205,7 +197,7 @@
        <link xlink:href="http://acpi.sourceforge.net/dsdt/index.php"/> (DSDT-Patches von Bruno Ducrot)
       </para>
      </listitem>
-    </itemizedlist><indexterm class="endofrange" startref="idx-power-management-ACPI"/>
+    </itemizedlist>
    </sect3>
   </sect2>
  </sect1>

--- a/l10n/sles/de-de/xml/printing.xml
+++ b/l10n/sles/de-de/xml/printing.xml
@@ -6,8 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>Druck</primary></indexterm>
+ </info>
  <para>
   <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> unterstützt zahlreiche Druckermodelle (auch entfernte Netzwerkdrucker). Drucker können manuell oder mit YaST konfiguriert werden. Anleitungen zur Konfiguration finden Sie unter <xref linkend="sec-y2-hw-print"/>. Grafische Dienstprogramme und Dienstprogramme an der Kommandozeile sind verfügbar, um Druckaufträge zu starten und zu verwalten. Wenn Ihr Drucker nicht wie erwartet verwendet werden kann, lesen Sie die Informationen unter <xref linkend="sec-drucken-prob"/>.
  </para>
@@ -266,15 +265,7 @@ Resolution/Output Resolution: 150dpi 300dpi *600dpi</screen>
   </para>
  </sect1>
  <sect1 xml:id="sec-p-appl-commandline">
-  <title>Drucken über die Kommandozeile</title><indexterm>
-
-  <primary>Drucken</primary>
-
-  <secondary>Kommandozeile</secondary></indexterm><indexterm>
-
-  <primary>Befehle</primary>
-
-  <secondary>lp</secondary></indexterm>
+  <title>Drucken über die Kommandozeile</title>
 
   <para>
    Um den Druckvorgang über die Kommandozeile zu starten, geben Sie <command>lp -d</command>
@@ -367,9 +358,7 @@ Resolution/Output Resolution: 150dpi 300dpi *600dpi</screen>
   </para>
 
   <sect2 xml:id="sec-drucken-gdi">
-   <title>Drucker ohne Unterstützung für eine Standard-Druckersprache</title><indexterm>
-   <primary> Drucken</primary>
-   <secondary> GDI-Drucker</secondary></indexterm> 
+   <title>Drucker ohne Unterstützung für eine Standard-Druckersprache</title>
    <para>
     Diese Drucker unterstützen keine der geläufigen Druckersprachen und können nur mit proprietären Steuersequenzen adressiert werden. Daher funktionieren sie nur mit den Betriebssystemversionen, für die der Hersteller einen Treiber zur Verfügung stellt. GDI ist eine von Microsoft für Grafikgeräte entwickelte Programmierschnittstelle. In der Regel liefert der Hersteller nur Treiber für Windows, und da Windows-Treiber die GDI-Schnittstelle verwenden, werden diese Drucker auch <emphasis>GDI-Drucker</emphasis> genannt. Das eigentliche Problem ist nicht die Programmierschnittstelle, sondern die Tatsache, dass diese Drucker nur mit der proprietären Druckersprache des jeweiligen Druckermodells adressiert werden können.
    </para>
@@ -395,12 +384,7 @@ Resolution/Output Resolution: 150dpi 300dpi *600dpi</screen>
   </sect2>
 
   <sect2 xml:id="sec-drucken-prob-netconnect">
-   <title>Netzwerkdrucker-Verbindungen</title><indexterm>
-   <primary>Drucken</primary>
-   <secondary>Drucken im Netzwerk</secondary></indexterm><indexterm>
-   <primary>Fehlerbehebung</primary>
-   <secondary>Netzwerk</secondary>
-   <tertiary/></indexterm>
+   <title>Netzwerkdrucker-Verbindungen</title>
    <para/>
    <variablelist>
     <varlistentry>

--- a/l10n/sles/de-de/xml/raid.xml
+++ b/l10n/sles/de-de/xml/raid.xml
@@ -7,19 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>YaST</primary>
-
- <secondary>RAID</secondary></indexterm><indexterm>
-
- <primary>RAID</primary>
-
- <secondary>YaST</secondary></indexterm><indexterm>
-
- <primary>Soft-RAID</primary>
-
- <see>RAID</see></indexterm>
+ </info>
 
  <para>
   In diesem Abschnitt werden die Aktionen beschrieben, die für die Erstellung und Konfiguration der verschiedenen RAID-Typen erforderlich sind. <phrase os="sles">Hintergrundinformationen zu RAID finden Sie im <xref linkend="sec-raid-intro"/></phrase>.

--- a/l10n/sles/de-de/xml/suse_emacs.xml
+++ b/l10n/sles/de-de/xml/suse_emacs.xml
@@ -6,28 +6,19 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-Emacs" class="startofrange">
- <primary>Emacs</primary></indexterm><indexterm xml:id="idx-editors-Emacs" class="startofrange">
- <primary>Editoren</primary>
- <secondary>Emacs</secondary></indexterm>
+ </info>
  <para>
   GNU Emacs ist eine komplexe Arbeitsumgebung. In den folgenden Abschnitten werden die beim Starten von GNU Emacs verarbeiteten Dateien beschrieben. Weitere Informationen hierzu erhalten Sie online unter <link xlink:href="http://www.gnu.org/software/emacs/"/>.
  </para>
  <para>
   Beim Starten liest Emacs mehrere Dateien, in denen die Einstellungen für den Benutzer, den Systemadministrator und den Distributor zur Anpassung oder Vorkonfiguration enthalten sind. Die Initialisierungsdatei <filename>~/.emacs</filename> ist in den Home-Verzeichnissen der einzelnen Benutzer von <filename>/etc/skel</filename> installiert. <filename>.emacs</filename> wiederum liest die Datei <filename>/etc/skel/.gnu-emacs</filename>. Zum Anpassen des Programms kopieren Sie <filename>.gnu-emacs</filename> in das Home-Verzeichnis (mit <command>cp /etc/skel/.gnu-emacs ~/.gnu-emacs</command>) und nehmen Sie dort die gewünschten Einstellungen vor.
- </para><indexterm>
- <primary>Konfigurationsdateien</primary>
- <secondary>.emacs</secondary></indexterm><indexterm>
- <primary>Emacs</primary>
- <secondary>.emacs</secondary></indexterm>
+ </para>
  <para>
   <filename>.gnu-emacs</filename> definiert die Datei <filename>~/.gnu-emacs-custom</filename> als <literal>custom-file</literal>. Wenn Benutzer in Emacs Einstellungen mit den <literal>customize</literal>-Optionen vornehmen, werden die Einstellungen in <filename>~/.gnu-emacs-custom</filename> gespeichert.
  </para>
  <para>
   Bei <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> wird mit dem <systemitem class="resource">emacs</systemitem>-Paket die Datei <filename>site-start.el</filename> im Verzeichnis <filename>/usr/share/emacs/site-lisp</filename> installiert. Die Datei <filename>site-start.el</filename> wird vor der Initialisierungsdatei <filename>~/.emacs</filename> geladen. Mit <filename>site-start.el</filename> wird unter anderem sichergestellt, dass spezielle Konfigurationsdateien mit Emacs-Add-on-Paketen, wie <systemitem class="resource">psgml</systemitem>, automatisch geladen werden. Konfigurationsdateien dieses Typs sind ebenfalls unter <filename>/usr/share/emacs/site-lisp</filename> gespeichert und beginnen immer mit <filename>suse-start-</filename>. Der lokale Systemadministrator kann systemweite Einstellungen in <filename>default.el</filename> festlegen.
- </para><indexterm>
- <primary> Emacs</primary>
- <secondary> default.el</secondary></indexterm> 
+ </para>
  <para>
   Weitere Informationen zu diesen Dateien finden Sie in der Info-Datei zu Emacs unter <emphasis>Init File:</emphasis> <literal>info:/emacs/InitFile</literal>. Informationen zum Deaktivieren des Ladens dieser Dateien (sofern erforderlich) stehen dort ebenfalls zur Verfügung.
  </para>
@@ -65,5 +56,5 @@
     Verschiedene Add-On-Pakete können bei Bedarf installiert werden: <systemitem class="resource">emacs-auctex</systemitem> (LaTeX), <systemitem class="resource">psgml</systemitem> (SGML und XML), <systemitem class="resource">gnuserv</systemitem> (Client- und Server-Vorgänge) und andere.
    </para>
   </listitem>
- </itemizedlist><indexterm class="endofrange" startref="idx-Emacs"/><indexterm class="endofrange" startref="idx-editors-Emacs"/>
+ </itemizedlist>
 </sect2>

--- a/l10n/sles/de-de/xml/suse_kb.xml
+++ b/l10n/sles/de-de/xml/suse_kb.xml
@@ -7,15 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>Tastatur</primary>
-
- <secondary>Layout</secondary></indexterm><indexterm>
-
- <primary>Tastatur</primary>
-
- <secondary>Zuordnung</secondary></indexterm>
+ </info>
 
  <para>
   Um die Tastaturzuordnung der Programme zu standardisieren, wurden Änderungen an folgenden Dateien vorgenommen:
@@ -30,51 +22,15 @@
 /etc/termcap
 /usr/share/terminfo/x/xterm
 /usr/share/X11/app-defaults/XTerm
-/usr/share/emacs/<replaceable>VERSION</replaceable>/site-lisp/term/*.el</screen><indexterm>
-
- <primary> Konfigurationsdateien</primary>
-
- <secondary> termcap</secondary></indexterm><indexterm>
-
- <primary>   Konfigurationsdateien</primary>
-
- <secondary> inputrc</secondary></indexterm> 
+/usr/share/emacs/<replaceable>VERSION</replaceable>/site-lisp/term/*.el</screen> 
 
  <para>
   Diese Änderungen betreffen nur Anwendungen, die <command>terminfo</command>-Einträge verwenden oder deren Konfigurationsdateien direkt geändert werden (<command>vi</command>, <command>emacs</command> usw.). Anwendungen, die nicht im Lieferumfang des Systems enthalten sind, sollten an diese Standards angepasst werden.
- </para><indexterm>
-
- <primary>Tastatur</primary>
-
- <secondary>Zuordnung</secondary>
-
- <tertiary>Compose</tertiary></indexterm><indexterm>
-
- <primary>Tastatur</primary>
-
- <secondary>Zuordnung</secondary>
-
- <tertiary>Multikey</tertiary></indexterm>
+ </para>
 
  <para>
   Unter X kann die Compose-Taste (Multi-Key) gemäß <filename>/etc/X11/Xmodmap</filename> aktiviert werden.
- </para><indexterm>
-
- <primary> Tastatur</primary>
-
- <secondary> X-Tastaturerweiterung</secondary></indexterm><indexterm>
-
- <primary>   Tastatur</primary>
-
- <secondary> XKB</secondary></indexterm><indexterm>
-
- <primary>   X-Tastaturerweiterung</primary>
-
- <see> Tastatur, XKB</see></indexterm><indexterm>
-
- <primary>   XKB</primary>
-
- <see> Tastatur, XKB</see></indexterm> 
+ </para>
 
  <para>
   Weitere Einstellungen sind mit der X-Tastaturerweiterung (XKB) möglich. Diese Erweiterung wird auch von der Desktop-Umgebung GNOME (gswitchit) verwendet.

--- a/l10n/sles/de-de/xml/suse_l10n.xml
+++ b/l10n/sles/de-de/xml/suse_l10n.xml
@@ -7,36 +7,19 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>System</primary>
-
- <secondary>Lokalisierung</secondary></indexterm><indexterm>
-
- <primary>I18N</primary></indexterm><indexterm>
-
- <primary>L10N</primary></indexterm><indexterm>
-
- <primary>Internationalisierung</primary></indexterm><indexterm>
-
- <primary>Lokalisierung</primary></indexterm>
+ </info>
 
  <para>
   Das System wurde zu einem großen Teil internationalisiert und kann an lokale Gegebenheiten angepasst werden. Die Internationalisierung (<emphasis>I18N</emphasis>) ermöglicht eine spezielle Lokalisierung (<emphasis>L10N</emphasis>). Die Abkürzungen I18N und L10N wurden von den ersten und letzten Buchstaben der englischsprachigen Begriffe und der Anzahl der dazwischen stehenden ausgelassenen Buchstaben abgeleitet.
  </para>
 
  <para>
-  Die Einstellungen werden mit <systemitem>LC_</systemitem>-Variablen vorgenommen, die in der Datei <filename>/etc/sysconfig/language</filename> definiert sind. Dies bezieht sich nicht nur auf die <emphasis>native Sprachunterstützung</emphasis>, sondern auch auf die Kategorien <emphasis>Meldungen</emphasis> (Sprache) <emphasis>Zeichensatz</emphasis>, <emphasis>Sortierreihenfolge</emphasis>, <emphasis>Uhrzeit und Datum</emphasis>, <emphasis>Zahlen</emphasis> und <emphasis>Währung</emphasis>. Diese Kategorien können direkt über eine eigene Variable oder indirekt mit einer Master-Variable in der Datei <filename>language</filename> festgelegt werden (weitere Informationen erhalten Sie auf der man-Seite zu <command>locale). </command> <indexterm>
-  <primary>Konfigurationsdateien</primary>
-  <secondary>Sprache</secondary>
-  </indexterm>
+  Die Einstellungen werden mit <systemitem>LC_</systemitem>-Variablen vorgenommen, die in der Datei <filename>/etc/sysconfig/language</filename> definiert sind. Dies bezieht sich nicht nur auf die <emphasis>native Sprachunterstützung</emphasis>, sondern auch auf die Kategorien <emphasis>Meldungen</emphasis> (Sprache) <emphasis>Zeichensatz</emphasis>, <emphasis>Sortierreihenfolge</emphasis>, <emphasis>Uhrzeit und Datum</emphasis>, <emphasis>Zahlen</emphasis> und <emphasis>Währung</emphasis>. Diese Kategorien können direkt über eine eigene Variable oder indirekt mit einer Master-Variable in der Datei <filename>language</filename> festgelegt werden (weitere Informationen erhalten Sie auf der man-Seite zu <command>locale). </command> 
  </para>
 
  <variablelist>
   <varlistentry>
-   <term><systemitem>RC_LC_MESSAGES</systemitem>, <systemitem>RC_LC_CTYPE</systemitem>, <systemitem>RC_LC_COLLATE</systemitem>, <systemitem>RC_LC_TIME</systemitem>, <systemitem>RC_LC_NUMERIC</systemitem>, <systemitem>RC_LC_MONETARY</systemitem><indexterm>
-    <primary>  Variablen</primary>
-    <secondary> Umgebung</secondary></indexterm> 
+   <term><systemitem>RC_LC_MESSAGES</systemitem>, <systemitem>RC_LC_CTYPE</systemitem>, <systemitem>RC_LC_COLLATE</systemitem>, <systemitem>RC_LC_TIME</systemitem>, <systemitem>RC_LC_NUMERIC</systemitem>, <systemitem>RC_LC_MONETARY</systemitem> 
    </term>
    <listitem>
     <para>
@@ -110,9 +93,7 @@ localedef -i en_US -f UTF-8 en_US.UTF-8
    </varlistentry>
    <varlistentry>
     <term>
-<systemitem>LANG=en_US.ISO-8859-1</systemitem><indexterm>
-     <primary>  Kodierung</primary>
-     <secondary> ISO-8859-1</secondary></indexterm> 
+<systemitem>LANG=en_US.ISO-8859-1</systemitem> 
     </term>
     <listitem>
      <para>
@@ -147,16 +128,7 @@ localedef -i en_US -f UTF-8 en_US.UTF-8
    </listitem>
   </itemizedlist>
   <para>
-   So wird sichergestellt, dass sämtliche Änderungen an <filename>/etc/sysconfig/language</filename> bei der nächsten Anmeldung in der entsprechenden Shell verfügbar sind, ohne dass sie manuell aktiviert werden müssen.<indexterm>
-   <primary>Konfigurationsdateien</primary>
-   <secondary> Sprache</secondary>
-   </indexterm><indexterm>
-   <primary>  Konfigurationsdateien</primary>
-   <secondary> Profil</secondary>
-   </indexterm> <indexterm>
-   <primary>   Konfigurationsdateien</primary>
-   <secondary> /etc/profile.d/lang.sh</secondary>
-   </indexterm>
+   So wird sichergestellt, dass sämtliche Änderungen an <filename>/etc/sysconfig/language</filename> bei der nächsten Anmeldung in der entsprechenden Shell verfügbar sind, ohne dass sie manuell aktiviert werden müssen. 
   </para>
   <para>
    Die Benutzer können die Standardeinstellungen des Systems außer Kraft setzen, indem Sie die Datei <filename>~/.bashrc</filename> entsprechend bearbeiten. Wenn Sie die systemübergreifende Einstellung <literal>en_US</literal> für Programmmeldungen beispielsweise nicht verwenden möchten, nehmen Sie z. B. <systemitem>LC_MESSAGES=es_ES</systemitem> auf, damit die Meldungen stattdessen auf Spanisch angezeigt werden.

--- a/l10n/sles/de-de/xml/suse_logfiles.xml
+++ b/l10n/sles/de-de/xml/suse_logfiles.xml
@@ -6,10 +6,8 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>Protokolldateien</primary></indexterm><indexterm>
- <primary>logrotate</primary></indexterm>
+ </info>
  <para>
   Mehrere Systemdienste ( <emphasis>Daemons</emphasis>) zeichnen zusammen mit dem Kernel selbst regelmäßig den Systemstatus und spezielle Ereignisse in Protokolldateien auf. Auf diese Weise kann der Administrator den Status des Systems zu einem bestimmten Zeitpunkt regelmäßig überprüfen, Fehler oder Fehlfunktionen erkennen und die Fehler mit Präzision beheben. Die Protokolldateien werden in der Regel, wie von FHS angegeben, unter <filename>/var/log</filename> gespeichert und werden täglich umfangreicher. Mit dem Paket <systemitem>logrotate</systemitem> kann der Umfang der Dateien gesteuert werden. Weitere Informationen finden Sie unter <xref linkend="sec-tuning-logfiles-logrotate"/>.
- </para> 
+ </para>
 </sect2>

--- a/l10n/sles/de-de/xml/suse_vc.xml
+++ b/l10n/sles/de-de/xml/suse_vc.xml
@@ -7,24 +7,12 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>Konsolen</primary>
-
- <secondary>Umschalten</secondary></indexterm>
+ </info>
 
  <para>
   Linux ist ein Multitasking-System für den Mehrbenutzerbetrieb. Die Vorteile dieser Funktionen können auch auf einem eigenständigen PC-System genutzt werden. Im Textmodus stehen sechs virtuelle Konsolen zur Verfügung. Mit den Tastenkombinationen <keycombo> <keycap function="alt"/> <keycap>F1</keycap> </keycombo> bis <keycombo> <keycap function="alt"/> <keycap>F6</keycap> </keycombo> können Sie zwischen den Konsolen umschalten. Die siebte Konsole ist für X und reserviert und in der zehnten Konsole werden Kernel-Meldungen angezeigt. 
 
- </para><indexterm>
-
- <primary>Konsolen</primary>
-
- <secondary>zuweisen</secondary></indexterm><indexterm>
-
- <primary>Konfigurationsdateien</primary>
-
-</indexterm>
+ </para>
 
  <para>
   Wenn Sie von X ohne Herunterfahren zu einer anderen Konsole wechseln möchten, verwenden Sie die Tasten <keycombo>

--- a/l10n/sles/de-de/xml/sw_managing_commandline.xml
+++ b/l10n/sles/de-de/xml/sw_managing_commandline.xml
@@ -11,9 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary> Installieren</primary>
- <secondary> Software</secondary></indexterm> 
+ </info>
  <xi:include href="zypper.xml"/>
  <xi:include href="rpm.xml"/>
 </chapter>

--- a/l10n/sles/de-de/xml/x86_inst_problem.xml
+++ b/l10n/sles/de-de/xml/x86_inst_problem.xml
@@ -7,9 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary> Problemlösung</primary></indexterm> 
+ </info>
 
  <para>
   Vor der Bereitstellung wird <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> umfangreichen Tests unterzogen. Dennoch treten gelegentlich Probleme beim Start oder bei der Installation auf.

--- a/l10n/sles/de-de/xml/yast2_gui.xml
+++ b/l10n/sles/de-de/xml/yast2_gui.xml
@@ -6,8 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-YaST-gui" class="startofrange">
- <primary>YaST</primary></indexterm>
+ </info>
  <para>
   YaST ist das Installations- und Konfigurationswerkzeug für <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>. Mit der grafischen Benutzeroberfläche können Sie das System während und nach der Installation schnell und einfach an Ihre Bedürfnisse anpassen. Damit können Sie die Hardware einrichten, das Netzwerk und die Systemdienste konfigurieren und auch die Sicherheitseinstellungen verfeinern.
  </para>

--- a/l10n/sles/de-de/xml/yast2_lang.xml
+++ b/l10n/sles/de-de/xml/yast2_lang.xml
@@ -6,14 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>System</primary>
- <secondary>Sprachen</secondary></indexterm><indexterm>
- <primary>YaST</primary>
- <secondary>Sprachen</secondary></indexterm><indexterm>
- <primary>Sprachen</primary></indexterm><indexterm>
- <primary>Konfigurieren</primary>
- <secondary>Sprachen</secondary></indexterm>
+ </info>
  <para>
   Für das Arbeiten in verschiedenen Ländern oder in einer mehrsprachigen Umgebung, muss Ihr Rechner entsprechend eingerichtet sein. <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> kann verschiedene <literal>Locales</literal> parallel verarbeiten. Eine Locale bezeichnet eine Reihe von Parametern, die die Sprache und die Ländereinstellungen, die in der Benutzeroberfläche angezeigt werden, definiert.
  </para>

--- a/l10n/sles/de-de/xml/yast2_ncurses.xml
+++ b/l10n/sles/de-de/xml/yast2_ncurses.xml
@@ -7,14 +7,10 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-YaST-text-mode" class="startofrange">
- <primary> YaST</primary>
- <secondary> Textmodus</secondary></indexterm> 
+ </info>
  <para>
   Dieser Abschnitt richtet sich an Systemadministratoren und Experten, die keinen X-Server auf Ihren Systemen ausführen und daher auf das textbasierte Installationswerkzeug angewiesen sind. Der Abschnitt enthält grundlegende Informationen zum Start und Betrieb von YaST im Textmodus.
- </para><indexterm>
- <primary> YaST</primary>
- <secondary> ncurses</secondary></indexterm> 
+ </para>
  <para>
   YaST verwendet im Textmodus die ncurses-Bibliothek, um eine bequeme pseudografische Bedienoberfläche zu bieten. Die ncurses-Bibliothek wird standardmäßig installiert. Die minimale unterstützte Größe des Terminal-Emulators, in dem Sie YaST ausführen, beträgt 80 x 25 Zeichen.
  </para>
@@ -245,11 +241,7 @@
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-yast-ncurses-commands">
-  <title>YaST-Kommandozeilenoptionen</title><indexterm>
-
-  <primary> YaST </primary>
-
-  <secondary>Kommandozeile</secondary></indexterm> 
+  <title>YaST-Kommandozeilenoptionen</title>
 
   <para>
    Neben der Schnittstelle im Textmodus bietet YaST auch eine reine Kommandozeilenschnittstelle. Eine Liste der YaST-Kommandozeilenoptionen erhalten Sie, wenn Sie Folgendes eingeben:
@@ -258,10 +250,7 @@
 <screen>yast -h</screen>
 
   <sect2 xml:id="sec-yast-ncurses-modulaufruf">
-   <title>Starten der einzelnen Module</title><indexterm>
-   <primary>YaST</primary>
-   <secondary> Textmodus</secondary>
-   <tertiary> Module</tertiary></indexterm>
+   <title>Starten der einzelnen Module</title>
    <para>
     Um Zeit zu sparen können die einzelnen YaST-Module direkt gestartet werden. Um ein Modul zu starten, geben Sie Folgendes ein:
    </para>
@@ -298,7 +287,7 @@
    <para>
     Wenn ein Modul keine Kommandozeilenunterstützung bietet, wird es im Textmodus gestartet und es wird folgende Meldung angezeigt.
    </para>
-<screen>This YaST module does not support the command line interface.</screen><indexterm class="endofrange" startref="idx-YaST-text-mode"/>
+<screen>This YaST module does not support the command line interface.</screen>
   </sect2>
  </sect1>
 </chapter>

--- a/l10n/sles/de-de/xml/yast2_sound.xml
+++ b/l10n/sles/de-de/xml/yast2_sound.xml
@@ -7,23 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>Konfigurieren</primary>
-
- <secondary>Soundkarten</secondary></indexterm><indexterm>
-
- <primary>YaST</primary>
-
- <secondary>Soundkarten</secondary></indexterm><indexterm>
-
- <primary>Sound</primary>
-
- <secondary>Konfigurieren in YaST</secondary></indexterm><indexterm>
-
- <primary>Karten</primary>
-
- <secondary>Soundkarten</secondary></indexterm>
+ </info>
 
  <para>
   YaST erkennt die meisten Soundkarten automatisch und konfiguriert sie mit den entsprechenden Werten. Wenn die Standardeinstellungen geändert werden sollen oder wenn eine Soundkarte eingerichtet werden soll, die nicht automatisch konfiguriert werden kann, verwenden Sie das YaST-Soundmodul. Damit können Sie auch weitere Soundkarten einrichten oder deren Reihenfolge ändern.
@@ -167,13 +151,7 @@
   </step>
   <step>
    <para>
-    <indexterm>
-    <primary>sound</primary>
-    <secondary>fonts</secondary>
-    </indexterm> <indexterm>
-    <primary>sound</primary>
-    <secondary>MIDI</secondary>
-    </indexterm>Wenn eine unterstützte Soundkarte erkannt wird, können Sie SoundFonts für die Wiedergabe von MIDI-Dateien installieren:
+     Wenn eine unterstützte Soundkarte erkannt wird, können Sie SoundFonts für die Wiedergabe von MIDI-Dateien installieren:
    </para>
    <substeps performance="required">
     <step>
@@ -203,12 +181,6 @@
  </procedure>
 
  <para>
-  Die Lautstärke und die Konfiguration aller installierten Soundkarten werden gespeichert, wenn Sie auf <guimenu>OK</guimenu> klicken und das YaST-Soundmodul verlassen. Die Mixereinstellungen werden in der Datei <filename>/etc/asound.state</filename> gespeichert. Die ALSA-Konfigurationsdaten werden am Ende der Datei <filename>/etc/modprobe.d/sound</filename> angefügt und in <filename>/etc/sysconfig/sound</filename> geschrieben.<indexterm>
-  <primary>Konfigurationsdateien</primary>
-  <secondary> asound.state</secondary>
-  </indexterm> <indexterm>
-  <primary>   Konfigurationsdateien</primary>
-  <secondary> modprobe.d/sound</secondary>
-  </indexterm>
+  Die Lautstärke und die Konfiguration aller installierten Soundkarten werden gespeichert, wenn Sie auf <guimenu>OK</guimenu> klicken und das YaST-Soundmodul verlassen. Die Mixereinstellungen werden in der Datei <filename>/etc/asound.state</filename> gespeichert. Die ALSA-Konfigurationsdaten werden am Ende der Datei <filename>/etc/modprobe.d/sound</filename> angefügt und in <filename>/etc/sysconfig/sound</filename> geschrieben. 
  </para>
 </sect1>

--- a/l10n/sles/de-de/xml/yast2_sw.xml
+++ b/l10n/sles/de-de/xml/yast2_sw.xml
@@ -11,11 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>YaST</primary>
- <secondary>Software</secondary></indexterm><indexterm>
- <primary>Konfigurieren</primary>
- <secondary>Software</secondary></indexterm>
+ </info>
  <para>
   Ändern Sie die gesammelte Software auf Ihrem System mit dem YaST-Software-Manager. Dieses YaST-Modul ist in zwei Varianten verfügbar: eine grafische Ausführung für X Window und eine textbasierte Ausführung für die Kommandozeile. Im Folgenden wird die grafische Variante beschrieben; weitere Informationen zum textbasierten YaST finden Sie in <xref linkend="cha-yast-text"/>.
  </para>

--- a/l10n/sles/de-de/xml/yast2_userman.xml
+++ b/l10n/sles/de-de/xml/yast2_userman.xml
@@ -99,13 +99,7 @@
   <title>Benutzerkonten verwalten</title>
 
   <para>
-   <indexterm>
-   <primary>Benutzer</primary>
-   <secondary> Konten erstellen</secondary>
-   </indexterm> <indexterm>
-   <primary>   Benutzer</primary>
-   <secondary> Konten ändern</secondary>
-   </indexterm>  In YaST können Benutzerkonten erstellt, geändert, gelöscht und vorübergehend deaktiviert werden. Ändern Sie keine Benutzerkonten, es sei denn, Sie sind ein erfahrener Benutzer oder Administrator.
+      In YaST können Benutzerkonten erstellt, geändert, gelöscht und vorübergehend deaktiviert werden. Ändern Sie keine Benutzerkonten, es sei denn, Sie sind ein erfahrener Benutzer oder Administrator.
   </para>
 
   <note>
@@ -189,11 +183,7 @@
   </tip>
 
   <procedure>
-   <title>Deaktivieren oder Löschen von Benutzerkonten</title><indexterm>
-   <primary> Benutzer</primary>
-   <secondary> Konten deaktivieren</secondary></indexterm><indexterm>
-   <primary>   Benutzer</primary>
-   <secondary> Konten löschen</secondary></indexterm> 
+   <title>Deaktivieren oder Löschen von Benutzerkonten</title>
    <step>
     <para>
      Öffnen Sie in YaST das Dialogfeld <guimenu>Verwaltung von Benutzern und Gruppen</guimenu>, und klicken Sie dort auf <guimenu>Benutzer</guimenu>.
@@ -241,9 +231,7 @@
 
    </para>
    <procedure>
-    <title>Konfigurieren von Passworteinstellungen</title><indexterm>
-    <primary> Benutzer</primary>
-    <secondary> Passworteinstellungen</secondary></indexterm> 
+    <title>Konfigurieren von Passworteinstellungen</title>
     <step>
      <para>
       Öffnen Sie in YaST das Dialogfeld <guimenu>Verwaltung von Benutzern und Gruppen</guimenu>, und klicken Sie dort auf den Karteireiter <guimenu>Benutzer</guimenu>.
@@ -298,11 +286,7 @@
   </sect2>
 
   <sect2 xml:id="sec-y2-userman-adv-crypto">
-   <title>Verwalten verschlüsselter Home-Verzeichnisse</title><indexterm>
-   <primary>Home-Verzeichnisse</primary>
-   <secondary> verschlüsseln</secondary></indexterm><indexterm>
-   <primary> Benutzer</primary>
-   <secondary> verschlüsselte Home-Verzeichnisse</secondary></indexterm>
+   <title>Verwalten verschlüsselter Home-Verzeichnisse</title>
    <para>
     Um Datendiebstahl in Home-Verzeichnissen und die Entfernung der Festplatte zu unterbinden, können Sie verschlüsselte Home-Verzeichnisse für Benutzer erstellen. Sie werden mit LUKS (Linux Unified Key Setup) verschlüsselt. Dabei werden ein Image und ein Image-Schlüssel für die Benutzer erstellt. Der Image-Schlüssel ist durch das Anmeldepasswort des Benutzers geschützt. Wenn sich der Benutzer am System anmeldet, wird das verschlüsselte Home-Verzeichnis eingehängt und die Inhalte werden für den Benutzer verfügbar gemacht.
    </para>
@@ -414,11 +398,7 @@
   </sect2>
 
   <sect2 xml:id="sec-y2-userman-adv-quota">
-   <title>Verwalten von Quoten</title><indexterm>
-   <primary>Benutzer</primary>
-   <secondary>Quoten</secondary></indexterm><indexterm>
-   <primary>Quoten</primary>
-   <secondary>Benutzer, Gruppen</secondary></indexterm>
+   <title>Verwalten von Quoten</title>
    <para>
     Um zu verhindern, dass die Systemkapazität ohne Benachrichtigung zur Neige geht, können Systemadministratoren Quoten für Benutzer oder Gruppen einrichten. Quoten können für ein oder mehrere Dateisysteme definiert werden und beschränken den Speicherplatz, der verwendet werden kann, sowie die Anzahl der Inodes (Index-Knoten), die hier erstellt werden können. Inodes sind Datenstrukturen eines Dateisystems, die grundlegende Informationen über normale Datei-, Verzeichnis- oder andere Dateisystemobjekte speichern. Sie speichern alle Attribute eines Dateisystemobjekts (z. B. Eigentümer des Objekts und Berechtigungen wie Lesen, Schreiben oder Ausführen), mit Ausnahme des Dateinamens und des Dateiinhalts.
    </para>
@@ -564,11 +544,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-y2-userman-defaults">
-  <title>Ändern der Standardeinstellungen für lokale Benutzer</title><indexterm>
-
-  <primary> Benutzer</primary>
-
-  <secondary> Standardeinstellungen</secondary></indexterm> 
+  <title>Ändern der Standardeinstellungen für lokale Benutzer</title>
 
   <para>
    Beim Erstellen von neuen lokalen Benutzern werden von YaST verschiedene Standardeinstellungen verwendet. Zu diesen Einstellungen zählen unter anderem die Primärgruppe sowie die Sekundärgruppen des Benutzers und die Zugriffsberechtigungen für das Home-Verzeichnis des Benutzers. Sie können diese Standardeinstellungen entsprechend Ihren Anforderungen ändern:
@@ -616,10 +592,7 @@
   <title>Zuweisen von Benutzern zu Gruppen</title>
 
   <para>
-   <indexterm>
-   <primary>Benutzer</primary>
-   <secondary> Gruppenzuweisung</secondary>
-   </indexterm>  Lokale Benutzer können mehreren Gruppen zugewiesen werden. Diese Zuweisung erfolgt gemäß den Standardeinstellungen, die Sie im Dialogfeld <guimenu>Verwaltung von Benutzern und Gruppen</guimenu> auf dem Karteireiter <guimenu>Standardeinstellungen für neue Benutzer</guimenu> festlegen. Im nächsten Abschnitt erfahren Sie, wie Sie die Gruppenzuweisung eines einzelnen Benutzers ändern. Informationen zur Änderung der Standardgruppenzuweisung für neue Benutzer erhalten Sie unter <xref linkend="sec-y2-userman-defaults"/>.
+     Lokale Benutzer können mehreren Gruppen zugewiesen werden. Diese Zuweisung erfolgt gemäß den Standardeinstellungen, die Sie im Dialogfeld <guimenu>Verwaltung von Benutzern und Gruppen</guimenu> auf dem Karteireiter <guimenu>Standardeinstellungen für neue Benutzer</guimenu> festlegen. Im nächsten Abschnitt erfahren Sie, wie Sie die Gruppenzuweisung eines einzelnen Benutzers ändern. Informationen zur Änderung der Standardgruppenzuweisung für neue Benutzer erhalten Sie unter <xref linkend="sec-y2-userman-defaults"/>.
   </para>
 
   <procedure>
@@ -660,19 +633,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-y2-userman-groups">
-  <title>Verwalten von Gruppen</title><indexterm>
-
-  <primary>Gruppen </primary>
-
-  <secondary>Verwaltung </secondary></indexterm><indexterm>
-
-  <primary>YaST </primary>
-
-  <secondary>Gruppenverwaltung </secondary></indexterm><indexterm>
-
-  <primary>Konfigurieren </primary>
-
-  <secondary>Gruppen</secondary></indexterm>
+  <title>Verwalten von Gruppen</title>
 
   <para>
    Mit YaST können Sie schnell und einfach Gruppen hinzufügen, bearbeiten und löschen.
@@ -744,11 +705,7 @@
   </para>
  </sect1>
  <sect1 xml:id="cha-y2-userman-authent">
-  <title>Ändern der Methode zur Benutzer-Authentifizierung</title><indexterm>
-
-  <primary> Benutzer</primary>
-
-  <secondary> Authentifizierung</secondary></indexterm> 
+  <title>Ändern der Methode zur Benutzer-Authentifizierung</title>
 
   <para>
    Wenn Ihr Computer an ein Netzwerk angeschlossen ist, können Sie die Authentifizierungsmethode ändern. Mit den zur Verfügung stehenden Optionen können Sie

--- a/l10n/sles/de-de/xml/yast2_you.xml
+++ b/l10n/sles/de-de/xml/yast2_you.xml
@@ -6,11 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>Ja</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>Aktualisierung</primary>
- <secondary>Online</secondary></indexterm><indexterm>
- <primary>YaST</primary>
- <secondary>Online-Update</secondary></indexterm>
+ </info>
  <para>
   SUSE stellt fortlaufend Sicherheitsaktualisierungen für Ihr Softwareprodukt bereit. Standardmäßig stellt das Miniprogramm für die Aktualisierung sicher, dass Ihr System stets auf dem neuesten Stand ist. Weitere Informationen zu diesem Miniprogramm finden Sie im <xref linkend="sec-updater"/>. Dieses Kapitel behandelt das alternative Tool für die Aktualisierung von Software-Paketen: die YaST-Online-Aktualisierung.
  </para>

--- a/l10n/sles/es-es/xml/aarch64_inst_problem.xml
+++ b/l10n/sles/es-es/xml/aarch64_inst_problem.xml
@@ -7,7 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>sí</dm:translation>
   </dm:docmanager>
- </info><indexterm> <primary>resolución de problemas</primary></indexterm>
+ </info>
 
  <para>
   Antes de su publicación, <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> se ha sometido a un programa intensivo de pruebas. A pesar de todo, a veces se producen problemas durante el arranque o la instalación.

--- a/l10n/sles/es-es/xml/common_intro_available_doc_i.xml
+++ b/l10n/sles/es-es/xml/common_intro_available_doc_i.xml
@@ -9,7 +9,7 @@
    </dm:bugtracker>
    <dm:translation>sí</dm:translation>
   </dm:docmanager>
- </info><indexterm> <primary>ayuda</primary> <secondary>manuales de SUSE</secondary></indexterm><indexterm> <primary>manuales de SUSE</primary></indexterm>
+ </info>
 
  <note>
   <title>documentación en línea y actualizaciones más recientes</title>

--- a/l10n/sles/es-es/xml/lvm.xml
+++ b/l10n/sles/es-es/xml/lvm.xml
@@ -7,7 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>sí</dm:translation>
   </dm:docmanager>
- </info><indexterm> <primary>YaST</primary> <secondary>LVM</secondary></indexterm><indexterm> <primary>LVM</primary> <secondary>YaST</secondary></indexterm><indexterm> <primary>Gestor de volúmenes lógicos</primary> <see>LVM</see></indexterm>
+ </info>
 
  <para>
   En esta sección se explican los pasos específicos que deben realizarse al configurar LVM. <phrase os="sles">Si necesita información sobre el gestor de volúmenes lógicos en general, consulte el <xref linkend="sec-lvm-explained"/>.</phrase>

--- a/l10n/sles/es-es/xml/raid.xml
+++ b/l10n/sles/es-es/xml/raid.xml
@@ -7,7 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>sí</dm:translation>
   </dm:docmanager>
- </info><indexterm> <primary>YaST</primary> <secondary>RAID</secondary></indexterm><indexterm> <primary>RAID</primary> <secondary>YaST</secondary></indexterm><indexterm> <primary>RAID por software</primary> <see>RAID</see></indexterm>
+ </info>
 
  <para>
   En esta sección se describen las acciones necesarias para crear y configurar varios tipos de RAID. <phrase os="sles">En caso de que necesite información sobre RAID, consulte <xref linkend="sec-raid-intro"/></phrase>.

--- a/l10n/sles/es-es/xml/x86_inst_problem.xml
+++ b/l10n/sles/es-es/xml/x86_inst_problem.xml
@@ -7,7 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>sí</dm:translation>
   </dm:docmanager>
- </info><indexterm> <primary>resolución de problemas</primary></indexterm>
+ </info>
 
  <para>
   Antes de su publicación, <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> se ha sometido a un programa intensivo de pruebas. A pesar de todo, a veces se producen problemas durante el arranque o la instalación.

--- a/l10n/sles/es-es/xml/yast2_lang.xml
+++ b/l10n/sles/es-es/xml/yast2_lang.xml
@@ -6,7 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>sí</dm:translation>
   </dm:docmanager>
- </info><indexterm> <primary>sistema</primary> <secondary>idiomas</secondary></indexterm><indexterm> <primary>YaST</primary> <secondary>idiomas</secondary></indexterm><indexterm> <primary>idiomas</primary></indexterm><indexterm> <primary>configuración</primary> <secondary>idiomas</secondary></indexterm>
+ </info>
  <para>
   Si trabaja en distintos países o en un entorno en el que se usen varios idiomas, necesitará configurar el equipo en consecuencia. <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> puede gestionar varias <literal>configuraciones regionales</literal> en paralelo. Una configuración regional es un conjunto de parámetros que definen los ajustes de idioma y país reflejados en la interfaz del usuario.
  </para>

--- a/l10n/sles/es-es/xml/yast2_sound.xml
+++ b/l10n/sles/es-es/xml/yast2_sound.xml
@@ -7,7 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>sí</dm:translation>
   </dm:docmanager>
- </info><indexterm> <primary>configuración</primary> <secondary>tarjetas de sonido</secondary></indexterm><indexterm> <primary>YaST</primary> <secondary>tarjetas de sonido</secondary></indexterm><indexterm> <primary>sonido</primary> <secondary>configuración en YaST</secondary></indexterm><indexterm> <primary>tarjetas</primary> <secondary>sonido</secondary></indexterm>
+ </info>
 
  <para>
   YaST detecta automáticamente la mayoría de las tarjetas de sonido y las configura con los valores apropiados. Para cambiar los ajustes por defecto o configurar una tarjeta de sonido que no se pueda configurar automáticamente, utilice el módulo de sonido de YaST. Ahí también podrá configurar tarjetas de sonido adicionales o cambiar su orden.
@@ -148,7 +148,7 @@
   </step>
   <step>
    <para>
-    <indexterm> <primary>sonido</primary> <secondary>fuentes</secondary> </indexterm> <indexterm> <primary>sonido</primary> <secondary>MIDI</secondary> </indexterm>Si se detecta una tarjeta de sonido compatible, puede instalar SoundFonts para reproducir archivos MIDI:
+     Si se detecta una tarjeta de sonido compatible, puede instalar SoundFonts para reproducir archivos MIDI:
    </para>
    <substeps performance="required">
     <step>
@@ -177,6 +177,6 @@
  </procedure>
 
  <para>
-  El volumen y la configuración de todas las tarjetas de sonido se guardan al hacer clic en <guimenu>Aceptar.</guimenu> También se sale del módulo de sonido de YaST Los valores de configuración del mezclador se guardan en el archivo <filename>/etc/asound.state</filename>. Los datos de configuración de ALSA se añaden al final del archivo <filename>/etc/modprobe.d/sound</filename> y se escriben en <filename>/etc/sysconfig/sound</filename>.<indexterm> <primary>archivos de configuración</primary> <secondary>asound.state</secondary> </indexterm> <indexterm> <primary>archivos de configuración</primary> <secondary>modprobe.d/sound</secondary> </indexterm>
+  El volumen y la configuración de todas las tarjetas de sonido se guardan al hacer clic en <guimenu>Aceptar.</guimenu> También se sale del módulo de sonido de YaST Los valores de configuración del mezclador se guardan en el archivo <filename>/etc/asound.state</filename>. Los datos de configuración de ALSA se añaden al final del archivo <filename>/etc/modprobe.d/sound</filename> y se escriben en <filename>/etc/sysconfig/sound</filename>. 
  </para>
 </sect1>

--- a/l10n/sles/es-es/xml/yast2_sw.xml
+++ b/l10n/sles/es-es/xml/yast2_sw.xml
@@ -11,7 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>sí</dm:translation>
   </dm:docmanager>
- </info><indexterm> <primary>YaST</primary> <secondary>software</secondary></indexterm><indexterm> <primary>configuración</primary> <secondary>software</secondary></indexterm>
+ </info>
  <para>
   Modifique la colección de software del sistema mediante el Gestor de software de YaST. Hay dos versiones de este módulo de YaST: una variante gráfica para X Window y una basada en texto para usar en la línea de comandos. La versión gráfica se describe aquí. Para obtener más detalles sobre la versión de texto, consulte el <xref linkend="cha-yast-text"/>.
  </para>

--- a/l10n/sles/es-es/xml/yast2_userman.xml
+++ b/l10n/sles/es-es/xml/yast2_userman.xml
@@ -97,7 +97,7 @@
   <title>Gestión de cuentas de usuario</title>
 
   <para>
-   <indexterm> <primary>usuarios</primary> <secondary>creación de cuentas</secondary> </indexterm> <indexterm> <primary>usuarios</primary> <secondary>modificación de cuentas</secondary> </indexterm> YaST permite crear, modificar, suprimir o inhabilitar temporalmente cuentas de usuario. No modifique las cuentas de usuario si no es un usuario o un administrador con experiencia.
+     YaST permite crear, modificar, suprimir o inhabilitar temporalmente cuentas de usuario. No modifique las cuentas de usuario si no es un usuario o un administrador con experiencia.
   </para>
 
   <note>
@@ -181,7 +181,7 @@
   </tip>
 
   <procedure>
-   <title>Inhabilitación o supresión de cuentas de usuario</title><indexterm> <primary>usuarios</primary> <secondary>inhabilitación de cuentas</secondary></indexterm><indexterm> <primary>usuarios</primary> <secondary>supresión de cuentas</secondary></indexterm>
+   <title>Inhabilitación o supresión de cuentas de usuario</title>
    <step>
     <para>
      Abra el recuadro de diálogo <guimenu>Administración de usuarios y grupos</guimenu> de YaST y haga clic en la pestaña <guimenu>Usuarios.</guimenu>
@@ -229,7 +229,7 @@
 
    </para>
    <procedure>
-    <title>Configuración de los ajustes de las contraseñas</title><indexterm> <primary>usuarios</primary> <secondary>definición de contraseñas</secondary></indexterm>
+    <title>Configuración de los ajustes de las contraseñas</title>
     <step>
      <para>
       Abra el recuadro de diálogo <guimenu>Administración de usuarios y grupos</guimenu> de YaST y seleccione la pestaña <guimenu>Usuarios.</guimenu>
@@ -284,7 +284,7 @@
   </sect2>
 
   <sect2 xml:id="sec-y2-userman-adv-crypto">
-   <title>Gestión de directorios personales cifrados</title><indexterm> <primary>directorios personales</primary> <secondary>cifrado</secondary></indexterm><indexterm> <primary>usuarios</primary> <secondary>directorios personales cifrados</secondary></indexterm>
+   <title>Gestión de directorios personales cifrados</title>
    <para>
     Para proteger los datos de los directorios personales contra robos o pérdidas del disco duro, puede crear directorios personales cifrados para los usuarios. Se cifran mediante LUKS (Linux Unified Key Setup, configuración de clave unificada de Linux), que genera una imagen y una clave de imagen para el usuario. La clave de imagen está protegida por la contraseña de entrada del usuario. Cuando el usuario entra al sistema, el directorio personal cifrado se monta y su contenido se pone a disposición del usuario.
    </para>
@@ -396,7 +396,7 @@
   </sect2>
 
   <sect2 xml:id="sec-y2-userman-adv-quota">
-   <title>Gestión de cuotas</title><indexterm> <primary>usuarios</primary> <secondary>cuotas</secondary></indexterm><indexterm> <primary>cuotas</primary> <secondary>usuarios, grupos</secondary></indexterm>
+   <title>Gestión de cuotas</title>
    <para>
     Para evitar que los recursos del sistema se agoten sin aviso, los administradores del sistema pueden configurar cuotas para usuarios o grupos. Es posible definir cuotas para uno o más sistemas de archivos y restringir la cantidad de espacio de disco que se puede usar o el número de inodes (nodos de índice) que se pueden crear. Los inodos son estructuras de datos de un sistema de archivos que almacenan información básica sobre un archivo normal, un directorio u otro objeto del sistema de archivos. Guardan todos los atributos de un objeto de sistema de archivos (como los permisos de propiedad, lectura, escritura o ejecución del usuario y el grupo), excepto el nombre del archivo y su contenido.
    </para>
@@ -541,7 +541,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-y2-userman-defaults">
-  <title>Cambio de los ajustes por defecto para usuarios locales</title><indexterm> <primary>usuarios</primary> <secondary>ajustes por defecto</secondary></indexterm>
+  <title>Cambio de los ajustes por defecto para usuarios locales</title>
 
   <para>
    Cuando se crean usuarios locales nuevos, YaST usa varios ajustes por defecto. Entre ellos, por ejemplo, el grupo principal y los grupos secundarios a los que pertenece el usuario o los permisos de acceso del directorio personal del usuario. Estos ajustes se pueden cambiar para adaptarlos a sus necesidades:
@@ -589,7 +589,7 @@
   <title>Asignación de usuarios a grupos</title>
 
   <para>
-   <indexterm> <primary>usuarios</primary> <secondary>asignación de grupo</secondary> </indexterm> Los usuarios locales se asignan a varios grupos según los ajustes por defecto a los que se pueden acceder desde el recuadro de diálogo <guimenu>Administración de usuarios y grupos</guimenu> en la pestaña <guimenu>por defecto para nuevos usuarios.</guimenu> A continuación se explica cómo se puede modificar la asignación de grupo de un usuario concreto. Si necesita cambiar las asignaciones de grupo por defecto de los usuarios nuevos, consulte la <xref linkend="sec-y2-userman-defaults"/>.
+    Los usuarios locales se asignan a varios grupos según los ajustes por defecto a los que se pueden acceder desde el recuadro de diálogo <guimenu>Administración de usuarios y grupos</guimenu> en la pestaña <guimenu>por defecto para nuevos usuarios.</guimenu> A continuación se explica cómo se puede modificar la asignación de grupo de un usuario concreto. Si necesita cambiar las asignaciones de grupo por defecto de los usuarios nuevos, consulte la <xref linkend="sec-y2-userman-defaults"/>.
   </para>
 
   <procedure>
@@ -630,7 +630,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-y2-userman-groups">
-  <title>Gestión de grupos</title><indexterm> <primary>grupos</primary> <secondary>gestión</secondary></indexterm><indexterm> <primary>YaST</primary> <secondary>gestión de grupos</secondary></indexterm><indexterm> <primary>configuración</primary> <secondary>grupos</secondary></indexterm>
+  <title>Gestión de grupos</title>
 
   <para>
    Con YaST también es posible añadir, modificar o suprimir grupos con facilidad.
@@ -700,7 +700,7 @@
   </para>
  </sect1>
  <sect1 xml:id="cha-y2-userman-authent">
-  <title>Cambio del método de autenticación de usuarios</title><indexterm> <primary>usuarios</primary> <secondary>autenticación</secondary></indexterm>
+  <title>Cambio del método de autenticación de usuarios</title>
 
   <para>
    Si el equipo está conectado a una red, es posible cambiar el método de autenticación. Están disponibles las siguientes opciones:

--- a/l10n/sles/fr-fr/xml/aarch64_inst_problem.xml
+++ b/l10n/sles/fr-fr/xml/aarch64_inst_problem.xml
@@ -7,7 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>oui</dm:translation>
   </dm:docmanager>
- </info><indexterm> <primary>solution</primary> </indexterm>
+ </info>
 
  <para>
   Avant la livraison, <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> est soumis à un programme de test approfondi. Malgré cela, des problèmes peuvent survenir lors du démarrage ou de l'installation.

--- a/l10n/sles/fr-fr/xml/common_intro_available_doc_i.xml
+++ b/l10n/sles/fr-fr/xml/common_intro_available_doc_i.xml
@@ -9,7 +9,7 @@
    </dm:bugtracker>
    <dm:translation>oui</dm:translation>
   </dm:docmanager>
- </info><indexterm> <primary>aide</primary> <secondary>manuels SUSE</secondary></indexterm><indexterm> <primary>manuels SUSE</primary></indexterm>
+ </info>
 
  <note>
   <title>documentation en ligne et dernières mises à jour</title>

--- a/l10n/sles/fr-fr/xml/lvm.xml
+++ b/l10n/sles/fr-fr/xml/lvm.xml
@@ -7,7 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>oui</dm:translation>
   </dm:docmanager>
- </info><indexterm> <primary>YaST</primary> <secondary>LVM</secondary></indexterm><indexterm> <primary>LVM</primary> <secondary>YaST</secondary></indexterm><indexterm> <primary>Gestionnaire de volumes logiques</primary> <see>LVM</see></indexterm>
+ </info>
 
  <para>
   Cette section explique les étapes spécifiques à effectuer lors de la configuration de LVM. <phrase os="sles">Si vous avez besoin d'informations sur le Gestionnaire de volumes logiques en général, reportez-vous au <xref linkend="sec-lvm-explained"/>.</phrase>

--- a/l10n/sles/fr-fr/xml/raid.xml
+++ b/l10n/sles/fr-fr/xml/raid.xml
@@ -7,7 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>oui</dm:translation>
   </dm:docmanager>
- </info><indexterm> <primary>YaST</primary> <secondary>RAID</secondary></indexterm><indexterm> <primary>RAID</primary> <secondary>YaST</secondary></indexterm><indexterm> <primary>Soft RAID</primary> <see>RAID</see></indexterm>
+ </info>
 
  <para>
   Cette section décrit les opérations requises pour créer et configurer les différents types de RAID. <phrase os="sles">Si vous avez besoin d'informations de base sur RAID, reportez-vous au <xref linkend="sec-raid-intro"/></phrase>.

--- a/l10n/sles/fr-fr/xml/x86_inst_problem.xml
+++ b/l10n/sles/fr-fr/xml/x86_inst_problem.xml
@@ -7,7 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>oui</dm:translation>
   </dm:docmanager>
- </info><indexterm> <primary>solution</primary> </indexterm>
+ </info>
 
  <para>
   Avant la livraison, <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> est soumis à un programme de test approfondi. Malgré cela, des problèmes peuvent survenir lors du démarrage ou de l'installation.

--- a/l10n/sles/fr-fr/xml/yast2_lang.xml
+++ b/l10n/sles/fr-fr/xml/yast2_lang.xml
@@ -6,7 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>oui</dm:translation>
   </dm:docmanager>
- </info><indexterm> <primary>système</primary> <secondary>langues</secondary></indexterm><indexterm> <primary>YaST</primary> <secondary>langues</secondary></indexterm><indexterm> <primary>langues</primary></indexterm><indexterm> <primary>configuration</primary> <secondary>langues</secondary></indexterm>
+ </info>
  <para>
   Si vous travaillez dans différents pays ou dans un environnement multilingue, votre ordinateur nécessite une configuration spécifique. <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> peut gérer différents <literal>paramètres locaux</literal> en parallèle. Un paramètre local est un ensemble de paramètres qui définit les paramètres de langue et de pays utilisés dans l'interface utilisateur.
  </para>

--- a/l10n/sles/fr-fr/xml/yast2_sound.xml
+++ b/l10n/sles/fr-fr/xml/yast2_sound.xml
@@ -7,7 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>oui</dm:translation>
   </dm:docmanager>
- </info><indexterm> <primary>configuration</primary> <secondary>cartes son</secondary></indexterm><indexterm> <primary>Yass</primary> <secondary>cartes son</secondary></indexterm><indexterm> <primary>son</primary> <secondary>configuration dans YaST</secondary></indexterm><indexterm> <primary>cartes</primary> <secondary>son</secondary></indexterm>
+ </info>
 
  <para>
   YaST détecte automatiquement la plupart des cartes son et les configure avec les valeurs appropriées. Pour modifier les paramètres par défaut ou si vous devez configurer une carte son qui n'a pas pu être configurée automatiquement, utilisez le module YaST relatif au son. Ce module vous permet également de configurer des cartes son supplémentaires ou de modifier leur ordre.
@@ -148,7 +148,7 @@
   </step>
   <step>
    <para>
-    <indexterm> <primary>sound</primary> <secondary>fonts</secondary> </indexterm> <indexterm> <primary>son</primary> <secondary>MIDI</secondary> </indexterm>Lorsqu'une carte son prise en charge est détectée, vous pouvez installer SoundFonts pour la lecture de fichiers MIDI :
+     Lorsqu'une carte son prise en charge est détectée, vous pouvez installer SoundFonts pour la lecture de fichiers MIDI :
    </para>
    <substeps performance="required">
     <step>
@@ -177,6 +177,6 @@
  </procedure>
 
  <para>
-  Le volume et la configuration de toutes les cartes son s'enregistrent lorsque vous cliquez sur <guimenu>OK</guimenu> et que vous quittez le module YaST relatif au son. Les paramètres du mélangeur sont enregistrés dans le fichier <filename>/etc/asound.state</filename>. Les données de configuration ALSA sont annexées à la fin du fichier <filename>/etc/modprobe.d/sound</filename> et écrites sur <filename>/etc/sysconfig/sound</filename>.<indexterm> <primary>fichiers de configuration</primary> <secondary>asound.state</secondary> </indexterm> <indexterm> <primary>fichiers de configuration</primary> <secondary>modprobe.d/sound</secondary> </indexterm>
+  Le volume et la configuration de toutes les cartes son s'enregistrent lorsque vous cliquez sur <guimenu>OK</guimenu> et que vous quittez le module YaST relatif au son. Les paramètres du mélangeur sont enregistrés dans le fichier <filename>/etc/asound.state</filename>. Les données de configuration ALSA sont annexées à la fin du fichier <filename>/etc/modprobe.d/sound</filename> et écrites sur <filename>/etc/sysconfig/sound</filename>. 
  </para>
 </sect1>

--- a/l10n/sles/fr-fr/xml/yast2_sw.xml
+++ b/l10n/sles/fr-fr/xml/yast2_sw.xml
@@ -11,7 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>oui</dm:translation>
   </dm:docmanager>
- </info><indexterm> <primary>YaST</primary> <secondary>logiciels</secondary> </indexterm> <indexterm> <primary>configuration</primary> <secondary>logiciels</secondary> </indexterm>
+ </info>
  <para>
   Modifiez la collection de logiciels de votre système via le gestionnaire de logiciels YaST. Ce module YaST est disponible en deux variantes : une variante graphique pour X Window et une variante texte à utiliser sur la ligne de commande. La variante graphique est décrite ici. Pour plus d'informations sur la variante texte de Yast, consultez le <xref linkend="cha-yast-text"/>.
  </para>

--- a/l10n/sles/fr-fr/xml/yast2_userman.xml
+++ b/l10n/sles/fr-fr/xml/yast2_userman.xml
@@ -97,7 +97,7 @@
   <title>Gestion des comptes utilisateur</title>
 
   <para>
-   <indexterm> <primary>utilisateurs</primary> <secondary>création de comptes</secondary> </indexterm> <indexterm> <primary>utilisateurs</primary> <secondary>modification de comptes</secondary> </indexterm> YaST permet de créer, de modifier, de supprimer ou de désactiver temporairement des comptes utilisateur. Ne modifiez les comptes utilisateur que si vous êtes un utilisateur expérimenté ou un administrateur.
+     YaST permet de créer, de modifier, de supprimer ou de désactiver temporairement des comptes utilisateur. Ne modifiez les comptes utilisateur que si vous êtes un utilisateur expérimenté ou un administrateur.
   </para>
 
   <note>
@@ -181,7 +181,7 @@
   </tip>
 
   <procedure>
-   <title>Désactivation ou suppression de comptes utilisateur</title><indexterm> <primary>utilisateurs</primary> <secondary>désactivation de comptes</secondary></indexterm><indexterm> <primary>utilisateurs</primary> <secondary>suppression de comptes</secondary></indexterm>
+   <title>Désactivation ou suppression de comptes utilisateur</title>
    <step>
     <para>
      Ouvrez la boîte de dialogue <guimenu>Gestion des utilisateurs et des groupes</guimenu> dans YaST et cliquez sur l'onglet <guimenu>Utilisateurs</guimenu>.
@@ -229,7 +229,7 @@
 
    </para>
    <procedure>
-    <title>Configuration des paramètres de mot de passe</title><indexterm> <primary>utilisateurs</primary> <secondary>paramètres de mot de passe</secondary></indexterm>
+    <title>Configuration des paramètres de mot de passe</title>
     <step>
      <para>
       Ouvrez la boîte de dialogue <guimenu>Gestion des utilisateurs et des groupes</guimenu> dans YaST, puis sélectionnez l'onglet <guimenu>Utilisateurs. </guimenu>
@@ -284,7 +284,7 @@
   </sect2>
 
   <sect2 xml:id="sec-y2-userman-adv-crypto">
-   <title>Gestion des répertoires privés codés</title><indexterm> <primary>répertoires privés</primary> <secondary>codage</secondary></indexterm><indexterm> <primary>utilisateurs</primary> <secondary>répertoires privés codés</secondary></indexterm>
+   <title>Gestion des répertoires privés codés</title>
    <para>
     Pour protéger les données des répertoires privés contre le vol et la suppression du disque dur, vous pouvez créer des répertoires privés codés pour les utilisateurs. Ceux-ci sont codés avec LUKS (Linux Unified Key Setup), qui génère une image et une clé d'image pour l'utilisateur. La clé d'image est protégée par le mot de passe de connexion de l'utilisateur. Lorsque l'utilisateur se connecte au système, son répertoire privé codé est monté et l'utilisateur peut accéder à son contenu.
    </para>
@@ -396,7 +396,7 @@
   </sect2>
 
   <sect2 xml:id="sec-y2-userman-adv-quota">
-   <title>Gestion des quotas</title><indexterm> <primary>utilisateurs</primary> <secondary>quotas</secondary></indexterm><indexterm> <primary>quotas</primary> <secondary>utilisateurs, groupes</secondary></indexterm>
+   <title>Gestion des quotas</title>
    <para>
     Pour éviter l'épuisement des capacités du système sans notification, les administrateurs peuvent définir des quotas pour les utilisateurs et les groupes. Les quotas peuvent être définis pour un ou plusieurs systèmes de fichiers et restreindre la quantité d'espace disque pouvant être utilisée et le nombre d'inodes (index nodes - nœuds d'index) pouvant être créés ici. Les inodes sont des structures de données sur un système de fichiers qui stockent des informations de base sur un fichier ordinaire, un répertoire ou un autre objet du système de fichiers. Ils stockent tous les attributs d'un objet du système de fichiers (comme la propriété des utilisateurs et des groupes, les autorisations de lecture, d'écriture ou d'exécution), à l'exception du nom et du contenu du fichier.
    </para>
@@ -541,7 +541,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-y2-userman-defaults">
-  <title>Modification des paramètres par défaut des utilisateurs locaux</title><indexterm> <primary>utilisateurs</primary> <secondary>paramètres par défaut</secondary></indexterm>
+  <title>Modification des paramètres par défaut des utilisateurs locaux</title>
 
   <para>
    Lorsque vous créez de nouveaux utilisateurs locaux, certains paramètres par défaut sont utilisés par YaST. Ces paramètres incluent par exemple le groupe principal et les groupes secondaires auxquels appartient l'utilisateur ou les autorisations d'accès au répertoire privé de l'utilisateur. Vous pouvez modifier ces paramètres par défaut selon vos besoins :
@@ -589,7 +589,7 @@
   <title>Affectation des utilisateurs à des groupes</title>
 
   <para>
-   <indexterm> <primary>utilisateurs</primary> <secondary>affectation aux groupes</secondary> </indexterm> Les utilisateurs locaux sont affectés à plusieurs groupes en fonction des paramètres par défaut accessibles depuis la boîte de dialogue <guimenu>Gestion des utilisateurs et des groupes</guimenu>, dans l'onglet <guimenu>Paramètres par défaut pour les nouveaux utilisateurs</guimenu>. La section suivante explique comment modifier l'affectation d'un utilisateur individuel à un groupe. Si vous devez modifier les affectations aux groupes par défaut pour les nouveaux utilisateurs, reportez-vous à la <xref linkend="sec-y2-userman-defaults"/>.
+    Les utilisateurs locaux sont affectés à plusieurs groupes en fonction des paramètres par défaut accessibles depuis la boîte de dialogue <guimenu>Gestion des utilisateurs et des groupes</guimenu>, dans l'onglet <guimenu>Paramètres par défaut pour les nouveaux utilisateurs</guimenu>. La section suivante explique comment modifier l'affectation d'un utilisateur individuel à un groupe. Si vous devez modifier les affectations aux groupes par défaut pour les nouveaux utilisateurs, reportez-vous à la <xref linkend="sec-y2-userman-defaults"/>.
   </para>
 
   <procedure>
@@ -630,7 +630,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-y2-userman-groups">
-  <title>Gestion des groupes</title><indexterm> <primary>groupes</primary> <secondary>gestion</secondary></indexterm><indexterm> <primary>YaST</primary> <secondary>gestion des groupes</secondary></indexterm><indexterm> <primary>configuration</primary> <secondary>groupes</secondary></indexterm>
+  <title>Gestion des groupes</title>
 
   <para>
    Avec YaST, vous pouvez également ajouter, modifier ou supprimer des groupes en toute simplicité.
@@ -700,7 +700,7 @@
   </para>
  </sect1>
  <sect1 xml:id="cha-y2-userman-authent">
-  <title>Modification de la méthode d'authentification des utilisateurs</title><indexterm> <primary>utilisateurs</primary> <secondary>authentification</secondary></indexterm>
+  <title>Modification de la méthode d'authentification des utilisateurs</title>
 
   <para>
    Si votre machine est connectée à un réseau, vous pouvez modifier la méthode d'authentification. Les options suivantes sont disponibles :

--- a/l10n/sles/it-it/xml/aarch64_inst_problem.xml
+++ b/l10n/sles/it-it/xml/aarch64_inst_problem.xml
@@ -7,9 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>sì</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary> soluzione dei problemi</primary></indexterm> 
+ </info>
 
  <para>
   Prima della consegna, <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> viene sottoposto a un programma di prova completo. Ciò nonostante, è possibile che durante l'installazione possano verificarsi problemi.

--- a/l10n/sles/it-it/xml/common_intro_available_doc_i.xml
+++ b/l10n/sles/it-it/xml/common_intro_available_doc_i.xml
@@ -9,13 +9,7 @@
    </dm:bugtracker>
    <dm:translation>sì</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>guida</primary>
-
- <secondary> manuali SUSE</secondary></indexterm><indexterm>
-
- <primary> manuali SUSE</primary></indexterm>
+ </info>
 
  <note>
   <title>documentazione online e ultimi aggiornamenti</title>

--- a/l10n/sles/it-it/xml/lvm.xml
+++ b/l10n/sles/it-it/xml/lvm.xml
@@ -7,19 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>sì</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>YaST</primary>
-
- <secondary>LVM</secondary></indexterm><indexterm>
-
- <primary>LVM</primary>
-
- <secondary>YaST</secondary></indexterm><indexterm>
-
- <primary>Logical Volume Manager</primary>
-
- <see>LVM</see></indexterm>
+ </info>
 
  <para>
   In questa sezione viene illustrata la procedura specifica da seguire per la configurazione di LVM. <phrase os="sles">Per informazioni generali su Logical Volume Manager, vedere <xref linkend="sec-lvm-explained"/>.</phrase>

--- a/l10n/sles/it-it/xml/raid.xml
+++ b/l10n/sles/it-it/xml/raid.xml
@@ -7,19 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>sì</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>YaST</primary>
-
- <secondary>RAID</secondary></indexterm><indexterm>
-
- <primary>RAID</primary>
-
- <secondary>YaST</secondary></indexterm><indexterm>
-
- <primary>Software RAID</primary>
-
- <see>RAID</see></indexterm>
+ </info>
 
  <para>
   In questa sezione vengono illustrate le operazioni da eseguire per creare e configurare vari tipi di RAID. <phrase os="sles">Per informazioni generali su RAID, vedere <xref linkend="sec-raid-intro"/></phrase>.

--- a/l10n/sles/it-it/xml/x86_inst_problem.xml
+++ b/l10n/sles/it-it/xml/x86_inst_problem.xml
@@ -7,9 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>sì</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary> soluzione dei problemi</primary></indexterm> 
+ </info>
 
  <para>
   Prima della consegna, <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> viene sottoposto a un programma di prova completo. Ciò nonostante, è possibile che durante l'installazione possano verificarsi problemi.

--- a/l10n/sles/it-it/xml/yast2_lang.xml
+++ b/l10n/sles/it-it/xml/yast2_lang.xml
@@ -6,14 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>sì</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>sistema</primary>
- <secondary>lingue</secondary></indexterm><indexterm>
- <primary>YaST</primary>
- <secondary>lingue</secondary></indexterm><indexterm>
- <primary>lingue</primary></indexterm><indexterm>
- <primary>configurazione</primary>
- <secondary>lingue</secondary></indexterm>
+ </info>
  <para>
   Se si lavora in paesi diversi o in ambienti multilingue, è necessario configurare il computer per il supporto di tali situazioni. <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> può gestire diverse <literal>impostazioni internazionali</literal> in parallelo. Per impostazioni internazionali si intendono un set di parametri che definiscono le impostazioni della lingua e del paese utilizzate dall'interfaccia utente.
  </para>

--- a/l10n/sles/it-it/xml/yast2_sound.xml
+++ b/l10n/sles/it-it/xml/yast2_sound.xml
@@ -7,23 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>sì</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>configurazione</primary>
-
- <secondary>schede sonore</secondary></indexterm><indexterm>
-
- <primary>YaST</primary>
-
- <secondary>schede sonore</secondary></indexterm><indexterm>
-
- <primary>suono</primary>
-
- <secondary>configurazione in YaST</secondary></indexterm><indexterm>
-
- <primary>schede</primary>
-
- <secondary>suono</secondary></indexterm>
+ </info>
 
  <para>
   YaST è in grado di rilevare automaticamente la maggior parte delle schede audio e di configurarle con i valori appropriati. Per modificare le impostazioni di default o per configurare una scheda audio che non è stato possibile configurare automaticamente, utilizzare il modulo audio di YaST. È possibile utilizzare questo modulo per configurare ulteriori schede audio oppure per modificarne l'ordine.
@@ -167,13 +151,7 @@
   </step>
   <step>
    <para>
-    <indexterm>
-    <primary>sound</primary>
-    <secondary>fonts</secondary>
-    </indexterm> <indexterm>
-    <primary>sound</primary>
-    <secondary>MIDI</secondary>
-    </indexterm>Quando si rileva una scheda audio supportata, è possibile installare SoundFonts per la riproduzione dei file MIDI:
+     Quando si rileva una scheda audio supportata, è possibile installare SoundFonts per la riproduzione dei file MIDI:
    </para>
    <substeps performance="required">
     <step>
@@ -203,12 +181,6 @@
  </procedure>
 
  <para>
-  Il volume e la configurazione di tutte le schede audio vengono salvati quando si fa clic su <guimenu>OK</guimenu> e si chiude il modulo audio di YaST. Le impostazioni del mixer vengono salvate nel file <filename>/etc/asound.state</filename>. I dati di configurazione ALSA vengono aggiunti alla fine del file <filename>/etc/modprobe.d/sound</filename> e scritti in <filename>/etc/sysconfig/sound</filename>.<indexterm>
-  <primary>file di configurazione</primary>
-  <secondary> asound.state</secondary>
-  </indexterm> <indexterm>
-  <primary>   file di configurazione</primary>
-  <secondary> modprobe.d/sound</secondary>
-  </indexterm>
+  Il volume e la configurazione di tutte le schede audio vengono salvati quando si fa clic su <guimenu>OK</guimenu> e si chiude il modulo audio di YaST. Le impostazioni del mixer vengono salvate nel file <filename>/etc/asound.state</filename>. I dati di configurazione ALSA vengono aggiunti alla fine del file <filename>/etc/modprobe.d/sound</filename> e scritti in <filename>/etc/sysconfig/sound</filename>. 
  </para>
 </sect1>

--- a/l10n/sles/it-it/xml/yast2_sw.xml
+++ b/l10n/sles/it-it/xml/yast2_sw.xml
@@ -11,11 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>sì</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>YaST</primary>
- <secondary>software</secondary></indexterm><indexterm>
- <primary>configurazione</primary>
- <secondary>software</secondary></indexterm>
+ </info>
  <para>
   È possibile modificare la raccolta software del sistema mediante il programma di gestione del software YaST. Questo modulo YaST è disponibile in due tipologie: una variante grafica per X Window e una variante basata su testo da utilizzare nella riga di comando. La variante grafica è descritta in questo documento. Per informazioni dettagliate sul modulo YaST basato su testo, vedere <xref linkend="cha-yast-text"/>.
  </para>

--- a/l10n/sles/it-it/xml/yast2_userman.xml
+++ b/l10n/sles/it-it/xml/yast2_userman.xml
@@ -99,13 +99,7 @@
   <title>Gestione dei conti utente</title>
 
   <para>
-   <indexterm>
-   <primary>utenti</primary>
-   <secondary> creazione account</secondary>
-   </indexterm> <indexterm>
-   <primary>   utenti</primary>
-   <secondary> modifica account</secondary>
-   </indexterm>  YaST consente di creare, modificare, eliminare o disabilitare temporaneamente gli account utente. Gli account utente devono essere modificati solo dagli utenti esperti o dall'amministratore.
+      YaST consente di creare, modificare, eliminare o disabilitare temporaneamente gli account utente. Gli account utente devono essere modificati solo dagli utenti esperti o dall'amministratore.
   </para>
 
   <note>
@@ -189,11 +183,7 @@
   </tip>
 
   <procedure>
-   <title>Disabilitazione o eliminazione di account utente</title><indexterm>
-   <primary> utenti</primary>
-   <secondary> disabilitazione account</secondary></indexterm><indexterm>
-   <primary>   utenti</primary>
-   <secondary> eliminazione account</secondary></indexterm> 
+   <title>Disabilitazione o eliminazione di account utente</title>
    <step>
     <para>
      Aprire la finestra di dialogo <guimenu>Amministrazione utenti e gruppi</guimenu> di YaST e fare clic sulla scheda <guimenu>Utenti</guimenu>.
@@ -241,9 +231,7 @@
 
    </para>
    <procedure>
-    <title>Configurazione delle impostazioni delle password</title><indexterm>
-    <primary> utenti</primary>
-    <secondary> impostazioni password</secondary></indexterm> 
+    <title>Configurazione delle impostazioni delle password</title>
     <step>
      <para>
       Aprire la finestra di dialogo <guimenu>Amministrazione utenti e gruppi</guimenu> di YaST e selezionare la scheda <guimenu>Utenti</guimenu>.
@@ -298,11 +286,7 @@
   </sect2>
 
   <sect2 xml:id="sec-y2-userman-adv-crypto">
-   <title>Gestione di directory home cifrate</title><indexterm>
-   <primary> directory home</primary>
-   <secondary> cifratura</secondary></indexterm><indexterm>
-   <primary>   utenti</primary>
-   <secondary> directory home cifrate</secondary></indexterm> 
+   <title>Gestione di directory home cifrate</title>
    <para>
     Per proteggere i dati delle directory home da furti e rimozione del disco rigido, è possibile creare directory home cifrate per gli utenti. Queste directory vengono cifrate con LUKS (Linux Unified Key Setup), che crea un'immagine e una chiave immagine per l'utente. La chiave utente è protetta dalla password di login dell'utente. Quando l'utente esegue il login al sistema, la directory home cifrata viene montata e il contenuto viene reso disponibile all'utente.
    </para>
@@ -414,11 +398,7 @@
   </sect2>
 
   <sect2 xml:id="sec-y2-userman-adv-quota">
-   <title>Gestione delle quote</title><indexterm>
-   <primary>utenti</primary>
-   <secondary>quote</secondary></indexterm><indexterm>
-   <primary>quote</primary>
-   <secondary>utenti, gruppi</secondary></indexterm>
+   <title>Gestione delle quote</title>
    <para>
     Per evitare che le capacità del sistema si esauriscano senza preavviso, gli amministratori di sistema possono configurare quote per utenti o gruppi. È possibile definire le quote per uno o più file system, nonché limitare la quantità di spazio su disco utilizzabile e il numero di inode (nodi indice) che è possibile creare. Gli inode sono strutture di dati su un file system che memorizzano informazioni di base su un file normale, directory o altri oggetti del file system. Memorizzano tutti gli attributi di un oggetto del file system (quali proprietà di utenti e gruppi e permessi di lettura, scrittura o di esecuzione) tranne nome file e contenuti.
    </para>
@@ -564,11 +544,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-y2-userman-defaults">
-  <title>Modifica delle impostazioni di default per utenti locali</title><indexterm>
-
-  <primary> utenti</primary>
-
-  <secondary> impostazioni di default</secondary></indexterm> 
+  <title>Modifica delle impostazioni di default per utenti locali</title>
 
   <para>
    YaST utilizza numerose impostazioni di default durante la creazione di nuovi utenti locali. Tali impostazioni comprendono, ad esempio, i gruppi primari e secondari a cui appartiene l'utente oppure le autorizzazioni di accesso alla home directory dell'utente. È possibile modificare queste impostazioni di default per soddisfare i requisiti:
@@ -616,10 +592,7 @@
   <title>Assegnazione di utenti a gruppi</title>
 
   <para>
-   <indexterm>
-   <primary>utenti</primary>
-   <secondary> assegnazione gruppi</secondary>
-   </indexterm>  Gli utenti locali sono assegnati a vari gruppi a seconda delle impostazioni di default alle quali è possibile accedere tramite la finestra di dialogo <guimenu>Amministrazione utenti e gruppi</guimenu>, nella scheda <guimenu>Default per nuovi utenti</guimenu>. Di seguito, viene illustrato come modificare la singola assegnazione di un gruppo di utenti. Se si necessita modificare le assegnazioni del gruppo di default per i nuovi utenti, consultare <xref linkend="sec-y2-userman-defaults"/>.
+     Gli utenti locali sono assegnati a vari gruppi a seconda delle impostazioni di default alle quali è possibile accedere tramite la finestra di dialogo <guimenu>Amministrazione utenti e gruppi</guimenu>, nella scheda <guimenu>Default per nuovi utenti</guimenu>. Di seguito, viene illustrato come modificare la singola assegnazione di un gruppo di utenti. Se si necessita modificare le assegnazioni del gruppo di default per i nuovi utenti, consultare <xref linkend="sec-y2-userman-defaults"/>.
   </para>
 
   <procedure>
@@ -660,19 +633,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-y2-userman-groups">
-  <title>Gestione dei gruppi</title><indexterm>
-
-  <primary>gruppi</primary>
-
-  <secondary>gestione</secondary></indexterm><indexterm>
-
-  <primary>YaST</primary>
-
-  <secondary>gestione gruppi</secondary></indexterm><indexterm>
-
-  <primary>configurazione</primary>
-
-  <secondary>gruppi</secondary></indexterm>
+  <title>Gestione dei gruppi</title>
 
   <para>
    Con YaST è anche possibile aggiungere, modificare o eliminare gruppi facilmente.
@@ -744,11 +705,7 @@
   </para>
  </sect1>
  <sect1 xml:id="cha-y2-userman-authent">
-  <title>Modifica UAM (User Authentication Method)</title><indexterm>
-
-  <primary> utenti</primary>
-
-  <secondary> autenticazione</secondary></indexterm> 
+  <title>Modifica UAM (User Authentication Method)</title>
 
   <para>
    Quando il computer è connesso a una rete, è possibile modificare il metodo di autenticazione. Sono disponibili le seguenti opzioni:

--- a/l10n/sles/ja-jp/xml/64bit_issues.xml
+++ b/l10n/sles/ja-jp/xml/64bit_issues.xml
@@ -6,8 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary> 64ビットLinux</primary></indexterm> 
+ </info>
  <para>
   <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase>は<phrase os="sles">複数の</phrase>64ビットプラットフォームで利用できます。ただし、付属のすべてのアプリケーションが64ビットプラットフォームに移植されているわけではありません。<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>は、64ビットシステム環境での32ビットアプリケーションの使用をサポートしています。この章では、このサポートを64ビットの<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>プラットフォームで実装する方法について簡潔に説明します。
  </para>
@@ -25,11 +24,7 @@
 
 
  <sect1 xml:id="sec-64bit-runt">
-  <title>ランタイムサポート</title><indexterm>
-
-  <primary> 64ビットLinux</primary>
-
-  <secondary>ランタイムサポート</secondary></indexterm> 
+  <title>ランタイムサポート</title>
 
   <important>
    <title>アプリケーションバージョン間の競合</title>
@@ -58,11 +53,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-64bit-kernel">
-  <title>カーネル仕様</title><indexterm>
-
-  <primary> 64ビットLinux</primary>
-
-  <secondary>カーネル仕様</secondary></indexterm> 
+  <title>カーネル仕様</title>
 
   <para>
    AMD 64/Intel 64<phrase os="sles">、IBM POWER、およびIBM Z</phrase>向けの64ビットカーネルには、64ビットと32ビットのカーネルABI(アプリケーションバイナリインタフェース)が用意されています。32ビットのカーネルABIは、該当する32ビットカーネルのABIと同じものです。つまり、32ビットアプリケーションが、32ビットカーネルの場合と同様に64ビットカーネルと通信できるということです。

--- a/l10n/sles/ja-jp/xml/aarch64_inst_problem.xml
+++ b/l10n/sles/ja-jp/xml/aarch64_inst_problem.xml
@@ -7,9 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary> 問題解決</primary></indexterm> 
+ </info>
 
  <para>
   <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase>は、広範囲なテストプログラムを経たうえで提供されています。それにもかかわらず、時折、ブートおよびインストール時に問題が発生することがあります。

--- a/l10n/sles/ja-jp/xml/adm_shell.xml
+++ b/l10n/sles/ja-jp/xml/adm_shell.xml
@@ -13,10 +13,7 @@
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
-<indexterm>
- <primary>シェル</primary></indexterm><indexterm>
- <primary>Bash</primary>
- <see>シェル</see></indexterm>
+
  <sect1 xml:id="sec-adm-whatistheshell">
   <title><quote>シェル</quote>とは何か?</title>
 
@@ -27,9 +24,7 @@
   </para>
 
   <sect2 xml:id="sec-adm-configfiles">
-   <title>Bash設定ファイルの知識</title><indexterm>
-   <primary>設定ファイル</primary>
-   <see> Bash</see></indexterm>
+   <title>Bash設定ファイルの知識</title>
    <para>
     シェルは、次のようにして呼び出すことができます。
    </para>
@@ -243,9 +238,7 @@
   <xi:include href="fs_structure_i.xml"/>
  </sect1>
  <sect1 xml:id="sec-adm-shellscripts">
-  <title>シェルスクリプトの作成</title><indexterm>
-
-  <primary>シェルスクリプト</primary></indexterm>
+  <title>シェルスクリプトの作成</title>
 
   <para>
    シェルスクリプトは、データの収集、テキスト内のワードやフレーズの検索など、さまざまな有用なタスクの実行に便利な方法です。次の例では、小型のシェルスクリプトでテキストをプリントします。
@@ -259,9 +252,7 @@ echo "Hello World" <co xml:id="co-adm-shell-echo"/></screen>
    <calloutlist>
     <callout arearefs="co-adm-shell-shebang">
      <para>
-      1行目は、このファイルがスクリプトであることを示す<emphasis>Shebang</emphasis> <indexterm>
-      <primary>Shebang</primary>
-      </indexterm>文字(<literal>#!</literal>)で始まります。スクリプトは、Shebang文字の後に指定されたインタープリタ(ここでは、<command>/bin/sh</command>)を使用して実行されます。
+      1行目は、このファイルがスクリプトであることを示す<emphasis>Shebang</emphasis> 文字(<literal>#!</literal>)で始まります。スクリプトは、Shebang文字の後に指定されたインタープリタ(ここでは、<command>/bin/sh</command>)を使用して実行されます。
      </para>
     </callout>
     <callout arearefs="co-adm-shell-comment">
@@ -411,9 +402,7 @@ echo "Hello World" <co xml:id="co-adm-shell-echo"/></screen>
 <screen>find / -name "foo*" 2&gt;/dev/null</screen>
  </sect1>
  <sect1 xml:id="sec-adm-alias">
-  <title>エイリアスの使用</title><indexterm>
-
-  <primary>aliases</primary></indexterm>
+  <title>エイリアスの使用</title>
 
   <para>
    エイリアスは、1つ以上のコマンドのショートカット定義です。エイリアスの構文は、次のとおりです。

--- a/l10n/sles/ja-jp/xml/adm_support.xml
+++ b/l10n/sles/ja-jp/xml/adm_support.xml
@@ -22,9 +22,7 @@
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
-<indexterm>
- <primary>サポート</primary></indexterm><indexterm>
- <primary>システム情報</primary></indexterm>
+
  <sect1 xml:id="sec-admsupport-hostinfo">
   <title>現在のシステム情報の表示</title>
 

--- a/l10n/sles/ja-jp/xml/apache2.xml
+++ b/l10n/sles/ja-jp/xml/apache2.xml
@@ -11,14 +11,9 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm class="startofrange" xml:id="idx-apache2">
- <primary> Apache</primary></indexterm> 
+ </info>
  <sect1 xml:id="sec-apache2-quickstart">
-  <title>クイックスタート</title><indexterm>
-
-  <primary> Apache</primary>
-
-  <secondary> クイックスタート</secondary></indexterm> 
+  <title>クイックスタート</title>
 
   <para>
    このセクションでは、Apacheを迅速に設定し、起動します。Apacheをインストールして設定するには、<systemitem class="username">root</systemitem>ユーザでなければなりません。
@@ -54,9 +49,7 @@
   </sect2>
 
   <sect2 xml:id="sec-apache2-quickstart-installation">
-   <title>インストール</title><indexterm>
-   <primary> Apache</primary>
-   <secondary> インストール</secondary></indexterm> 
+   <title>インストール</title>
    <para>
     <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>のApacheは、デフォルトではインストールされません。<quote>そのまますぐに</quote>実行できる標準の事前定義された設定を使用してインストールするには、次の手順を使用します。
    </para>
@@ -129,11 +122,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-apache2-configuration">
-  <title>Apacheの設定</title><indexterm>
-
-  <primary> Apache</primary>
-
-  <secondary> 環境設定</secondary></indexterm> 
+  <title>Apacheの設定</title>
 
   <para>
    <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>には、2つの設定オプションがあります。
@@ -167,10 +156,7 @@
   </important>
 
   <sect2 xml:id="sec-apache2-configuration-manually-configfiles">
-   <title>Apache設定ファイル</title><indexterm>
-   <primary> Apache</primary>
-   <secondary> 環境設定</secondary>
-   <tertiary> ファイル</tertiary></indexterm> 
+   <title>Apache設定ファイル</title>
    <para>
     このセクションでは、Apache設定ファイルの概要を示します。環境設定にYaSTを使用する場合は、これらのファイルを操作する必要はありません。ただし、後で手動設定に切り替える場合に、この情報が役立つことがあります。
    </para>
@@ -362,18 +348,12 @@
   </sect2>
 
   <sect2 xml:id="sec-apache2-configuration-manually">
-   <title>Apacheを手動で設定する</title><indexterm class="startofrange" xml:id="idx-apache2-configuration-manually">
-   <primary> Apache</primary>
-   <secondary> 環境設定</secondary>
-   <tertiary> 手動</tertiary></indexterm> 
+   <title>Apacheを手動で設定する</title>
    <para>
     Apacheを手動設定するには、<systemitem class="username">root</systemitem>ユーザとしてプレーンテキストの設定ファイルを編集する必要があります。
    </para>
    <sect3 xml:id="sec-apache2-configuration-manually-vhost">
-    <title>仮想ホスト設定</title><indexterm>
-    <primary>  Apache </primary>
-    <secondary>環境設定</secondary>
-    <tertiary>仮想ホスト</tertiary></indexterm>
+    <title>仮想ホスト設定</title>
     <para>
      仮想ホスト <emphasis>という用語は、同じ物理マシンから複数のURI (universal resource identifiers)のサービスを行えるApacheの機能を指しています。</emphasis>これは、www.example.comとwww.example.netのような複数のドメインを、1台の物理マシン上の単一のWebサーバで保持できることを意味しています。
     </para>
@@ -558,7 +538,7 @@ Allow from all</screen>
   Require all granted
   &lt;/Directory&gt;
 &lt;/VirtualHost&gt;</screen>
-     </example><indexterm class="endofrange" startref="idx-apache2-configuration-manually"/>
+     </example>
     </sect4>
    </sect3>
   </sect2>
@@ -570,15 +550,7 @@ Allow from all</screen>
 
  </sect1>
  <sect1 xml:id="sec-apache2-start-stop">
-  <title>Apacheの起動および停止</title><indexterm>
-
-  <primary>Apache</primary>
-
-  <secondary>起動</secondary></indexterm><indexterm>
-
-  <primary>Apache</primary>
-
-  <secondary>停止</secondary></indexterm>
+  <title>Apacheの起動および停止</title>
 
   <remark>taroth 2014-02-11: @file-maintainer: please give the following a
  thorough check - so far I only replaced the rc* commands by the systemctl
@@ -707,11 +679,7 @@ Allow from all</screen>
   </tip>
  </sect1>
  <sect1 xml:id="sec-apache2-modules">
-  <title>モジュールのインストール、有効化、および設定</title><indexterm class="startofrange" xml:id="idx-apache2-modules">
-
-  <primary> Apache</primary>
-
-  <secondary> モジュール</secondary></indexterm> 
+  <title>モジュールのインストール、有効化、および設定</title>
 
   <para>
    Apacheソフトウェアは、モジュール形式で構築されており、一部の主要タスクを除いてはモジュールごとに処理されます。この方法で、HTTPさえもモジュールによって処理されています(<systemitem>http_core</systemitem>)。
@@ -761,10 +729,7 @@ Allow from all</screen>
   </variablelist>
 
   <sect2 xml:id="sec-apache2-modules-installing">
-   <title>モジュールのインストール</title><indexterm>
-   <primary> Apache </primary>
-   <secondary>モジュール </secondary>
-   <tertiary>インストール</tertiary></indexterm> 
+   <title>モジュールのインストール</title>
    <para>
     <xref linkend="sec-apache2-quickstart-installation"/>で説明されているデフォルトインストールを行った場合は、すべての基本モジュールと拡張モジュール、Prefork MPM(マルチプロセシングモジュール)、および外部モジュールの<systemitem>mod_python</systemitem>がすでにインストールされています。
    </para>
@@ -790,10 +755,7 @@ Allow from all</screen>
   </sect2>
 
   <sect2 xml:id="sec-apache2-modules-base-extension">
-   <title>基本および拡張モジュール</title><indexterm>
-   <primary> Apache </primary>
-   <secondary>モジュール </secondary>
-   <tertiary>使用可能</tertiary></indexterm> 
+   <title>基本および拡張モジュール</title>
    <para>
     すべての基本および拡張モジュールは、Apacheのマニュアルに詳しく説明されています。ここでは、主要なモジュールについて簡単に説明します。各モジュールの詳細については、<link xlink:href="http://httpd.apache.org/docs/2.4/mod/">http://httpd.apache.org/docs/2.4/mod/</link>を参照してください。
    </para>
@@ -1010,10 +972,7 @@ Allow from all</screen>
   </sect2>
 
   <sect2 xml:id="sec-apache2-modules-mpm">
-   <title>マルチプロセシングモジュール</title><indexterm>
-   <primary> Apache </primary>
-   <secondary>モジュール </secondary>
-   <tertiary>マルチプロセシング</tertiary></indexterm> 
+   <title>マルチプロセシングモジュール</title>
    <para>
     <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>には、Apacheで使用するための2つの異なるマルチプロセッシングモジュール(MPM)が用意されています。
    </para>
@@ -1062,10 +1021,7 @@ Allow from all</screen>
   </sect2>
 
   <sect2 xml:id="sec-apache2-modules-external">
-   <title>外部モジュール</title><indexterm>
-   <primary>Apache</primary>
-   <secondary>モジュール</secondary>
-   <tertiary>外部</tertiary></indexterm>
+   <title>外部モジュール</title>
    <para>
     ここでは、<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>に付属しているすべての外部モジュールを記載しています。モジュールのドキュメントは、記載のディレクトリ内に存在します。
    </para>
@@ -1157,10 +1113,7 @@ Allow from all</screen>
   </sect2>
 
   <sect2 xml:id="sec-apache2-modules-building-modules">
-   <title>コンパイル</title><indexterm>
-   <primary>Apache</primary>
-   <secondary>モジュール</secondary>
-   <tertiary>作成</tertiary></indexterm>
+   <title>コンパイル</title>
    <para>
     上級ユーザは、カスタムのモジュールを記述してApacheを拡張することができます。Apache用のモジュールを開発したり、サードパーティのモジュールをコンパイルしたりするには、<systemitem>apache2-devel</systemitem>パッケージ、および対応する開発ツールが必要です。<systemitem>apache2-devel</systemitem>には、Apache用の追加モジュールのコンパイルに必要な<command>apxs2</command>ツールも含まれています。
    </para>
@@ -1194,15 +1147,11 @@ Allow from all</screen>
 apxs2 -cia <replaceable>MODULE</replaceable>.c</screen>
    <para>
     ここで、<option>-c</option>はモジュールをコンパイルし、<option>-i</option>はモジュールをインストールし、<option>-a</option>はモジュールをアクティブにします。<command>apxs2</command>のその他のオプションについては、<systemitem>apxs2(1)</systemitem> manページを参照してください。
-   </para><indexterm class="endofrange" startref="idx-apache2-modules"/>
+   </para>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-apache2-cgi">
-  <title>CGIスクリプトの有効化</title><indexterm>
-
-  <primary> Apache</primary>
-
-  <secondary> CGIスクリプト</secondary></indexterm> 
+  <title>CGIスクリプトの有効化</title>
 
   <para>
    ApacheのCGI(コモンゲートウェイインタフェース)により、通常CGIスクリプトと呼ばれるプログラムまたはスクリプトを含んだ動的コンテンツを作成できます。CGIスクリプトは、どのプログラム言語でも作成できます。通常、PerlまたはPHPなどのスクリプト言語が使用されます。
@@ -1306,11 +1255,7 @@ apxs2 -cia <replaceable>MODULE</replaceable>.c</screen>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-apache2-ssl">
-  <title>SSLをサポートするセキュアWebサーバのセットアップ</title><indexterm class="startofrange" xml:id="idx-apache2-ssl">
-
-  <primary> Apache</primary>
-
-  <secondary> SSL</secondary></indexterm> 
+  <title>SSLをサポートするセキュアWebサーバのセットアップ</title>
 
   <para>
    クレジットカード情報などの機密データをWebサーバやクライアント間で送信する場合は必ず、認証を使用して、安全で、暗号化された接続の確立を推奨します。<systemitem>mod_ssl</systemitem>は、クライアントとWebサーバ間のHTTP通信にセキュアソケットレイヤ(SSL)プロトコルとトランスポートレイヤセキュリティ(TLS)プロトコルを使用して、強力な暗号化を行います。SSL/TLSを使用することにより、Webサーバとクライアント間でプライベートな接続が確立されます。データの整合性が保証され、クライアントとサーバとの間の相互認証が可能になります。
@@ -1329,10 +1274,7 @@ apxs2 -cia <replaceable>MODULE</replaceable>.c</screen>
   </para>
 
   <sect2 xml:id="sec-apache2-ssl-certificate">
-   <title>SSL証明書の作成</title><indexterm>
-   <primary> Apache</primary>
-   <secondary>SSL</secondary>
-   <tertiary>SSL証明書の作成</tertiary></indexterm> 
+   <title>SSL証明書の作成</title>
    <para>
     SSL/TLSをWebサーバで使用するには、SSL証明書を作成する必要があります。この証明書は、両者が互いに相手を識別できるように、Webサーバとクライアント間の認証に必要です。証明書の整合性を確認するには、すべてのユーザが信用する者によって署名される必要があります。
    </para>
@@ -1538,10 +1480,7 @@ sudo cp new.cert.key /etc/apache2/ssl.key/server.key</screen>
   </sect2>
 
   <sect2 xml:id="sec-apache2-ssl-configuration">
-   <title>SSLサポートのあるApacheの設定</title><indexterm>
-   <primary> Apache</primary>
-   <secondary>SSL</secondary>
-   <tertiary>SSLサポートのあるApacheの設定</tertiary></indexterm> 
+   <title>SSLサポートのあるApacheの設定</title>
    <para>
     Webサーバ側のSSLとTLS要求用のデフォルトのポートは 443です。ポート 80をリスンする<quote>通常</quote>のApacheと、ポート 443をリスンするSSL/TL対応のApacheとの間に競合は生じません。通常、ポート80とポート443への要求はそれぞれ別の仮想ホストが処理し、別の仮想サーバに送られます。
    </para>
@@ -1609,7 +1548,7 @@ sudo cp new.cert.key /etc/apache2/ssl.key/server.key</screen>
      <para>
       サーバ設定で<literal>off</literal>に設定されると、サーバはSNIサポートがないかのように動作します。SSL要求は、(ポート443に対して)定義された<emphasis>最初の</emphasis>仮想ホストによって処理されます。
      </para>
-    </important><indexterm class="endofrange" startref="idx-apache2-ssl"/>
+    </important>
    </sect3>
   </sect2>
  </sect1>
@@ -1780,11 +1719,7 @@ apachectl start</screen>
   </itemizedlist>
  </sect1>
  <sect1 xml:id="sec-apache2-security">
-  <title>セキュリティ問題の回避</title><indexterm>
-
-  <primary> Apache</primary>
-
-  <secondary> セキュリティ</secondary></indexterm> 
+  <title>セキュリティ問題の回避</title>
 
   <para>
    公共のインターネットに公開しているWebサーバについては、管理面での不断の努力が求められます。ソフトウェアと、偶然の設定ミスの両方に関連したセキュリティの問題が発生することは避けられません。それらに対処するためのいくつかのヒントを紹介します。
@@ -1858,11 +1793,7 @@ apachectl start</screen>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-apache2-troubleeshooting">
-  <title>トラブルシューティング</title><indexterm>
-
-  <primary>Apache</primary>
-
-  <secondary> トラブルシューティング</secondary></indexterm>
+  <title>トラブルシューティング</title>
 
   <para>
    Apacheが起動しないと、Webページにアクセスすることはできず、ユーザがWebサーバに接続することもできないので、問題の原因を見つけ出すことは重要です。次に、エラーが説明されている場所とチェックすべき重要事項について説明します。
@@ -2011,7 +1942,7 @@ apachectl start</screen>
    <title>その他の情報源</title>
    <para>
     <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>のApacheに固有な問題が発生した場合は、Technical Information Search (<link xlink:href="http://www.suse.com/support"/>)を参照してください。Apacheの沿革は、<link xlink:href="http://httpd.apache.org/ABOUT_APACHE.html"/>で参照できます。このページでは、Apacheというサーバ名の由来についても説明しています。
-   </para><indexterm class="endofrange" startref="idx-apache2"/>
+   </para>
   </sect2>
  </sect1>
 </chapter>

--- a/l10n/sles/ja-jp/xml/apache2_yast_i.xml
+++ b/l10n/sles/ja-jp/xml/apache2_yast_i.xml
@@ -6,10 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm class="startofrange" xml:id="idx-apache2-configuration-yast">
- <primary>Apache</primary>
- <secondary> 設定</secondary>
- <tertiary> YaST</tertiary></indexterm>
+ </info>
  <para>
   YaSTを使用してWebサーバを設定するには、YaSTを起動して、<menuchoice> <guimenu>ネットワークサービス</guimenu> <guimenu>HTTPサーバ</guimenu> </menuchoice>の順に選択します。このモジュールを初めて起動するときに、<guimenu>HTTPサーバウィザード</guimenu>が起動して、サーバ管理に関していくつかの基本的な事項を決定するように要求されます。このウィザードの完了後、<guimenu>HTTPサーバ</guimenu>のモジュールを呼び出すたびに、<guimenu>HTTPサーバの環境設定</guimenu>ダイアログが起動します。詳細については、<xref linkend="sec-apache2-configuration-yast-server-configuration"/>を参照してください。
  </para>
@@ -221,7 +218,7 @@
    <title>メインホストまたはホスト</title>
    <para>
     これらのダイアログは、すでに説明したものと同じです。詳細については、<xref linkend="sec-apache2-configuration-yast-wizard-default-host"/>および<xref linkend="sec-apache2-configuration-yast-wizard-virtual-hosts"/>を参照してください。
-   </para><indexterm class="endofrange" startref="idx-apache2-configuration-yast"/>
+   </para>
   </sect4>
  </sect3>
 </sect2>

--- a/l10n/sles/ja-jp/xml/apps_brasero.xml
+++ b/l10n/sles/ja-jp/xml/apps_brasero.xml
@@ -15,26 +15,9 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-brasero" class="startofrange">
- <primary> Brasero</primary></indexterm> 
+ </info>
  <sect1 xml:id="sec-brasero-creating">
-  <title>データCDまたはDVDの作成</title><indexterm>
-
-  <primary>CD</primary>
-
-  <secondary>作成</secondary>
-
-  <tertiary>データ</tertiary></indexterm><indexterm>
-
-  <primary>K3b</primary>
-
-  <secondary>データCD</secondary></indexterm><indexterm>
-
-  <primary>DVD</primary>
-
-  <secondary>作成</secondary>
-
-  <tertiary>データ</tertiary></indexterm>
+  <title>データCDまたはDVDの作成</title>
 
   <para>
    Braseroを初めて起動すると、<xref linkend="fig-brasero-main" xrefstyle="select:label nopage"/>に示されたようなメインウィンドウが表示されます。
@@ -116,17 +99,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-brasero-creatingaudiocd">
-  <title>オーディオCDの作成</title><indexterm>
-
-  <primary> CD</primary>
-
-  <secondary> 作成</secondary>
-
-  <tertiary> オーディオ</tertiary></indexterm><indexterm>
-
-  <primary>   Brasero</primary>
-
-  <secondary> オーディオCD</secondary></indexterm> 
+  <title>オーディオCDの作成</title>
 
   <para>
    オーディオCDの作成とデータCDの作成に大きな違いはありません。次の手順に従います。
@@ -168,19 +141,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-brasero-copying">
-  <title>CDまたはDVDのコピー</title><indexterm>
-
-  <primary>CD</primary>
-
-  <secondary>コピー</secondary></indexterm><indexterm>
-
-  <primary>Brasero</primary>
-
-  <secondary>CDのコピー</secondary></indexterm><indexterm>
-
-  <primary>DVD</primary>
-
-  <secondary>コピー</secondary></indexterm>
+  <title>CDまたはDVDのコピー</title>
 
   <para>
    CDまたはDVDをコピーするには、次の手順に従います。
@@ -216,15 +177,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-gnome-writingiso">
-  <title>ISOイメージの書き込み</title><indexterm>
-
-  <primary>CD</primary>
-
-  <secondary>ISO</secondary></indexterm><indexterm>
-
-  <primary>DVD</primary>
-
-  <secondary>ISOイメージ</secondary></indexterm>
+  <title>ISOイメージの書き込み</title>
 
   <para>
    すでにISOイメージが存在する場合は、<guimenu>Burn image (イメージの書き込み)</guimenu>をクリックするか、<menuchoice> <guimenu>Project (プロジェクト)</guimenu> <guimenu>New Project (新規プロジェクト)</guimenu>
@@ -232,11 +185,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-brasero-multisession">
-  <title>マルチセッションCDまたはDVDの作成</title><indexterm>
-
-  <primary> CD</primary>
-
-  <secondary> マルチセッション</secondary></indexterm> 
+  <title>マルチセッションCDまたはDVDの作成</title>
 
   <para>
    マルチセッションのディスクでは、データを複数回にわたって書き込むことができます。この機能は、メディアよりも小さなバックアップを書き込む場合などに役立ちます。セッションごとに、バックアップファイルを追加していくことができます。興味深い点として、この機能はデータCDやDVDだけに限られているわけではありません。マルチセッションディスクにオーディオセッションを追加することもできます。
@@ -274,6 +223,6 @@
 
   <para>
    Braseroの詳細については、<link xlink:href="https://wiki.gnome.org/Apps/Brasero"/>を参照してください。
-  </para><indexterm class="endofrange" startref="idx-brasero"/>
+  </para>
  </sect1>
 </chapter>

--- a/l10n/sles/ja-jp/xml/apps_ekiga.xml
+++ b/l10n/sles/ja-jp/xml/apps_ekiga.xml
@@ -11,12 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-voip" class="startofrange">
- <primary>voice over IP</primary></indexterm><indexterm>
- <primary>アプリケーション</primary>
- <secondary>ネットワーク</secondary>
- <tertiary>Ekiga</tertiary></indexterm><indexterm xml:id="idx-ekiga" class="startofrange">
- <primary>Ekiga</primary></indexterm>
+ </info>
  <note>
   <title>Ekigaがインストールされていない場合があります。</title>
   <para>
@@ -387,11 +382,7 @@
   </table>
  </sect1>
  <sect1 xml:id="sec-ekiga-firstcall">
-  <title>電話をかける</title><indexterm>
-
-  <primary>Ekiga</primary>
-
-  <secondary>通話</secondary></indexterm>
+  <title>電話をかける</title>
 
   <para>
    Ekigaを適切に設定し終えたら、簡単に電話をかけられます。
@@ -531,8 +522,8 @@
   </para>
 
   <para>
-   プライベートな電話ネットワークを設定するには、<literal>PBX</literal>ソフトウェアのAsterisk <link xlink:href="http://www.asterisk.org/"/>を検討できます。詳細については、<link xlink:href="http://www.voip-info.org/wiki-Asterisk"/>を参照してください。<indexterm startref="idx-ekiga" class="endofrange"/>
-   <indexterm startref="idx-voip" class="endofrange"/> 
+   プライベートな電話ネットワークを設定するには、<literal>PBX</literal>ソフトウェアのAsterisk <link xlink:href="http://www.asterisk.org/"/>を検討できます。詳細については、<link xlink:href="http://www.voip-info.org/wiki-Asterisk"/>を参照してください。
+    
   </para>
  </sect1>
 </chapter>

--- a/l10n/sles/ja-jp/xml/apps_firefox.xml
+++ b/l10n/sles/ja-jp/xml/apps_firefox.xml
@@ -11,13 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm class="startofrange" xml:id="idx-firefox">
- <primary>Firefox</primary></indexterm><indexterm class="startofrange" xml:id="idx-browsers-firefox">
- <primary>Webブラウザ</primary>
- <secondary>Firefox</secondary></indexterm><indexterm>
- <primary>アプリケーション</primary>
- <secondary>ネットワーク</secondary>
- <tertiary>Firefox</tertiary></indexterm>
+ </info>
  <sect1 xml:id="sec-firefox-start">
   <title>Firefoxの起動</title>
 
@@ -27,11 +21,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-firefox-navigating">
-  <title>Webサイトのナビゲート</title><indexterm>
-
-  <primary> Firefox</primary>
-
-  <secondary> 移動</secondary></indexterm> 
+  <title>Webサイトのナビゲート</title>
 
   <para>
    Firefoxのルックアンドフィールは、他のブラウザと似ています。このツールを「<xref linkend="fig-firefox-main"/>」に示します。ウィンドウの上部には、Webアドレス用のロケーションバーと検索バーがあります。またブックマークは、ブックマークツールバーからすばやくアクセスするために使用できます。Firefoxのさまざまな機能の詳細については、メニューバーの<guimenu>ヘルプ</guimenu>メニューを使用してください。
@@ -72,9 +62,7 @@
   </figure>
 
   <sect2 xml:id="sec-firefox-locationbar">
-   <title>ロケーションバー</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> ロケーションバー</secondary></indexterm> 
+   <title>ロケーションバー</title>
    <para>
     ロケーションバーに入力すると、オートコンプリートドロップダウンボックスが開きます。これまでのロケーションアドレスやブックマークの中から、入力した文字を含むものがすべて表示されます。一致する語句は太字で強調表示されます。最近に最も頻繁にアクセスされたエントリがリストの最初に表示されます。
    </para>
@@ -87,9 +75,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-zoom">
-   <title>ズーム</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary> ズーム</secondary></indexterm>
+   <title>ズーム</title>
    <para>
     Firefoxでは、ページズーム、そしてデフォルトのテキストズームの2つのズームオプションが提供されています。テキストズームではテキストサイズのみが変更されますが、ページズームではグラフィックを含むページの全要素とともにページ全体がそのまま均等に拡大されます。
    </para>
@@ -102,11 +88,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-tabbedbrowsing">
-   <title>タブブラウズ</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary>タブ</secondary></indexterm><indexterm>
-   <primary>Firefox</primary>
-   <secondary>タブブラウズ</secondary></indexterm>
+   <title>タブブラウズ</title>
    <para>
     タブブラウズを使用すると、複数のWebサイトを1つのウィンドウにロードすることができます。使用中のページを切り替えるには、ウィンドウの上部にあるタブを使用します。一度に複数のWebページを表示することが多い場合、タブブラウズによってページを切り替えるのが容易になります。
    </para>
@@ -153,9 +135,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-sidebar">
-   <title>サイドバーの使用</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> サイドバー</secondary></indexterm> 
+   <title>サイドバーの使用</title>
    <para>
     ブラウザウィンドウの左側を使用して、ブックマークやブラウズ履歴を表示できます。拡張機能によって、サイドバーを使用するための新しい方法が追加されることがあります。サイドバーを表示するには、メニューバーから<menuchoice> <guimenu>表示</guimenu>
     <guimenu>サイドバー</guimenu> </menuchoice>の順に選択し、目的のコンテンツを選択します。
@@ -170,13 +150,7 @@
   </para>
 
   <sect2 xml:id="sec-firefox-searchengine">
-   <title>Web上での情報の検索</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> 検索</secondary></indexterm><indexterm>
-   <primary>   Firefox</primary>
-   <secondary> 検索バー</secondary></indexterm><indexterm>
-   <primary>   Firefox</primary>
-   <secondary> web検索</secondary></indexterm> 
+   <title>Web上での情報の検索</title>
    <para>
     Firefoxには検索バーがあり、Google、Yahoo、Amazonなどのさまざまな検索エンジンにアクセスできます。たとえば、現在のエンジンでSUSEに関する情報を検索する場合は、検索バーをクリックし、「<literal>SUSE</literal>」と入力して、<keycap function="enter"/>を押します。検索結果がウィンドウに表示されます。
    </para>
@@ -231,9 +205,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-searchengine-smartkeywords">
-    <title>オンライン検索へのキーワードの追加</title><indexterm>
-    <primary>Firefox</primary>
-    <secondary> キーワード</secondary></indexterm>
+    <title>オンライン検索へのキーワードの追加</title>
     <para>
      Firefoxでは、独自の「キーワード」<emphasis/>を定義することができます。キーワードは、特定の検索エンジンのURLショートカットとして使用する略語です。たとえば、Wikipediaでの検索のキーワードとして<literal>ws</literal>を定義した場合、ロケーションバーに「<literal>ws <replaceable>SEARCHTERM</replaceable></literal>」と入力すると、Wikipediaで<replaceable>SEARCHTERM</replaceable>を検索できるようになります。
     </para>
@@ -275,26 +247,18 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-findinfo-page">
-   <title>現在のページ内での検索</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> ページの検索</secondary></indexterm> 
+   <title>現在のページ内での検索</title>
    <para>
     Webページ内を検索するには、メニューバーで<menuchoice>
     <guimenu>編集</guimenu> <guimenu> 検索</guimenu> </menuchoice>の順にクリックするか、<keycombo> <keycap function="control"/> <keycap>F</keycap> </keycombo>を押します。検索バーが表示されます。通常、このバーはウィンドウの一番下に表示されます。テキストボックスにクエリを入力します。Firefoxでは、入力中にこのフレーズに一致した最初の文字列が検索されます。このフレーズと一致するその他の項目を検索するには、<keycap>F3</keycap>を押すか、検索バーの<guimenu>次を検索</guimenu>ボタンをクリックします。<guimenu>すべて強調表示</guimenu>ボタンをクリックすると、このフレーズに一致したすべての文字列が強調表示されます。<guimenu>大文字/小文字を区別する</guimenu>オプションを選択すると、検索で大文字と小文字が区別されます。
-   </para><indexterm>
-   <primary>Firefox</primary>
-   <secondary>のクイック検索機能</secondary></indexterm>
+   </para>
    <para>
     Firefoxには2つのクイック検索オプションも用意されています。Webページ上で検索する任意の場所をクリックするか、<keycap>/</keycap>キーを押し、その後すぐ検索用語を入力します。検索用語に一致した最初の文字列が入力中に強調表示されます。次の検索用語を検索するには、<keycap>F3</keycap>を使用します。クイック検索をリンクにのみ限定することもできます。この検索オプションは、<keycap>'</keycap>キーを押すことで使用できます。
    </para>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-firefox-bookmarks">
-  <title>ブックマークの管理</title><indexterm>
-
-  <primary> Firefox</primary>
-
-  <secondary> ブックマーク</secondary></indexterm> 
+  <title>ブックマークの管理</title>
 
   <para>
    ブックマークにより、お気に入りのWebサイトへのリンクを保存しておくことができます。またFirefoxでは、1回のマウスクリックのみで新しいブックマークを非常に簡単に追加できるだけでなく、大量のブックマークコレクションを管理するために複数の方法が用意されています。ブックマークをフォルダに分類したり、タグで分類したりできます。また、スマートブックマークフォルダでフィルタすることもできます。
@@ -313,13 +277,7 @@
   </para>
 
   <sect2 xml:id="sec-firefox-bookmarks-organise">
-   <title>ブックマークの整理</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary>ブックマーク</secondary>
-   <tertiary>管理</tertiary></indexterm><indexterm>
-   <primary>Firefox</primary>
-   <secondary>ブックマーク</secondary>
-   <tertiary>ライブラリ</tertiary></indexterm>
+   <title>ブックマークの整理</title>
    <para>
     <guimenu>ライブラリ</guimenu>を使用すると、各ブックマークのプロパティ(名前とURL)を管理したり、ブックマークをフォルダやセクション内に分類したりできます。この機能は、<xref linkend="fig-firefox-library"/>に示しています。
    </para>
@@ -400,10 +358,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-tags">
-   <title>タグ</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> ブックマーク</secondary>
-   <tertiary> タグ</tertiary></indexterm> 
+   <title>タグ</title>
    <para>
     タグは、複数のカテゴリでブックマークを記録するための便利な方法です。必要な数の単語でブックマークにタグを付けることができます。たとえば、<literal>suse</literal>というタグが付けられたすべてのサイトにアクセスするには、ロケーションバーに「<literal>suse</literal>」と入力します。それぞれのタグについて、ライブラリの<systemitem>最近付けたタグ</systemitem>フォルダに項目が自動的に作成されます。タグの項目をブックマークツールバーにドラッグアンドドロップすると、簡単にアクセスできます。
    </para>
@@ -413,13 +368,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-imexport">
-   <title>ブックマークのインポートとエクスポート</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary>ブックマーク</secondary>
-   <tertiary>インポート</tertiary></indexterm><indexterm>
-   <primary>Firefox</primary>
-   <secondary>ブックマーク</secondary>
-   <tertiary>エクスポート</tertiary></indexterm>
+   <title>ブックマークのインポートとエクスポート</title>
 
    <para>
     別のブラウザまたはHTML形式のファイルからブックマークをインポートするには、メニューバーから<menuchoice>
@@ -436,10 +385,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-live">
-   <title>ライブブックマーク</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> ブックマーク</secondary>
-   <tertiary> ライブブックマーク</tertiary></indexterm> 
+   <title>ライブブックマーク</title>
    <para>
     ライブブックマークは、最新のニュースを確認できるように、ブックマークメニュー内に見出しを表示する機能です。これにより、お気に入りのサイトをすばやく一覧できます。ライブブックマークは自動的に更新されます。多くのサイトとブログは、この形式をサポートしています。
    </para>
@@ -450,20 +396,14 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-smart">
-   <title>スマートブックマークフォルダ</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> ブックマーク</secondary>
-   <tertiary> スマートブックマーク</tertiary></indexterm> 
+   <title>スマートブックマークフォルダ</title>
    <para>
     スマートブックマークフォルダは、動的に更新される仮想ブックマークフォルダです。3つのスマートブックマークフォルダがあります。<guimenu>よく見るページ</guimenu>のリンクは、ブックマークツールバーから利用できます。<guimenu>最近ブックマークしたページ</guimenu>のリンクと<guimenu>最近付けたタグ</guimenu>は、ブックマークメニューから利用できます。
    </para>
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-toolbar">
-   <title>ブックマークツールバー</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> ブックマーク</secondary>
-   <tertiary> ツールバー</tertiary></indexterm> 
+   <title>ブックマークツールバー</title>
    <para>
     <literal>ブックマークツールバー</literal>がロケーションバーの下に表示され、ブックマークにすぐにアクセスできます。ブックマークを直接追加、整理、編集することもできます。デフォルトで<literal>ブックマークツールバー</literal>には、事前定義されたブックマークがいくつかのフォルダに分類されて登録されています(<xref linkend="fig-firefox-main"/>を参照)。
    </para>
@@ -476,15 +416,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-firefox-downloadmanager">
-  <title>ダウンロードマネージャの使用</title><indexterm>
-
-  <primary> Firefox</primary>
-
-  <secondary>ダウンロードマネージャ</secondary></indexterm><indexterm>
-
-  <primary>ダウンロードマネージャ</primary>
-
-  <secondary>Firefox </secondary></indexterm>
+  <title>ダウンロードマネージャの使用</title>
 
   <para>
    ダウンロードマネージャは、現在または以前のダウンロードを管理します。ダウンロードマネージャを起動するには、メニューバーで<menuchoice>
@@ -504,20 +436,14 @@
   </tip>
  </sect1>
  <sect1 xml:id="sec-firefox-security">
-  <title>セキュリティ</title><indexterm>
-
-  <primary>Firefox</primary>
-
-  <secondary>セキュリティ</secondary></indexterm>
+  <title>セキュリティ</title>
 
   <para>
    インターネットを閲覧するリスクが高まっているために、Firefoxでは閲覧をより安全にするためのさまざまな手段が用意されています。有害なソフトウェア(マルウェア)を含むことが分かっているサイトや機密データを詐取(フィッシング)することが分かっているサイトにアクセスしようとしているかどうかが自動的にチェックされ、これらのサイトにアクセスすることを防ぎます。インスタントWebサイトIDによりサイトの正当性を簡単にチェックでき、パスワードマネージャとポップアップブロッカーによりセキュリティが強化されます。プライベートブラウジングを使用すれば、Firefoxによってコンピュータにデータが記録されることなく、インターネットを閲覧できます。
   </para>
 
   <sect2 xml:id="sec-firefox-security-instant-id">
-   <title>インスタントWebサイトID</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> サイトID</secondary></indexterm> 
+   <title>インスタントWebサイトID</title>
    <para>
     Firefoxでは、WebページのIDを一目でチェックできます。ロケーションバーのアドレスの横に表示されるアイコンは、使用可能な識別情報と、通信が暗号化されているかどうかを示します。
    </para>
@@ -630,11 +556,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-firefox-customizing">
-  <title>Firefoxのカスタマイズ</title><indexterm>
-
-  <primary> Firefox</primary>
-
-  <secondary> 設定</secondary></indexterm> 
+  <title>Firefoxのカスタマイズ</title>
 
   <para>
    Firefoxは縦横にカスタマイズできます。
@@ -663,9 +585,7 @@
   </para>
 
   <sect2 xml:id="sec-firefox-preferences">
-   <title>Preferences (初期設定)</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> 初期設定</secondary></indexterm> 
+   <title>Preferences (初期設定)</title>
    <para>
     Firefoxには、幅広い設定オプションが用意されています。これらのオプションを使用するには、メニューバーで<menuchoice> <guimenu>編集</guimenu>
     <guimenu>設定</guimenu> </menuchoice>の順に選択します。各オプションの詳細については、オンラインヘルプを参照してください。ダイアログで疑問符アイコンをクリックすると、アクセスできます。
@@ -682,9 +602,7 @@
     </mediaobject>
    </figure>
    <sect3 xml:id="sec-firefox-preferences-sessions">
-    <title>セッション管理</title><indexterm>
-    <primary> Firefox</primary>
-    <secondary> セッション管理</secondary></indexterm> 
+    <title>セッション管理</title>
     <para>
      デフォルトでは、Firefoxがクラッシュした後、または拡張機能をインストールして再起動した後にのみ、セッション(ウィンドウおよびタブ)が自動的に復元されます。ただし、起動するたびにセッションが復元されるように設定することもできます。<xref linkend="sec-firefox-preferences"/>の説明に従って［設定］ダイアログを開き、<guimenu>一般</guimenu>カテゴリに移動します。<guimenu>Firefoxを起動するとき</guimenu>オプションを<guimenu>前回終了時のウィンドウとタブを表示する</guimenu>に設定します。
     </para>
@@ -695,17 +613,13 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-preferences-language">
-    <title>Webサイトに対する言語の初期設定</title><indexterm>
-    <primary> Firefox</primary>
-    <secondary> 言語</secondary></indexterm> 
+    <title>Webサイトに対する言語の初期設定</title>
     <para>
      Webサーバに要求を送信するときにブラウザは常に、ユーザによって選択された言語に関する情報を送信します。複数の言語が使用可能であり(この言語パラメータを評価するように設定される)Webサイトでは、ブラウザが要求する言語でページが表示されます。<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>では、デスクトップと同じ言語を使用するように希望の言語があらかじめ設定されています。この設定を変更するには、<xref linkend="sec-firefox-preferences"/>の説明に従って<guimenu>設定</guimenu>ウィンドウを開き、<guimenu>コンテンツ</guimenu>カテゴリに移動して、希望の言語を<guimenu>選択</guimenu>します。
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-preferences-spelling">
-    <title>スペルチェック</title><indexterm>
-    <primary> Firefox</primary>
-    <secondary> スペルチェック</secondary></indexterm> 
+    <title>スペルチェック</title>
     <para>
      デフォルトでは、複数行のテキストボックスに入力した内容がFirefoxによってスペルチェックされます。スペルミスのある単語には、赤い下線が引かれます。単語を修正するには、単語を右クリックし、コンテキストメニューから適切なスペルを選択します。また、単語が正しい場合は、単語を辞書に追加できます。
     </para>
@@ -716,13 +630,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-extensions">
-   <title>アドオン</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary>アドオン</secondary></indexterm><indexterm>
-   <primary>Firefox</primary>
-   <secondary>拡張機能</secondary></indexterm><indexterm>
-   <primary>Firefox</primary>
-   <secondary>テーマ</secondary></indexterm>
+   <title>アドオン</title>
    <para>
     拡張機能を使用すると、ニーズに合わせてFirefoxをパーソナライズできます。拡張機能によって、Firefoxのルックアンドフィールを変更したり、既存の機能を強化したり、機能を追加したりできます。たとえば、ダウンロードマネージャの機能強化、天気の表示、Webミュージックプレーヤの管理などが可能です。Web開発者を支援する拡張機能や、広告やスクリプトなどのコンテンツをブロックしてセキュリティを強化する拡張機能もあります。
    </para>
@@ -733,10 +641,7 @@
     Firefoxの標準的なルックアンドフィールが気に入らない場合は、新しい<emphasis>テーマ</emphasis>をインストールします。テーマを変更しても、ブラウザの外観が変わるだけで機能そのものに影響はありません。
    </para>
    <sect3 xml:id="sec-firefox-extensions-install">
-    <title>アドオンのインストール</title><indexterm>
-    <primary> Firefox</primary>
-    <secondary> アドオン</secondary>
-    <tertiary> インストール</tertiary></indexterm> 
+    <title>アドオンのインストール</title>
     <para>
      拡張機能またはテーマを追加するには、メニューバーから<menuchoice>
      <guimenu>ツール</guimenu> <guimenu>アドオン</guimenu> </menuchoice>の順にクリックしてアドオンマネージャを起動します。推奨されるアドオンの選択肢または前回の検索結果を表示する<guimenu>アドオン入手</guimenu>タブが開きます。
@@ -761,10 +666,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-extensions-manage">
-    <title>アドオンの管理</title><indexterm>
-    <primary> Firefox</primary>
-    <secondary> アドオン</secondary>
-    <tertiary> 管理</tertiary></indexterm> 
+    <title>アドオンの管理</title>
     <para>
      アドオンマネージャはまた、拡張機能、テーマ、およびプラグインを管理するための便利なインタフェースを提供します。<guimenu>拡張機能</guimenu>は有効/無効にしたり、アンインストールしたりできます。拡張機能が設定可能な場合は、<guimenu>初期設定</guimenu>ボタンを押して設定オプションにアクセスできます。<guimenu>テーマ</guimenu>タブでは、テーマを<guimenu>アンインストール</guimenu>したり、<guimenu>有効化</guimenu>をクリックすることにより別のテーマを有効にしたりできます。保留中の拡張機能およびテーマのインストールも一覧に表示されます。インストールを中止するには<guimenu>キャンセル</guimenu>を選択します。ユーザとして<guimenu>プラグイン</guimenu>をインストールすることはできませんが、アドオンマネージャで無効または有効にすることは可能です。
     </para>
@@ -777,15 +679,7 @@
 
  </sect1>
  <sect1 xml:id="sec-firefox-printing">
-  <title>Firefoxからの印刷</title><indexterm>
-
-  <primary>Firefox</primary>
-
-  <secondary>印刷</secondary></indexterm><indexterm>
-
-  <primary>印刷</primary>
-
-  <secondary>Firefox</secondary></indexterm>
+  <title>Firefoxからの印刷</title>
 
   <para>
    Webページを実際に印刷する前に、印刷プレビュー機能を使用して印刷されたページの外観を制御できます。メニューバーから、<menuchoice> <guimenu>ファイル</guimenu> <guimenu>印刷プレビュー</guimenu>
@@ -821,6 +715,6 @@
    </member>
    <member><emphasis>キーボードショートカット</emphasis>:<link xlink:href="http://support.mozilla.org/kb/Keyboard+shortcuts"/>
    </member>
-  </simplelist><indexterm startref="idx-firefox" class="endofrange"/><indexterm class="endofrange" startref="idx-browsers-firefox"/>
+  </simplelist>
  </sect1>
 </chapter>

--- a/l10n/sles/ja-jp/xml/apps_gimp.xml
+++ b/l10n/sles/ja-jp/xml/apps_gimp.xml
@@ -11,26 +11,12 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-gimp" class="startofrange">
- <primary>GIMP</primary></indexterm><indexterm xml:id="idx-graphics-editing" class="startofrange">
- <primary>グラフィックス</primary>
- <secondary>編集</secondary></indexterm><indexterm>
- <primary>アプリケーション</primary>
- <secondary>グラフィックス</secondary>
- <tertiary>GIMP</tertiary></indexterm>
+ </info>
  <para>
   GIMPは、非常に複雑なプログラムです。この章で説明するのは、限られた範囲の機能、ツール、およびメニュー項目です。このプログラムの詳細情報については、<xref linkend="sec-gimp-moreinfo"/>を参照してください。
  </para>
  <sect1 xml:id="sec-gimp-graphics">
-  <title>グラフィックファイルの形式</title><indexterm>
-
-  <primary>グラフィックス</primary>
-
-  <secondary>ピクセル</secondary></indexterm><indexterm>
-
-  <primary>グラフィックス</primary>
-
-  <secondary>ベクタ</secondary></indexterm>
+  <title>グラフィックファイルの形式</title>
 
   <para>
    デジタルグラフィックには主に、ラスタとベクタという2つのタイプがあります。GIMPはラスタグラフィックの操作を目的として作成されています。ラスタはデジタル写真やスキャンした画像に最もよく使用されます。
@@ -87,11 +73,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-gimp-starting">
-  <title>GIMPの起動</title><indexterm>
-
-  <primary> GIMP</primary>
-
-  <secondary> 起動</secondary></indexterm> 
+  <title>GIMPの起動</title>
 
   <para>
    GIMPを起動するには、<menuchoice><guimenu>Applications (アプリケーション)</guimenu>
@@ -129,10 +111,7 @@
     <guimenu>ファイル</guimenu>メニューには、<guimenu>新規</guimenu>、<guimenu>開く</guimenu>、<guimenu>保存</guimenu>、<guimenu>印刷</guimenu>、<guimenu>閉じる</guimenu>などの標準ファイル操作が用意されています。<guimenu>終了</guimenu>はアプリケーションを終了します。
    </para>
    <para>
-    <indexterm>
-    <primary>GIMP</primary>
-    <secondary>ビュー</secondary>
-    </indexterm><guimenu>表示</guimenu>メニュー内の項目を使用して、画像と画像ウィンドウの表示方法を制御します。<guimenu> 新規ビュー</guimenu>は、現在の画像を表示する 2番目の表示ウィンドウを開きます。1つのビューに加えた変更は、その画像を表示している他のすべてのビューに反映されます。追加のビューは、あるビューで画像を拡大表示して操作しながら、他のビューで画像全体を表示する場合に役立ちます。現在のウィンドウの拡大レベルを調整するには、<guimenu>ズーム</guimenu>を使用します。<guimenu>Fit Image in Window (ウィンドウに合わせる)</guimenu>が選択されている場合、現在の画像表示サイズに合わせて、画像ウィンドウのサイズが適切に変更されます。
+    <guimenu>表示</guimenu>メニュー内の項目を使用して、画像と画像ウィンドウの表示方法を制御します。<guimenu> 新規ビュー</guimenu>は、現在の画像を表示する 2番目の表示ウィンドウを開きます。1つのビューに加えた変更は、その画像を表示している他のすべてのビューに反映されます。追加のビューは、あるビューで画像を拡大表示して操作しながら、他のビューで画像全体を表示する場合に役立ちます。現在のウィンドウの拡大レベルを調整するには、<guimenu>ズーム</guimenu>を使用します。<guimenu>Fit Image in Window (ウィンドウに合わせる)</guimenu>が選択されている場合、現在の画像表示サイズに合わせて、画像ウィンドウのサイズが適切に変更されます。
    </para>
   </sect2>
 
@@ -185,9 +164,7 @@
   </para>
 
   <sect2 xml:id="sec-gimp-getstart-creating">
-   <title>新しい画像の作成</title><indexterm>
-   <primary> GIMP</primary>
-   <secondary> 画像の作成</secondary></indexterm> 
+   <title>新しい画像の作成</title>
    <procedure>
     <step>
      <para>
@@ -198,9 +175,7 @@
     <step>
      <para>
       必要に応じて、<guimenu>Template</guimenu>という名前の事前定義された設定を選択します。
-     </para><indexterm>
-     <primary>GIMP</primary>
-     <secondary> テンプレート</secondary></indexterm>
+     </para>
      <note>
       <title>カスタムテンプレート</title>
       <para>
@@ -238,9 +213,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-getstart-open">
-   <title>既存の画像を開く</title><indexterm>
-   <primary> GIMP</primary>
-   <secondary> 画像を開く</secondary></indexterm> 
+   <title>既存の画像を開く</title>
    <para>
     既存の画像を開くには、<menuchoice> <guimenu>File (ファイル)</guimenu>
     <guimenu>Open (開く)</guimenu></menuchoice>の順に選択します。
@@ -251,11 +224,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gimp-saving">
-  <title>画像の保存とエクスポート</title><indexterm>
-
-  <primary>GIMP</primary>
-
-  <secondary> 画像の保存</secondary></indexterm>
+  <title>画像の保存とエクスポート</title>
 
   <para>
    GIMPでは、画像の保存とエクスポートが区別されます。
@@ -287,10 +256,7 @@
 
 
    <varlistentry>
-    <term>JPEG<indexterm>
-     <primary> ファイル</primary>
-     <secondary> 形式</secondary>
-     <tertiary> JPG</tertiary></indexterm> 
+    <term>JPEG 
     </term>
     <listitem>
      <para>
@@ -299,10 +265,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>GIF <indexterm>
-     <primary> ファイル</primary>
-     <secondary> 形式</secondary>
-     <tertiary> GIF</tertiary></indexterm> 
+    <term>GIF  
     </term>
     <listitem>
      <para>
@@ -311,10 +274,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>PNG <indexterm>
-     <primary> ファイル</primary>
-     <secondary> 形式</secondary>
-     <tertiary> PNG</tertiary></indexterm> 
+    <term>PNG  
     </term>
     <listitem>
      <para>
@@ -325,20 +285,14 @@
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-gimp-basics">
-  <title>画像の編集</title><indexterm xml:id="idx-gimp-editing-images" class="startofrange">
-
-  <primary> GIMP</primary>
-
-  <secondary> 画像の編集</secondary></indexterm> 
+  <title>画像の編集</title>
 
   <para>
    GIMPには、画像に変更を加えるためのさまざまなツールがあります。ここでは、ちょっとした編集を行う場合に最適な機能を取り上げています。
   </para>
 
   <sect2 xml:id="sec-gimp-basics-size">
-   <title>画像サイズの変更</title><indexterm xml:id="idx-graphics-resizing" class="startofrange">
-   <primary> 画像</primary>
-   <secondary> サイズ変更</secondary></indexterm> 
+   <title>画像サイズの変更</title>
    <para>
     画像をスキャンしたり、デジカメから写真をロードした場合、それをWebページに表示したり、印刷したりするために、サイズを変更しなければならないことがあります。これらの画像は、縮小したり、不要な部分をカットしたりすることで、簡単にサイズを小さくすることができます。
    </para>
@@ -346,9 +300,7 @@
     画像サイズを大きくする方は、より大変です。画像はラスタで構成されているため、画像を大きくすると画像品質が低下してしまいます。画像を編集する前に、元の画像のコピーを保持しておくことをお勧めします。
    </para>
    <sect3 xml:id="sec-gimp-basics-size-cropping">
-    <title>イメージのクロッピング</title><indexterm>
-    <primary> GIMP</primary>
-    <secondary> クロッピング</secondary></indexterm> 
+    <title>イメージのクロッピング</title>
     <procedure>
      <step>
       <para>
@@ -374,9 +326,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-size-scaling">
-    <title>画像の拡大/縮小</title><indexterm>
-    <primary> GIMP</primary>
-    <secondary> 画像の拡大/縮小</secondary></indexterm> 
+    <title>画像の拡大/縮小</title>
     <procedure>
      <step>
       <para>
@@ -427,14 +377,12 @@
        終了したら、<guimenu>Resize (サイズ変更)</guimenu>をクリックします。
       </para>
      </step>
-    </procedure><indexterm startref="idx-graphics-resizing" class="endofrange"/>
+    </procedure>
    </sect3>
   </sect2>
 
   <sect2 xml:id="sec-gimp-basics-select">
-   <title>画像の一部の選択</title><indexterm xml:id="idx-gimp-selecting" class="startofrange">
-   <primary> GIMP</primary>
-   <secondary> 選択</secondary></indexterm> 
+   <title>画像の一部の選択</title>
    <para>
     画像の一部にのみ画像処理を行う必要がある場合もあります。その場合、作業対象となる画像の部分を選択する必要があります。作業対象領域を選択する際には、ツールボックスの選択ツールやクイックマスクを使用することも、さまざまなオプションを組み合わせて使用することもできます。選択範囲は、<guimenu>Select</guimenu>下の項目を使って変更することもできます。選択範囲は<emphasis>marching ants</emphasis>と呼ばれる点線で表示されます。
    </para>
@@ -543,9 +491,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-select-quickmask">
-    <title>クイックマスクの使用</title><indexterm>
-    <primary> GIMP</primary>
-    <secondary> クイックマスク</secondary></indexterm> 
+    <title>クイックマスクの使用</title>
     <para>
      クイックマスクは、ペイントツールを使って画像の一部を選択する方法です。効果的に使用するには、最初に<guimenu>Scissors (はさみ)</guimenu>ツールや<guimenu>Free Select (自由選択)</guimenu>ツールを使用して大まかな選択範囲を作成しておきます。その後、<guimenu>Quick Mask (クイックマスク)</guimenu>の使用を開始してください。
     </para>
@@ -577,7 +523,7 @@
        終了したら、画像ウィンドウの左下隅にあるアイコンをクリックして、通常の選択ビューに戻ります。選択範囲が点線で表示されます。
       </para>
      </step>
-    </procedure><indexterm startref="idx-gimp-selecting" class="endofrange"/>
+    </procedure>
    </sect3>
   </sect2>
 
@@ -590,9 +536,7 @@
     大部分のツールでは、現在のツールのアイコンに矢印が付いた形状になります。ペイントツールの場合は、現在のブラシのアウトラインが表示されます。そのため、画像内のどこをペイントするのか、そしてどれだけの範囲がペイントされるのかを明確に把握することができます。
    </para>
    <sect3 xml:id="sec-gimp-basics-color-selecting">
-    <title>色の選択</title><indexterm>
-    <primary> GIMP</primary>
-    <secondary> 色</secondary></indexterm> 
+    <title>色の選択</title>
     <para>
      GIMPのツールボックスには、常に2つの色見本が表示されます。前景色は描画ツールで使用されます。背景色は前景色と比べるとはるかに使用頻度が低くなりますが、前景色になるように簡単に切り替えることができます。
     </para>
@@ -650,9 +594,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-color-text">
-    <title>テキストの追加</title><indexterm>
-    <primary> GIMP</primary>
-    <secondary> テキスト</secondary></indexterm> 
+    <title>テキストの追加</title>
     <para>
      テキストを追加するには、テキストツールを使用します。ツールオプションを使用して、目的のフォントおよびテキストプロパティを選択します。画像をクリックし、テキストの作成を開始します。
     </para>
@@ -661,9 +603,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-color-clone">
-    <title>画像の修正 - クローンツール</title><indexterm>
-    <primary> GIMP</primary>
-    <secondary> 画像の修正</secondary></indexterm> 
+    <title>画像の修正 - クローンツール</title>
     <para>
      画像を修正する場合は、クローンツールが役立ちます。このツールは、画像内の他の部分の情報を使って画像をペイントすることができます。必要に応じて、パターンから情報を取得することもできます。
     </para>
@@ -680,9 +620,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-basics-levels">
-   <title>色レベルの調整</title><indexterm>
-   <primary> GIMP</primary>
-   <secondary> レベル</secondary></indexterm> 
+   <title>色レベルの調整</title>
    <para>
     理想的な印刷/表示結果を得るために、画像を調節しなければならないようなこともあります。
    </para>
@@ -713,9 +651,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-basics-undo">
-   <title>操作の取り消し</title><indexterm>
-   <primary> GIMP</primary>
-   <secondary> 取り消し</secondary></indexterm> 
+   <title>操作の取り消し</title>
    <para>
     GIMPで行う操作の大半は、それを取り消してやり直すことができます。変更履歴を表示するには、デフォルトのレイアウトに用意されているUndoダイアログを使用するか、画像ウィンドウのメニューから<menuchoice>
     <guimenu>ウィンドウ</guimenu> <guimenu>Dockable Dialogs (格納式ダイアログ)</guimenu>
@@ -732,9 +668,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-advanced-layers">
-   <title>レイヤ</title><indexterm>
-   <primary> GIMP</primary>
-   <secondary> レイヤ</secondary></indexterm> 
+   <title>レイヤ</title>
    <para>
     GIMPでは、レイヤが重要な役割を果たします。画像の各部を個別のレイヤで修正することにより、それぞれの部分を、残りの画像に影響を与えずに変更、移動、または削除することができます。
    </para>
@@ -747,9 +681,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-advanced-modes">
-   <title>画像モード</title><indexterm>
-   <primary> GIMP</primary>
-   <secondary> 画像モード</secondary></indexterm> 
+   <title>画像モード</title>
    <para>
     GIMPには3つの画像モードがあります。
    </para>
@@ -776,24 +708,14 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-advanced-effects">
-   <title>特殊効果</title><indexterm>
-   <primary> GIMP</primary>
-   <secondary> 効果</secondary></indexterm> 
+   <title>特殊効果</title>
    <para>
     GIMPには、さまざまなフィルタやスクリプトが用意されています。これらのフィルタやスクリプトを使って、画像にさまざまな特殊効果を適用することができます。特殊効果を適用するには、<guimenu>フィルタ</guimenu>を使用します。どのような特殊効果があるかは、実際に試してみてください。
-   </para><indexterm startref="idx-gimp-editing-images" class="endofrange"/>
+   </para>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gimp-printing">
-  <title>画像の印刷</title><indexterm>
-
-  <primary>GIMP</primary>
-
-  <secondary>印刷</secondary></indexterm><indexterm>
-
-  <primary>印刷</primary>
-
-  <secondary>GIMP</secondary></indexterm>
+  <title>画像の印刷</title>
 
   <para>
    画像を印刷するには、画像メニューから<menuchoice> <guimenu>ファイル</guimenu>
@@ -866,6 +788,6 @@
      GIMPおよびGNOMEデスクトップ環境専用のIRCネットワークであるGIMPNetが用意されています。任意のIRCクライアントで<literal>irc.gimp.org</literal>サーバを参照することにより、GIMPNetに接続できます。<literal>#gimp-users</literal>チャネルは、GIMPの使用に関する質問を行うのに最適な場所です。開発者の議論をご覧になりたい場合は、<literal>#gimp</literal>チャネルに参加してください。
     </para>
    </listitem>
-  </itemizedlist><indexterm class="endofrange" startref="idx-gimp"/><indexterm class="endofrange" startref="idx-graphics-editing"/>
+  </itemizedlist>
  </sect1>
 </chapter>

--- a/l10n/sles/ja-jp/xml/autofs.xml
+++ b/l10n/sles/ja-jp/xml/autofs.xml
@@ -11,8 +11,7 @@
     <systemitem>autofs</systemitem>は、指定したディレクトリをオンデマンドベースで自動的にマウントするプログラムです。これは高い効率を実現するためにカーネルモジュールに基づいており、ローカルディレクトリとネットワーク共有の両方を管理できます。これらの自動的なマウントポイントは、アクセスがあった場合にのみマウントされ、非アクティブな状態が一定時間続くとアンマウントされます。このオンデマンドの動作によって帯域幅が節約され、<filename>/etc/fstab</filename>で管理する静的マウントよりも高いパフォーマンスが得られます。<systemitem>autofs</systemitem>は制御スクリプトですが、<command>automount</command>は実際の自動マウントを実行するコマンド(デーモン)です。
    </para>
   </abstract>
- </info><indexterm>
- <primary>AutoFS</primary></indexterm>
+ </info>
  <sect1 xml:id="sec-autofs-installation">
   <title>インストール</title>
 

--- a/l10n/sles/ja-jp/xml/common_intro_available_doc_i.xml
+++ b/l10n/sles/ja-jp/xml/common_intro_available_doc_i.xml
@@ -9,13 +9,7 @@
    </dm:bugtracker>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>ヘルプ</primary>
-
- <secondary> SUSEマニュアル</secondary></indexterm><indexterm>
-
- <primary> SUSEマニュアル</primary></indexterm>
+ </info>
 
  <note>
   <title>オンラインヘルプと最新のアップデート</title>

--- a/l10n/sles/ja-jp/xml/fs_structure_i.xml
+++ b/l10n/sles/ja-jp/xml/fs_structure_i.xml
@@ -6,9 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>ディレクトリ</primary>
- <secondary>構造</secondary></indexterm>
+ </info>
  <para>
   次のテーブルでは、Linuxシステムの最も重要な上位レベルディレクトリについて、短い概要を示します。それらのディレクトリおよび重要なサブディレクトリの詳細については、後続のリストを参照してください。
  </para>
@@ -244,9 +242,7 @@
  </para>
  <variablelist>
   <varlistentry>
-   <term><filename>/bin</filename><indexterm>
-    <primary>ディレクトリ</primary>
-    <secondary>/bin</secondary></indexterm>
+   <term><filename>/bin</filename>
    </term>
    <listitem>
     <para>
@@ -255,9 +251,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/boot</filename><indexterm>
-    <primary>ディレクトリ</primary>
-    <secondary>/boot</secondary></indexterm>
+   <term><filename>/boot</filename>
    </term>
    <listitem>
     <para>
@@ -266,9 +260,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/dev</filename><indexterm>
-    <primary>ディレクトリ</primary>
-    <secondary>/dev</secondary></indexterm> 
+   <term><filename>/dev</filename> 
    </term>
    <listitem>
     <para>
@@ -277,9 +269,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/etc</filename><indexterm>
-    <primary>ディレクトリ</primary>
-    <secondary>/etc</secondary></indexterm> 
+   <term><filename>/etc</filename> 
    </term>
    <listitem>
     <para>
@@ -288,9 +278,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/home/<replaceable>USERNAME</replaceable></filename><indexterm>
-    <primary>ディレクトリ</primary>
-    <secondary>/home</secondary></indexterm>
+   <term><filename>/home/<replaceable>USERNAME</replaceable></filename>
    </term>
    <listitem>
     <para>
@@ -305,9 +293,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/lib</filename><indexterm>
-    <primary>ディレクトリ</primary>
-    <secondary>/lib</secondary></indexterm>
+   <term><filename>/lib</filename>
    </term>
    <listitem>
     <para>
@@ -316,9 +302,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/media</filename><indexterm>
-    <primary>ディレクトリ</primary>
-    <secondary>/media</secondary></indexterm>
+   <term><filename>/media</filename>
    </term>
    <listitem>
     <para>
@@ -329,9 +313,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/mnt</filename><indexterm>
-    <primary>ディレクトリ</primary>
-    <secondary>/mnt</secondary></indexterm>
+   <term><filename>/mnt</filename>
    </term>
    <listitem>
     <para>
@@ -340,9 +322,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/opt</filename><indexterm>
-    <primary>ディレクトリ</primary>
-    <secondary>/opt</secondary></indexterm>
+   <term><filename>/opt</filename>
    </term>
    <listitem>
     <para>
@@ -351,9 +331,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/root</filename><indexterm>
-    <primary>ディレクトリ</primary>
-    <secondary>/root</secondary></indexterm>
+   <term><filename>/root</filename>
    </term>
    <listitem>
     <para>
@@ -362,9 +340,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/run</filename><indexterm>
-    <primary>ディレクトリ</primary>
-    <secondary>/run</secondary></indexterm>
+   <term><filename>/run</filename>
    </term>
    <listitem>
     <para>
@@ -373,9 +349,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/sbin</filename><indexterm>
-    <primary>ディレクトリ</primary>
-    <secondary>/sbin</secondary></indexterm>
+   <term><filename>/sbin</filename>
    </term>
    <listitem>
     <para>
@@ -384,9 +358,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/srv</filename><indexterm>
-    <primary>ディレクトリ</primary>
-    <secondary>/srv</secondary></indexterm>
+   <term><filename>/srv</filename>
    </term>
    <listitem>
     <para>
@@ -395,9 +367,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/tmp</filename><indexterm>
-    <primary>ディレクトリ</primary>
-    <secondary>/tmp</secondary></indexterm>
+   <term><filename>/tmp</filename>
    </term>
    <listitem>
     <para>
@@ -412,9 +382,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/usr</filename><indexterm>
-    <primary>ディレクトリ</primary>
-    <secondary>/usr</secondary></indexterm>
+   <term><filename>/usr</filename>
    </term>
    <listitem>
     <para>
@@ -465,9 +433,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/var</filename><indexterm>
-    <primary>ディレクトリ</primary>
-    <secondary>/var</secondary></indexterm>
+   <term><filename>/var</filename>
    </term>
    <listitem>
     <para>

--- a/l10n/sles/ja-jp/xml/fuse.xml
+++ b/l10n/sles/ja-jp/xml/fuse.xml
@@ -12,15 +12,10 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>FUSE</primary></indexterm>
+ </info>
 
  <sect1 xml:id="sec-fuse-config">
-  <title>FUSEの設定</title><indexterm>
-
-  <primary>FUSE</primary>
-
-  <secondary>設定</secondary></indexterm>
+  <title>FUSEの設定</title>
 
   <para>
    FUSEを使用するには、まず、<systemitem class="resource">fuse</systemitem>パッケージをインストールする必要があります。使用するファイルシステムによって、別々のパッケージとして使用できるプラグインを追加する必要があります。 
@@ -31,13 +26,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-fuse-ntfs">
-  <title>NTFSパーティションのマウント</title><indexterm>
-
-  <primary>FUSE</primary>
-
-  <secondary>ntfs-3g</secondary></indexterm><indexterm>
-
-  <primary>ntfs-3g</primary></indexterm>
+  <title>NTFSパーティションのマウント</title>
 
   <para>
    NTFS(<emphasis>New Technology File System</emphasis>)は、Windowsのデフォルトのファイルシステムです。通常の状況では、特権のないユーザは外部のFUSEライブラリを使用してNTFSブロックデバイスをマウントできません。そのため、次に説明する方法でWindowsパーティションをマウントするには、ルート特権が必要です。

--- a/l10n/sles/ja-jp/xml/grub2.xml
+++ b/l10n/sles/ja-jp/xml/grub2.xml
@@ -11,10 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>ブート</primary>
- <secondary>GRUB 2</secondary></indexterm><indexterm>
- <primary>GRUB 2</primary></indexterm>
+ </info>
  <sect1 xml:id="sec-grub2-new-features">
   <title>GRUB LegacyとGRUB 2の主な相違点</title>
 
@@ -67,9 +64,7 @@
    <varlistentry>
     <term><filename>/boot/grub2/grub.cfg</filename>
     </term>
-    <listitem><indexterm>
-     <primary>GRUB 2</primary>
-     <secondary> grub.cfg</secondary></indexterm>
+    <listitem>
      <para>
       このファイルには、GRUB 2メニュー項目の設定が含まれます。これは、GRUB Legacyで使用されていた<filename>menu.lst</filename>に代わるものです。<filename>grub.cfg</filename>は編集しないでください。コマンド<command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>によって自動的に生成されます。
      </para>
@@ -78,9 +73,7 @@
    <varlistentry>
     <term><filename>/boot/grub2/custom.cfg</filename>
     </term>
-    <listitem><indexterm>
-     <primary>GRUB 2</primary>
-     <secondary> custom.cfg</secondary></indexterm>
+    <listitem>
      <para>
       このオプションファイルは、ブート時に<filename>grub.cfg</filename>によって直接調達され、ブートメニューにカスタム項目を追加するために使用できます。<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>からは、<command>grub-once</command>を使用する場合も、これらのエントリが解析されます。
      </para>
@@ -89,9 +82,7 @@
    <varlistentry>
     <term><filename>/etc/default/grub</filename>
     </term>
-    <listitem><indexterm>
-     <primary>GRUB 2</primary>
-     <secondary> /etc/default/grub</secondary></indexterm>
+    <listitem>
      <para>
       このファイルは、GRUB 2のユーザ設定を制御し、通常は背景やテーマなどの追加の環境設定を含みます。
      </para>
@@ -100,9 +91,7 @@
    <varlistentry>
     <term><filename>/etc/grub.d/</filename>にあるスクリプト
     </term>
-    <listitem><indexterm>
-     <primary>GRUB 2</primary>
-     <secondary> /etc/grub.d/</secondary></indexterm>
+    <listitem>
      <para>
       このディレクトリのスクリプトは、コマンド<command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>の実行中に読み込まれます。スクリプトの命令はメインの設定ファイル<filename>/boot/grub/grub.cfg</filename>に統合されます。
      </para>
@@ -111,9 +100,7 @@
    <varlistentry xml:id="vle-grub2-sysconfig">
     <term><filename>/etc/sysconfig/bootloader</filename>
     </term>
-    <listitem><indexterm>
-     <primary>GRUB 2</primary>
-     <secondary> sysconfig/bootloader</secondary></indexterm>
+    <listitem>
      <para>
       この設定ファイルは、ブートローダタイプや、UEFIセキュアブートサポートを有効にするかどうかなどのいくつかの基本的な設定を保持します。
      </para>
@@ -142,13 +129,7 @@
   </note>
 
   <sect2 xml:id="sec-grub2-cfg">
-   <title><filename>/boot/grub2/grub.cfg</filename>ファイル</title><indexterm>
-   <primary>設定ファイル</primary>
-   <secondary>grub.cfg</secondary></indexterm><indexterm>
-   <primary>GRUB 2</primary>
-   <secondary>ブートメニュー</secondary></indexterm><indexterm>
-   <primary>GRUB 2</primary>
-   <secondary>grub.cfg</secondary></indexterm>
+   <title><filename>/boot/grub2/grub.cfg</filename>ファイル</title>
    <para>
     ブートメニューを含むグラフィカルスプラッシュ画面は、GRUB 2の設定ファイル<filename>/boot/grub2/grub.cfg</filename>に基づいており、このファイルにはメニューを使用してブートできるすべてのパーティションまたはオペレーティングシステムに関する情報が含まれています。
    </para>
@@ -161,11 +142,7 @@
   </sect2>
 
   <sect2 xml:id="sec-grub2-etc-default-grub">
-   <title><filename>/etc/default/grub</filename>ファイル</title><indexterm>
-   <primary>設定ファイル</primary>
-   <secondary> /etc/default/grub</secondary></indexterm><indexterm>
-   <primary> GRUB 2</primary>
-   <secondary> /etc/default/grub</secondary></indexterm>
+   <title><filename>/etc/default/grub</filename>ファイル</title>
    <para>
     ここには、メニューを表示するタイミングやブートするデフォルトのOSなど、GRUB 2のより一般的なオプションが含まれます。すべての使用可能なオプションについては、次のコマンドの出力を参照してください。
    </para>
@@ -422,9 +399,7 @@
   </sect2>
 
   <sect2 xml:id="sec-grub2-map">
-   <title>BIOSドライブとLinuxドライブのマッピング</title><indexterm>
-   <primary>GRUB 2</primary>
-   <secondary> device.map</secondary></indexterm>
+   <title>BIOSドライブとLinuxドライブのマッピング</title>
    <para>
     GRUB Legacyでは、<filename>device.map</filename>設定ファイルを使用して、BIOSドライブ番号からLinuxデバイス名を派生させていました。BIOSドライブとLinuxデバイスのマッピングは常に正しく推測できるとは限りません。たとえば、BIOS設定でIDEとSCSIのブートシーケンスが入れ替わると、GRUB Legacyは誤った順序を取得します。
    </para>
@@ -440,9 +415,7 @@
   </sect2>
 
   <sect2 xml:id="sec-grub2-menu-change">
-   <title>ブート手順実行中のメニューエントリの編集</title><indexterm>
-   <primary>GRUB 2</primary>
-   <secondary> メニューエディタ</secondary></indexterm>
+   <title>ブート手順実行中のメニューエントリの編集</title>
    <para>
     メニューエントリを直接編集できると、誤設定が原因でシステムがブートしなくなった場合に役立ちます。また、システム設定を変更せずに新しい設定をテストする場合にも使用できます。
    </para>
@@ -518,9 +491,7 @@
   </sect2>
 
   <sect2 xml:id="sec-grub2-password">
-   <title>ブートパスワードの設定</title><indexterm>
-   <primary>GRUB 2</primary>
-   <secondary> ブートパスワード</secondary></indexterm>
+   <title>ブートパスワードの設定</title>
    <para>
     GRUB 2は、オペレーティングシステムのブート前でも、ファイルシステムにアクセスできるようにします。rootパーミッションを持たないユーザは、システムのブート後、アクセス権のないLinuxシステム上のファイルにアクセスできます。この種のアクセスを阻止したり、ユーザによる特定のメニューエントリのブートを防止するために、ブートパスワードを設定できます。
    </para>

--- a/l10n/sles/ja-jp/xml/help_admin.xml
+++ b/l10n/sles/ja-jp/xml/help_admin.xml
@@ -6,10 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>ヘルプ</primary></indexterm><indexterm>
- <primary>ドキュメント</primary>
- <see>ヘルプ</see></indexterm>
+ </info>
  <para>
   <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase>ではさまざまな情報源とドキュメントが提供されており、その多くはインストール済みのシステムに統合されています。
  </para>
@@ -32,9 +29,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>デスクトップヘルプセンター<indexterm>
-    <primary>ヘルプ</primary>
-    <secondary>ヘルプセンター</secondary></indexterm>
+   <term>デスクトップヘルプセンター
    </term>
    <listitem>
     <para>
@@ -55,10 +50,7 @@
   <title>ドキュメントディレクトリ</title>
 
   <para>
-   <indexterm>
-   <primary>ヘルプ</primary>
-   <secondary>/usr/share/doc</secondary>
-   </indexterm>インストールされたLinuxシステム上のドキュメント検索用の従来のディレクトリは、<filename>/usr/share/doc</filename>です。このディレクトリには通常、リリースノート、マニュアルなどに加えて、システムにインストールされたパッケージに関する情報が含まれます。
+   インストールされたLinuxシステム上のドキュメント検索用の従来のディレクトリは、<filename>/usr/share/doc</filename>です。このディレクトリには通常、リリースノート、マニュアルなどに加えて、システムにインストールされたパッケージに関する情報が含まれます。
   </para>
 
   <note>
@@ -71,12 +63,7 @@
   <sect2 xml:id="sec-help-onboard-docdir-manual">
    <title>SUSEマニュアル</title>
    <para>
-    <indexterm>
-    <primary>ヘルプ</primary>
-    <secondary>SUSEマニュアル</secondary>
-    </indexterm> <indexterm>
-    <primary>SUSEマニュアル</primary>
-    </indexterm> これらのガイドブックは、HTMLおよびPDFの各バージョンが複数の言語で提供されています。<filename>manual</filename>サブディレクトリには、製品で使用可能な大半のSUSEマニュアルのHTMLバージョンがあります。製品で使用可能なすべての文書の概要については、マニュアルの序文を参照してください。
+      これらのガイドブックは、HTMLおよびPDFの各バージョンが複数の言語で提供されています。<filename>manual</filename>サブディレクトリには、製品で使用可能な大半のSUSEマニュアルのHTMLバージョンがあります。製品で使用可能なすべての文書の概要については、マニュアルの序文を参照してください。
    </para>
    <para>
     複数の言語がインストールされている場合、<filename>/usr/share/doc/manual</filename>には異なる言語版のマニュアルが含まれる場合があります。SUSEマニュアルのHTMLバージョンは、両デスクトップのヘルプセンターでも利用可能です。インストールメディアでの文書のPDF版およびHTML版の検索場所については、<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>のリリースノートを参照してください。これらの文書は、インストールされたシステムの<filename>/usr/share/doc/release-notes/</filename>、またはオンラインの製品固有のWebページ(<link os="sles;sled" xlink:href="http://www.suse.com/releasenotes/"/>)で参照できます。
@@ -87,10 +74,7 @@
   <sect2 xml:id="sec-help-onboard-docdir-pkg">
    <title>パッケージのマニュアル</title>
    <para>
-    <indexterm>
-    <primary>ヘルプ</primary>
-    <secondary>パッケージドキュメント</secondary>
-    </indexterm><filename>packages</filename>の下で、システムにインストールしたソフトウェアパッケージに含まれているドキュメントを見つけてください。各パッケージについて、サブディレクトリ<filename>/usr/share/doc/packages/<replaceable>PACKAGENAME</replaceable></filename>が作成されます。このサブディレクトリには、パッケージのREADMEファイルが含まれます。さらにサンプル、環境設定ファイル、または追加スクリプトが含まれることがあります。次のリストに、<filename>/usr/share/doc/packages</filename>の下にある一般的なファイルを示します。これらのエントリはいずれも必須ではなく、多くのパッケージがその一部のみを含みます。
+    <filename>packages</filename>の下で、システムにインストールしたソフトウェアパッケージに含まれているドキュメントを見つけてください。各パッケージについて、サブディレクトリ<filename>/usr/share/doc/packages/<replaceable>PACKAGENAME</replaceable></filename>が作成されます。このサブディレクトリには、パッケージのREADMEファイルが含まれます。さらにサンプル、環境設定ファイル、または追加スクリプトが含まれることがあります。次のリストに、<filename>/usr/share/doc/packages</filename>の下にある一般的なファイルを示します。これらのエントリはいずれも必須ではなく、多くのパッケージがその一部のみを含みます。
    </para>
    <variablelist>
     <varlistentry>
@@ -191,11 +175,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-help-onboard-manpages">
-  <title>manページ</title><indexterm>
-
-  <primary>ヘルプ</primary>
-
-  <secondary>マニュアルページ</secondary></indexterm>
+  <title>manページ</title>
 
   <para>
    マニュアルページは、どのLinuxシステムにおいても重要な役割を担っています。マニュアルページでは、コマンドと利用可能なオプションおよびパラメータについての使用法が説明されています。マニュアルページは、<command>man</command>の後にコマンド名(たとえば「<command>man ls</command>」)を入力して開くことができます。
@@ -340,22 +320,14 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-help-onboard-infopages">
-  <title>情報ページ</title><indexterm>
-
-  <primary>ヘルプ</primary>
-
-  <secondary>情報ページ</secondary></indexterm>
+  <title>情報ページ</title>
 
   <para>
    情報ページは、システム上にあるもう1つの重要な情報ソースです。 通常、情報ページの内容はマニュアルページよりも詳細です。これらはコマンドラインオプションよりも詳細な情報で構成され、チュートリアルやリファレンスマニュアル全体が含まれている場合もあります。特定のコマンドの情報ページを表示するには、<command>info</command>の後にコマンド名(たとえば「<command>info ls</command>」)を入力します。シェルで直接ビューアを使用してinfoページを参照し、<quote>ノード</quote>と呼ばれるさまざまなセクションを表示できます。<keycap function="space"/>を使用して前に移動し、<keycap function="backspace"/>を使用して後ろに移動します。ノード内で、<keycap function="pageup"/>および<keycap function="pagedown"/>を使用して参照することもできますが、前および後ろのノードにも移動できるのは<keycap function="space"/>および<keycap function="backspace"/>のみです。<keycap>Q</keycap>を押すと、表示モードを終了します。すべてのコマンドに情報ページが付属するわけではありません。逆も同様です。
   </para>
  </sect1>
  <sect1 xml:id="sec-help-online">
-  <title>リソースのオンライン化</title><indexterm>
-
-  <primary>ヘルプ</primary>
-
-  <secondary>オンラインヘルプ</secondary></indexterm>
+  <title>リソースのオンライン化</title>
 
   <para>
    オンラインバージョンのSUSEマニュアル(<filename>/usr/share/doc</filename>にインストールされます)に加えて、Webで製品固有のマニュアルやドキュメントにアクセスすることもできます。<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>用に提供されているすべてのマニュアルの概要については、<phrase os="sles;sled"><link xlink:href="http://www.suse.com/doc/"/></phrase>にある製品ごとのマニュアルに関するWebページをご覧してください。

--- a/l10n/sles/ja-jp/xml/help_user.xml
+++ b/l10n/sles/ja-jp/xml/help_user.xml
@@ -12,16 +12,11 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-help">
- <primary>ヘルプ</primary></indexterm><indexterm>
- <primary>ドキュメント</primary>
- <see>ヘルプ</see></indexterm>
+ </info>
 
  <variablelist>
   <varlistentry>
-   <term>デスクトップヘルプセンター<indexterm>
-    <primary>ヘルプ</primary>
-    <secondary>ヘルプセンター</secondary></indexterm>
+   <term>デスクトップヘルプセンター
    </term>
    <listitem>
     <para>
@@ -56,11 +51,7 @@
   </varlistentry>
  </variablelist>
  <sect1 xml:id="sec-help-onboard-yelp">
-  <title>GNOMEヘルプの使用</title><indexterm>
-
-  <primary>ヘルプ</primary>
-
-  <secondary>ヘルプ</secondary></indexterm>
+  <title>GNOMEヘルプの使用</title>
 
   <para>
    GNOMEデスクトップでアプリケーションから直接ヘルプを起動するには、<guimenu>Help (ヘルプ)</guimenu>ボタンをクリックするか、または<keycap>F1</keycap>を押します。どちらのオプションでもヘルプセンターのアプリケーションのマニュアルに直接アクセスできます。ただし、ターミナルを開いて「<command>yelp</command>」と入力するか、またはメインメニューから<menuchoice><guimenu>アプリケーション</guimenu>
@@ -91,9 +82,7 @@
   <title>追加のヘルプリソース</title>
 
   <para>
-   <indexterm>
-   <primary>ヘルプ</primary>
-   <secondary>オンラインマニュアル</secondary> </indexterm> <filename>/usr/share/doc</filename>にインストールされたSUSEマニュアルに加えて、Webで製品固有のマニュアルやドキュメントにアクセスすることもできます。<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>用に提供されているすべてのマニュアルの概要については、<link os="sles;sled" xlink:href="https://documentation.suse.com/"/>にある製品ごとのマニュアルに関するWebページをご覧してください。
+    <filename>/usr/share/doc</filename>にインストールされたSUSEマニュアルに加えて、Webで製品固有のマニュアルやドキュメントにアクセスすることもできます。<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>用に提供されているすべてのマニュアルの概要については、<link os="sles;sled" xlink:href="https://documentation.suse.com/"/>にある製品ごとのマニュアルに関するWebページをご覧してください。
   </para>
 
   <para>
@@ -141,29 +130,20 @@
   </para>
 
   <sect2 xml:id="sec-help-more-tldp">
-   <title>Linux Documentation Project</title><indexterm>
-   <primary>TLDP</primary></indexterm><indexterm>
-   <primary>ヘルプ</primary>
-   <secondary>Linuxマニュアルプロジェクト(TLDP)</secondary></indexterm>
+   <title>Linux Documentation Project</title>
    <para>
     TLDP(Linux Documentation Project)は、Linux関係のマニュアルを作成するボランティアチームによって運営されています(<link xlink:href="http://www.tldp.org"/>を参照)。マニュアルのセットには初心者向けのチュートリアルも含まれますが、主にシステム管理者などの経験者向けの内容になっています。TLDPは、Howto(操作方法)、FAQ(よくある質問)、ガイド(ハンドブック)を無償で提供しています。TLDPからのマニュアルの一部は、<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>上でも利用できます。
    </para>
 
 
    <sect3 xml:id="sec-helpmore-tldp-faq">
-    <title>FAQ (よくある質問と答え)</title><indexterm>
-    <primary>ヘルプ</primary>
-    <secondary>TLDP</secondary>
-    <tertiary>FAQ</tertiary></indexterm>
+    <title>FAQ (よくある質問と答え)</title>
     <para>
      FAQ(よくある質問)は、一連の質問と回答をまとめたものです。FAQはもともと、初歩的な同じ質問が繰り返し投稿されるのを減らすため、Usenetニュースグループが始めたものです。
     </para>
    </sect3>
    <sect3 xml:id="sec-helpmore-tldp-guides">
-    <title>ガイド</title><indexterm>
-    <primary>ヘルプ</primary>
-    <secondary>TLDP</secondary>
-    <tertiary>ガイド</tertiary></indexterm>
+    <title>ガイド</title>
     <para>
      さまざまなトピックまたはプログラムのマニュアルやガイドは<link xlink:href="http://www.tldp.org/guides.html"/>から参照できます。『<citetitle>Bash Guide for Beginners (初心者のためのBashガイド)</citetitle>』から『<citetitle>Linux File System Hierarchy </citetitle>』、『<citetitle>Linux Administrator's Security Guide (Linux管理者のセキュリティガイド)</citetitle>』などがあります。一般に、ガイドブックの内容はHowtoやFAQよりも、詳細な情報を網羅しています。これらのガイドブックは通常、上級者によって執筆されており、内容も上級者向けです。
     </para>
@@ -175,9 +155,7 @@
 
 
   <sect2 xml:id="sec-help-more-wikipedia">
-   <title>Wikipedia:無償のオンライン百科事典</title><indexterm>
-   <primary>ヘルプ</primary>
-   <secondary>Wikipedia</secondary></indexterm>
+   <title>Wikipedia:無償のオンライン百科事典</title>
    <remark>Translators: Translate the link http://en.wikipedia.org into your language: Replace "en"
     with your ISO language code.</remark>
    <para>
@@ -186,11 +164,7 @@
   </sect2>
 
   <sect2 xml:id="sec-help-more-standards">
-   <title>規格と仕様</title><indexterm>
-   <primary>ヘルプ</primary>
-   <secondary>規格</secondary></indexterm><indexterm>
-   <primary>ヘルプ</primary>
-   <secondary>仕様</secondary></indexterm>
+   <title>規格と仕様</title>
    <para>
     規格と仕様に関する情報は、さまざまな情報源から提供されます。
    </para>

--- a/l10n/sles/ja-jp/xml/lvm.xml
+++ b/l10n/sles/ja-jp/xml/lvm.xml
@@ -7,19 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>YaST</primary>
-
- <secondary>LVM</secondary></indexterm><indexterm>
-
- <primary>LVM</primary>
-
- <secondary>YaST</secondary></indexterm><indexterm>
-
- <primary>論理ボリュームマネージャ</primary>
-
- <see>LVM</see></indexterm>
+ </info>
 
  <para>
   このセクションでは、LVMを設定する詳細なステップについて説明します。<phrase os="sles">一般的な論理ボリュームマネージャの情報については、<xref linkend="sec-lvm-explained"/>を参照してください。</phrase>

--- a/l10n/sles/ja-jp/xml/mobile.xml
+++ b/l10n/sles/ja-jp/xml/mobile.xml
@@ -11,36 +11,16 @@
     モバイルコンピューティングという言葉から連想されるのはラップトップ、PDA、携帯電話、そしてこれらを使ったデータ交換ではないでしょうか。外付けハードディスク、フラッシュディスク、デジタルカメラなどのモバイルハードウェアコンポーネントは、ラップトップやデスクトップシステムに接続できます。多くのソフトウェアコンポーネントで、モバイルコンピューティングを想定しており、一部のアプリケーションは、モバイル使用に合わせて特別に作成されています。
    </para>
   </abstract>
- </info><indexterm xml:id="idx-mobility" class="startofrange">
- <primary>モビリティ</primary></indexterm>
+ </info>
  <sect1 xml:id="sec-mobile-nbook">
-  <title>ラップトップ</title><indexterm class="startofrange" xml:id="idx-notebook">
-
-  <primary>ラップトップ</primary></indexterm><indexterm>
-
-  <primary>ラップトップ</primary>
-
-  <secondary>ハードウェア</secondary></indexterm><indexterm>
-
-  <primary>ラップトップ</primary>
-
-  <secondary>PCMCIA</secondary></indexterm><indexterm>
-
-  <primary>PCMCIA</primary></indexterm><indexterm>
-
-  <primary>モビリティ</primary>
-
-  <secondary>ラップトップ</secondary></indexterm>
+  <title>ラップトップ</title>
 
   <para>
    ラップトップのハードウェアは通常のデスクトップシステムとは異なります。これは交換可能性、空間要件、電力消費などの基準を考慮する必要があるためです。モバイルハードウェアメーカーは、ラップトップハードウェアを拡張するために使用可能なPCMCIA(Personal Computer Memory Card International Association)、Mini PCI、Mini PCIeなどの標準インタフェースを開発してきました。この標準はメモリカード、ネットワークインタフェースカード、および外部ハードディスクをカバーします。
   </para>
 
   <sect2 xml:id="sec-mobile-powerm">
-   <title>電源消費量</title><indexterm>
-   <primary>ラップトップ</primary>
-   <secondary>電源消費量</secondary></indexterm><indexterm>
-   <primary>電源管理</primary></indexterm>
+   <title>電源消費量</title>
    <para>
     ラップトップの製造時、消費電力を最適化したシステムコンポーネントを組み込むことで、電源に接続しなくてもシステムを快適に使用できるようにしています。電源の管理に関するこうした貢献は少なくともオペレーティングシステムの貢献度と同じくらい重要です。<phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase>はラップトップの電源消費量を制御するさまざまな方法をサポートすることで、バッテリー使用時の動作時間に数々の効果をあげています。次のリストでは電源消費量節約への貢献度の高い順に各項目を示します。
    </para>
@@ -77,8 +57,7 @@
   </sect2>
 
   <sect2 xml:id="sec-mobile-nbook-change">
-   <title>操作環境の変化の統合</title><indexterm>
-   <primary>ラップトップ</primary></indexterm>
+   <title>操作環境の変化の統合</title>
    <para>
     モバイルコンピューティングに使用する場合、ご使用のシステムを操作環境の変化に順応させる必要があります。多くのサービスは環境に依存するので、環境を構成するクライアントの再設定が必要です。<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>がこのタスクを処理します。
    </para>
@@ -138,12 +117,7 @@
      <term>NetworkManager</term>
      <listitem>
       <para>
-       <indexterm>
-       <primary>NetworkManager</primary>
-       </indexterm> <indexterm>
-       <primary>ラップトップ</primary>
-       <secondary>NetworkManager</secondary>
-       </indexterm> NetworkManagerは、特にラップトップでのモバイルネットワーキング用に調整されています。NetworkManagerは、ネットワーク環境間、またはモバイルブロードバンド(GPRS、EDGE、または3G)、ワイヤレスLAN、Ethernetなどのさまざまなタイプのネットワーク間を容易に、自動的に切り替える方法を提供します。NetworkManagerは、ワイヤレスLANでのWEPおよびWPA-PSKの暗号化をサポートします。また、ダイアルアップ接続もサポートします。GNOMEデスクトップには、NetworkManagerのフロントエンドが含まれています。詳細については、<xref linkend="sec-nm-configure"/>を参照してください。
+         NetworkManagerは、特にラップトップでのモバイルネットワーキング用に調整されています。NetworkManagerは、ネットワーク環境間、またはモバイルブロードバンド(GPRS、EDGE、または3G)、ワイヤレスLAN、Ethernetなどのさまざまなタイプのネットワーク間を容易に、自動的に切り替える方法を提供します。NetworkManagerは、ワイヤレスLANでのWEPおよびWPA-PSKの暗号化をサポートします。また、ダイアルアップ接続もサポートします。GNOMEデスクトップには、NetworkManagerのフロントエンドが含まれています。詳細については、<xref linkend="sec-nm-configure"/>を参照してください。
       </para>
       <table>
        <title>NetworkManagerの使用</title>
@@ -229,12 +203,7 @@
      <term>SLP</term>
      <listitem>
       <para>
-       <indexterm>
-       <primary>ラップトップ</primary>
-       <secondary>SLP</secondary>
-       </indexterm> <indexterm>
-       <primary>SLP</primary>
-       </indexterm>サービスロケーションプロトコル(SLP)は既存のネットワークでのラップトップの接続を容易にします。SLPがなければラップトップの管理者は通常ネットワークで使用可能なサービスに関する詳細な知識が必要になります。SLPはローカルネットワーク上のすべてのクライアントに対し、使用可能な特定のタイプのサービスについてブロードキャストします。SLPをサポートするアプリケーションはSLPとは別に情報を処理し、自動的に設定することが可能です。SLPはシステムのインストールにも使用でき、適切なインストールソースの検索作業が最小化されます。<phrase os="sles;osuse">SLPの詳細については、<xref linkend="cha-slp"/>を参照してください。</phrase>
+        サービスロケーションプロトコル(SLP)は既存のネットワークでのラップトップの接続を容易にします。SLPがなければラップトップの管理者は通常ネットワークで使用可能なサービスに関する詳細な知識が必要になります。SLPはローカルネットワーク上のすべてのクライアントに対し、使用可能な特定のタイプのサービスについてブロードキャストします。SLPをサポートするアプリケーションはSLPとは別に情報を処理し、自動的に設定することが可能です。SLPはシステムのインストールにも使用でき、適切なインストールソースの検索作業が最小化されます。<phrase os="sles;osuse">SLPの詳細については、<xref linkend="cha-slp"/>を参照してください。</phrase>
       </para>
      </listitem>
     </varlistentry>
@@ -247,8 +216,7 @@
     モバイル用途には、専用ソフトウェアにより対応されるシステムモニタリング(特にバッテリの充電)、データ同期、周辺機器との無線通信、インターネットなど、さまざまなタスク領域が存在します。以降のセクションでは、<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>が各タスクに提供する最も重要なアプリケーションについて説明します。
    </para>
    <sect3 xml:id="sec-mobile-nbook-soft-mon">
-    <title>システムモニタリング</title><indexterm>
-    <primary>システムモニタリング</primary></indexterm>
+    <title>システムモニタリング</title>
     <para>
      <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>では2種類のシステムモニタリングツールを提供しています。
     </para>
@@ -257,12 +225,7 @@
       <term>電源管理</term>
       <listitem>
        <para>
-        <indexterm>
-        <primary>システムモニタリング</primary>
-        <secondary>電源管理</secondary>
-        </indexterm> <indexterm>
-        <primary>電源管理</primary>
-        </indexterm> <guimenu>電源管理</guimenu>は、GNOMEデスクトップの省エネルギー関係の動作を調整できるアプリケーションです。通常は、<menuchoice><guimenu>コンピュータ</guimenu> <guimenu>コントロールセンター</guimenu> <guimenu>システム</guimenu> <guimenu>電源管理</guimenu></menuchoice>を介してアクセスします。
+          <guimenu>電源管理</guimenu>は、GNOMEデスクトップの省エネルギー関係の動作を調整できるアプリケーションです。通常は、<menuchoice><guimenu>コンピュータ</guimenu> <guimenu>コントロールセンター</guimenu> <guimenu>システム</guimenu> <guimenu>電源管理</guimenu></menuchoice>を介してアクセスします。
        </para>
       </listitem>
      </varlistentry>
@@ -270,10 +233,7 @@
       <term>システムモニタ</term>
       <listitem>
        <para>
-        <indexterm>
-        <primary>システムモニタリング</primary>
-        <secondary>システムモニタ</secondary>
-        </indexterm><guimenu>システムモニタ</guimenu>は、測定可能なシステムパラメータを1つのモニタリング環境に集めます。このモニタは、デフォルトでは、3つのタブに出力情報を表示します。<guimenu>プロセス</guimenu>は、CPUロード、メモリ使用量、プロセスのID番号と優先度など、現在実行中のプロセスの詳細情報を提供します。収集されたデータの表示とフィルタリングをカスタマイズできます。新しいタイプのプロセス情報を追加するには、プロセステーブルのヘッダを左クリックして、隠したい列やビューに追加したい列を選択します。さまざまなデータページで各種のシステムパラメータを監視したり、ネットワーク上でさまざまなマシンにあるデータを並行して収集したりすることも可能です。<guimenu>リソース</guimenu>タブには、CPU、メモリ、およびネットワークの履歴のグラフが表示され、<guimenu>ファイルシステム</guimenu>タブにはすべてのパーティションとその使用量が一覧にされます。
+        <guimenu>システムモニタ</guimenu>は、測定可能なシステムパラメータを1つのモニタリング環境に集めます。このモニタは、デフォルトでは、3つのタブに出力情報を表示します。<guimenu>プロセス</guimenu>は、CPUロード、メモリ使用量、プロセスのID番号と優先度など、現在実行中のプロセスの詳細情報を提供します。収集されたデータの表示とフィルタリングをカスタマイズできます。新しいタイプのプロセス情報を追加するには、プロセステーブルのヘッダを左クリックして、隠したい列やビューに追加したい列を選択します。さまざまなデータページで各種のシステムパラメータを監視したり、ネットワーク上でさまざまなマシンにあるデータを並行して収集したりすることも可能です。<guimenu>リソース</guimenu>タブには、CPU、メモリ、およびネットワークの履歴のグラフが表示され、<guimenu>ファイルシステム</guimenu>タブにはすべてのパーティションとその使用量が一覧にされます。
        </para>
       </listitem>
      </varlistentry>
@@ -289,13 +249,7 @@
       <term>電子メールの同期化</term>
       <listitem>
        <para>
-        <indexterm>
-        <primary>データの同期</primary>
-        <secondary>電子メール</secondary>
-        </indexterm> <indexterm>
-        <primary>電子メール</primary>
-        <secondary>同期</secondary>
-        </indexterm> オフィスネットワークで電子メールを保存するためにIMAPアカウントを使用します。これで、<xref linkend="book-gnomeuser"/>に記載されているとおり、Mozilla ThunderbirdやEvolutionなどの切断型IMAP対応電子メールクライアントを使用するワークステーションから電子メールにアクセスできるようになります。<literal>送信メッセージ</literal>で常に同じフォルダを使用するには、電子メールクライアントでの設定が必要になります。また、この機能により、同期プロセスが完了した時点でステータス情報とともにすべてのメッセージが使用可能になります。未送信メールについての信頼できるフィードバックを受信するためには、システム全体で使用されるMTA postfixまたはsendmailの代わりに、メッセージ送信用のメールクライアントに実装されたSMTPサーバーを使用します。
+          オフィスネットワークで電子メールを保存するためにIMAPアカウントを使用します。これで、<xref linkend="book-gnomeuser"/>に記載されているとおり、Mozilla ThunderbirdやEvolutionなどの切断型IMAP対応電子メールクライアントを使用するワークステーションから電子メールにアクセスできるようになります。<literal>送信メッセージ</literal>で常に同じフォルダを使用するには、電子メールクライアントでの設定が必要になります。また、この機能により、同期プロセスが完了した時点でステータス情報とともにすべてのメッセージが使用可能になります。未送信メールについての信頼できるフィードバックを受信するためには、システム全体で使用されるMTA postfixまたはsendmailの代わりに、メッセージ送信用のメールクライアントに実装されたSMTPサーバーを使用します。
        </para>
       </listitem>
      </varlistentry>
@@ -303,18 +257,14 @@
       <term>ファイルとディレクトリの同期</term>
       <listitem>
        <para>
-        <indexterm>
-        <primary>データの同期</primary>
-        </indexterm> ラップトップとワークステーション間のデータの同期に対応するユーティリティが複数あります。最もよく使用されるものには、<command>rsync</command>というコマンドラインツールがあります。詳細については、そのマニュアルページを参照してください(<command>man 1 rsync</command>)。
+         ラップトップとワークステーション間のデータの同期に対応するユーティリティが複数あります。最もよく使用されるものには、<command>rsync</command>というコマンドラインツールがあります。詳細については、そのマニュアルページを参照してください(<command>man 1 rsync</command>)。
        </para>
       </listitem>
      </varlistentry>
     </variablelist>
    </sect3>
    <sect3 xml:id="sec-mobile-nbook-soft-wifi">
-    <title>ワイヤレス通信: Wi-Fi</title><indexterm>
-    <primary>ネットワーク</primary>
-    <secondary> Wi-Fi</secondary></indexterm>
+    <title>ワイヤレス通信: Wi-Fi</title>
     <para>
      Wi-Fiは、これらのワイヤレステクノロジの中では最大規模で、規模が大きく、ときに物理的に離れているネットワークでの運用に適している唯一のテクノロジと言えます。個々のマシンを相互に接続して、独立したワイヤレスネットワークを構築することも、インターネットにアクセスすることも可能です。<emphasis/>「アクセスポイント」と呼ばれるデバイスがWi-Fi対応デバイスの基地局として機能し、インターネットへのアクセスの中継点としての役目を果たします。モバイルユーザは、場所や、どのアクセスポイントが最適な接続を提供するかに応じてさまざまなアクセスポイントを切り替えることができます。Wi-Fiユーザは携帯電話網と同様の、特定のアクセス場所にとらわれる必要のない大規模ネットワークを使用できます。
     </para>
@@ -579,34 +529,19 @@
    <sect3 xml:id="sec-mobile-nbook-soft-bluetooth">
     <title>ワイヤレス通信: Bluetooth</title>
     <para>
-     <indexterm>
-     <primary>ネットワーク</primary>
-     <secondary>Bluetooth</secondary>
-     </indexterm> <indexterm>
-     <primary>Bluetooth</primary>
-     </indexterm> Bluetoothはすべての無線テクノロジに対するブロードキャストアプリケーション周波数を使用します。BluetoothはIrDAのように、コンピュータ(ラップトップ)およびPDAまたは携帯電話間で通信するために使用できます。また範囲内に存在する別のコンピュータと接続するために使用することもできます。Bluetoothは、キーボードやマウスなど無線システムコンポーネントとの接続にも用いられます。ただし、このテクノロジはリモートシステムをネットワークに接続するほどには至っていません。壁のような物理的な障害物をはさんで行う通信にはWi-Fiテクノロジが適しています。
+       Bluetoothはすべての無線テクノロジに対するブロードキャストアプリケーション周波数を使用します。BluetoothはIrDAのように、コンピュータ(ラップトップ)およびPDAまたは携帯電話間で通信するために使用できます。また範囲内に存在する別のコンピュータと接続するために使用することもできます。Bluetoothは、キーボードやマウスなど無線システムコンポーネントとの接続にも用いられます。ただし、このテクノロジはリモートシステムをネットワークに接続するほどには至っていません。壁のような物理的な障害物をはさんで行う通信にはWi-Fiテクノロジが適しています。
     </para>
    </sect3>
    <sect3 xml:id="sec-mobile-nbook-soft-irda">
     <title>ワイヤレス通信: IrDA</title>
     <para>
-     <indexterm>
-     <primary>ネットワーク</primary>
-     <secondary>IrDA</secondary>
-     </indexterm> <indexterm>
-     <primary>IrDA</primary>
-     </indexterm> IrDAは狭い範囲での無線テクノロジです。通信を行う両者は相手の見える位置にいなくてはなりません。壁のような障害物をはさむことはできません。IrDAで利用できるアプリケーションはラップトップと携帯電話間でファイルの転送を行うアプリケーションです。ラップトップから携帯電話までの距離が短い場合はIrDAを使用できます。受信者へのファイルの長距離送信はモバイルネットワークで処理します。IrDAのもう1つのアプリケーションは、オフィスでの印刷ジョブを無線転送するアプリケーションです。
+       IrDAは狭い範囲での無線テクノロジです。通信を行う両者は相手の見える位置にいなくてはなりません。壁のような障害物をはさむことはできません。IrDAで利用できるアプリケーションはラップトップと携帯電話間でファイルの転送を行うアプリケーションです。ラップトップから携帯電話までの距離が短い場合はIrDAを使用できます。受信者へのファイルの長距離送信はモバイルネットワークで処理します。IrDAのもう1つのアプリケーションは、オフィスでの印刷ジョブを無線転送するアプリケーションです。
     </para>
    </sect3>
   </sect2>
 
   <sect2 xml:id="sec-mobile-nbook-sec">
-   <title>データのセキュリティ</title><indexterm>
-   <primary>モビリティ</primary>
-   <secondary>データのセキュリティ</secondary></indexterm><indexterm>
-   <primary>セキュリティ</primary>
-   <secondary>暗号化ファイルシステム</secondary></indexterm><indexterm>
-   <primary>データのセキュリティ</primary></indexterm>
+   <title>データのセキュリティ</title>
    <para>
     無認証のアクセスに対し、複数の方法でラップトップ上のデータを保護するのが理想的です。実行可能なセキュリティ対策は次の領域になります。
    </para>
@@ -649,43 +584,11 @@
       </para>
      </listitem>
     </varlistentry>
-   </variablelist><indexterm class="endofrange" startref="idx-notebook"/>
+   </variablelist>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-mobile-hw">
-  <title>モバイルハードウェア</title><indexterm>
-
-  <primary>モビリティ</primary>
-
-  <secondary>USB</secondary></indexterm><indexterm>
-
-  <primary>モビリティ</primary>
-
-  <secondary>FireWire (IEEE1394)</secondary></indexterm><indexterm>
-
-  <primary>FireWire (IEEE1394)</primary>
-
-  <secondary>ハードディスク</secondary></indexterm><indexterm>
-
-  <primary>USB</primary>
-
-  <secondary>ハードディスク</secondary></indexterm><indexterm>
-
-  <primary>USB</primary>
-
-  <secondary>フラッシュドライブ</secondary></indexterm><indexterm>
-
-  <primary>フラッシュドライブ</primary></indexterm><indexterm>
-
-  <primary>モビリティ</primary>
-
-  <secondary>外部ハードディスク</secondary></indexterm><indexterm>
-
-  <primary>モビリティ</primary>
-
-  <secondary>デジタルカメラ</secondary></indexterm><indexterm>
-
-  <primary>デジタルカメラ</primary></indexterm>
+  <title>モバイルハードウェア</title>
 
   <para>
    <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>はFireWire (IEEE 1394)またはUSB経由のモバイルストレージデバイスを自動検出します。<emphasis/>「モバイルストレージデバイス」という用語は、FireWire、ハードディスク、USBフラッシュディスク、デジタルカメラのいずれにも適用されます。これらのデバイスは、対応するインタフェースを介してシステムに接続されると、自動的に検出されて設定されます。GNOMEのファイルマネージャは、モバイルハードウェアアイテムを柔軟に処理します。これらのメディアを安全にアンマウントするには、ファイルマネージャの<guimenu>ボリュームのマウント解除</guimenu>(GNOME)機能を使用します。詳細については、<xref linkend="book-gnomeuser"/>を参照してください。
@@ -717,19 +620,7 @@
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-mobile-comm">
-  <title>モバイルデバイス(スマートフォンおよびタブレット)</title><indexterm>
-
-  <primary>モビリティ</primary>
-
-  <secondary>スマートフォン</secondary></indexterm><indexterm>
-
-  <primary>モビリティ</primary>
-
-  <secondary>タブレット</secondary></indexterm><indexterm>
-
-  <primary>スマートフォン</primary></indexterm><indexterm>
-
-  <primary>タブレット</primary></indexterm>
+  <title>モバイルデバイス(スマートフォンおよびタブレット)</title>
 
   <para>
    デスクトップシステムまたはラップトップは、Bluetooth、Wi-Fi、または直接USB接続を介してモバイルデバイスと通信できます。接続方法の選択は、ご使用のモバイルデバイスのモデルおよび固有のニーズによって異なります。USBを介してモバイルデバイスをデスクトップマシンまたはラップトップに接続すると、通常、便利な外部ストレージとしてデバイスを使用できます。BluetoothまたはWi-Fi接続を設定すると、モバイルデバイスを操作し、デスクトップマシンまたはラップトップから直接その機能を制御できるようになります。接続されたモバイルデバイスを制御するために使用可能ないくつかのオープンソースグラフィカルユーティリティ(<link xlink:href="https://community.kde.org/KDEConnect">KDE Connect</link>と<link xlink:href="https://extensions.gnome.org/extension/1319/gsconnect/">GSConnect</link>が有名)があります。

--- a/l10n/sles/ja-jp/xml/net_config_files.xml
+++ b/l10n/sles/ja-jp/xml/net_config_files.xml
@@ -7,10 +7,7 @@
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
-<indexterm>
- <primary> 環境設定ファイル</primary></indexterm><indexterm xml:id="idx-networks-configuration-files" class="startofrange">
- <primary>ネットワーク</primary>
- <secondary>環境設定ファイル </secondary></indexterm>
+
  <para>
   ここでは、ネットワークの環境設定ファイルの概要を紹介し、その目的と使用される形式について説明します。
  </para>
@@ -82,21 +79,13 @@ MACVLAN_DEVICE='eth0'
   <para>
    <filename>ifcfg.template</filename>については、<xref linkend="sec-basicnet-manconf-files-config-etc"/>を参照してください。
   </para>
-<indexterm>
-  <primary> 環境設定ファイル</primary>
-  <secondary> ifcfg-*</secondary></indexterm> 
+ 
   <para arch="zseries" os="sles">
    IBM Zは、USBをサポートしていません。インタフェースファイル名とネットワークエイリアスには、<literal>qeth</literal>のようなIBM Z固有の要素が含まれます。
   </para>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-config-etc">
-  <title><filename>/etc/sysconfig/network/config</filename>、<filename>/etc/sysconfig/network/dhcp</filename>、および<filename>/etc/sysconfig/network/wireless</filename></title><indexterm>
-  <primary> 環境設定ファイル</primary>
-  <secondary> ネットワーク</secondary></indexterm><indexterm>
-  <primary>   環境設定ファイル</primary>
-  <secondary> dhcp</secondary></indexterm><indexterm>
-  <primary>   環境設定ファイル</primary>
-  <secondary> ワイヤレス</secondary></indexterm> 
+  <title><filename>/etc/sysconfig/network/config</filename>、<filename>/etc/sysconfig/network/dhcp</filename>、および<filename>/etc/sysconfig/network/wireless</filename></title>
   <para>
    <filename>config</filename>ファイルには、<command>ifup</command>、<command>ifdown</command>、および<command>ifstatus</command>の動作に関する汎用的な設定が記述されています。また、<filename>dhcp</filename>にはDHCPの設定が、<filename>wireless</filename>には無線LANカードの設定が記述されています。3つの環境設定ファイル内の変数にはコメントが付きます。<filename>/etc/sysconfig/network/config</filename>の一部の変数は、<filename>ifcfg-*</filename>ファイルでも使用できます。このファイルでは、それらの変数がより高い優先順位で処理されます。<filename>/etc/sysconfig/network/ifcfg.template</filename>ファイルは、インタフェースごとに指定できる変数を一覧表示します。ただし、<filename>/etc/sysconfig/network/config</filename>の変数の大半はグローバル変数であり、ifcfgファイル内で上書きすることはできません。たとえば、<systemitem>NETWORKMANAGER</systemitem>や<systemitem>NETCONFIG_*</systemitem>は、グローバル変数です。
   </para>
@@ -115,19 +104,9 @@ MACVLAN_DEVICE='eth0'
 
  <sect3 xml:id="sec-basicnet-manconf-files-routes">
   <title><filename>/etc/sysconfig/network/routes</filename>と<filename>/etc/sysconfig/network/ifroute-*</filename></title>
-<indexterm xml:id="idx-routing" class="startofrange">
-  <primary>ルーティング</primary></indexterm><indexterm>
-  <primary>ルーティング</primary>
-  <secondary>経路</secondary></indexterm><indexterm>
-  <primary>環境設定ファイル</primary>
-  <secondary>経路</secondary></indexterm><indexterm>
-  <primary>設定</primary>
-  <secondary>ルーティング</secondary></indexterm>
+
   <para>
-   TCP/IPパケットのスタティックルーティングは、<filename>/etc/sysconfig/network/routes</filename>および<filename>/etc/sysconfig/network/ifroute-*</filename>ファイルによって決定されます。ホストへのルート、ゲートウェイ経由のホストへのルート、およびネットワークへのルートなど、さまざまなシステムタスクが必要とするすべてのスタティックルートは、<filename>/etc/sysconfig/network/routes</filename>ファイルに指定できます。個別のルーティングが必要な各インタフェースに対して、付加環境設定ファイル<filename>/etc/sysconfig/network/ifroute-*</filename>を定義します。ワイルドカード(<literal>*</literal>)はインタフェース名で読み替えてください。経路の環境設定ファイルのエントリは次のようになります。<indexterm>
-   <primary>ルーティング</primary>
-   <secondary>静的</secondary>
-   </indexterm>
+   TCP/IPパケットのスタティックルーティングは、<filename>/etc/sysconfig/network/routes</filename>および<filename>/etc/sysconfig/network/ifroute-*</filename>ファイルによって決定されます。ホストへのルート、ゲートウェイ経由のホストへのルート、およびネットワークへのルートなど、さまざまなシステムタスクが必要とするすべてのスタティックルートは、<filename>/etc/sysconfig/network/routes</filename>ファイルに指定できます。個別のルーティングが必要な各インタフェースに対して、付加環境設定ファイル<filename>/etc/sysconfig/network/ifroute-*</filename>を定義します。ワイルドカード(<literal>*</literal>)はインタフェース名で読み替えてください。経路の環境設定ファイルのエントリは次のようになります。
   </para>
 <screen># Destination     Gateway           Netmask            Interface  Options</screen>
 
@@ -170,21 +149,13 @@ default           204.127.235.41    0.0.0.0            eth0
 # Destination     [Gateway]                -           Interface
 2001:DB8:100::/64 -                        -           eth0
 2001:DB8:100::/32 fe80::216:3eff:fe6d:c042 -           eth0</screen>
-  </example><indexterm class="endofrange" startref="idx-routing"/>
+  </example>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-resolv">
   <title><filename>/etc/resolv.conf</filename></title>
-<indexterm>
-  <primary> 環境設定ファイル </primary>
-  <secondary>resolv.conf</secondary></indexterm> 
+ 
   <para>
-   <filename>/etc/resolv.conf</filename>には、ホストが属するドメインが指定されています(キーワード<systemitem>search</systemitem>)。<systemitem>search</systemitem>オプションでは、最大256文字で最大6つのドメインを指定できます。完全修飾でない名前を解決する場合は、<systemitem>search</systemitem>の各エントリを付加して完全修飾名の生成が試みられます。<systemitem>nameserver</systemitem>オプションでは、1行に1つずつ、最大3つのネームサーバを指定できます。コメントの先頭には、ハッシュマークまたはセミコロン記号(<literal>#</literal>または<literal>;</literal>)を付加します。例については、<xref linkend="dat-netz-etc-resolv-conf"/>を参照してください。<indexterm>
-   <primary>DNS</primary>
-   <secondary>ドメイン</secondary>
-   </indexterm> <indexterm>
-   <primary>DNS</primary>
-   <secondary>ネームサーバ</secondary>
-   </indexterm>
+   <filename>/etc/resolv.conf</filename>には、ホストが属するドメインが指定されています(キーワード<systemitem>search</systemitem>)。<systemitem>search</systemitem>オプションでは、最大256文字で最大6つのドメインを指定できます。完全修飾でない名前を解決する場合は、<systemitem>search</systemitem>の各エントリを付加して完全修飾名の生成が試みられます。<systemitem>nameserver</systemitem>オプションでは、1行に1つずつ、最大3つのネームサーバを指定できます。コメントの先頭には、ハッシュマークまたはセミコロン記号(<literal>#</literal>または<literal>;</literal>)を付加します。例については、<xref linkend="dat-netz-etc-resolv-conf"/>を参照してください。 
   </para>
   <para>
    ただし、<filename>/etc/resolv.conf</filename>は、手動では編集しないでください。このファイルは、<command>netconfig</command>スクリプトで生成されます。YaSTを使用せずに静的DNS設定を定義するには、<filename>/etc/sysconfig/network/config</filename>ファイルの該当する変数を手動で編集します。
@@ -307,9 +278,7 @@ nameserver 192.168.1.116</screen>
 
  <sect3 xml:id="sec-basicnet-manconf-hosts">
   <title><filename>/etc/hosts</filename></title>
-<indexterm>
-  <primary> 環境設定ファイル </primary>
-  <secondary>hosts</secondary></indexterm> 
+ 
   <para>
    このファイル(<xref linkend="dat-netz-etc-hosts"/>を参照)では、IPアドレスがホスト名に割り当てられています。ネームサーバが実装されていない場合は、IP接続をセットアップするすべてのホストをここに一覧にする必要があります。ファイルには、各ホストについて1行を入力し、IPアドレス、完全修飾ホスト名、およびホスト名を指定します。IPアドレスは、行頭に指定し、各エントリはブランクとタブで区切ります。コメントは常に<literal>#</literal>記号の後に記入します。
   </para>
@@ -321,9 +290,7 @@ nameserver 192.168.1.116</screen>
   </example>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-networks">
-  <title><filename>/etc/networks</filename></title><indexterm>
-  <primary>環境設定ファイル</primary>
-  <secondary>ネットワーク</secondary></indexterm>
+  <title><filename>/etc/networks</filename></title>
   <para>
    このファイルには、ネットワーク名とネットワークアドレスの対応が記述されています。形式は、ネットワーク名をアドレスの前に指定すること以外は、<filename>hosts</filename>ファイルと同様です。詳細については、<xref linkend="dat-netz-networks"/>を参照してください。
   </para>
@@ -334,9 +301,7 @@ localnet     192.168.0.0</screen>
   </example>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-host">
-  <title><filename>/etc/host.conf</filename></title><indexterm>
-  <primary> 環境設定ファイル</primary>
-  <secondary>host.conf</secondary></indexterm> 
+  <title><filename>/etc/host.conf</filename></title>
   <para>
    このファイルは、名前解決(<emphasis>resolver</emphasis>ライブラリによるホスト名とネットワーク名の変換)を制御します。このファイルは、libc4またはlibc5にリンクされているプログラムについてのみ使用されます。最新のglibcプログラムについては、<filename>/etc/nsswitch.conf</filename>の設定を参照してください。パラメータは常に、1行に1つずつ入力する必要があります。コメントは<literal>#</literal>記号の後に記入します。<xref linkend="tab-netz-param-hostconf"/>に、利用可能なパラメータを示します。<filename>/etc/host.conf</filename>の例については、<xref linkend="dat-netz-etc-hostconf"/>を参照してください。
   </para>
@@ -434,13 +399,9 @@ multi on</screen>
   </example>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-nsswitch">
-  <title><filename>/etc/nsswitch.conf</filename></title><indexterm>
-  <primary> 環境設定ファイル</primary>
-  <secondary> nsswitch.conf</secondary></indexterm> 
+  <title><filename>/etc/nsswitch.conf</filename></title>
   <para>
-   GNU C Library 2.0を導入すると、<emphasis>Name Service Switch</emphasis> (NSS)も合わせて導入されます。詳細については、<systemitem>nsswitch.conf(5)</systemitem> manページおよび『<emphasis>The GNU C Library Reference Manual</emphasis>』を参照してください。<indexterm>
-   <primary>NSS</primary>
-   </indexterm>
+   GNU C Library 2.0を導入すると、<emphasis>Name Service Switch</emphasis> (NSS)も合わせて導入されます。詳細については、<systemitem>nsswitch.conf(5)</systemitem> manページおよび『<emphasis>The GNU C Library Reference Manual</emphasis>』を参照してください。
   </para>
   <para>
    クエリの順序は、ファイル<filename>/etc/nsswitch.conf</filename>で定義します。<filename>nsswitch.conf</filename>の例については、<xref linkend="dat-netz-nsswitchconf"/>を参照してください。コメントの先頭には<literal>#</literal>記号が付きます。この例では、<filename>hosts</filename>データベースの下のエントリは、要求がDNSを介して、<filename>/etc/hosts</filename>(<option>files</option>)に送信されることを意味しています<phrase os="sles;osuse">(<xref linkend="cha-dns"/>参照)。</phrase>
@@ -468,10 +429,7 @@ shadow:     compat
 </screen>
   </example>
   <para>
-   NSSで利用できる<quote>データベース</quote>については、<xref linkend="tab-netz-nnswitch-db"/>を参照してください。<indexterm>
-   <primary>NSS</primary>
-   <secondary>データベース</secondary>
-   </indexterm> NSSデータベースの環境設定オプションについては、<xref linkend="tab-netz-nnswitch-conf"/>を参照してください。
+   NSSで利用できる<quote>データベース</quote>については、<xref linkend="tab-netz-nnswitch-db"/>を参照してください。 NSSデータベースの環境設定オプションについては、<xref linkend="tab-netz-nnswitch-conf"/>を参照してください。
   </para>
   <table xml:id="tab-netz-nnswitch-db">
    <title>/etc/nsswitch.confで利用できるデータベース</title>
@@ -706,9 +664,7 @@ shadow:     compat
   </table>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-nscd">
-  <title><filename>/etc/nscd.conf</filename></title><indexterm>
-  <primary> 環境設定ファイル</primary>
-  <secondary>nscd.conf</secondary></indexterm> 
+  <title><filename>/etc/nscd.conf</filename></title>
   <para>
    このファイルは、nscd (name service cache daemon)の環境設定に使用します。<systemitem>nscd(8)</systemitem>および<systemitem>nscd.conf(5)</systemitem>マニュアルページを参照してください。デフォルトでは、nscdによって<option>passwd</option>、<option>groups</option>と<option>hosts</option>のシステムエントリがキャッシュされます。これは、NISやLDAPのようにディレクトリサービスのパフォーマンスにとって重要です。このようになっていないと、names、groupsまたはhostsにアクセスするたびにネットワーク接続を使用する必要があるためです。
    
@@ -720,12 +676,10 @@ shadow:     compat
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-hostname">
   <title><filename>/etc/HOSTNAME</filename></title>
-<indexterm>
-  <primary> 環境設定ファイル</primary>
-  <secondary> HOSTNAME</secondary></indexterm> 
+ 
   <para>
    <filename>/etc/HOSTNAME</filename>には、完全修飾ホスト名(FQHN)が含まれています。完全修飾ホスト名は、ドメイン名が付加されたホスト名です。このファイルに指定できるのは、ホスト名が設定されている1行のみです。このファイルはマシンのブート時に読み込まれます。
   </para>
-<indexterm class="endofrange" startref="idx-networks-configuration-files"/>
+
  </sect3>
 </sect2>

--- a/l10n/sles/ja-jp/xml/net_dhcp.xml
+++ b/l10n/sles/ja-jp/xml/net_dhcp.xml
@@ -13,12 +13,7 @@
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
-<indexterm class="startofrange" xml:id="idx-DHCP">
- <primary>DHCP</primary></indexterm><indexterm>
- <primary>ネットワーク</primary>
- <secondary>DHCP</secondary></indexterm><indexterm>
- <primary>IPアドレス</primary>
- <secondary>動的割り当て</secondary></indexterm>
+
  <tip arch="zseries" os="sles">
   <title>IBM Z: DHCPのサポート</title>
   <para>
@@ -40,15 +35,7 @@
  <sect1 xml:id="sec-dhcp-yast">
   <title>YaSTによるDHCPサーバの設定</title>
 
-<indexterm>
 
-  <primary>YaST</primary>
-
-  <secondary> DHCP</secondary></indexterm><indexterm>
-
-  <primary> DHCP</primary>
-
-  <secondary> YaSTによる設定</secondary></indexterm>
 
   <para>
    DHCPサーバをインストールするには、YaSTを起動して、<menuchoice><guimenu>ソフトウェア</guimenu> <guimenu>ソフトウェア管理</guimenu></menuchoice>の順に選択します。<menuchoice><guimenu>フィルタ</guimenu>
@@ -292,39 +279,20 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-dhcp-soft">
-  <title>DHCPソフトウェアパッケージ</title><indexterm>
-
-  <primary> DHCP</primary>
-
-  <secondary> パッケージ</secondary></indexterm> 
+  <title>DHCPソフトウェアパッケージ</title>
 
   <para>
    <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>では、DHCPサーバとDHCPクライアントのどちらも利用できます。使用可能なDHCPサーバは、Internet Systems Consortiumによって公開された<systemitem class="daemon">dhcpd</systemitem>です。クライアント側には、<systemitem>dhcp-client</systemitem> (同じくISCが公開)および<systemitem>wicked</systemitem>パッケージに付属のツールがあります。
   </para>
 
   <para>
-   デフォルトでは、<systemitem>wicked</systemitem>ツールは、<systemitem>wickedd-dhcp4</systemitem>および<systemitem>wickedd-dhcp6</systemitem>というサービスに付属してインストールされています。どちらもシステムをブートするたびに自動的に起動され、DHCPサーバを検出します。環境設定ファイルは必要ありません。標準的なセットアップであればほとんどの場合、そのまま使用できます。複雑な状況で使用する場合は、環境設定ファイル<filename>/etc/dhclient.conf</filename>および<filename>/etc/dhclient6.conf</filename>によって制御されるISC <systemitem>dhcp-client</systemitem>を使用します。<indexterm>
-   <primary>環境設定ファイル</primary>
-   <secondary> dhclient.conf</secondary>
-   </indexterm>
+   デフォルトでは、<systemitem>wicked</systemitem>ツールは、<systemitem>wickedd-dhcp4</systemitem>および<systemitem>wickedd-dhcp6</systemitem>というサービスに付属してインストールされています。どちらもシステムをブートするたびに自動的に起動され、DHCPサーバを検出します。環境設定ファイルは必要ありません。標準的なセットアップであればほとんどの場合、そのまま使用できます。複雑な状況で使用する場合は、環境設定ファイル<filename>/etc/dhclient.conf</filename>および<filename>/etc/dhclient6.conf</filename>によって制御されるISC <systemitem>dhcp-client</systemitem>を使用します。
   </para>
  </sect1>
  <sect1 xml:id="sec-dhcp-server">
   <title>DHCPサーバdhcpd</title>
 
-<indexterm>
 
-  <primary>環境設定ファイル</primary>
-
-  <secondary>dhcpd.conf</secondary></indexterm><indexterm class="startofrange" xml:id="idx-dhcp-server">
-
-  <primary>DHCP</primary>
-
-  <secondary>サーバ</secondary></indexterm><indexterm class="startofrange" xml:id="idx-dhcp-dhcpd">
-
-  <primary>DHCP</primary>
-
-  <secondary>dhcpd</secondary></indexterm>
 
   <para>
    DHCPシステムの中核には、動的ホスト環境設定プロトコルデーモンがあります。このサーバは、環境設定ファイル<filename>/etc/dhcpd.conf</filename>に定義された設定に従ってアドレスを「リース」し、その使用状況を監視します。<emphasis/>システム管理者は、このファイルのパラメータと値を変更して、プログラムの動作をさまざまな方法で調整できます。<xref linkend="dat-dhcp-conf"/>で、<filename>/etc/dhcpd.conf</filename>ファイルの基本的な例を見てみましょう。
@@ -400,12 +368,10 @@ subnet 192.168.2.0 netmask 255.255.255.0
 
   <para>
    デフォルトの<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>システムでは、セキュリティ上の理由から、chroot環境でDHCPデーモンを起動します。デーモンが見つけられるように、環境設定ファイルは、chroot環境にコピーします。通常は、<command>systemctl start dhcpd</command>コマンドによって自動的にこのファイルがコピーされるので、手動でコピーする必要はありません。
-  </para><indexterm class="endofrange" startref="idx-dhcp-server"/><indexterm class="endofrange" startref="idx-dhcp-dhcpd"/>
+  </para>
 
   <sect2 xml:id="sec-dhcp-statip">
-   <title>固定IPアドレスを持つクライアント</title><indexterm>
-   <primary> DHCP</primary>
-   <secondary>静的アドレスの割り当て</secondary></indexterm> 
+   <title>固定IPアドレスを持つクライアント</title>
    <para>
     DHCPは、事前定義の静的アドレスを特定のクライアントに割り当てる場合にも使用できます。明示的に割り当てられるアドレスは、プールから割り当てられる動的アドレスに常に優先します。たとえばアドレスが不足していて、サーバがクライアント間でアドレスを再配布する必要がある場合でも、静的アドレスは動的アドレスと違って期限切れになりません。
    </para>
@@ -476,6 +442,6 @@ fixed-address 192.168.2.100;
 
   <para>
    DHCPの詳細については、<emphasis>Internet Systems Consortium</emphasis>のWebサイト(<link xlink:href="https://www.isc.org/dhcp/"/>)を参照してください。また、<option>dhcpd</option>、<option>dhcpd.conf</option>、<option>dhcpd.leases</option>、および<option>dhcp-options</option>のマニュアルページにも詳細が記載されています。
-  </para><indexterm class="endofrange" startref="idx-DHCP"/>
+  </para>
  </sect1>
 </chapter>

--- a/l10n/sles/ja-jp/xml/net_dns.xml
+++ b/l10n/sles/ja-jp/xml/net_dns.xml
@@ -16,21 +16,9 @@
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
-<indexterm>
- <primary>ドメインネームシステム</primary>
- <see>DNS</see></indexterm><indexterm>
- <primary>DNS</primary>
- <secondary>設定</secondary></indexterm><indexterm>
- <primary>設定</primary>
- <secondary>DNS</secondary></indexterm><indexterm>
- <primary>ネームサーバ</primary>
- <see>DNS</see></indexterm>
+
  <sect1 xml:id="sec-dns-basic">
-  <title>DNS用語</title><indexterm>
-
-  <primary> DNS</primary>
-
-  <secondary> 用語</secondary></indexterm> 
+  <title>DNS用語</title>
 
   <variablelist>
    <varlistentry>
@@ -489,25 +477,11 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-dns-bind">
-  <title>BINDネームサーバの起動</title><indexterm xml:id="idx-DNS-BIND" class="startofrange">
-
-  <primary>DNS</primary>
-
-  <secondary>BIND</secondary></indexterm><indexterm xml:id="idx-BIND" class="startofrange">
-
-  <primary>BIND</primary></indexterm>
+  <title>BINDネームサーバの起動</title>
 
   <para>
    <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase>システムでは、ネームサーバBIND (<emphasis>Berkeley Internet Name Domain</emphasis>)は、事前設定されて提供されるので、インストールが正常に完了すればただちに起動できます。通常、すでにインターネットに接続し、<filename>/etc/resolv.conf</filename>の<systemitem class="domainname">localhost</systemitem>にネームサーバアドレス<systemitem class="ipaddress">127.0.0.1</systemitem>が入力されている場合、プロバイダのDNSを知らなくても、既に機能する名前解決メカニズムが存在します。この場合、BINDは、ルートネームサーバを介して名前の解決を行うため、処理が非常に遅くなります。通常、効率的で安全な名前解決を実現するには、<filename>forwarders</filename>の下の設定ファイル<systemitem>/etc/named.conf</systemitem>にプロバイダのDNSとそのIPアドレスを入力する必要があります。いままでこれが機能している場合、ネームサーバは、純粋な<emphasis>キャッシュ専用</emphasis>ネームサーバとして動作しています。ネームサーバは、そのゾーンを設定してはじめて、正しいDNSにすることができます。簡単な例については、<filename>/usr/share/doc/packages/bind/config</filename>のドキュメントを参照してください。
-  </para><indexterm>
-
-  <primary> 環境設定ファイル</primary>
-
-  <secondary> resolv.conf</secondary></indexterm><indexterm>
-
-  <primary>   環境設定ファイル</primary>
-
-  <secondary> named.conf</secondary></indexterm> 
+  </para>
 
   <tip>
    <title>ネームサーバ情報の自動取得</title>
@@ -524,25 +498,10 @@
    ネームサーバを起動するには、<command>root</command>ユーザとして、<systemitem class="username">systemctl start named</systemitem>コマンドを入力します。<command>systemctl status named</command>を使用して、ネームサーバ(呼びだされたネームサーバプロセス)が正常に起動したかどうかを確認します。サーバが正常に起動したらすぐに、<command>host</command>または<command>dig</command>プログラムを用いてローカルシステム上でネームサーバをテストしてください。デフォルトサーバ<systemitem class="domainname">localhost</systemitem>とそのアドレス<systemitem class="ipaddress">127.0.0.1</systemitem>が返されるはずです。これが返されない場合は、<filename>/etc/resolv.conf</filename>に含まれているネームサーバエントリが誤っているか、同ファイルが存在しないかのいずれかです。最初のテストとして、「<command>host</command><option>127.0.0.1</option>」を入力します。これは常に機能するはずです。エラーメッセージが表示された場合は、<command>systemctl status named</command>コマンドを使用して、サーバが実際に起動されていることを確認します。ネームサーバが起動しないか、予期しない動作をする場合は、<command>journalctl -e</command>の出力を確認します。
   </para>
 
-<indexterm>
 
-  <primary>ログファイル</primary>
-
-  <secondary>メッセージ</secondary></indexterm><indexterm>
-
-  <primary>DNS</primary>
-
-  <secondary>起動</secondary></indexterm><indexterm>
-
-  <primary>DNS</primary>
-
-  <secondary>トラブルシューティング</secondary></indexterm>
 
   <para>
-   プロバイダのネームサーバ(またはすでにネットワーク上で動作しているネームサーバ)をフォワーダとして使用する場合は、<systemitem>forwarders</systemitem>の下の<systemitem>options</systemitem>セクションに、対応するIPアドレスまたはアドレスを入力します。<xref linkend="ex-forward"/>に含まれているアドレスは、単なる例です。各自サイトの設定に合わせて変更してください。<indexterm>
-   <primary>DNS</primary>
-   <secondary> 転送</secondary>
-   </indexterm>
+   プロバイダのネームサーバ(またはすでにネットワーク上で動作しているネームサーバ)をフォワーダとして使用する場合は、<systemitem>forwarders</systemitem>の下の<systemitem>options</systemitem>セクションに、対応するIPアドレスまたはアドレスを入力します。<xref linkend="ex-forward"/>に含まれているアドレスは、単なる例です。各自サイトの設定に合わせて変更してください。
   </para>
 
   <example xml:id="ex-forward">
@@ -563,11 +522,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-dns-named">
-  <title>The /etc/named.conf環境設定ファイル</title><indexterm xml:id="idx-configuration-files-named-conf" class="startofrange">
-
-  <primary> 環境設定ファイル</primary>
-
-  <secondary>host.conf</secondary></indexterm> 
+  <title>The /etc/named.conf環境設定ファイル</title>
 
   <para>
    BINDネームサーバ自体のすべての設定は、<filename>/etc/named.conf</filename>ファイルに格納されます。ただし、処理するドメインのゾーンデータ(ホスト名、IPアドレスなどで構成されている)は、<filename>/var/lib/named</filename>ディレクトリ内の個別のファイルに格納されます。この詳細については、後述します。
@@ -602,9 +557,7 @@ zone "." in {
   </example>
 
   <sect2 xml:id="sec-dns-named-options">
-   <title>重要な設定オプション</title><indexterm>
-   <primary> DNS</primary>
-   <secondary> オプション</secondary></indexterm> 
+   <title>重要な設定オプション</title>
    <variablelist>
     <varlistentry>
      <term>directory "<replaceable>FILENAME</replaceable>";</term>
@@ -632,9 +585,7 @@ zone "." in {
     </varlistentry>
     <varlistentry>
      <term>listen-on port 53 { 127.0.0.1; <replaceable>IP-ADDRESS</replaceable>; };</term>
-     <listitem><indexterm>
-      <primary>ポート</primary>
-      <secondary>53</secondary></indexterm>
+     <listitem>
       <para>
        BINDがクライアントからのクエリを受け取るネットワークインタフェースとポートを指定します。<literal>port 53</literal>はデフォルトポートであるため、明示的に指定する必要はありません。<literal/>ローカルホストからの要求を許可するには、<literal>127.0.0.1</literal>と記述します。このエントリ全体を省略した場合は、すべてのインタフェースがデフォルトで使用されます。
       </para>
@@ -719,9 +670,7 @@ zone "." in {
   </sect2>
 
   <sect2 xml:id="sec-dns-named-log">
-   <title>ロギング</title><indexterm>
-   <primary> DNS</primary>
-   <secondary> ログの記録</secondary></indexterm> 
+   <title>ロギング</title>
    <para>
     BINDでは、何を、どのように、どこにログ出力するかを詳細に設定できます。通常は、デフォルト設定のままで十分です。<xref linkend="ex-no-log"/>に、このエントリの最も簡単な形式、すなわちログをまったく出力しない例を示します。
    </para>
@@ -810,13 +759,7 @@ zone "." in {
   </sect2>
  </sect1>
  <sect1 xml:id="sec-dns-zonefile">
-  <title>ゾーンファイル</title><indexterm>
-
-  <primary> DNS</primary>
-
-  <secondary> ゾーン</secondary>
-
-  <tertiary> ファイル</tertiary></indexterm> 
+  <title>ゾーンファイル</title>
 
   <para>
    ゾーンファイルは2種類必要です。一方はIPアドレスをホスト名に割り当て、もう一方は逆にIPアドレスのホスト名を提供します。
@@ -994,10 +937,7 @@ pluto     AAAA 2345:00D2:DA11::1234:5678:9ABC:DEF0</screen>
 
 
   <para>
-   擬似ドメイン<literal>in-addr.arpa</literal>は、IPアドレスからホスト名への逆引き参照に使用されます。このドメインの前に、IPアドレスのネットワーク部分が逆順に指定されます。たとえば、<systemitem class="ipaddress">192.168</systemitem>は、<systemitem>168.192.in-addr.arpa</systemitem>に解決されます。参照先 <xref linkend="dat-arpa"/>。<indexterm>
-   <primary>DNS</primary>
-   <secondary> 逆引き</secondary>
-   </indexterm>
+   擬似ドメイン<literal>in-addr.arpa</literal>は、IPアドレスからホスト名への逆引き参照に使用されます。このドメインの前に、IPアドレスのネットワーク部分が逆順に指定されます。たとえば、<systemitem class="ipaddress">192.168</systemitem>は、<systemitem>168.192.in-addr.arpa</systemitem>に解決されます。参照先 <xref linkend="dat-arpa"/>。
   </para>
 
 
@@ -1064,9 +1004,9 @@ pluto     AAAA 2345:00D2:DA11::1234:5678:9ABC:DEF0</screen>
   </variablelist>
 
   <para>
-   通常、ゾーン転送は、異なるバージョンのBIND間でも問題なく行えるはずです。<indexterm class="endofrange" startref="idx-DNS-BIND"/>
-   <indexterm class="endofrange" startref="idx-BIND"/>
-   <indexterm class="endofrange" startref="idx-configuration-files-named-conf"/>
+   通常、ゾーン転送は、異なるバージョンのBIND間でも問題なく行えるはずです。
+   
+   
 
   </para>
  </sect1>

--- a/l10n/sles/ja-jp/xml/net_samba.xml
+++ b/l10n/sles/ja-jp/xml/net_samba.xml
@@ -11,16 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-Samba" class="startofrange">
- <primary>Samba</primary></indexterm><indexterm>
- <primary>SMB</primary>
- <see>Samba</see></indexterm><indexterm>
- <primary>macOS</primary>
- <secondary>ファイル共有</secondary></indexterm><indexterm>
- <primary>Windows</primary>
- <secondary>ファイル共有</secondary></indexterm><indexterm>
- <primary>Linux</primary>
- <secondary>別のOSとのファイル共有</secondary></indexterm>
+ </info>
  <sect1 xml:id="sec-samba-term">
   <title>用語集</title>
 
@@ -33,18 +24,7 @@
     <term>SMBプロトコル</term>
     <listitem>
      <para>
-      <indexterm>
-      <primary>Samba</primary>
-      <secondary>SMB</secondary>
-      </indexterm> <indexterm>
-      <primary>プロトコル</primary>
-      <secondary>SMB</secondary>
-      </indexterm> <indexterm>
-      <primary>smbd</primary>
-      </indexterm>SambaはSMB(サーバメッセージブロック)プロトコルを使用します。SMBは<phrase role="productname">NetBIOS</phrase>サービスを基にしています。Microsoftがこのプロトコルをリリースしたので、他のソフトウェアメーカはMicrosoftドメインネットワークに接続できるようになりました。Sambaでは、SMBプロトコルがTCP/IPプロトコルの上で動作するので、すべてのクライアントにTCP/IPプロトコルをインストールする必要があります。<indexterm>
-      <primary>Samba</primary>
-      <secondary> TCP/IP</secondary>
-      </indexterm>
+        SambaはSMB(サーバメッセージブロック)プロトコルを使用します。SMBは<phrase role="productname">NetBIOS</phrase>サービスを基にしています。Microsoftがこのプロトコルをリリースしたので、他のソフトウェアメーカはMicrosoftドメインネットワークに接続できるようになりました。Sambaでは、SMBプロトコルがTCP/IPプロトコルの上で動作するので、すべてのクライアントにTCP/IPプロトコルをインストールする必要があります。
      </para>
      <tip arch="zseries" os="sles">
       <title>IBM Z: NetBIOSのサポート</title>
@@ -58,13 +38,7 @@
     <term>CIFSプロトコル</term>
     <listitem>
      <para>
-      <indexterm>
-      <primary>Samba</primary>
-      <secondary>CIFS</secondary>
-      </indexterm> <indexterm>
-      <primary>プロトコル</primary>
-      <secondary>CIFS </secondary>
-      </indexterm>CIFS (common Internet file system)プロトコルは、Sambaがサポートしているプロトコルです。CIFSは、ネットワーク上で使用する標準のリモートファイルシステムで、ユーザグループによる共同作業およびネットワーク間でのドキュメントの共有ができるようにします。
+       CIFS (common Internet file system)プロトコルは、Sambaがサポートしているプロトコルです。CIFSは、ネットワーク上で使用する標準のリモートファイルシステムで、ユーザグループによる共同作業およびネットワーク間でのドキュメントの共有ができるようにします。
      </para>
     </listitem>
    </varlistentry>
@@ -72,22 +46,16 @@
     <term>NetBIOS</term>
     <listitem>
      <para>
-      <indexterm>
-      <primary>NetBIOS</primary>
-      </indexterm>NetBIOSは、マシン間通信用に設計された、ネームサービスを提供するソフトウェアインタフェース(API)です。これにより、ネットワークに接続されたマシンが、それ自体の名前を維持できます。予約を行えば、これらのマシンを名前によって指定できます。名前を確認する一元的なプロセスはありません。ネットワーク上のマシンでは、すでに使用済みの名前でない限り、名前をいくつでも予約できます。NetBIOSインタフェースは、異なるネットワークアーキテクチャに実装できるようになっています。ネットワークハードウェアと比較的密接に機能する実装は<phrase role="productname">NetBEUI</phrase>と呼ばれますが、これはよく<phrase role="productname">NetBIOS</phrase>とも呼ばれます。NetBIOSとともに実装されるネットワークプロトコルは、Novell IPX (TCP/IP経由の NetBIOS)とTCP/IPです。
+      NetBIOSは、マシン間通信用に設計された、ネームサービスを提供するソフトウェアインタフェース(API)です。これにより、ネットワークに接続されたマシンが、それ自体の名前を維持できます。予約を行えば、これらのマシンを名前によって指定できます。名前を確認する一元的なプロセスはありません。ネットワーク上のマシンでは、すでに使用済みの名前でない限り、名前をいくつでも予約できます。NetBIOSインタフェースは、異なるネットワークアーキテクチャに実装できるようになっています。ネットワークハードウェアと比較的密接に機能する実装は<phrase role="productname">NetBEUI</phrase>と呼ばれますが、これはよく<phrase role="productname">NetBIOS</phrase>とも呼ばれます。NetBIOSとともに実装されるネットワークプロトコルは、Novell IPX (TCP/IP経由の NetBIOS)とTCP/IPです。
      </para>
      <para>
       TCP/IP経由で送信されたNetBIOS名は、<filename>/etc/hosts</filename>で使用されている名前、またはDNSで定義された名前とまったく共通点がありません。NetBIOSは独自の、完全に独立した名前付け規則を使用しています。しかし、管理を容易にするために、DNSホスト名に対応する名前を使用するか、DNSをネイティブで使用することをお勧めします。これはSambaが使用するデフォルトでもあります。
-     </para><indexterm>
-     <primary>Samba </primary>
-     <secondary>名前</secondary></indexterm>
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>Sambaサーバ</term>
-    <listitem><indexterm>
-     <primary>Samba</primary>
-     <secondary> サーバ</secondary></indexterm>
+    <listitem>
      <para>
       Sambaサーバは、SMB/CIFSサービスおよびNetBIOS over IPネーミングサービスをクライアントに提供します。Linuxの場合、3種類のSambaサーバデーモン(SMB/CIFSサービス用smnd、ネーミングサービス用nmbd、認証用winbind)が用意されています。
      </para>
@@ -95,9 +63,7 @@
    </varlistentry>
    <varlistentry>
     <term>Sambaクライアント</term>
-    <listitem><indexterm xml:id="idx-Samba-clients" class="startofrange">
-     <primary> Samba</primary>
-     <secondary> クライアント</secondary></indexterm> 
+    <listitem> 
      <para>
       Sambaクライアントは、SMBプロトコルを介してSambaサーバからSambaサービスを使用するシステムです。WindowsやmacOSなどの一般的なオペレーティングシステムは、SMBプロトコルをサポートしています。TCP/IPプロトコルは、すべてのコンピュータにインストールする必要があります。Sambaは、異なるUNIXフレーバーに対してクライアントを提供します。Linuxでは、SMB用のカーネルモジュールがあり、LinuxシステムレベルでのSMBリソースの統合が可能です。Sambaクライアントに対していずれのデーモンも実行する必要はありません。
      </para>
@@ -107,16 +73,7 @@
     <term>共有</term>
     <listitem>
      <para>
-      <indexterm>
-      <primary>Samba</primary>
-      <secondary>共有</secondary>
-      </indexterm>SMBサーバは、そのクライアントに対し、共有によってリソースを提供します。共有は、サーバ上のサブディレクトリのあるディレクトリおよびプリンタです。これは名前によってエクスポートされ、名前によってアクセスされます。共有名にはどのような名前も設定できます。エクスポートディレクトリの名前である必要はありません。プリンタにも名前が割り当てられます。クライアントはプリンタに名前でアクセスできます。<indexterm>
-      <primary>印刷</primary>
-      <secondary>Samba</secondary>
-      </indexterm> <indexterm>
-      <primary>Samba</primary>
-      <secondary>プリンタ</secondary>
-      </indexterm> <indexterm class="endofrange" startref="idx-Samba-clients"/>
+      SMBサーバは、そのクライアントに対し、共有によってリソースを提供します。共有は、サーバ上のサブディレクトリのあるディレクトリおよびプリンタです。これは名前によってエクスポートされ、名前によってアクセスされます。共有名にはどのような名前も設定できます。エクスポートディレクトリの名前である必要はありません。プリンタにも名前が割り当てられます。クライアントはプリンタに名前でアクセスできます。  
      </para>
     </listitem>
    </varlistentry>
@@ -124,10 +81,7 @@
     <term>DC</term>
     <listitem>
      <para>
-      <indexterm>
-      <primary>Samba</primary>
-      <secondary> DC</secondary>
-      </indexterm>ドメインコントローラ(DC)は、ドメインのアカウントを処理するサーバです。データレプリケーションには、1つのドメインの中で追加のドメインコントローラが使用できます。
+      ドメインコントローラ(DC)は、ドメインのアカウントを処理するサーバです。データレプリケーションには、1つのドメインの中で追加のドメインコントローラが使用できます。
      </para>
     </listitem>
    </varlistentry>
@@ -156,34 +110,10 @@
    <para>
     <systemitem>winbind</systemitem>は、独立したサービスであり、個別の<systemitem>samba-winbind</systemitem>パッケージとしても提供されます。
    </para>
-  </tip><indexterm>
-
-  <primary>Samba</primary>
-
-  <secondary>起動</secondary></indexterm><indexterm>
-
-  <primary>Samba</primary>
-
-  <secondary>停止</secondary></indexterm>
+  </tip>
  </sect1>
  <sect1 xml:id="sec-samba-serv-inst">
-  <title>Sambaサーバの設定</title><indexterm>
-
-  <primary>Samba</primary>
-
-  <secondary>インストール</secondary></indexterm><indexterm>
-
-  <primary>Samba</primary>
-
-  <secondary>サーバ</secondary></indexterm><indexterm>
-
-  <primary>Samba</primary>
-
-  <secondary>設定</secondary></indexterm><indexterm>
-
-  <primary>設定</primary>
-
-  <secondary>Samba</secondary></indexterm>
+  <title>Sambaサーバの設定</title>
 
   <para os="sles;osuse">
    <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase>のSambaサーバは、YaSTを使って、または手動で設定することができます。手動で設定を行えば細かい点まで調整できますが、YaSTのGUIほど便利ではありません。
@@ -288,16 +218,7 @@
   <sect2 xml:id="sec-samba-serv-inst-manual" os="sles;osuse">
    <title>サーバの手動設定</title>
    <para>
-    <indexterm>
-    <primary> Samba</primary>
-    <secondary> 設定</secondary>
-    </indexterm> <indexterm>
-    <primary>   設定</primary>
-    <secondary> Samba</secondary>
-    </indexterm> <indexterm>
-    <primary>   環境設定ファイル</primary>
-    <secondary> smb.conf</secondary>
-    </indexterm>  Sambaをサーバとして使用する場合は、<systemitem class="resource">samba</systemitem>をインストールします。Sambaの主要設定ファイルは、 <filename>/etc/samba/smb.conf </filename>です。このファイルは2つの論理部分に分けられます。<literal>[global]</literal>セクションには、中心的なグローバル設定が含まれます。次のデフォルトのセクションには、個別のファイルとプリンタ共有が入っています。
+        Sambaをサーバとして使用する場合は、<systemitem class="resource">samba</systemitem>をインストールします。Sambaの主要設定ファイルは、 <filename>/etc/samba/smb.conf </filename>です。このファイルは2つの論理部分に分けられます。<literal>[global]</literal>セクションには、中心的なグローバル設定が含まれます。次のデフォルトのセクションには、個別のファイルとプリンタ共有が入っています。
    </para>
    <itemizedlist mark="bullet" spacing="normal">
     <listitem>
@@ -380,9 +301,7 @@
     </variablelist>
    </sect3>
    <sect3 xml:id="sec-samba-smb-conf-shares">
-    <title>共有</title><indexterm>
-    <primary> Samba</primary>
-    <secondary> シェア</secondary></indexterm> 
+    <title>共有</title>
     <para>
      次の例では、SMBクライアントがCD-ROMドライブとユーザディレクトリ(<literal>homes</literal>)を利用できるようにする方法を示します。
     </para>
@@ -498,13 +417,7 @@
     </warning>
    </sect3>
    <sect3 xml:id="sec-samba-rechte">
-    <title>セキュリティレベル</title><indexterm xml:id="idx-Samba-security" class="startofrange">
-    <primary>Samba</primary>
-    <secondary>セキュリティ</secondary></indexterm><indexterm>
-    <primary>セキュリティ</primary>
-    <secondary>Samba</secondary></indexterm><indexterm>
-    <primary>Samba</primary>
-    <secondary>パーミッション</secondary></indexterm>
+    <title>セキュリティレベル</title>
     <para>
      セキュリティを向上させるため、各共有へのアクセスは、パスワードによって保護されています。SMBでは、次の方法で権限を確認できます。
     </para>
@@ -540,31 +453,19 @@
     </para>
     <para>
      この詳細については、『Samba 3 HOWTO』を参照してください。つのシステムに複数のサーバをセットアップする場合は、オプション<option>interfaces</option>および<option>bind interfaces only</option>に注意してください。
-    </para><indexterm class="endofrange" startref="idx-Samba-security"/>
+    </para>
    </sect3>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-samba-client-inst">
-  <title>クライアントの設定</title><indexterm>
-
-  <primary> Samba</primary>
-
-  <secondary> クライアント</secondary></indexterm> 
+  <title>クライアントの設定</title>
 
   <para>
    クライアントは、TCP/IP経由でのみSambaサーバにアクセスできます。IPX経由のNetBEUIおよびNetBIOSは、Sambaで使用できません。
   </para>
 
   <sect2 xml:id="sec-samba-client-inst-yast">
-   <title>YaSTによるSambaクライアントの設定</title><indexterm>
-   <primary>YaST</primary>
-   <secondary>Samba</secondary>
-   <tertiary>クライアント</tertiary></indexterm><indexterm>
-   <primary>Samba</primary>
-   <secondary>クライアント</secondary></indexterm><indexterm>
-   <primary>設定</primary>
-   <secondary>Samba</secondary>
-   <tertiary>クライアント</tertiary></indexterm>
+   <title>YaSTによるSambaクライアントの設定</title>
    <para>
     SambaクライアントをSambaサーバまたはWindowsサーバ上のリソース(ファイルまたはプリンタ)にアクセスするように設定します。NTまたはActive Directoryのドメインまたはワークグループを、<menuchoice> <guimenu> ネットワークサービス</guimenu>
     <guimenu>Windowsドメインメンバーシップ</guimenu></menuchoice>の順に選択して表示したダイアログに入力します。<guimenu>Linuxの認証にもSMBの情報を使用する</guimenu>を有効にした場合、ユーザ認証は、Samba、NT、またはKerberosのサーバ上で実行されます。
@@ -578,11 +479,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-samba-anmeld-serv">
-  <title>ログインサーバとしてのSamba</title><indexterm>
-
-  <primary> Samba</primary>
-
-  <secondary> ログイン</secondary></indexterm> 
+  <title>ログインサーバとしてのSamba</title>
 
   <para>
    Windowsクライアントが大部分を占めるネットワークでは、ユーザが有効なアカウントとパスワードを持つ場合のみ登録できることが求められるのが普通です。Windowsベースのネットワークでは、このタスクはPDC (プライマリドメインコントローラ)によって処理されます。Windows NTサーバをPDCとして使用することもできますが、Sambaサーバを使用しても処理できます。<xref linkend="dat-samba-smb-conf-dom"/>に示すように、<filename>smb.conf</filename>の<literal>[global]</literal>セクションにエントリを追加する必要があります。
@@ -601,11 +498,7 @@
   </para>
 
 <screen>useradd hostname\$
-smbpasswd -a -m hostname</screen><indexterm>
-
-  <primary> コマンド</primary>
-
-  <secondary>smbpasswd</secondary></indexterm> 
+smbpasswd -a -m hostname</screen> 
 
   <para>
    <command>useradd</command>コマンドを使用すると、ドル記号が追加されます。コマンド<command>smbpasswd</command>を指定すると、パラメータ<option>-m</option>を使用したときにドル記号が自動的に挿入されます。コメント付きの設定例(<filename>/usr/share/doc/packages/Samba/examples/smb.conf.SuSE</filename>)には、この作業を自動化するための設定が含まれています。
@@ -1075,14 +968,11 @@ No shadow copies found in system.</screen>
 
   <para>
    Sambaのマニュアルは<systemitem>samba-doc</systemitem>パッケージに付属していますが、デフォルトではインストールされません。インストールするには、<command>zypper install samba-doc</command>を実行します。コマンドラインから「<command>apropos</command>
-   <option> samba</option>」と入力するとマニュアルページを参照できます。または、<filename>/usr/share/doc/packages/samba</filename>ディレクトリに格納されているその他のオンラインマニュアルと例を参照できます。また、コメント付きの設定例(<filename>smb.conf.SUSE</filename>)が<filename>examples</filename>サブディレクトリに用意されています。Samba関連の情報を参照できるもう1つのファイルは、<filename>/usr/share/doc/packages/samba/README.SUSE</filename>です。<indexterm>
-   <primary>環境設定ファイル</primary>
-   <secondary> smb.conf</secondary>
-   </indexterm>
+   <option> samba</option>」と入力するとマニュアルページを参照できます。または、<filename>/usr/share/doc/packages/samba</filename>ディレクトリに格納されているその他のオンラインマニュアルと例を参照できます。また、コメント付きの設定例(<filename>smb.conf.SUSE</filename>)が<filename>examples</filename>サブディレクトリに用意されています。Samba関連の情報を参照できるもう1つのファイルは、<filename>/usr/share/doc/packages/samba/README.SUSE</filename>です。
   </para>
 
   <para>
    Sambaチームが作成した『Samba- HOWTO』(<link xlink:href="https://wiki.samba.org"/>を参照)では、トラブルシューティングについても説明されています。またマニュアルのPart Vでは、手順を追って設定を確認するためのガイドが用意されています。
-  </para><indexterm class="endofrange" startref="idx-Samba"/>
+  </para>
  </sect1>
 </chapter>

--- a/l10n/sles/ja-jp/xml/net_slp.xml
+++ b/l10n/sles/ja-jp/xml/net_slp.xml
@@ -11,14 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>ネットワーク</primary>
- <secondary>SLP</secondary></indexterm><indexterm>
- <primary>サービスロケーションプロトコル</primary>
- <see>SLP</see></indexterm><indexterm>
- <primary>SLP</primary></indexterm><indexterm>
- <primary>プロトコル</primary>
- <secondary>SLP</secondary></indexterm>
+ </info>
  <para>
   <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase>は、SLPによって提供されるインストールソースを使用するインストールをサポートしています。また、多くのシステムサービスは、統合SLPをサポートしています。ご利用のシステムでインストールサーバ、ファイルサーバ、プリントサーバなどのSLPを使用することにより、ネットワークに接続されたクライアントに一元的な管理機能を提供します。SLPサポートを提供するサービスには、cupsd、login、ntp、openldap2、postfix、rpasswd、rsyncd、saned、sshd (fish経由)、vnc、およびypservがあります。
  </para>

--- a/l10n/sles/ja-jp/xml/net_yast.xml
+++ b/l10n/sles/ja-jp/xml/net_yast.xml
@@ -9,15 +9,7 @@
   </dm:docmanager>
  </info>
 
-<indexterm xml:id="idx-networks-integrating" class="startofrange">
 
- <primary>ネットワーク</primary>
-
- <secondary>設定</secondary></indexterm><indexterm>
-
- <primary>カード</primary>
-
- <secondary>ネットワーク</secondary></indexterm>
 
  <para>
   Linuxでは多くのタイプのネットワーク接続がサポートされています。その多くは、異なるデバイス名と、ファイルシステム内の複数の場所に分散した設定ファイルを使用しています。手動によるネットワーク設定のさまざまな面についての詳細は、<xref linkend="sec-basicnet-manconf"/>を参照してください。
@@ -37,13 +29,7 @@
 
  <sect2 xml:id="sec-basicnet-yast-netcard">
   <title>YaSTでのネットワークカードの設定</title>
-<indexterm>
-  <primary>カード</primary>
-  <secondary>ネットワーク</secondary></indexterm><indexterm>
-  <primary>ネットワーク</primary>
-  <secondary>YaST</secondary></indexterm><indexterm>
-  <primary>YaST</primary>
-  <secondary>ネットワークカード</secondary></indexterm><indexterm/>
+
   <para>
    YaSTでEthernetカードまたはWi-Fi/Bluetoothカードを設定するには、<menuchoice> <guimenu>システム</guimenu> <guimenu> ネットワーク設定</guimenu>
    </menuchoice>の順に選択します。モジュールの開始後に、YaSTは<guimenu>ネットワーク設定</guimenu>ダイアログを表示します。ダイアログには<guimenu>グローバルオプション</guimenu>、<guimenu>概要</guimenu>、<guimenu>ホスト名/DNS</guimenu>、および<guimenu>ルーティング</guimenu>の4つのタブがあります。
@@ -107,10 +93,7 @@
    </para>
    <sect4 xml:id="sec-basicnet-yast-change-address">
     <title>IPアドレスの設定</title>
-<indexterm>
-    <primary> ネットワーク</primary>
-    <secondary> YaST</secondary>
-    <tertiary> IPアドレス</tertiary></indexterm> 
+ 
     <para>
      <guimenu>Network Card Setup</guimenu>ダイアログの<guimenu>アドレス</guimenu>タブで、ネットワークカードのIPアドレス、またはそのIPアドレスの決定方法を設定できます。IPv4およびIPv6の両アドレスがサポートされます。ネットワークカードは、<guimenu>IPアドレスなし</guimenu>(ボンドデバイスで有用)の場合や、<guimenu>静的に割り当てられたIPアドレス</guimenu>(IPv4またはIPv6)、あるいは<guimenu>DHCP</guimenu>または<guimenu>Zeroconf</guimenu>のいずれかまたは両方を経由して割り当てられる<guimenu>動的アドレス</guimenu>を持つ場合もあります。
     </para>
@@ -181,13 +164,7 @@
     </para>
    </sect4>
    <sect4 xml:id="sec-basicnet-yast-configure-addresses">
-    <title>複数のアドレスの設定</title><indexterm>
-    <primary>ネットワーク</primary>
-    <secondary>YaST</secondary>
-    <tertiary>エイリアス</tertiary></indexterm><indexterm>
-    <primary>ネットワーク</primary>
-    <secondary>YaST</secondary>
-    <tertiary>アドレス</tertiary></indexterm>
+    <title>複数のアドレスの設定</title>
     <para>
      1台のネットワークデバイスに、複数のIPアドレスを割り当てることができます。
     </para>
@@ -287,10 +264,7 @@
    </sect4>
    <sect4 xml:id="sec-basicnet-yast-change-start">
     <title>ネットワークデバイスの有効化</title>
-<indexterm>
-    <primary> ネットワーク</primary>
-    <secondary> YaST</secondary>
-    <tertiary> 有効化</tertiary></indexterm> 
+ 
     <para>
      <command>wicked</command>を使った方法を使用している場合、デバイスをブート時、ケーブル接続時、カード検出時、または手動で起動するように設定したり、起動しないように設定したりすることができます。デバイスの起動方法を変更するには、次の手順に従います。
     </para>
@@ -503,10 +477,7 @@
    </procedure>
   </sect3>
   <sect3 xml:id="sec-basicnet-yast-change-host">
-   <title>ホスト名とDNSの設定</title><indexterm>
-   <primary>ネットワーク</primary>
-   <secondary> YaST</secondary>
-   <tertiary> ホスト名</tertiary></indexterm>
+   <title>ホスト名とDNSの設定</title>
    <para>
     Ethernetカードがすでに利用できる状態で、インストール時にネットワーク設定を変更しなかった場合、コンピュータのホスト名が自動的に生成され、DHCPが有効になります。また、ホストがネットワークに参加するために必要なネームサービス情報も自動的に生成されます。ネットワークアドレス設定にDHCPを使用している場合は、ドメインネームサーバのリストは自動的に記入されます。静的設定を利用する場合は、これらの項目を手動で設定してください。
    </para>
@@ -593,10 +564,7 @@ yast dns edit nameserver3=192.168.1.118</screen>
 
   <sect3 xml:id="sec-basicnet-yast-change-route">
    <title>ルーティングの設定</title>
-<indexterm>
-   <primary> ネットワーク</primary>
-   <secondary> YaST</secondary>
-   <tertiary> ゲートウェイ</tertiary></indexterm> 
+ 
    <para>
     コンピュータを他のコンピュータやネットワークと通信させるには、ネットワークトラフィックが正しい経路を通過するように、ルーティング情報を設定する必要があります。DHCPを使用している場合、この情報は自動的に設定されます。静的アドレスを使用する場合は、このデータを手作業で追加する必要があります。
    </para>

--- a/l10n/sles/ja-jp/xml/nm.xml
+++ b/l10n/sles/ja-jp/xml/nm.xml
@@ -6,10 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>インターネット</primary>
- <secondary>接続</secondary></indexterm><indexterm>
- <primary>NetworkManager</primary></indexterm>
+ </info>
  <para>
   NetworkManagerは、ラップトップなどの携帯用コンピュータのための理想的なソリューションです。NetworkManagerは、802.1x保護ネットワークへの接続など、ネットワーク接続のための最新の暗号化タイプおよび標準をサポートしています。802.1Xは、「IEEE Standard for Local and Metropolitan Area Networks—Port-Based Network Access Control」(ポートごとにネットワークアクセスの制御を行う、ローカル/メトロポリタンエリアネットワーク向け IEEE 標準)です。<quote/>NetworkManagerを使用すると、ネットワークインタフェースの設定および移動時の有線/ワイヤレスネットワーク間の切り替えについて心配する必要がなくなります。NetworkManagerでは、既知のワイヤレスネットワークに自動的に接続するか、または複数のネットワーク接続を並行して管理できます。後者の場合、最も高速な接続がデフォルトとして使用されます。さらに、利用可能なネットワーク間を手動で切り換えたり、システムトレイのアプレットを使用してネットワーク接続を管理できます。
 
@@ -38,11 +35,7 @@
   </itemizedlist>
  </sect1>
  <sect1 xml:id="sec-nm-activate">
-  <title>NetworkManagerの有効化/無効化</title><indexterm>
-
-  <primary> NetworkManager</primary>
-
-  <secondary> 有効化</secondary></indexterm>
+  <title>NetworkManagerの有効化/無効化</title>
 
   <para>
    ラップトップコンピュータでは、NetworkManagerがデフォルトで有効です。ただし、YaSTネットワーク設定モジュールでいつでも有効または無効にできます。
@@ -110,11 +103,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-nm-configure">
-  <title>ネットワーク接続の設定</title><indexterm>
-
-  <primary> NetworkManager</primary>
-
-  <secondary> 設定</secondary></indexterm>
+  <title>ネットワーク接続の設定</title>
 
   <para>
    YaSTでNetworkManagerを有効にした後、GNOMEで使用可能なNetworkManagerフロントエンドでネットワーク接続を設定します。有線、無線、モバイルブロードバンド、DSL、VPN接続など、あらゆるタイプのネットワーク接続に対応するタブが表示されます。
@@ -318,10 +307,7 @@
   </sect2>
 
   <sect2 xml:id="sec-nm-vpn">
-   <title>NetworkManagerとVPN</title><indexterm>
-   <primary>NetworkManager</primary>
-   <secondary>VPN</secondary></indexterm><indexterm>
-   <primary>VPN</primary></indexterm>
+   <title>NetworkManagerとVPN</title>
    <para>
     NetworkManagerは、数種類のVPN (仮想私設網)技術をサポートしています.各技術について、<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>にはNetworkManagerの一般的なサポートを提供する基本パッケージが付属しています。加えて、アプレットに対応するデスクトップ固有のパッケージをインストールすることも必要です。
    </para>
@@ -517,11 +503,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-nm-security">
-  <title>NetworkManagerとセキュリティ</title><indexterm>
-
-  <primary> NetworkManager</primary>
-
-  <secondary> セキュリティ</secondary></indexterm>
+  <title>NetworkManagerとセキュリティ</title>
 
   <para>
    NetworkManagerは、ワイヤレス接続を「信頼された」と「信頼なし」という2種類で区別します。 「信頼された」接続とは、過去に明示的に選択したネットワークです。 その他は「信頼なし」です。信頼された接続は、アクセスポイントのMACアドレスと名前で識別されます。MACアドレスを使用して、信頼された接続が同じ名前でも、異なるアクセスポイントを使用できないようにすることができます。
@@ -651,11 +633,7 @@
   </qandaset>
  </sect1>
  <sect1 xml:id="sec-nm-trouble">
-  <title>トラブルシューティング</title><indexterm>
-
-  <primary> NetworkManager</primary>
-
-  <secondary> トラブルシューティング</secondary></indexterm>
+  <title>トラブルシューティング</title>
 
   <para>
    場合によっては、接続に関する問題が発生することがあります。NetworkManagerに関してよく発生する問題としては、アプレットが起動しない、VPNオプションがないなどがあります。これらの問題の解決、防止方法は、使用ツールによって異なります。

--- a/l10n/sles/ja-jp/xml/pcmcia_apm.xml
+++ b/l10n/sles/ja-jp/xml/pcmcia_apm.xml
@@ -39,9 +39,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>ハイバーネーション(ディスクに保存)<indexterm>
-     <primary>電源管理</primary>
-     <secondary>ハイバーネーション</secondary></indexterm> 
+    <term>ハイバーネーション(ディスクに保存) 
     </term>
     <listitem>
      <para>
@@ -55,9 +53,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>バッテリモニタ<indexterm>
-     <primary>電源管理</primary>
-     <secondary>バッテリモニタ</secondary></indexterm> 
+    <term>バッテリモニタ 
     </term>
     <listitem>
      <para>
@@ -84,11 +80,7 @@
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-pmanage-acpi">
-  <title>ACIP(詳細設定と電源インタフェース)</title><indexterm xml:id="idx-power-management-ACPI" class="startofrange">
-
-  <primary> 電源管理</primary>
-
-  <secondary> ACPI</secondary></indexterm> 
+  <title>ACIP(詳細設定と電源インタフェース)</title>
 
   <para>
    ACPIは、オペレーティングシステムが個々のハードウェアコンポーネントをセットアップし、制御できるように設計されています。ACPIは、PnP(Power Management Plug and Play)とAPM(Advanced Power Management)の両方に優先します。また、ACPIはバッテリ、ACアダプタ、温度、ファン、および <quote>close lid </quote>や <quote>battery low </quote>などのシステムイベントに関する情報も提供します。
@@ -205,7 +197,7 @@
        <link xlink:href="http://acpi.sourceforge.net/dsdt/index.php"/> (Bruno DucrotによるDSDTパッチ)
       </para>
      </listitem>
-    </itemizedlist><indexterm class="endofrange" startref="idx-power-management-ACPI"/>
+    </itemizedlist>
    </sect3>
   </sect2>
  </sect1>

--- a/l10n/sles/ja-jp/xml/printing.xml
+++ b/l10n/sles/ja-jp/xml/printing.xml
@@ -6,8 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary> 印刷</primary></indexterm> 
+ </info>
  <para>
   <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase>は、リモートネットワークプリンタも含め、さまざまな種類のプリンタを使った印刷をサポートしています。プリンタは手動で設定することも、YaSTを使用して設定することもできます。設定の詳細については、<xref linkend="sec-y2-hw-print"/>を参照してください。プリントジョブの開始、管理には、グラフィカルインタフェースまたはコマンドラインユーティリティの両方を利用できます。 プリンタが正常に動作しない場合は、<xref linkend="sec-drucken-prob"/>を参照してください。
  </para>
@@ -266,15 +265,7 @@ Resolution/Output Resolution: 150dpi 300dpi *600dpi</screen>
   </para>
  </sect1>
  <sect1 xml:id="sec-p-appl-commandline">
-  <title>コマンドラインからの印刷</title><indexterm>
-
-  <primary>印刷</primary>
-
-  <secondary>コマンドライン</secondary></indexterm><indexterm>
-
-  <primary>コマンド</primary>
-
-  <secondary>lp</secondary></indexterm>
+  <title>コマンドラインからの印刷</title>
 
   <para>
    コマンドラインから印刷するには、「<command>lp -d</command>
@@ -367,9 +358,7 @@ Resolution/Output Resolution: 150dpi 300dpi *600dpi</screen>
   </para>
 
   <sect2 xml:id="sec-drucken-gdi">
-   <title>標準的なプリンタ言語をサポートしないプリンタ</title><indexterm>
-   <primary> 印刷</primary>
-   <secondary> GDIプリンタ</secondary></indexterm> 
+   <title>標準的なプリンタ言語をサポートしないプリンタ</title>
    <para>
     これらのプリンタは、共通のプリンタ言語をサポートしておらず、独自のコントロールシーケンスを使用しないと対処できません。そのため、これらのプリンタは、メーカがドライバを添付した特定のバージョンのオペレーティングシステムでのみ動作します。GDIは、Microsoft*がグラフィックデバイス用に開発したプログラミングインタフェースです。通常、メーカーはWindows用のドライバだけを提供しており、WindowsドライバはGDIインタフェースを使用しているため、これらのプリンタは「<emphasis>GDIプリンタ</emphasis>」と呼ばれることもあります。実質的な問題は、このプログラミングインタフェースではなく、これらのプリンタを制御できるのは、各プリンタモデルが採用している独自のプリンタ言語のみということです。
    </para>
@@ -395,12 +384,7 @@ Resolution/Output Resolution: 150dpi 300dpi *600dpi</screen>
   </sect2>
 
   <sect2 xml:id="sec-drucken-prob-netconnect">
-   <title>ネットワークプリンタ接続</title><indexterm>
-   <primary>印刷</primary>
-   <secondary>ネットワーク</secondary></indexterm><indexterm>
-   <primary>印刷</primary>
-   <secondary>トラブルシューティング</secondary>
-   <tertiary>ネットワーク</tertiary></indexterm>
+   <title>ネットワークプリンタ接続</title>
    <para/>
    <variablelist>
     <varlistentry>

--- a/l10n/sles/ja-jp/xml/raid.xml
+++ b/l10n/sles/ja-jp/xml/raid.xml
@@ -7,19 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>YaST</primary>
-
- <secondary>RAID</secondary></indexterm><indexterm>
-
- <primary>RAID</primary>
-
- <secondary>YaST</secondary></indexterm><indexterm>
-
- <primary>ソフトウェアRAID</primary>
-
- <see>RAID</see></indexterm>
+ </info>
 
  <para>
   このセクションでは、さまざまなタイプのRAIDを作成して設定するために必要なアクションについて説明します。<phrase os="sles">RAIDの背景情報については、<xref linkend="sec-raid-intro"/></phrase>を参照してください。

--- a/l10n/sles/ja-jp/xml/suse_emacs.xml
+++ b/l10n/sles/ja-jp/xml/suse_emacs.xml
@@ -6,28 +6,19 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-Emacs" class="startofrange">
- <primary>Emacs</primary></indexterm><indexterm xml:id="idx-editors-Emacs" class="startofrange">
- <primary>エディタ</primary>
- <secondary>Emacs</secondary></indexterm>
+ </info>
  <para>
   GNU Emacsは、複合作業環境です。ここでは、GNU Emacsを起動する際に処理される設定ファイルについて説明します。詳細については、<link xlink:href="http://www.gnu.org/software/emacs/"/>を参照してください。
  </para>
  <para>
   Emacsは起動時に、カスタマイズまたは事前設定に関するユーザ、システム管理者、およびディストリビュータの設定が含まれるいくつかのファイルを読み取ります。<filename>~/.emacs</filename>初期化ファイルは、<filename>/etc/skel</filename>から各ユーザのホームディレクトリにインストールされます。その後、<filename>.emacs</filename>は、<filename>/etc/skel/.gnu-emacs</filename>ファイルを読み取ります。プログラムをカスタマイズするには、<filename>.gnu-emacs</filename>をホームディレクトリにコピーし(<command>cp /etc/skel/.gnu-emacs ~/.gnu-emacs</command>を使用)、このディレクトリで希望どおりに設定します。
- </para><indexterm>
- <primary>設定ファイル</primary>
- <secondary>.emacs</secondary></indexterm><indexterm>
- <primary>Emacs</primary>
- <secondary>.emacs</secondary></indexterm>
+ </para>
  <para>
   <filename>.gnu-emacs</filename>は、<filename>~/.gnu-emacs-custom</filename>ファイルを<literal>custom-file</literal>として定義します。Emacsで<literal>customize</literal>を使用して設定を行う場合、この設定は、<filename>~/.gnu-emacs-custom</filename>に保存されます。
  </para>
  <para>
   <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>では、<systemitem class="resource">emacs</systemitem>パッケージは<filename>site-start.el</filename>ファイルを<filename>/usr/share/emacs/site-lisp</filename>ディレクトリにインストールします。<filename>site-start.el</filename>ファイルは、<filename>~/.emacs</filename>初期化ファイルの前にロードされます。<filename>site-start.el</filename>は、<systemitem class="resource">psgml</systemitem>などのEmacsアドオンパッケージと共に配布される特殊な設定ファイルが自動的にロードされるようにします。この種類の設定ファイルも<filename>/usr/share/emacs/site-lisp</filename>に置かれ、ファイル名は常に<filename>suse-start-</filename>で始まります。ローカルのシステム管理者は、<filename>default.el</filename>でシステム全体の設定を指定できます。
- </para><indexterm>
- <primary> Emacs</primary>
- <secondary> default.el</secondary></indexterm> 
+ </para>
  <para>
   これらのファイルの詳細については、<literal>info:/emacs/InitFile</literal>の「Init File」<emphasis/>にあるEmacs情報ファイルを参照してください。これらのファイルを無効にする(必要な場合)方法についても記載されています。
  </para>
@@ -65,5 +56,5 @@
     必要に応じて<systemitem class="resource">emacs-auctex</systemitem>(LaTeX)、<systemitem class="resource">psgml</systemitem>(SGMLおよびXML)、<systemitem class="resource">gnuserv</systemitem>(クライアント/サーバ操作)など、さまざまなアドオンパッケージをインストールできます。
    </para>
   </listitem>
- </itemizedlist><indexterm class="endofrange" startref="idx-Emacs"/><indexterm class="endofrange" startref="idx-editors-Emacs"/>
+ </itemizedlist>
 </sect2>

--- a/l10n/sles/ja-jp/xml/suse_kb.xml
+++ b/l10n/sles/ja-jp/xml/suse_kb.xml
@@ -7,15 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>キーボード</primary>
-
- <secondary>レイアウト</secondary></indexterm><indexterm>
-
- <primary>キーボード</primary>
-
- <secondary>マッピング</secondary></indexterm>
+ </info>
 
  <para>
   プログラムのキーボードマッピングを標準化するために、次のファイルに変更が行われました。
@@ -30,51 +22,15 @@
 /etc/termcap
 /usr/share/terminfo/x/xterm
 /usr/share/X11/app-defaults/XTerm
-/usr/share/emacs/<replaceable>VERSION</replaceable>/site-lisp/term/*.el</screen><indexterm>
-
- <primary> 環境設定ファイル</primary>
-
- <secondary> termcap</secondary></indexterm><indexterm>
-
- <primary>   環境設定ファイル</primary>
-
- <secondary> inputrc</secondary></indexterm> 
+/usr/share/emacs/<replaceable>VERSION</replaceable>/site-lisp/term/*.el</screen> 
 
  <para>
   これらの変更は、<command>terminfo</command>エントリを使用するアプリケーション、またはその設定ファイルが直接変更されるアプリケーション(<command>vi</command>、<command>emacs</command>など)にのみ影響します。システムに付随しないアプリケーションは、これらのデフォルト値に合わせる必要があります。
- </para><indexterm>
-
- <primary>キーボード</primary>
-
- <secondary>マッピング</secondary>
-
- <tertiary>作成</tertiary></indexterm><indexterm>
-
- <primary>キーボード</primary>
-
- <secondary>マッピング</secondary>
-
- <tertiary>マルチキー</tertiary></indexterm>
+ </para>
 
  <para>
   Xの下では、&lt;compose&gt;キー(マルチキー)を<filename>/etc/X11/Xmodmap</filename>で説明されているように有効化できます。
- </para><indexterm>
-
- <primary> キーボード</primary>
-
- <secondary> Xキーボード拡張</secondary></indexterm><indexterm>
-
- <primary>   キーボード</primary>
-
- <secondary> XKB</secondary></indexterm><indexterm>
-
- <primary>   Xキーボード拡張</primary>
-
- <see> キーボード、XKB</see></indexterm><indexterm>
-
- <primary>   XKB</primary>
-
- <see> キーボード、XKB</see></indexterm> 
+ </para>
 
  <para>
   詳しい設定は、Xキーボード拡張(XKB)を使って行うことができます。この拡張機能は、デスクトップ環境GNOME (gswitchit)によっても使用されます。

--- a/l10n/sles/ja-jp/xml/suse_l10n.xml
+++ b/l10n/sles/ja-jp/xml/suse_l10n.xml
@@ -7,36 +7,19 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>システム</primary>
-
- <secondary>ローカライズ</secondary></indexterm><indexterm>
-
- <primary>I18N</primary></indexterm><indexterm>
-
- <primary>L10N</primary></indexterm><indexterm>
-
- <primary>国際化</primary></indexterm><indexterm>
-
- <primary>ローカライズ</primary></indexterm>
+ </info>
 
  <para>
   本システムは、非常に広い範囲で国際化されており、現地の状況に合わせて柔軟に変更できます。国際化(<emphasis/>「I18N」)が特定のローカライズ(<emphasis/>「L10N」)を可能にします。I18NとL10Nという略語は、語の最初と最後の文字の間に、省略されている文字数を挟み込んだ表記です。
  </para>
 
  <para>
-  設定は、ファイル<systemitem>/etc/sysconfig/language</systemitem>の変数<filename>LC_</filename>で定義します。これは、単なる<emphasis>現地語サポート</emphasis>だけでなく、<emphasis>Messages</emphasis>(メッセージ) (言語)、<emphasis>Character Set</emphasis>(文字セット)、<emphasis>Sort Order</emphasis>(ソート順)、<emphasis>Time and Date</emphasis>(時刻と日付)、<emphasis>Numbers</emphasis>(数字)および<emphasis>Money</emphasis>(通貨)の各カテゴリも指します。これらのカテゴリはそれぞれ、独自の変数を使用して直接定義することも、ファイル<filename>language</filename>にあるマスタ変数を使用して間接的に定義することも可能です(<command>locale</command>コマンドでmanページを参照)。<indexterm>
-  <primary>設定ファイル</primary>
-  <secondary>言語</secondary>
-  </indexterm>
+  設定は、ファイル<systemitem>/etc/sysconfig/language</systemitem>の変数<filename>LC_</filename>で定義します。これは、単なる<emphasis>現地語サポート</emphasis>だけでなく、<emphasis>Messages</emphasis>(メッセージ) (言語)、<emphasis>Character Set</emphasis>(文字セット)、<emphasis>Sort Order</emphasis>(ソート順)、<emphasis>Time and Date</emphasis>(時刻と日付)、<emphasis>Numbers</emphasis>(数字)および<emphasis>Money</emphasis>(通貨)の各カテゴリも指します。これらのカテゴリはそれぞれ、独自の変数を使用して直接定義することも、ファイル<filename>language</filename>にあるマスタ変数を使用して間接的に定義することも可能です(<command>locale</command>コマンドでmanページを参照)。
  </para>
 
  <variablelist>
   <varlistentry>
-   <term><systemitem>RC_LC_MESSAGES</systemitem>, <systemitem>RC_LC_CTYPE</systemitem>, <systemitem>RC_LC_COLLATE</systemitem>, <systemitem>RC_LC_TIME</systemitem>, <systemitem>RC_LC_NUMERIC</systemitem>, <systemitem>RC_LC_MONETARY</systemitem><indexterm>
-    <primary> 変数</primary>
-    <secondary> 環境</secondary></indexterm> 
+   <term><systemitem>RC_LC_MESSAGES</systemitem>, <systemitem>RC_LC_CTYPE</systemitem>, <systemitem>RC_LC_COLLATE</systemitem>, <systemitem>RC_LC_TIME</systemitem>, <systemitem>RC_LC_NUMERIC</systemitem>, <systemitem>RC_LC_MONETARY</systemitem> 
    </term>
    <listitem>
     <para>
@@ -110,9 +93,7 @@ localedef -i en_US -f UTF-8 en_US.UTF-8
    </varlistentry>
    <varlistentry>
     <term>
-<systemitem>LANG=en_US.ISO-8859-1</systemitem><indexterm>
-     <primary> エンコード</primary>
-     <secondary> ISO-8859-1</secondary></indexterm> 
+<systemitem>LANG=en_US.ISO-8859-1</systemitem> 
     </term>
     <listitem>
      <para>
@@ -147,16 +128,7 @@ localedef -i en_US -f UTF-8 en_US.UTF-8
    </listitem>
   </itemizedlist>
   <para>
-   これによって、<filename>/etc/sysconfig/language</filename>に加えられたすべての変更が、これらを手動で有効にしなくても、各シェルへの次回ログイン時に使用可能になります。<indexterm>
-   <primary>設定ファイル</primary>
-   <secondary> 言語</secondary>
-   </indexterm><indexterm>
-   <primary>  設定ファイル</primary>
-   <secondary> プロファイル</secondary>
-   </indexterm> <indexterm>
-   <primary>   設定ファイル</primary>
-   <secondary> /etc/profile.d/lang.sh</secondary>
-   </indexterm>
+   これによって、<filename>/etc/sysconfig/language</filename>に加えられたすべての変更が、これらを手動で有効にしなくても、各シェルへの次回ログイン時に使用可能になります。 
   </para>
   <para>
    ユーザは、同様に<filename>~/.bashrc</filename>ファイルを編集して、システムのデフォルトを上書きすることができます。たとえば、システム設定の<literal>en_US</literal>をプログラムメッセージに使用しない場合は、<systemitem>LC_MESSAGES=es_ES</systemitem>を指定してメッセージが英語の代わりにスペイン語で表示されるようにします。

--- a/l10n/sles/ja-jp/xml/suse_logfiles.xml
+++ b/l10n/sles/ja-jp/xml/suse_logfiles.xml
@@ -6,10 +6,8 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>ログファイル</primary></indexterm><indexterm>
- <primary>logrotate</primary></indexterm>
+ </info>
  <para>
   カーネルそのものと一緒になって、定期的にシステムのステータスおよび特定イベントをログファイルに記録するシステムサービス(「デーモン」<emphasis/>)が複数あります。これにより、管理者は、一定間隔でシステムのステータスを定期的にチェックし、エラーまたは障害のある機能を認識し、そのトラブルシューティングをピンポイントで実行できます。通常、これらのログファイルは、FHSで指定されるように<filename>/var/log</filename>内に格納され、毎日記録が追加されるためにサイズが増大します。<systemitem>logrotate</systemitem>パッケージを使用して、これらのファイルが増大するのを制御できます。詳細については、<xref linkend="sec-tuning-logfiles-logrotate"/>を参照してください。
- </para> 
+ </para>
 </sect2>

--- a/l10n/sles/ja-jp/xml/suse_vc.xml
+++ b/l10n/sles/ja-jp/xml/suse_vc.xml
@@ -7,24 +7,12 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary> コンソール</primary>
-
- <secondary> 切り替え</secondary></indexterm> 
+ </info>
 
  <para>
   Linuxは、マルチユーザ、マルチタスクのシステムです。これらの機能は、スタンドアロンのPCシステム上でも利用できます。テキストモードでは、6つのバーチャルコンソールが使用できます。<keycombo> <keycap function="alt"/> <keycap>F1</keycap> </keycombo>～<keycombo> <keycap function="alt"/> <keycap>F6</keycap> </keycombo>を使用して切り替えます。7番目のコンソールはX用に予約されており、10番目のコンソールにはカーネルメッセージが表示されます。
 
- </para><indexterm>
-
- <primary>コンソール</primary>
-
- <secondary>割り当て</secondary></indexterm><indexterm>
-
- <primary>環境設定ファイル</primary>
-
-</indexterm>
+ </para>
 
  <para>
   Xを終了せずにXからコンソールに切り替えるには、<keycombo>

--- a/l10n/sles/ja-jp/xml/sw_managing_commandline.xml
+++ b/l10n/sles/ja-jp/xml/sw_managing_commandline.xml
@@ -11,9 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary> インストール</primary>
- <secondary> ソフトウェア</secondary></indexterm> 
+ </info>
  <xi:include href="zypper.xml"/>
  <xi:include href="rpm.xml"/>
 </chapter>

--- a/l10n/sles/ja-jp/xml/x86_inst_problem.xml
+++ b/l10n/sles/ja-jp/xml/x86_inst_problem.xml
@@ -7,9 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary> 問題解決</primary></indexterm> 
+ </info>
 
  <para>
   <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase>は、広範囲なテストプログラムを経たうえで提供されています。それにもかかわらず、時折、ブートおよびインストール時に問題が発生することがあります。

--- a/l10n/sles/ja-jp/xml/yast2_gui.xml
+++ b/l10n/sles/ja-jp/xml/yast2_gui.xml
@@ -6,8 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-YaST-gui" class="startofrange">
- <primary>YaST</primary></indexterm>
+ </info>
  <para>
   YaSTは、<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>用のインストールおよび設定ツールです。グラフィカルインタフェースを備えており、インストール中でもインストール後でもシステムをすばやくカスタマイズできます。YaSTを使用して、ハードウェアのセットアップ、ネットワークやシステムサービスの設定、セキュリティ設定を行うことができます。
  </para>

--- a/l10n/sles/ja-jp/xml/yast2_lang.xml
+++ b/l10n/sles/ja-jp/xml/yast2_lang.xml
@@ -6,14 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>システム</primary>
- <secondary>言語</secondary></indexterm><indexterm>
- <primary>YaST</primary>
- <secondary>言語</secondary></indexterm><indexterm>
- <primary>言語</primary></indexterm><indexterm>
- <primary>設定</primary>
- <secondary>言語</secondary></indexterm>
+ </info>
  <para>
   別の国での作業、多国語環境での操作が必要な場合は、それに対応するコンピュータの設定が必要です。<phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> は、複数の<literal>ロケール</literal>を並行して扱うことができます。ロケールは、ユーザインタフェースに反映される言語と国を定義するパラメータのセットです。
  </para>

--- a/l10n/sles/ja-jp/xml/yast2_ncurses.xml
+++ b/l10n/sles/ja-jp/xml/yast2_ncurses.xml
@@ -7,14 +7,10 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-YaST-text-mode" class="startofrange">
- <primary> YaST</primary>
- <secondary>テキストモード</secondary></indexterm> 
+ </info>
  <para>
   このセクションは、システムでXサーバを実行せずに、テキストベースのインストールツールを使用しているシステム管理者や専門家の方を対象にしています。ここでは、YaSTをテキストモードで起動して操作するための基本的な情報を説明しています。
- </para><indexterm>
- <primary> YaST</primary>
- <secondary> ncurses</secondary></indexterm> 
+ </para>
  <para>
   テキストモードのYaSTは、ncursesライブラリを使用して、使いやすい擬似グラフィカルユーザインタフェースを提供します。ncursesライブラリは、デフォルトでインストールされています。YaSTを実行するためのターミナルエミュレータの最小サポートサイズは、80x25文字です。
  </para>
@@ -245,11 +241,7 @@
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-yast-ncurses-commands">
-  <title>YaSTコマンドラインオプション</title><indexterm>
-
-  <primary> YaST</primary>
-
-  <secondary> コマンドライン</secondary></indexterm> 
+  <title>YaSTコマンドラインオプション</title>
 
   <para>
    テキストモードのインタフェースのほか、YaSTには、シンプルなコマンドラインインタフェースがあります。YaSTコマンドラインオプションのリストを表示するには、次のように入力します。
@@ -258,10 +250,7 @@
 <screen>yast -h</screen>
 
   <sect2 xml:id="sec-yast-ncurses-modulaufruf">
-   <title>個別モジュールの起動</title><indexterm>
-   <primary>YaST</primary>
-   <secondary>テキストモード</secondary>
-   <tertiary>モジュール</tertiary></indexterm>
+   <title>個別モジュールの起動</title>
    <para>
     時間節約のため、個別のYaSTモジュールを直接起動できます。モジュールを起動するには、次のように入力します。
    </para>
@@ -298,7 +287,7 @@
    <para>
     モジュールにコマンドラインサポートがない場合、モジュールはテキストモードで起動され、次のメッセージが表示されます。
    </para>
-<screen>This YaST module does not support the command line interface.</screen><indexterm class="endofrange" startref="idx-YaST-text-mode"/>
+<screen>This YaST module does not support the command line interface.</screen>
   </sect2>
  </sect1>
 </chapter>

--- a/l10n/sles/ja-jp/xml/yast2_sound.xml
+++ b/l10n/sles/ja-jp/xml/yast2_sound.xml
@@ -7,23 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>設定</primary>
-
- <secondary>サウンドカード</secondary></indexterm><indexterm>
-
- <primary>YaST</primary>
-
- <secondary>サウンドカード</secondary></indexterm><indexterm>
-
- <primary>サウンド</primary>
-
- <secondary>YaSTでの設定</secondary></indexterm><indexterm>
-
- <primary>カード</primary>
-
- <secondary>サウンド</secondary></indexterm>
+ </info>
 
  <para>
   YaSTでは、ほとんどのサウンドカードが自動的に検出され、適切な値で設定されます。デフォルト設定を変更する場合や自動設定できなかったサウンドカードを設定する場合は、YaSTのサウンドモジュールを使用します。このモジュールでは、追加のサウンドカードを設定したり、サウンドカードの順序を切り替えることもできます。
@@ -167,13 +151,7 @@
   </step>
   <step>
    <para>
-    <indexterm>
-    <primary>サウンド</primary>
-    <secondary>フォント</secondary>
-    </indexterm> <indexterm>
-    <primary>サウンド</primary>
-    <secondary>MIDI</secondary>
-    </indexterm>サポートされているサウンドカードが検出された場合は、MIDIファイルの再生用にサウンドフォントをインストールできます。
+     サポートされているサウンドカードが検出された場合は、MIDIファイルの再生用にサウンドフォントをインストールできます。
    </para>
    <substeps performance="required">
     <step>
@@ -203,12 +181,6 @@
  </procedure>
 
  <para>
-  <guimenu>OK</guimenu>をクリックしてYaSTのサウンドモジュールを終了すると、すべてのサウンドカードの音量と設定が保存されます。ミキサーの設定は、<filename>/etc/asound.state</filename>ファイルに保存されます。ALSA設定データは、<filename>/etc/modprobe.d/sound</filename>ファイルの末尾に付加され、<filename>/etc/sysconfig/sound</filename>に書き込まれます。<indexterm>
-  <primary>設定ファイル</primary>
-  <secondary> asound.state</secondary>
-  </indexterm> <indexterm>
-  <primary>   設定ファイル</primary>
-  <secondary> modprobe.d/sound</secondary>
-  </indexterm>
+  <guimenu>OK</guimenu>をクリックしてYaSTのサウンドモジュールを終了すると、すべてのサウンドカードの音量と設定が保存されます。ミキサーの設定は、<filename>/etc/asound.state</filename>ファイルに保存されます。ALSA設定データは、<filename>/etc/modprobe.d/sound</filename>ファイルの末尾に付加され、<filename>/etc/sysconfig/sound</filename>に書き込まれます。 
  </para>
 </sect1>

--- a/l10n/sles/ja-jp/xml/yast2_sw.xml
+++ b/l10n/sles/ja-jp/xml/yast2_sw.xml
@@ -11,11 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>YaST</primary>
- <secondary>ソフトウェア</secondary></indexterm><indexterm>
- <primary>設定</primary>
- <secondary>ソフトウェア</secondary></indexterm>
+ </info>
  <para>
   YaSTのソフトウェアマネージャでシステムのソフトウェアコレクションを変更します。このYaSTモジュールには、X Window向けのグラフィックバージョンとコマンドライン向けのテキストベースバージョンの2種類があります。ここではグラフィックバージョンについて説明します。テキストベースのYaSTについては<xref linkend="cha-yast-text"/>を参照してください。
  </para>

--- a/l10n/sles/ja-jp/xml/yast2_userman.xml
+++ b/l10n/sles/ja-jp/xml/yast2_userman.xml
@@ -99,13 +99,7 @@
   <title>ユーザアカウントの管理</title>
 
   <para>
-   <indexterm>
-   <primary>ユーザ</primary>
-   <secondary>アカウントの作成</secondary>
-   </indexterm> <indexterm>
-   <primary> ユーザ</primary>
-   <secondary>アカウントの変更</secondary>
-   </indexterm> YaSTでは、ユーザアカウントの作成、変更、削除、または一時的な無効化が可能です。熟練したユーザか管理者でない限り、ユーザアカウントを変更しないでください。
+     YaSTでは、ユーザアカウントの作成、変更、削除、または一時的な無効化が可能です。熟練したユーザか管理者でない限り、ユーザアカウントを変更しないでください。
   </para>
 
   <note>
@@ -189,11 +183,7 @@
   </tip>
 
   <procedure>
-   <title>ユーザアカウントを無効化または削除する</title><indexterm>
-   <primary> ユーザ</primary>
-   <secondary> アカウントの無効化</secondary></indexterm><indexterm>
-   <primary>   ユーザ</primary>
-   <secondary> アカウントの削除</secondary></indexterm> 
+   <title>ユーザアカウントを無効化または削除する</title>
    <step>
     <para>
      YaSTの<guimenu>ユーザとグループの管理</guimenu>ダイアログを開き、<guimenu>ユーザ</guimenu>タブをクリックします。
@@ -241,9 +231,7 @@
 
    </para>
    <procedure>
-    <title>パスワードを設定する</title><indexterm>
-    <primary> ユーザ</primary>
-    <secondary> パスワード設定</secondary></indexterm> 
+    <title>パスワードを設定する</title>
     <step>
      <para>
       YaSTの<guimenu>ユーザとグループの管理</guimenu>ダイアログを開き、<guimenu>ユーザ</guimenu>タブを選択します。
@@ -298,11 +286,7 @@
   </sect2>
 
   <sect2 xml:id="sec-y2-userman-adv-crypto">
-   <title>暗号化ホームディレクトリを管理する</title><indexterm>
-   <primary> ホームディレクトリ</primary>
-   <secondary> 暗号化</secondary></indexterm><indexterm>
-   <primary>   ユーザ</primary>
-   <secondary> 暗号化されたホームディレクトリ</secondary></indexterm> 
+   <title>暗号化ホームディレクトリを管理する</title>
    <para>
     ホームディレクトリ中のデータを、盗用やハードディスクの持ち出しなどの犯罪から保護するために、暗号化ホームディレクトリを作成できます。これらはLUKS(Linux Unified Key Setup)で暗号化され、イメージとイメージキーがユーザ用に生成されます。イメージキーはユーザのログインパスワードで保護されます。ユーザがシステムにログインすると、暗号化 ホームディレクトリがマウントされ、その内容を利用できるようになります。
    </para>
@@ -414,11 +398,7 @@
   </sect2>
 
   <sect2 xml:id="sec-y2-userman-adv-quota">
-   <title>クオータの管理</title><indexterm>
-   <primary>ユーザ</primary>
-   <secondary>クオータ</secondary></indexterm><indexterm>
-   <primary>クオータ</primary>
-   <secondary>ユーザ、グループ</secondary></indexterm>
+   <title>クオータの管理</title>
    <para>
     システム容量が通知なく枯渇することのないように、システム管理者はユーザまたはグループに対するクオータを設定できます。クオータは、1つ以上のファイルシステムに対して定義されるもので、これにより使用可能なディスク容量および作成可能なiノード(インデックスノード)の数を制限できます。iノードは、通常のファイル、ディレクトリ、または他のファイルシステムオブジェクトに関する基本的な情報を保存するファイルシステム上のデータ構造です。また、ファイル名とコンテンツを除いて、ファイルシステムオブジェクト(ユーザおよびグループの所有権、読み取り、書き込み、または実行のパーミッションなど)のすべての属性を保存します。
    </para>
@@ -564,11 +544,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-y2-userman-defaults">
-  <title>ローカルユーザのデフォルト設定の変更</title><indexterm>
-
-  <primary> ユーザ</primary>
-
-  <secondary> デフォルト設定</secondary></indexterm> 
+  <title>ローカルユーザのデフォルト設定の変更</title>
 
   <para>
    新しくローカルユーザを作成する際には、いくつかのデフォルト設定がYaSTで使用されます。これらには、たとえば、ユーザが属するプライマリグループとセカンダリグループ、ユーザのホームディレクトリのアクセスパーミッションなどが含まれます。これらのデフォルト設定値は、必要に応じて変更することができます。
@@ -616,10 +592,7 @@
   <title>グループへのユーザの割り当て</title>
 
   <para>
-   <indexterm>
-   <primary>ユーザ</primary>
-   <secondary>グループの割り当て</secondary>
-   </indexterm><guimenu>ユーザとグループの管理</guimenu>ダイアログの<guimenu>新しいユーザのデフォルト設定</guimenu>タブからアクセス可能なデフォルト設定に従って、さまざまなグループにローカルユーザが割り当てられます。次に、個別ユーザのグループ割り当てを変更する方法を説明します。新しいユーザに対するデフォルトのグループの割り当てを変更する必要がある場合については、<xref linkend="sec-y2-userman-defaults"/>を参照してください。
+   <guimenu>ユーザとグループの管理</guimenu>ダイアログの<guimenu>新しいユーザのデフォルト設定</guimenu>タブからアクセス可能なデフォルト設定に従って、さまざまなグループにローカルユーザが割り当てられます。次に、個別ユーザのグループ割り当てを変更する方法を説明します。新しいユーザに対するデフォルトのグループの割り当てを変更する必要がある場合については、<xref linkend="sec-y2-userman-defaults"/>を参照してください。
   </para>
 
   <procedure>
@@ -660,19 +633,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-y2-userman-groups">
-  <title>グループを管理する</title><indexterm>
-
-  <primary>グループ</primary>
-
-  <secondary>管理</secondary></indexterm><indexterm>
-
-  <primary>YaST</primary>
-
-  <secondary>グループ管理</secondary></indexterm><indexterm>
-
-  <primary>設定</primary>
-
-  <secondary>グループ</secondary></indexterm>
+  <title>グループを管理する</title>
 
   <para>
    YaSTでは、グループの追加、変更、または削除も容易に実行できます。
@@ -744,11 +705,7 @@
   </para>
  </sect1>
  <sect1 xml:id="cha-y2-userman-authent">
-  <title>ユーザ認証方法を変更する</title><indexterm>
-
-  <primary> ユーザ</primary>
-
-  <secondary> 認証</secondary></indexterm> 
+  <title>ユーザ認証方法を変更する</title>
 
   <para>
    マシンがネットワークに接続されている場合は認証方法を変更できます。次のオプションを指定できます。

--- a/l10n/sles/ja-jp/xml/yast2_you.xml
+++ b/l10n/sles/ja-jp/xml/yast2_you.xml
@@ -6,11 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>アップデート</primary>
- <secondary>オンライン</secondary></indexterm><indexterm>
- <primary>YaST</primary>
- <secondary>オンラインアップデート</secondary></indexterm>
+ </info>
  <para>
   SUSEはお買い上げの製品に対し、継続的にソフトウェアセキュリティのアップデートを提供します。デフォルトでは、システムを最新の状態に維持するために更新アプレットが使用されます。アップデートアプレットの詳細については、<xref linkend="sec-updater"/>を参照してください。この章では、ソフトウェアパッケージをアップデートする代替ツールとして、YaSTオンラインアップデートを紹介します。
  </para>

--- a/l10n/sles/ko-kr/xml/aarch64_inst_problem.xml
+++ b/l10n/sles/ko-kr/xml/aarch64_inst_problem.xml
@@ -7,9 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>예</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary> 문제 해결책</primary></indexterm> 
+ </info>
 
  <para>
   <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase>는 전달 전에 광범위한 테스트 프로그램을 거치게 됩니다. 그러나 부팅 또는 설치하는 중에 문제가 자주 발생합니다.

--- a/l10n/sles/ko-kr/xml/common_intro_available_doc_i.xml
+++ b/l10n/sles/ko-kr/xml/common_intro_available_doc_i.xml
@@ -9,13 +9,7 @@
    </dm:bugtracker>
    <dm:translation>예</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>help</primary>
-
- <secondary> SUSE 설명서</secondary></indexterm><indexterm>
-
- <primary> SUSE 설명서</primary></indexterm>
+ </info>
 
  <note>
   <title>온라인 문서 및 최신 업데이트</title>

--- a/l10n/sles/ko-kr/xml/lvm.xml
+++ b/l10n/sles/ko-kr/xml/lvm.xml
@@ -7,19 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>예</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>YaST</primary>
-
- <secondary> LVM</secondary></indexterm><indexterm>
-
- <primary> LVM</primary>
-
- <secondary> YaST</secondary></indexterm><indexterm>
-
- <primary> 논리적 볼륨 관리자</primary>
-
- <see> LVM</see></indexterm>
+ </info>
 
  <para>
   이 섹션에서는 LVM 구성을 위해 필요한 구체적인 단계를 설명합니다. <phrase os="sles">논리적 볼륨 관리자에 대한 일반적인 정보가 필요하면 <xref linkend="sec-lvm-explained"/> 항목을 참조하십시오.</phrase>

--- a/l10n/sles/ko-kr/xml/raid.xml
+++ b/l10n/sles/ko-kr/xml/raid.xml
@@ -7,19 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>예</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>YaST</primary>
-
- <secondary>RAID</secondary></indexterm><indexterm>
-
- <primary>RAID</primary>
-
- <secondary>YaST</secondary></indexterm><indexterm>
-
- <primary>소프트 RAID</primary>
-
- <see>RAID</see></indexterm>
+ </info>
 
  <para>
   이 섹션에서는 다양한 유형의 RAID 생성 및 구성에 필요한 작업을 설명합니다. <phrase os="sles">RAID에 관한 배경 정보가 필요한 경우 <xref linkend="sec-raid-intro"/></phrase> 항목을 참조하십시오.

--- a/l10n/sles/ko-kr/xml/x86_inst_problem.xml
+++ b/l10n/sles/ko-kr/xml/x86_inst_problem.xml
@@ -7,9 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>예</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary> 문제 해결책</primary></indexterm> 
+ </info>
 
  <para>
   <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase>는 전달 전에 광범위한 테스트 프로그램을 거치게 됩니다. 그러나 부팅 또는 설치하는 중에 문제가 자주 발생합니다.

--- a/l10n/sles/ko-kr/xml/yast2_lang.xml
+++ b/l10n/sles/ko-kr/xml/yast2_lang.xml
@@ -6,14 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>예</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>시스템</primary>
- <secondary>언어</secondary></indexterm><indexterm>
- <primary>YaST</primary>
- <secondary>언어</secondary></indexterm><indexterm>
- <primary>언어</primary></indexterm><indexterm>
- <primary>구성</primary>
- <secondary>언어</secondary></indexterm>
+ </info>
  <para>
   다른 국가에서 작업하거나 다국어 환경에서 작업해야 할 경우 이를 지원하도록 컴퓨터를 설정해야 합니다. <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase>에서는 서로 다른 <literal>로케일</literal>을 병렬로 처리할 수 있습니다. 로케일은 사용자 인터페이스에 적용된 언어 및 국가 설정을 정의하는 파라미터 집합입니다.
  </para>

--- a/l10n/sles/ko-kr/xml/yast2_sound.xml
+++ b/l10n/sles/ko-kr/xml/yast2_sound.xml
@@ -7,23 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>예</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>구성</primary>
-
- <secondary>사운드 카드</secondary></indexterm><indexterm>
-
- <primary>YaST</primary>
-
- <secondary>사운드 카드</secondary></indexterm><indexterm>
-
- <primary>사운드</primary>
-
- <secondary>YaST에서 구성</secondary></indexterm><indexterm>
-
- <primary>카드</primary>
-
- <secondary>사운드</secondary></indexterm>
+ </info>
 
  <para>
   YaST는 대부분의 사운드 카드를 자동으로 감지하고 이 카드를 적합한 값으로 구성합니다. 기본 설정을 변경하거나 자동으로 구성할 수 없는 사운드 카드를 설정하려면 YaST 사운드 모듈을 사용하십시오. 여기서 추가 사운드 카드를 설정하거나 순서를 전환할 수도 있습니다.
@@ -167,13 +151,7 @@
   </step>
   <step>
    <para>
-    <indexterm>
-    <primary>sound</primary>
-    <secondary>fonts</secondary>
-    </indexterm> <indexterm>
-    <primary>sound</primary>
-    <secondary>MIDI</secondary>
-    </indexterm>지원되는 사운드 카드가 감지되면 MIDI 파일의 재생에 대한 SoundFont를 설치할 수 있습니다.
+     지원되는 사운드 카드가 감지되면 MIDI 파일의 재생에 대한 SoundFont를 설치할 수 있습니다.
    </para>
    <substeps performance="required">
     <step>
@@ -203,12 +181,6 @@
  </procedure>
 
  <para>
-  <guimenu>확인</guimenu>을 클릭하고 YaST 사운드 모듈을 종료하면 모든 사운드 카드의 볼륨 및 구성이 저장됩니다. 믹서 설정은 <filename>/etc/asound.state</filename> 파일에 저장됩니다. ALSA 구성 데이터는 <filename>/etc/modprobe.d/sound</filename> 파일의 끝에 추가되고, <filename>/etc/sysconfig/sound</filename>에 기록됩니다.<indexterm>
-  <primary>구성 파일</primary>
-  <secondary> asound.state</secondary>
-  </indexterm> <indexterm>
-  <primary>   구성 파일</primary>
-  <secondary> modprobe.d/sound</secondary>
-  </indexterm>
+  <guimenu>확인</guimenu>을 클릭하고 YaST 사운드 모듈을 종료하면 모든 사운드 카드의 볼륨 및 구성이 저장됩니다. 믹서 설정은 <filename>/etc/asound.state</filename> 파일에 저장됩니다. ALSA 구성 데이터는 <filename>/etc/modprobe.d/sound</filename> 파일의 끝에 추가되고, <filename>/etc/sysconfig/sound</filename>에 기록됩니다. 
  </para>
 </sect1>

--- a/l10n/sles/ko-kr/xml/yast2_sw.xml
+++ b/l10n/sles/ko-kr/xml/yast2_sw.xml
@@ -11,11 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>예</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>YaST</primary>
- <secondary>소프트웨어</secondary></indexterm><indexterm>
- <primary>구성</primary>
- <secondary>소프트웨어</secondary></indexterm>
+ </info>
  <para>
   YaST 소프트웨어 관리자로 시스템의 소프트웨어 모음을 변경하십시오. 이 YaST 모듈은 두 가지 특징인 X Window용 그래픽 변형 및 명령줄에서 사용할 텍스트 기반 변형으로 사용할 수 있습니다. 그래픽 특징은 여기에서 설명합니다. 텍스트 기반 YaST에 대한 자세한 내용은 <xref linkend="cha-yast-text"/>를 참조하십시오.
  </para>

--- a/l10n/sles/ko-kr/xml/yast2_userman.xml
+++ b/l10n/sles/ko-kr/xml/yast2_userman.xml
@@ -99,13 +99,7 @@
   <title>사용자 계정 관리</title>
 
   <para>
-   <indexterm>
-   <primary>사용자</primary>
-   <secondary> 계정 생성</secondary>
-   </indexterm> <indexterm>
-   <primary>   사용자</primary>
-   <secondary> 계정 수정</secondary>
-   </indexterm>  YaST에서는 사용자 계정을 생성, 수정, 삭제하거나 일시적으로 비활성화하는 옵션을 제공합니다. 숙련된 사용자 또는 관리자가 아니면 사용자 계정을 수정하지 마십시오.
+      YaST에서는 사용자 계정을 생성, 수정, 삭제하거나 일시적으로 비활성화하는 옵션을 제공합니다. 숙련된 사용자 또는 관리자가 아니면 사용자 계정을 수정하지 마십시오.
   </para>
 
   <note>
@@ -189,11 +183,7 @@
   </tip>
 
   <procedure>
-   <title>사용자 계정 비활성화 또는 삭제</title><indexterm>
-   <primary> 사용자</primary>
-   <secondary> 계정 비활성화</secondary></indexterm><indexterm>
-   <primary>   사용자</primary>
-   <secondary> 계정 삭제</secondary></indexterm> 
+   <title>사용자 계정 비활성화 또는 삭제</title>
    <step>
     <para>
      YaST <guimenu>사용자 및 그룹 관리</guimenu> 대화 상자를 열고 <guimenu>사용자</guimenu> 탭을 클릭하십시오.
@@ -241,9 +231,7 @@
 
    </para>
    <procedure>
-    <title>비밀번호 설정 구성</title><indexterm>
-    <primary> 사용자</primary>
-    <secondary> 비밀번호 설정</secondary></indexterm> 
+    <title>비밀번호 설정 구성</title>
     <step>
      <para>
       YaST <guimenu>사용자 및 그룹 관리</guimenu> 대화 상자를 열고 <guimenu>사용자</guimenu> 탭을 선택합니다.
@@ -298,11 +286,7 @@
   </sect2>
 
   <sect2 xml:id="sec-y2-userman-adv-crypto">
-   <title>암호화된 홈 디렉토리 관리</title><indexterm>
-   <primary> 홈 디렉토리</primary>
-   <secondary> 암호화</secondary></indexterm><indexterm>
-   <primary>   사용자</primary>
-   <secondary> 암호화된 홈 디렉토리</secondary></indexterm> 
+   <title>암호화된 홈 디렉토리 관리</title>
    <para>
     홈 디렉토리의 데이터 도용 및 하드 디스크 삭제를 방지하기 위해 사용자에 대한 암호화된 홈 디렉토리를 생성할 수 있습니다. 이러한 디렉토리는 LUKS(Linux Unified Key Setup)로 암호화되어, 사용자에 대한 이미지 및 이미지 키가 생성됩니다. 이미지 키는 사용자의 로그인 비밀번호로 보호됩니다. 사용자가 시스템에 로그인할 때 암호화된 홈 디렉토리가 탑재되고 사용자가 내용을 사용할 수 있습니다.
    </para>
@@ -414,11 +398,7 @@
   </sect2>
 
   <sect2 xml:id="sec-y2-userman-adv-quota">
-   <title>할당량 관리</title><indexterm>
-   <primary>사용자</primary>
-   <secondary>할당량</secondary></indexterm><indexterm>
-   <primary>할당량</primary>
-   <secondary>사용자, 그룹</secondary></indexterm>
+   <title>할당량 관리</title>
    <para>
     시스템 성능이 알림 없이 소진되지 않도록 하기 위해 시스템 관리자는 사용자 또는 그룹에 대한 할당량을 설정할 수 있습니다. 할당량은 하나 이상의 파일 시스템에 대해 정의될 수 있고 사용할 수 있는 디스크 공간과 이 공간에서 생성할 수 있는 inodes(인덱스 노드) 수를 제한합니다. Inodes는 일반 파일, 디렉토리 또는 기타 파일 시스템 객체에 대한 기본적인 정보를 저장하는 파일 시스템의 데이터 구조입니다. 이들은 파일 이름 및 내용을 제외한 파일 시스템 객체의 모든 특성(예: 사용자 및 그룹 소유권, 읽기, 쓰기 또는 실행 권한)을 저장합니다.
    </para>
@@ -564,11 +544,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-y2-userman-defaults">
-  <title>로컬 사용자에 대한 기본 설정 변경</title><indexterm>
-
-  <primary> 사용자</primary>
-
-  <secondary> 기본 설정</secondary></indexterm> 
+  <title>로컬 사용자에 대한 기본 설정 변경</title>
 
   <para>
    새 로컬 사용자를 생성할 때 YaST는 여러 가지 기본 설정을 사용합니다. 예를 들어, 사용자가 속하는 주 그룹과 보조 그룹 또는 사용자 홈 디렉토리의 액세스 권한 등입니다. 이러한 기본 설정을 변경하여 사용자의 요구사항을 충족시킬 수 있습니다.
@@ -616,10 +592,7 @@
   <title>그룹에 사용자 할당</title>
 
   <para>
-   <indexterm>
-   <primary>사용자</primary>
-   <secondary> 그룹 할당</secondary>
-   </indexterm>  로컬 사용자는 <guimenu>사용자 및 그룹 관리</guimenu> 대화 상자의 <guimenu>새로운 사용자의 기본값</guimenu> 탭에서 액세스할 수 있는 기본 설정에 따라 여러 그룹에 할당됩니다. 다음에서 개별 사용자의 그룹 할당을 수정하는 방법을 배웁니다. 새 사용자에 대한 기본 그룹 할당을 변경해야 할 경우 <xref linkend="sec-y2-userman-defaults"/>을 참조하십시오.
+     로컬 사용자는 <guimenu>사용자 및 그룹 관리</guimenu> 대화 상자의 <guimenu>새로운 사용자의 기본값</guimenu> 탭에서 액세스할 수 있는 기본 설정에 따라 여러 그룹에 할당됩니다. 다음에서 개별 사용자의 그룹 할당을 수정하는 방법을 배웁니다. 새 사용자에 대한 기본 그룹 할당을 변경해야 할 경우 <xref linkend="sec-y2-userman-defaults"/>을 참조하십시오.
   </para>
 
   <procedure>
@@ -660,19 +633,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-y2-userman-groups">
-  <title>그룹 관리</title><indexterm>
-
-  <primary>그룹</primary>
-
-  <secondary>관리</secondary></indexterm><indexterm>
-
-  <primary>YaST</primary>
-
-  <secondary>그룹 관리</secondary></indexterm><indexterm>
-
-  <primary>구성</primary>
-
-  <secondary>그룹</secondary></indexterm> 
+  <title>그룹 관리</title>
 
   <para>
    YaST를 사용하여 그룹을 쉽게 추가, 수정 또는 삭제할 수도 있습니다.
@@ -744,11 +705,7 @@
   </para>
  </sect1>
  <sect1 xml:id="cha-y2-userman-authent">
-  <title>사용자 인증 방법 변경</title><indexterm>
-
-  <primary> 사용자</primary>
-
-  <secondary> 인증</secondary></indexterm> 
+  <title>사용자 인증 방법 변경</title>
 
   <para>
    시스템이 네트워크에 연결되어 있을 때 인증 방법을 변경할 수 있습니다. 다음 옵션을 사용할 수 있습니다.

--- a/l10n/sles/pt-br/xml/aarch64_inst_problem.xml
+++ b/l10n/sles/pt-br/xml/aarch64_inst_problem.xml
@@ -7,9 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>problem solution</primary></indexterm>
+ </info>
 
  <para>
   Prior to delivery, <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> is subjected to an extensive test

--- a/l10n/sles/pt-br/xml/apps_brasero.xml
+++ b/l10n/sles/pt-br/xml/apps_brasero.xml
@@ -19,26 +19,9 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-brasero" class="startofrange">
- <primary>Brasero</primary></indexterm>
+ </info>
  <sect1 xml:id="sec-brasero-creating">
-  <title>Creating a Data CD or DVD</title><indexterm>
-
-  <primary>CDs</primary>
-
-  <secondary>creating</secondary>
-
-  <tertiary>data</tertiary></indexterm><indexterm>
-
-  <primary>K3b</primary>
-
-  <secondary>data CDs</secondary></indexterm><indexterm>
-
-  <primary>DVDs</primary>
-
-  <secondary>creating</secondary>
-
-  <tertiary>data</tertiary></indexterm>
+  <title>Creating a Data CD or DVD</title>
 
   <para>
    After starting Brasero for the first time, the main window appears as shown
@@ -131,17 +114,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-brasero-creatingaudiocd">
-  <title>Creating an Audio CD</title><indexterm>
-
-  <primary>CDs</primary>
-
-  <secondary>creating</secondary>
-
-  <tertiary>audio</tertiary></indexterm><indexterm>
-
-  <primary>Brasero</primary>
-
-  <secondary>audio CDs</secondary></indexterm>
+  <title>Creating an Audio CD</title>
 
   <para>
    There are no significant differences between creating an audio CD and
@@ -190,19 +163,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-brasero-copying">
-  <title>Copying a CD or DVD</title><indexterm>
-
-  <primary>CDs</primary>
-
-  <secondary>copying</secondary></indexterm><indexterm>
-
-  <primary>Brasero</primary>
-
-  <secondary>copying CDs</secondary></indexterm><indexterm>
-
-  <primary>DVDs</primary>
-
-  <secondary>copying</secondary></indexterm>
+  <title>Copying a CD or DVD</title>
 
   <para>
    To copy a CD or DVD, proceed as follows:
@@ -241,15 +202,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-gnome-writingiso">
-  <title>Writing ISO Images</title><indexterm>
-
-  <primary>CDs</primary>
-
-  <secondary>ISO images</secondary></indexterm><indexterm>
-
-  <primary>DVDs</primary>
-
-  <secondary>ISO images</secondary></indexterm>
+  <title>Writing ISO Images</title>
 
   <para>
    If you already have an ISO image, click <guimenu>Burn image</guimenu> or go
@@ -262,11 +215,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-brasero-multisession">
-  <title>Creating a Multisession CD or DVD</title><indexterm>
-
-  <primary>CDs</primary>
-
-  <secondary>multisession</secondary></indexterm>
+  <title>Creating a Multisession CD or DVD</title>
 
   <para>
    Multisession discs can be used to write data in more than one burning
@@ -314,6 +263,6 @@
   <para>
    You can find more information about Brasero at
    <link xlink:href="https://wiki.gnome.org/Apps/Brasero"/>.
-  </para><indexterm class="endofrange" startref="idx-brasero"/>
+  </para>
  </sect1>
 </chapter>

--- a/l10n/sles/pt-br/xml/apps_ekiga.xml
+++ b/l10n/sles/pt-br/xml/apps_ekiga.xml
@@ -12,12 +12,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-voip" class="startofrange">
- <primary>voice over IP</primary></indexterm><indexterm>
- <primary>applications</primary>
- <secondary>network</secondary>
- <tertiary>Ekiga</tertiary></indexterm><indexterm xml:id="idx-ekiga" class="startofrange">
- <primary>Ekiga</primary></indexterm>
+ </info>
  <note>
   <title>Ekiga May Not Be Installed</title>
   <para>
@@ -419,11 +414,7 @@
   </table>
  </sect1>
  <sect1 xml:id="sec-ekiga-firstcall">
-  <title>Making a Call</title><indexterm>
-
-  <primary>Ekiga</primary>
-
-  <secondary>calling</secondary></indexterm>
+  <title>Making a Call</title>
 
   <para>
    After Ekiga is properly configured, making a call is easy.
@@ -598,8 +589,8 @@
    <literal>PBX</literal> software Asterisk
    <link xlink:href="http://www.asterisk.org/"/>. Find information about it at
    <link xlink:href="http://www.voip-info.org/wiki-Asterisk"/>.
-   <indexterm startref="idx-ekiga" class="endofrange"/>
-   <indexterm startref="idx-voip" class="endofrange"/>
+   
+   
   </para>
  </sect1>
 </chapter>

--- a/l10n/sles/pt-br/xml/apps_firefox.xml
+++ b/l10n/sles/pt-br/xml/apps_firefox.xml
@@ -11,7 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes (sim)</dm:translation>
   </dm:docmanager>
- </info><indexterm class="startofrange" xml:id="idx-firefox"> <primary>Firefox</primary> </indexterm> <indexterm class="startofrange" xml:id="idx-browsers-firefox"><primary>browsers da Web</primary> <secondary>Firefox</secondary> </indexterm> <indexterm> <primary>aplicativos</primary> <secondary>rede</secondary> <tertiary>Firefox</tertiary> </indexterm>
+ </info> 
  <sect1 xml:id="sec-firefox-start">
   <title>Iniciando o Firefox</title>
 
@@ -20,7 +20,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-firefox-navigating">
-  <title>Navegando em sites na Web</title><indexterm> <primary>Firefox</primary> <secondary>navegando</secondary> </indexterm>
+  <title>Navegando em sites na Web</title>
 
   <para>
    A aparência do Firefox é similar a de outros browsers. Isso é mostrado na <xref linkend="fig-firefox-main"/>. Na parte superior da janela, você encontra a barra de localização para endereços da Web e a barra de pesquisa. Favoritos também estão disponíveis para acesso rápido na barra de ferramentas dos favoritos. Para obter mais informações sobre os vários recursos do Firefox, use o menu <guimenu>Ajuda</guimenu> na barra de menus.
@@ -52,7 +52,7 @@
   </figure>
 
   <sect2 xml:id="sec-firefox-locationbar">
-   <title>Barra de Localização</title><indexterm> <primary>Firefox</primary> <secondary>barra de localização</secondary> </indexterm>
+   <title>Barra de Localização</title>
    <para>
     Quando você digita na barra de localização, aparece uma caixa suspensa de preenchimento automático. Ela mostra todos os endereços de localização anteriores e favoritos que incluem os caracteres que você está digitando. A frase correspondente é realçada em negrito. As entradas visitadas mais frequentemente e recentemente são listadas primeiro.
    </para>
@@ -65,7 +65,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-zoom">
-   <title>Ampliando</title><indexterm> <primary>Firefox</primary> <secondary>zoom</secondary> </indexterm>
+   <title>Ampliando</title>
    <para>
     O Firefox oferece duas opções de zoom: zoom de página (o padrão) e zoom de texto. O zoom da página amplia a página inteira como está, com todos os respectivos elementos expandidos igualmente, incluindo os gráficos. Já o zoom de texto muda apenas o tamanho do texto.
    </para>
@@ -75,7 +75,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-tabbedbrowsing">
-   <title>Navegação por guias</title><indexterm> <primary>Firefox</primary> <secondary>guias</secondary> </indexterm> <indexterm> <primary>Firefox</primary> <secondary>navegação com guias</secondary> </indexterm>
+   <title>Navegação por guias</title>
    <para>
     A navegação com guias permite carregar vários sites na Web em uma única janela. Para alternar entre as páginas em uso, clique nas guias na parte superior da janela. Se você usa frequentemente mais de uma página da Web de uma vez, a navegação com guias facilita alternar entre as páginas. 
    </para>
@@ -116,7 +116,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-sidebar">
-   <title>Usando o painel lateral</title><indexterm> <primary>Firefox</primary> <secondary>painel lateral</secondary> </indexterm>
+   <title>Usando o painel lateral</title>
    <para>
     Use a lateral esquerda da janela do browser para ver os favoritos ou o histórico de navegação. As extensões também podem permitir novas maneiras de usar o painel lateral. Para exibir a barra lateral, na barra de menus, selecione <menuchoice> <guimenu>Exibir</guimenu> <guimenu>Barra lateral</guimenu> </menuchoice> e selecione o conteúdo desejado.
    </para>
@@ -130,7 +130,7 @@
   </para>
 
   <sect2 xml:id="sec-firefox-searchengine">
-   <title>Localizando informações na Web</title><indexterm> <primary>Firefox</primary> <secondary>pesquisando com</secondary> </indexterm> <indexterm> <primary>Firefox</primary> <secondary>barra de pesquisa</secondary> </indexterm> <indexterm> <primary>Firefox</primary> <secondary>pesquisa na web</secondary> </indexterm>
+   <title>Localizando informações na Web</title> 
    <para>
     O Firefox dispõe de uma barra de pesquisa capaz de acessar diferentes mecanismos como Google, Yahoo ou Amazon. Por exemplo, para localizar informações sobre o SUSE usando o mecanismo atual, clique na barra de pesquisa, digite <literal>SUSE</literal> e pressione <keycap function="enter"/>. Os resultados são exibidos na janela. 
    </para>
@@ -185,7 +185,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-searchengine-smartkeywords">
-    <title>Adicionando palavras-chave às pesquisas online</title><indexterm> <primary>Firefox</primary> <secondary>palavras-chave</secondary></indexterm>
+    <title>Adicionando palavras-chave às pesquisas online</title>
     <para>
      O Firefox permite definir suas próprias <emphasis>palavras-chave</emphasis>: abreviações usadas como atalhos de URL para determinado mecanismo de pesquisa. Se você definiu <literal>ws</literal> como uma palavra-chave para a pesquisa na Wikipédia, por exemplo, pode digitar <literal>ws <replaceable>TERMODEPESQUISA</replaceable></literal> na barra de localização para pesquisar por <replaceable>TERMODEPESQUISA</replaceable> na Wikipédia.
     </para>
@@ -227,17 +227,17 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-findinfo-page">
-   <title>Pesquisando na página atual</title><indexterm><primary>Firefox</primary> <secondary>localizando na página</secondary> </indexterm>
+   <title>Pesquisando na página atual</title>
    <para>
     Para pesquisar em uma página da Web, na barra de menus, clique em <menuchoice> <guimenu>Editar</guimenu> <guimenu>Localizar</guimenu> </menuchoice> ou pressione <keycombo> <keycap function="control"/> <keycap>F</keycap> </keycombo>. A barra de localização é aberta. Geralmente, aparece uma barra na parte inferior da janela. Digite a consulta na caixa de texto. O Firefox encontra a primeira ocorrência da frase digitada. Você pode encontrar outras ocorrências da frase pressionando <keycap>F3</keycap> ou o botão <guimenu>Next</guimenu> (Avançar) na barra de localização. Se clicar no botão <guimenu>Realçar tudo</guimenu>, todas as ocorrências da frase serão realçadas. Marque a opção <guimenu>Diferenciar maiúsc./minúsc.</guimenu> para que a consulta diferencie maiúsculas de minúsculas.
-   </para><indexterm> <primary>Firefox</primary> <secondary>localização rápida</secondary> </indexterm>
+   </para>
    <para>
     O Firefox também oferece duas opções de localização rápida. Clique em qualquer lugar em que deseja iniciar a pesquisa na página da Web, digite <keycap>/</keycap> seguido, sem espaço, do termo de pesquisa. A primeira ocorrência do termo de pesquisa é realçada enquanto você digita. Use <keycap>F3</keycap> para localizar a próxima ocorrência. Também é possível limitar a localização rápida apenas a links. Esta opção de pesquisa fica disponível quando você digita <keycap>'</keycap>.
    </para>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-firefox-bookmarks">
-  <title>Gerenciando marcadores</title><indexterm> <primary>Firefox</primary> <secondary>marcadores</secondary> </indexterm>
+  <title>Gerenciando marcadores</title>
 
   <para>
    Os marcadores oferecem uma maneira fácil de gravar links nos seus sites favoritos. O Firefox não só facilita bastante a adição de novos favoritos com apenas um clique do mouse, como também oferece várias formas de gerenciar grandes coleções de favoritos. É possível classificar favoritos em pastas, classificá-los com tags ou filtrá-los com pastas de favoritos inteligentes.
@@ -256,7 +256,7 @@
   </para>
 
   <sect2 xml:id="sec-firefox-bookmarks-organise">
-   <title>Organizando favoritos</title><indexterm> <primary>Firefox</primary> <secondary>favoritos</secondary> <tertiary>gerenciando</tertiary> </indexterm> <indexterm> <primary>Firefox</primary> <secondary>favoritos</secondary> <tertiary>Biblioteca</tertiary> </indexterm>
+   <title>Organizando favoritos</title>
    <para>
     A <guimenu>Biblioteca</guimenu> pode ser usada para gerenciar as propriedades (nome e endereço) de cada favorito e organizar os favoritos em pastas e seções. Ele se assemelha à <xref linkend="fig-firefox-library"/>.
    </para>
@@ -335,7 +335,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-tags">
-   <title>Tags</title><indexterm> <primary>Firefox</primary> <secondary>favoritos</secondary> <tertiary>tags</tertiary> </indexterm>
+   <title>Tags</title>
    <para>
     As tags oferecem um modo prático de arquivar um favorito sob várias categorias. Você pode marcar um favorito com quantos termos desejar. Por exemplo, para acessar todos os sites marcados com <literal>suse</literal>, digite <literal>suse</literal> na barra de localização. Para cada tag, um item é automaticamente criado na pasta <systemitem>Tags recentes</systemitem> da biblioteca. Arraste e solte um item de uma tag na barra de ferramentas de favoritos para acessá-lo facilmente.
    </para>
@@ -345,7 +345,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-imexport">
-   <title>Importando e exportando favoritos</title><indexterm> <primary>Firefox</primary> <secondary>favoritos</secondary> <tertiary>importando</tertiary> </indexterm> <indexterm> <primary>Firefox</primary> <secondary>favoritos</secondary> <tertiary>exportando</tertiary> </indexterm>
+   <title>Importando e exportando favoritos</title>
 
    <para>
     Para importar favoritos de outro browser ou de um arquivo no formato HTML, abra a biblioteca escolhendo, na barra de menus, <menuchoice> <guimenu>Favoritos</guimenu> <guimenu>Exibir todos os favoritos</guimenu> </menuchoice>. Para iniciar o Assistente de Importação, clique em <menuchoice> <guimenu>Importar e backup</guimenu> <guimenu>Importar favoritos em HTML</guimenu> </menuchoice> e escolha o local de importação. Clique em <guimenu>Avançar</guimenu> para iniciar a importação. As importações de um arquivo HTML são feitas como estão.
@@ -359,7 +359,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-live">
-   <title>Marcadores ativos</title><indexterm> <primary>Firefox</primary> <secondary>favoritos</secondary> <tertiary>favoritos ativos</tertiary> </indexterm>
+   <title>Marcadores ativos</title>
    <para>
     As Últimas notícias exibem manchetes no menu de favoritos e mantêm você atualizado com as notícias mais recentes. Desse modo, você pode economizar tempo com uma rápida olhada nos seus sites favoritos. Favoritos ativos são atualizados automaticamente. Muitos sites e blogs suportam esse formato. 
    </para>
@@ -370,14 +370,14 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-smart">
-   <title>Pastas de favoritos inteligentes</title><indexterm> <primary>Firefox</primary> <secondary>favoritos</secondary> <tertiary>favoritos inteligentes</tertiary> </indexterm>
+   <title>Pastas de favoritos inteligentes</title>
    <para>
     As pastas de favoritos inteligentes são pastas de favoritos virtuais dinamicamente atualizadas. Há três pastas de favoritos inteligentes: Os links <guimenu>Mais visitados</guimenu> estão disponíveis na barra de ferramentas de favoritos. Os links <guimenu>Favoritos recentes</guimenu> e <guimenu>Tags recentes</guimenu> estão localizados no menu Favoritos.
    </para>
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-toolbar">
-   <title>A Barra de Ferramentas de Favoritos</title><indexterm> <primary>Firefox</primary> <secondary>favoritos</secondary> <tertiary>barra de ferramentas</tertiary> </indexterm>
+   <title>A Barra de Ferramentas de Favoritos</title>
    <para>
     A <literal>Barra dos favoritos</literal> aparece abaixo da barra de localização e possibilita o acesso rápido aos favoritos. Você também pode adicionar, organizar e editar favoritos diretamente. Por padrão, a <literal>barra de ferramentas Favoritos</literal> é preenchida com um conjunto predefinido de favoritos organizados em várias pastas (consulte a <xref linkend="fig-firefox-main"/>).
    </para>
@@ -390,7 +390,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-firefox-downloadmanager">
-  <title>Usando o gerenciador de downloads</title><indexterm> <primary>Firefox</primary> <secondary>gerenciador de downloads</secondary> </indexterm> <indexterm> <primary>gerenciadores de downloads</primary> <secondary>Firefox</secondary> </indexterm>
+  <title>Usando o gerenciador de downloads</title>
 
   <para>
    Monitore os downloads atuais e antigos com o gerenciador de downloads. Para iniciar o gerenciador de downloads, na barra de menus, clique em <menuchoice> <guimenu>Ferramentas</guimenu> <guimenu>Downloads</guimenu> </menuchoice>. Durante o download de um arquivo, uma barra de progresso indica o status do download. Caso necessário, pause o download e continue-o mais tarde. Para abrir um arquivo obtido por download com o aplicativo associado, clique em <guimenu>Abrir</guimenu>. Para abrir o local em que o arquivo foi gravado, escolha <guimenu>Abrir pasta</guimenu>. <guimenu>Remover do histórico</guimenu> apenas apaga a entrada do gerenciador de downloads, mas não apaga o arquivo do disco rígido.
@@ -408,14 +408,14 @@
   </tip>
  </sect1>
  <sect1 xml:id="sec-firefox-security">
-  <title>Segurança</title><indexterm> <primary>Firefox</primary> <secondary>segurança</secondary> </indexterm>
+  <title>Segurança</title>
 
   <para>
    Já que navegar na Internet está cada vez mais arriscado, o Firefox oferece várias medidas para tornar a navegação mais segura. Ele verifica automaticamente se você está tentando acessar sites conhecidos por conter software prejudicial (malware) ou roubar dados sigilosos (phishing) e o impede de entrar nesses sites. O ID instantâneo do site permite verificar facilmente a legitimidade de um site, e um gerenciador de senha e bloqueador de popup oferecem segurança adicional. Com a Navegação privativa, é possível navegar pela Internet sem que o Firefox registre os dados em seu computador.
   </para>
 
   <sect2 xml:id="sec-firefox-security-instant-id">
-   <title>Identidade do site instantânea</title><indexterm> <primary>Firefox</primary> <secondary>identidade do site</secondary> </indexterm>
+   <title>Identidade do site instantânea</title>
    <para>
     O Firefox permite a você verificar rapidamente a identidade de uma página da Web. O ícone na barra de localização ao lado do endereço indica quais informações de identidade estão disponíveis e se a comunicação é criptografada:
    </para>
@@ -522,7 +522,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-firefox-customizing">
-  <title>Personalizando o Firefox</title><indexterm> <primary>Firefox</primary> <secondary>configurando</secondary> </indexterm>
+  <title>Personalizando o Firefox</title>
 
   <para>
    O Firefox pode ser personalizado de forma abrangente. 
@@ -551,7 +551,7 @@
   </para>
 
   <sect2 xml:id="sec-firefox-preferences">
-   <title>Preferências</title><indexterm> <primary>Firefox</primary> <secondary>preferências</secondary> </indexterm>
+   <title>Preferências</title>
    <para>
     O Firefox oferece uma enorme variedade de opções de configuração. Elas estão disponíveis em <menuchoice> <guimenu>Editar</guimenu> <guimenu>Preferências</guimenu> </menuchoice> na barra de menus. Cada opção está descrita em detalhes na Ajuda online, que pode ser acessada clicando no ícone de ponto de interrogação na caixa de diálogo.
    </para>
@@ -567,7 +567,7 @@
     </mediaobject>
    </figure>
    <sect3 xml:id="sec-firefox-preferences-sessions">
-    <title>Gerenciamento de sessões</title><indexterm> <primary>Firefox</primary> <secondary>gerenciamento de sessões</secondary> </indexterm>
+    <title>Gerenciamento de sessões</title>
     <para>
      Por padrão, o Firefox restaura automaticamente a sua sessão (janelas e guias) somente após uma falha ou reinicialização por causa de uma extensão. Entretanto, é possível configurá-lo para restaurar uma sessão toda vez que ele for iniciado: Abra a caixa de diálogo Preferências, conforme descrito na <xref linkend="sec-firefox-preferences"/>, e vá para a categoria <guimenu>Geral</guimenu>. Defina a opção <guimenu>Ao iniciar o Firefox:</guimenu> como <guimenu>Abrir janelas e abas da última sessão</guimenu>.
     </para>
@@ -576,13 +576,13 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-preferences-language">
-    <title>Preferências de idioma para sites na Web</title><indexterm> <primary>Firefox</primary> <secondary>idioma</secondary> </indexterm>
+    <title>Preferências de idioma para sites na Web</title>
     <para>
      Ao enviar uma solicitação ao servidor Web , o browser sempre envia as informações sobre o idioma preferencial do usuário. Sites disponíveis em mais de um idioma (e que são configurados para avaliar esse parâmetro de idioma) exibem suas páginas no idioma solicitado pelo browser. No <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>, o idioma preferencial é pré-configurado para usar o mesmo idioma da área de trabalho. Para mudar essa configuração, abra a janela <guimenu>Preferências</guimenu>, conforme descrito na <xref linkend="sec-firefox-preferences"/>, vá para a categoria <guimenu>Conteúdo</guimenu> e clique em <guimenu>Selecionar</guimenu> para escolher o idioma preferencial.
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-preferences-spelling">
-    <title>Correção ortográfica</title><indexterm> <primary>Firefox</primary> <secondary>correção ortográfica</secondary> </indexterm>
+    <title>Correção ortográfica</title>
     <para>
      Por padrão, o Firefox verifica a ortografia enquanto que você digita em caixas de texto de várias linhas. As palavras com erros ortográficos são sublinhadas em vermelho. Para corrigir uma palavra, clique o botão direito do mouse nela e escolha a grafia correta no menu de contexto. Também é possível adicionar a palavra ao dicionário, se estiver correta.
     </para>
@@ -593,7 +593,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-extensions">
-   <title>Complementos</title><indexterm> <primary>Firefox</primary> <secondary>complementos</secondary> </indexterm> <indexterm> <primary>Firefox</primary> <secondary>extensões</secondary> </indexterm> <indexterm> <primary>Firefox</primary> <secondary>temas</secondary> </indexterm>
+   <title>Complementos</title> 
    <para>
     As extensões permitem personalizar o Firefox para ajustá-lo às suas necessidades. Com as extensões, é possível mudar a aparência do Firefox, aprimorar as funcionalidades existentes e adicionar funções. Por exemplo, as extensões podem aperfeiçoar o gerenciador de downloads, mostrar o clima ou controlar os players de música da Web. Outras extensões auxiliam os desenvolvedores da Web ou reforçam a segurança bloqueando tipos de conteúdo como anúncios ou scripts.
    </para>
@@ -604,7 +604,7 @@
     Se você não gostar da aparência do Firefox, instale um novo <emphasis>tema</emphasis>. Os temas não mudam a funcionalidade do browser, somente a aparência.
    </para>
    <sect3 xml:id="sec-firefox-extensions-install">
-    <title>Instalando complementos</title><indexterm> <primary>Firefox</primary> <secondary>complementos</secondary> <tertiary>instalando</tertiary> </indexterm>
+    <title>Instalando complementos</title>
     <para>
      Para adicionar uma extensão ou um tema, inicie o gerenciador de complementos em <menuchoice> <guimenu>Ferramentas</guimenu> <guimenu>Complementos</guimenu> </menuchoice> na barra de menus. Uma janela é aberta com a guia <guimenu>Adicionar</guimenu> exibindo opções de complementos recomendados ou os resultados da sua última pesquisa.
     </para>
@@ -628,7 +628,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-extensions-manage">
-    <title>Gerenciando complementos</title><indexterm> <primary>Firefox</primary> <secondary>complementos</secondary> <tertiary>gerenciando</tertiary> </indexterm>
+    <title>Gerenciando complementos</title>
     <para>
      O Gerenciador de Complementos também oferece uma interface conveniente para gerenciar extensões, temas e plug-ins. As <guimenu>extensões</guimenu> podem ser habilitadas, desabilitadas ou desinstaladas. Se a extensão for configurável, suas opções de configuração poderão ser acessadas por meio do botão <guimenu>Preferências</guimenu>. Na guia <guimenu>Aparência</guimenu>, é possível <guimenu>Desinstalar</guimenu> um tema ou ativar um tema diferente clicando em <guimenu>Ativar</guimenu>. Também aparecem na lista instalações pendentes de extensão e tema. Selecione <guimenu>Cancelar</guimenu> para interromper a instalação. Apesar de não ser possível instalar <guimenu>Plug-ins</guimenu> como um usuário, você pode desabilitá-los ou habilitá-los pelo Gerenciador de plug-ins.
     </para>
@@ -641,7 +641,7 @@
 
  </sect1>
  <sect1 xml:id="sec-firefox-printing">
-  <title>Imprimindo no Firefox</title><indexterm> <primary>Firefox</primary> <secondary>imprimindo</secondary> </indexterm> <indexterm><primary>imprimindo</primary> <secondary>Firefox</secondary></indexterm>
+  <title>Imprimindo no Firefox</title>
 
   <para>
    Antes de imprimir realmente uma página da Web, você pode usar a função de visualização de impressão para controlar a aparência que a página impressa terá. Na barra de menus, escolha <menuchoice> <guimenu>Arquivo</guimenu> <guimenu>Visualizar impressão</guimenu> </menuchoice>. Configure o tamanho do papel e a orientação por impressora em <guimenu>Configuração de página</guimenu>.
@@ -675,6 +675,6 @@
    </member>
    <member><emphasis>Atalhos do teclado</emphasis>: <link xlink:href="http://support.mozilla.org/kb/Keyboard+shortcuts"/>
    </member>
-  </simplelist><indexterm startref="idx-firefox" class="endofrange"/><indexterm class="endofrange" startref="idx-browsers-firefox"/>
+  </simplelist>
  </sect1>
 </chapter>

--- a/l10n/sles/pt-br/xml/apps_gimp.xml
+++ b/l10n/sles/pt-br/xml/apps_gimp.xml
@@ -16,13 +16,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-gimp" class="startofrange">
- <primary>GIMP</primary></indexterm><indexterm xml:id="idx-graphics-editing" class="startofrange">
- <primary>graphics</primary>
- <secondary>editing</secondary></indexterm><indexterm>
- <primary>applications</primary>
- <secondary>graphics</secondary>
- <tertiary>GIMP</tertiary></indexterm>
+ </info>
  <para>
   GIMP is an extremely complex program. Only a small range of features, tools,
   and menu items are discussed in this chapter. See
@@ -30,15 +24,7 @@
   information about the program.
  </para>
  <sect1 xml:id="sec-gimp-graphics">
-  <title>Graphics Formats</title><indexterm>
-
-  <primary>graphics</primary>
-
-  <secondary>pixel</secondary></indexterm><indexterm>
-
-  <primary>graphics</primary>
-
-  <secondary>vector</secondary></indexterm>
+  <title>Graphics Formats</title>
 
   <para>
    There are two main types of digital graphics: raster and vector. GIMP is
@@ -116,11 +102,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-gimp-starting">
-  <title>Starting GIMP</title><indexterm>
-
-  <primary>GIMP</primary>
-
-  <secondary>starting</secondary></indexterm>
+  <title>Starting GIMP</title>
 
   <para>
    To start GIMP, select <menuchoice><guimenu>Applications</guimenu>
@@ -174,10 +156,7 @@
     <guimenu>Close</guimenu>. <guimenu>Quit</guimenu> quits the application.
    </para>
    <para>
-    <indexterm>
-    <primary>GIMP</primary>
-    <secondary>views</secondary>
-    </indexterm> With the items in the <guimenu>View</guimenu> menu, control
+     With the items in the <guimenu>View</guimenu> menu, control
     the display of the image and the image window. <guimenu>New View</guimenu>
     opens a second display window of the current image. Changes made in one
     view are reflected in all other views of that image. Alternate views are
@@ -260,9 +239,7 @@
   </para>
 
   <sect2 xml:id="sec-gimp-getstart-creating">
-   <title>Creating a New Image</title><indexterm>
-   <primary>GIMP</primary>
-   <secondary>creating images</secondary></indexterm>
+   <title>Creating a New Image</title>
    <procedure>
     <step>
      <para>
@@ -275,9 +252,7 @@
      <para>
       If desired, select a predefined setting called a
       <guimenu>Template</guimenu>.
-     </para><indexterm>
-     <primary>GIMP</primary>
-     <secondary>templates</secondary></indexterm>
+     </para>
      <note>
       <title>Custom Templates</title>
       <para>
@@ -330,9 +305,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-getstart-open">
-   <title>Opening an Existing Image</title><indexterm>
-   <primary>GIMP</primary>
-   <secondary>opening images</secondary></indexterm>
+   <title>Opening an Existing Image</title>
    <para>
     To open an existing image, select <menuchoice> <guimenu>File</guimenu>
     <guimenu>Open</guimenu></menuchoice>.
@@ -344,11 +317,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gimp-saving">
-  <title>Saving and Exporting Images</title><indexterm>
-
-  <primary>GIMP</primary>
-
-  <secondary>saving images</secondary></indexterm>
+  <title>Saving and Exporting Images</title>
 
   <para>
    GIMP makes a distinction between saving and exporting images.
@@ -394,10 +363,7 @@
 
 
    <varlistentry>
-    <term>JPEG<indexterm>
-     <primary>files</primary>
-     <secondary>formats</secondary>
-     <tertiary>JPG</tertiary></indexterm>
+    <term>JPEG
     </term>
     <listitem>
      <para>
@@ -412,10 +378,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>GIF<indexterm>
-     <primary>files</primary>
-     <secondary>formats</secondary>
-     <tertiary>GIF</tertiary></indexterm>
+    <term>GIF
     </term>
     <listitem>
      <para>
@@ -429,10 +392,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>PNG<indexterm>
-     <primary>files</primary>
-     <secondary>formats</secondary>
-     <tertiary>PNG</tertiary></indexterm>
+    <term>PNG
     </term>
     <listitem>
      <para>
@@ -449,11 +409,7 @@
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-gimp-basics">
-  <title>Editing Images</title><indexterm xml:id="idx-gimp-editing-images" class="startofrange">
-
-  <primary>GIMP</primary>
-
-  <secondary>editing images</secondary></indexterm>
+  <title>Editing Images</title>
 
   <para>
    GIMP provides several tools for making changes to images. The functions
@@ -461,9 +417,7 @@
   </para>
 
   <sect2 xml:id="sec-gimp-basics-size">
-   <title>Changing the Size of an Image</title><indexterm xml:id="idx-graphics-resizing" class="startofrange">
-   <primary>graphics</primary>
-   <secondary>resizing</secondary></indexterm>
+   <title>Changing the Size of an Image</title>
    <para>
     After an image is scanned or a digital photograph is loaded from the
     camera, it is often necessary to modify the size for display on a Web page
@@ -477,9 +431,7 @@
     cropping.
    </para>
    <sect3 xml:id="sec-gimp-basics-size-cropping">
-    <title>Cropping an Image</title><indexterm>
-    <primary>GIMP</primary>
-    <secondary>cropping</secondary></indexterm>
+    <title>Cropping an Image</title>
     <procedure>
      <step>
       <para>
@@ -514,9 +466,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-size-scaling">
-    <title>Scaling an Image</title><indexterm>
-    <primary>GIMP</primary>
-    <secondary>scaling images</secondary></indexterm>
+    <title>Scaling an Image</title>
     <procedure>
      <step>
       <para>
@@ -583,14 +533,12 @@
        When you are finished, click <guimenu>Resize</guimenu>.
       </para>
      </step>
-    </procedure><indexterm startref="idx-graphics-resizing" class="endofrange"/>
+    </procedure>
    </sect3>
   </sect2>
 
   <sect2 xml:id="sec-gimp-basics-select">
-   <title>Selecting Parts of Images</title><indexterm xml:id="idx-gimp-selecting" class="startofrange">
-   <primary>GIMP</primary>
-   <secondary>selecting</secondary></indexterm>
+   <title>Selecting Parts of Images</title>
    <para>
     It is often useful to perform an image operation on only part of an image.
     To do this, the part of the image with which you want to work must be
@@ -746,9 +694,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-select-quickmask">
-    <title>Using the Quick Mask</title><indexterm>
-    <primary>GIMP</primary>
-    <secondary>quick mask</secondary></indexterm>
+    <title>Using the Quick Mask</title>
     <para>
      The quick mask is a way of selecting parts of an image using the paint
      tools. A good way to use it is to first create a rough selection using the
@@ -795,7 +741,7 @@
        then displayed with the marching ants.
       </para>
      </step>
-    </procedure><indexterm startref="idx-gimp-selecting" class="endofrange"/>
+    </procedure>
    </sect3>
   </sect2>
 
@@ -814,9 +760,7 @@
     area will be painted.
    </para>
    <sect3 xml:id="sec-gimp-basics-color-selecting">
-    <title>Selecting Colors</title><indexterm>
-    <primary>GIMP</primary>
-    <secondary>colors</secondary></indexterm>
+    <title>Selecting Colors</title>
     <para>
      The GIMP toolbox always shows two color swatches. The foreground color is
      used by the paint tools. The background color is used much more rarely,
@@ -899,9 +843,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-color-text">
-    <title>Adding Text</title><indexterm>
-    <primary>GIMP</primary>
-    <secondary>text</secondary></indexterm>
+    <title>Adding Text</title>
     <para>
      To add text, use the text tool. Use the tool options to select the desired
      font and text properties. Click into the image, then start writing.
@@ -914,9 +856,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-color-clone">
-    <title>Retouching Images—The Clone Tool</title><indexterm>
-    <primary>GIMP</primary>
-    <secondary>retouching images</secondary></indexterm>
+    <title>Retouching Images—The Clone Tool</title>
     <para>
      The clone tool is ideal for retouching images. It enables you to paint in
      an image using information from another part of the image. If desired, it
@@ -941,9 +881,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-basics-levels">
-   <title>Adjusting Color Levels</title><indexterm>
-   <primary>GIMP</primary>
-   <secondary>levels</secondary></indexterm>
+   <title>Adjusting Color Levels</title>
    <para>
     Images often need a little adjusting to get ideal print or display results.
    </para>
@@ -983,9 +921,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-basics-undo">
-   <title>Undoing Mistakes</title><indexterm>
-   <primary>GIMP</primary>
-   <secondary>undo</secondary></indexterm>
+   <title>Undoing Mistakes</title>
    <para>
     Most modifications made in GIMP can be undone. To view a history of
     modifications, use the undo dialog included in the default window layout or
@@ -1008,9 +944,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-advanced-layers">
-   <title>Layers</title><indexterm>
-   <primary>GIMP</primary>
-   <secondary>layers</secondary></indexterm>
+   <title>Layers</title>
    <para>
     Layers are a very important aspect of GIMP. By drawing parts of your image
     on separate layers, you can change, move, or delete those parts without
@@ -1036,9 +970,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-advanced-modes">
-   <title>Image Modes</title><indexterm>
-   <primary>GIMP</primary>
-   <secondary>image modes</secondary></indexterm>
+   <title>Image Modes</title>
    <para>
     GIMP has three image modes:
    </para>
@@ -1069,27 +1001,17 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-advanced-effects">
-   <title>Special Effects</title><indexterm>
-   <primary>GIMP</primary>
-   <secondary>effects</secondary></indexterm>
+   <title>Special Effects</title>
    <para>
     GIMP includes a wide range of filters and scripts for enhancing images,
     adding special effects to them or making artistic manipulations. They are
     available in <guimenu>Filters</guimenu>. Experimenting is the best way to
     find out what is available.
-   </para><indexterm startref="idx-gimp-editing-images" class="endofrange"/>
+   </para>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gimp-printing">
-  <title>Printing Images</title><indexterm>
-
-  <primary>GIMP</primary>
-
-  <secondary>printing</secondary></indexterm><indexterm>
-
-  <primary>printing</primary>
-
-  <secondary>GIMP</secondary></indexterm>
+  <title>Printing Images</title>
 
   <para>
    To print an image, select <menuchoice> <guimenu>File</guimenu>
@@ -1192,6 +1114,6 @@
      discussions, join the <literal>#gimp</literal> channel.
     </para>
    </listitem>
-  </itemizedlist><indexterm class="endofrange" startref="idx-gimp"/><indexterm class="endofrange" startref="idx-graphics-editing"/>
+  </itemizedlist>
  </sect1>
 </chapter>

--- a/l10n/sles/pt-br/xml/common_intro_available_doc_i.xml
+++ b/l10n/sles/pt-br/xml/common_intro_available_doc_i.xml
@@ -9,13 +9,7 @@
    </dm:bugtracker>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>help</primary>
-
- <secondary>SUSE manuals</secondary></indexterm><indexterm>
-
- <primary>SUSE manuals</primary></indexterm>
+ </info>
 
  <note>
   <title>Online Documentation and Latest Updates</title>

--- a/l10n/sles/pt-br/xml/help_user.xml
+++ b/l10n/sles/pt-br/xml/help_user.xml
@@ -12,11 +12,11 @@
    <dm:bugtracker/>
    <dm:translation>sim</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-help"> <primary>ajuda</primary></indexterm><indexterm><primary>documentação</primary><see>ajuda </see></indexterm>
+ </info>
 
  <variablelist>
   <varlistentry>
-   <term>Centro de Ajuda da Área de Trabalho <indexterm> <primary>ajuda</primary> <secondary>centro de ajuda</secondary></indexterm>
+   <term>Centro de Ajuda da Área de Trabalho 
    </term>
    <listitem>
     <para>
@@ -51,7 +51,7 @@
   </varlistentry>
  </variablelist>
  <sect1 xml:id="sec-help-onboard-yelp">
-  <title>Usando a ajuda do GNOME</title><indexterm> <primary>ajuda</primary> <secondary>Ajuda</secondary></indexterm>
+  <title>Usando a ajuda do GNOME</title>
 
   <para>
    Na área de trabalho do GNOME, para iniciar a Ajuda diretamente de um aplicativo, clique no botão <guimenu>Ajuda</guimenu> ou pressione <keycap>F1</keycap>. Ambas as opções o levam diretamente à documentação do aplicativo no centro de ajuda. No entanto, você também pode iniciar a Ajuda abrindo um terminal e digitando <command>yelp</command> ou, no menu principal, clicando em <menuchoice><guimenu>Aplicativos</guimenu><guimenu>Favoritos</guimenu><guimenu>Ajuda</guimenu></menuchoice>.
@@ -81,7 +81,7 @@
   <title>Recursos de ajuda adicionais</title>
 
   <para>
-   <indexterm> <primary>ajuda</primary> <secondary>documentação online</secondary> </indexterm> Além dos manuais do SUSE instalados em <filename>/usr/share/doc</filename>, você pode acessar a documentação e os manuais específicos do produto na Web. Para uma visão geral de toda a documentação disponível para o <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>, visite a página de documentação específica do seu produto na Web em <link os="sles;sled" xlink:href="https://documentation.suse.com/"/>.
+    Além dos manuais do SUSE instalados em <filename>/usr/share/doc</filename>, você pode acessar a documentação e os manuais específicos do produto na Web. Para uma visão geral de toda a documentação disponível para o <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>, visite a página de documentação específica do seu produto na Web em <link os="sles;sled" xlink:href="https://documentation.suse.com/"/>.
   </para>
 
   <para>
@@ -129,20 +129,20 @@
   </para>
 
   <sect2 xml:id="sec-help-more-tldp">
-   <title>O Projeto de Documentação do Linux</title><indexterm> <primary>TLDP</primary></indexterm><indexterm> <primary>ajuda</primary> <secondary>Projeto de documentação do Linux (TLDP)</secondary></indexterm>
+   <title>O Projeto de Documentação do Linux</title>
    <para>
     O TLDP (The Linux Documentation Project — O Projeto de Documentação do Linux) é administrado por uma equipe de voluntários que escrevem a documentação relacionada ao Linux (acesse <link xlink:href="http://www.tldp.org"/>). O conjunto de documentos contém tutoriais para iniciantes, mas é direcionado principalmente a usuários experientes e administradores de sistema profissionais. O TLDP publica HOWTOs, FAQs e guias (manuais) sob uma licença gratuita. Partes da documentação do TLDP também estão disponíveis no <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>.
    </para>
 
 
    <sect3 xml:id="sec-helpmore-tldp-faq">
-    <title>Perguntas frequentes (FAQ)</title><indexterm> <primary>ajuda</primary> <secondary>TLDP</secondary> <tertiary>FAQ</tertiary></indexterm>
+    <title>Perguntas frequentes (FAQ)</title>
     <para>
      FAQs (perguntas frequentes) são uma série de perguntas e respostas. Elas provêm de grupos de discussão da Usenet, onde o objetivo era reduzir a resposta contínua das mesmas perguntas básicas.
     </para>
    </sect3>
    <sect3 xml:id="sec-helpmore-tldp-guides">
-    <title>Guias</title><indexterm> <primary>ajuda</primary> <secondary>TLDP</secondary> <tertiary>guias</tertiary></indexterm>
+    <title>Guias</title>
     <para>
      Você encontra manuais e guias sobre tópicos ou programas variados em <link xlink:href="http://www.tldp.org/guides.html"/>. Eles variam de <citetitle>Bash Guide for Beginners</citetitle> (Guia do Bash para Iniciantes), <citetitle>Linux File System Hierarchy</citetitle> (Hierarquia do Sistema de Arquivos do Linux) ao <citetitle>Linux Administrator's Security Guide</citetitle> (Guia de Segurança do Administrador do Linux). Em geral, os guias são mais detalhados e abrangentes do que os HOWTOs ou as perguntas frequentes (FAQs). Eles são geralmente escritos por especialistas para especialistas.
     </para>
@@ -154,7 +154,7 @@
 
 
   <sect2 xml:id="sec-help-more-wikipedia">
-   <title>Wikipédia: a enciclopédia livre online</title><indexterm> <primary>ajuda</primary> <secondary>Wikipédia</secondary></indexterm> <remark>Translators: Translate the link http://en.wikipedia.org into your language: Replace "en"
+   <title>Wikipédia: a enciclopédia livre online</title><remark>Translators: Translate the link http://en.wikipedia.org into your language: Replace "en"
     with your ISO language code.</remark>
    <para>
     Wikipedia é uma <quote>enciclopédia multilíngue que pode ser lida e editada por qualquer pessoa</quote> (consulte <link xlink:href="http://en.wikipedia.org"/>). O conteúdo da Wikipédia é criado por seus usuários e publicado sob uma licença dual gratuita (GFDL e CC-BY-SA). No entanto, como qualquer visitante pode editar a Wikipédia, ela deve ser usada apenas como um ponto de partida ou um guia geral. Há muita informação incompleta ou incorreta nela.
@@ -162,7 +162,7 @@
   </sect2>
 
   <sect2 xml:id="sec-help-more-standards">
-   <title>Padrões e especificações</title><indexterm> <primary>ajuda</primary> <secondary>padrões</secondary></indexterm><indexterm> <primary>ajuda</primary> <secondary>especificações</secondary></indexterm>
+   <title>Padrões e especificações</title>
    <para>
     Há várias fontes que fornecem informações sobre padrões ou especificações.
    </para>

--- a/l10n/sles/pt-br/xml/lvm.xml
+++ b/l10n/sles/pt-br/xml/lvm.xml
@@ -7,19 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>YaST</primary>
-
- <secondary>LVM</secondary></indexterm><indexterm>
-
- <primary>LVM</primary>
-
- <secondary>YaST</secondary></indexterm><indexterm>
-
- <primary>Logical Volume Manager</primary>
-
- <see>LVM</see></indexterm>
+ </info>
 
  <para>
   This section explains specific steps to take when configuring LVM.

--- a/l10n/sles/pt-br/xml/raid.xml
+++ b/l10n/sles/pt-br/xml/raid.xml
@@ -7,7 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes (sim)</dm:translation>
   </dm:docmanager>
- </info><indexterm> <primary>YaST</primary> <secondary>RAID</secondary></indexterm><indexterm> <primary>RAID</primary> <secondary>YaST</secondary></indexterm><indexterm> <primary>soft RAID</primary> <see>RAID</see></indexterm>
+ </info>
 
  <para>
   Esta seção descreve as ações necessárias para criar e configurar vários tipos de RAID. <phrase os="sles">Se você precisar de informações sobre o RAID, consulte a <xref linkend="sec-raid-intro"/></phrase>.

--- a/l10n/sles/pt-br/xml/x86_inst_problem.xml
+++ b/l10n/sles/pt-br/xml/x86_inst_problem.xml
@@ -7,7 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes (sim)</dm:translation>
   </dm:docmanager>
- </info><indexterm> <primary>solução de problemas</primary> </indexterm>
+ </info>
 
  <para>
   Antes de ser disponibilizado, o <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> passa por um longo programa de testes. Apesar disso, alguns problemas ocorrem ocasionalmente durante o boot ou a instalação.

--- a/l10n/sles/pt-br/xml/yast2_lang.xml
+++ b/l10n/sles/pt-br/xml/yast2_lang.xml
@@ -6,14 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>system</primary>
- <secondary>languages</secondary></indexterm><indexterm>
- <primary>YaST</primary>
- <secondary>languages</secondary></indexterm><indexterm>
- <primary>languages</primary></indexterm><indexterm>
- <primary>configuring</primary>
- <secondary>languages</secondary></indexterm>
+ </info>
  <para>
   Working in different countries or having to work in a multilingual
   environment requires your computer to be set up to support this.

--- a/l10n/sles/pt-br/xml/yast2_sound.xml
+++ b/l10n/sles/pt-br/xml/yast2_sound.xml
@@ -7,23 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>configuring</primary>
-
- <secondary>sound cards</secondary></indexterm><indexterm>
-
- <primary>YaST</primary>
-
- <secondary>sound cards</secondary></indexterm><indexterm>
-
- <primary>sound</primary>
-
- <secondary>configuring in YaST</secondary></indexterm><indexterm>
-
- <primary>cards</primary>
-
- <secondary>sound</secondary></indexterm>
+ </info>
 
  <para>
   YaST detects most sound cards automatically and configures them with the
@@ -208,13 +192,7 @@
   </step>
   <step>
    <para>
-    <indexterm>
-    <primary>sound</primary>
-    <secondary>fonts</secondary>
-    </indexterm> <indexterm>
-    <primary>sound</primary>
-    <secondary>MIDI</secondary>
-    </indexterm>When a supported sound card is detected, you can install SoundFonts for
+     When a supported sound card is detected, you can install SoundFonts for
     playback of MIDI files:
    </para>
    <substeps performance="required">
@@ -264,12 +242,6 @@
   are saved to the file <filename>/etc/asound.state</filename>. The ALSA
   configuration data is appended to the end of the file
   <filename>/etc/modprobe.d/sound</filename> and written to
-  <filename>/etc/sysconfig/sound</filename>.<indexterm>
-  <primary>configuration files</primary>
-  <secondary>asound.state</secondary>
-  </indexterm> <indexterm>
-  <primary>configuration files</primary>
-  <secondary>modprobe.d/sound</secondary>
-  </indexterm>
+  <filename>/etc/sysconfig/sound</filename>. 
  </para>
 </sect1>

--- a/l10n/sles/pt-br/xml/yast2_sw.xml
+++ b/l10n/sles/pt-br/xml/yast2_sw.xml
@@ -11,7 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes (sim)</dm:translation>
   </dm:docmanager>
- </info><indexterm> <primary>YaST</primary> <secondary>software</secondary> </indexterm> <indexterm> <primary>configurando</primary> <secondary>software</secondary> </indexterm>
+ </info>
  <para>
   Mude a coleção de softwares do seu sistema com o Gerenciador de Software do YaST. Esse módulo do YaST está disponível em dois tipos: uma variante gráfica para o X Window e uma variante baseada em texto para usar na linha de comando. O tipo gráfico está descrito aqui. Para saber detalhes do YaST baseado em texto, consulte o <xref linkend="cha-yast-text"/>.
  </para>

--- a/l10n/sles/pt-br/xml/yast2_userman.xml
+++ b/l10n/sles/pt-br/xml/yast2_userman.xml
@@ -97,7 +97,7 @@
   <title>Gerenciando contas de usuário</title>
 
   <para>
-   <indexterm> <primary>usuários</primary> <secondary>criando contas</secondary> </indexterm> <indexterm> <primary>usuários</primary> <secondary>modificando contas</secondary> </indexterm> O YaST oferece para criar, modificar, apagar ou desabilitar temporariamente as contas dos usuários. Não modifique as contas do usuário, a menos que você seja um usuário experiente ou administrador.
+     O YaST oferece para criar, modificar, apagar ou desabilitar temporariamente as contas dos usuários. Não modifique as contas do usuário, a menos que você seja um usuário experiente ou administrador.
   </para>
 
   <note>
@@ -181,7 +181,7 @@
   </tip>
 
   <procedure>
-   <title>Desabilitando ou apagando contas de usuários</title><indexterm> <primary>usuários</primary> <secondary>desabilitando contas</secondary> </indexterm> <indexterm> <primary>usuários</primary> <secondary>apagando contas</secondary> </indexterm>
+   <title>Desabilitando ou apagando contas de usuários</title>
    <step>
     <para>
      Abra a caixa de diálogo <guimenu>Administração de Usuário e Grupo</guimenu> do YaST e clique na guia <guimenu>Usuários</guimenu>.
@@ -229,7 +229,7 @@
 
    </para>
    <procedure>
-    <title>Definindo configurações de senha</title><indexterm> <primary>usuários</primary> <secondary>configurações de senha</secondary> </indexterm>
+    <title>Definindo configurações de senha</title>
     <step>
      <para>
       Abra a caixa de diálogo <guimenu>Administração de Usuário e Grupo</guimenu> do YaST e selecione a guia <guimenu>Usuários</guimenu>.
@@ -284,7 +284,7 @@
   </sect2>
 
   <sect2 xml:id="sec-y2-userman-adv-crypto">
-   <title>Gerenciando diretórios pessoais criptografados</title><indexterm> <primary>diretórios pessoais</primary> <secondary>criptografando</secondary> </indexterm> <indexterm> <primary>users</primary> <secondary>diretórios pessoais criptografados</secondary> </indexterm>
+   <title>Gerenciando diretórios pessoais criptografados</title>
    <para>
     Para proteger os dados dos diretórios pessoais contra roubo e remoção de disco rígido, você pode criar diretórios pessoais criptografados para os usuários. Eles são criptografados com LUKS (Linux Unified Key Setup), que resulta em uma imagem e uma chave de imagem gerada para o usuário. A chave de imagem é protegida com a senha de login do usuário. Quando o usuário efetua login no sistema, o diretório pessoal criptografado é montado e o conteúdo é disponibilizado ao usuário.
    </para>
@@ -396,7 +396,7 @@
   </sect2>
 
   <sect2 xml:id="sec-y2-userman-adv-quota">
-   <title>Gerenciando cotas</title><indexterm> <primary>usuários</primary> <secondary>cotas</secondary> </indexterm> <indexterm> <primary>cotas</primary> <secondary>usuários, grupos</secondary> </indexterm>
+   <title>Gerenciando cotas</title>
    <para>
     Para evitar o esgotamento dos recursos do sistema sem qualquer notificação, os administradores de sistema podem configurar cotas para usuários ou grupos. É possível definir quotas para um ou mais sistemas de arquivos, e restringir a quantidade de espaço em disco que pode ser usada e o número de inodes (nós do índice) que podem ser criados lá. Os inodes são estruturas de dados em um sistema de arquivos que armazenam informações básicas sobre um arquivo, um diretório ou outro objeto de sistema de arquivos comum. Eles armazenam todos os atributos de um objeto de sistema de arquivos (como propriedade do usuário e do grupo, permissões de leitura, gravação ou execução), exceto nome de arquivo e conteúdo.
    </para>
@@ -541,7 +541,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-y2-userman-defaults">
-  <title>Mudando as configurações padrão para usuários locais</title><indexterm> <primary>usuários</primary> <secondary>configurações padrão</secondary> </indexterm>
+  <title>Mudando as configurações padrão para usuários locais</title>
 
   <para>
    Ao criar novos usuários locais, várias configurações padrão são usadas pelo YaST. Elas incluem, por exemplo, o grupo principal e os grupos secundários aos quais o usuário pertence, ou as permissões de acesso do diretório pessoal do usuário. Você poderá mudar essas configurações padrão de acordo com os seus requisitos:
@@ -589,7 +589,7 @@
   <title>Atribuindo usuários a grupos</title>
 
   <para>
-   <indexterm> <primary>usuário</primary> <secondary>atribuição de grupo</secondary> </indexterm> Os usuários locais são atribuídos a vários grupos de acordo com as configurações padrão que podem ser acessadas na caixa de diálogo <guimenu>Administração de Usuário e Grupo</guimenu>, na guia <guimenu>Padrões para Novos Usuários</guimenu>. Aprenda a seguir como modificar a atribuição de grupo de um usuário individual. Se precisar mudar as atribuições de grupo padrão para os novos usuários, consulte a <xref linkend="sec-y2-userman-defaults"/>.
+    Os usuários locais são atribuídos a vários grupos de acordo com as configurações padrão que podem ser acessadas na caixa de diálogo <guimenu>Administração de Usuário e Grupo</guimenu>, na guia <guimenu>Padrões para Novos Usuários</guimenu>. Aprenda a seguir como modificar a atribuição de grupo de um usuário individual. Se precisar mudar as atribuições de grupo padrão para os novos usuários, consulte a <xref linkend="sec-y2-userman-defaults"/>.
   </para>
 
   <procedure>
@@ -630,7 +630,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-y2-userman-groups">
-  <title>Gerenciando grupos</title><indexterm> <primary>grupos</primary> <secondary>gerenciando</secondary> </indexterm> <indexterm> <primary>YaST</primary> <secondary>gerenciamento de grupo</secondary> </indexterm> <indexterm> <primary>configurando</primary> <secondary>grupos</secondary> </indexterm>
+  <title>Gerenciando grupos</title> 
 
   <para>
    Com o YaST, você também pode adicionar, modificar ou apagar grupos facilmente.
@@ -700,7 +700,7 @@
   </para>
  </sect1>
  <sect1 xml:id="cha-y2-userman-authent">
-  <title>Mudando o método de autenticação do usuário</title><indexterm> <primary>usuários</primary> <secondary>autenticação</secondary> </indexterm>
+  <title>Mudando o método de autenticação do usuário</title>
 
   <para>
    Com a máquina conectada à rede, você pode mudar o método de autenticação. As seguintes opções estão disponíveis:

--- a/l10n/sles/zh-cn/xml/64bit_issues.xml
+++ b/l10n/sles/zh-cn/xml/64bit_issues.xml
@@ -6,8 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>64 位 Linux</primary></indexterm> 
+ </info>
  <para>
   <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> 可用于<phrase os="sles">多种</phrase> 64 位平台。但是这并不表示内含的所有应用程序都已移植到 64 位平台上。<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 支持在 64 位系统环境中使用 32 位应用程序。本章简单介绍了如何在 64 位<phrase role="productname"><phrase os="sles"> SUSE Linux Enterprise Server</phrase></phrase> 平台上实现这种支持。
  </para>
@@ -25,11 +24,7 @@
 
 
  <sect1 xml:id="sec-64bit-runt">
-  <title>运行时支持</title><indexterm>
-
-  <primary> 64 位 Linux</primary>
-
-  <secondary> 运行时支持</secondary></indexterm> 
+  <title>运行时支持</title>
 
   <important>
    <title>应用程序版本之间的冲突</title>
@@ -58,11 +53,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-64bit-kernel">
-  <title>内核规范</title><indexterm>
-
-  <primary> 64 位 Linux</primary>
-
-  <secondary> 内核规范</secondary></indexterm> 
+  <title>内核规范</title>
 
   <para>
    AMD64/Intel 64<phrase os="sles">、IBM POWER 和 IBM Z</phrase> 适用的 64 位内核提供 64 位和 32 位两种内核 ABI（应用程序二进制接口）。后者与对应的 32 位内核的 ABI 相同。这意味着 32 位应用程序可以以与 32 位内核交流的相同方式与 64 位内核进行交流。

--- a/l10n/sles/zh-cn/xml/aarch64_inst_problem.xml
+++ b/l10n/sles/zh-cn/xml/aarch64_inst_problem.xml
@@ -7,9 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary> 问题解决</primary></indexterm> 
+ </info>
 
  <para>
   交付之前，<phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> 经过了大量的测试。尽管如此，在引导或安装期间还是会偶然发生问题。

--- a/l10n/sles/zh-cn/xml/adm_shell.xml
+++ b/l10n/sles/zh-cn/xml/adm_shell.xml
@@ -13,10 +13,7 @@
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
-<indexterm>
- <primary>外壳</primary></indexterm><indexterm>
- <primary>Bash</primary>
- <see>外壳</see></indexterm>
+
  <sect1 xml:id="sec-adm-whatistheshell">
   <title>什么是<quote>外壳</quote>？</title>
 
@@ -27,9 +24,7 @@
   </para>
 
   <sect2 xml:id="sec-adm-configfiles">
-   <title>了解 Bash 配置文件</title><indexterm>
-   <primary>配置文件</primary>
-   <see> Bash</see></indexterm>
+   <title>了解 Bash 配置文件</title>
    <para>
     外壳可调用为：
    </para>
@@ -243,9 +238,7 @@
   <xi:include href="fs_structure_i.xml"/>
  </sect1>
  <sect1 xml:id="sec-adm-shellscripts">
-  <title>编写外壳脚本</title><indexterm>
-
-  <primary>外壳脚本</primary></indexterm>
+  <title>编写外壳脚本</title>
 
   <para>
    使用外壳脚本可以方便地完成各种任务：收集数据、在文本中搜索单词或短语，以及执行其他有用的操作。以下示例显示用于打印文本的小外壳脚本：
@@ -259,9 +252,7 @@ echo "Hello World" <co xml:id="co-adm-shell-echo"/></screen>
    <calloutlist>
     <callout arearefs="co-adm-shell-shebang">
      <para>
-      第一行开头是 <emphasis>Shebang</emphasis> <indexterm>
-      <primary>Shebang</primary>
-      </indexterm> 字符 (<literal>#!</literal>)，它表示此文件是一个脚本。该脚本使用 Shebang 后的指定解释程序执行，在本示例中为 <command>/bin/sh</command>。
+      第一行开头是 <emphasis>Shebang</emphasis>  字符 (<literal>#!</literal>)，它表示此文件是一个脚本。该脚本使用 Shebang 后的指定解释程序执行，在本示例中为 <command>/bin/sh</command>。
      </para>
     </callout>
     <callout arearefs="co-adm-shell-comment">
@@ -411,9 +402,7 @@ echo "Hello World" <co xml:id="co-adm-shell-echo"/></screen>
 <screen>find / -name "foo*" 2&gt;/dev/null</screen>
  </sect1>
  <sect1 xml:id="sec-adm-alias">
-  <title>使用别名</title><indexterm>
-
-  <primary>aliases</primary></indexterm>
+  <title>使用别名</title>
 
   <para>
    别名是一个或多个命令的快捷方式定义。别名的语法为：

--- a/l10n/sles/zh-cn/xml/adm_support.xml
+++ b/l10n/sles/zh-cn/xml/adm_support.xml
@@ -22,9 +22,7 @@
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
-<indexterm>
- <primary>支持</primary></indexterm><indexterm>
- <primary>系统信息</primary></indexterm>
+
  <sect1 xml:id="sec-admsupport-hostinfo">
   <title>显示当前系统信息</title>
 

--- a/l10n/sles/zh-cn/xml/apache2.xml
+++ b/l10n/sles/zh-cn/xml/apache2.xml
@@ -11,14 +11,9 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm class="startofrange" xml:id="idx-apache2">
- <primary>Apache</primary></indexterm>
+ </info>
  <sect1 xml:id="sec-apache2-quickstart">
-  <title>快速入门</title><indexterm>
-
-  <primary> Apache</primary>
-
-  <secondary> 快速入门</secondary></indexterm> 
+  <title>快速入门</title>
 
   <para>
    借助本节内容，可快速设置并启动 Apache。您必须是 <systemitem class="username">root</systemitem> 用户才能安装和配置 Apache。
@@ -54,9 +49,7 @@
   </sect2>
 
   <sect2 xml:id="sec-apache2-quickstart-installation">
-   <title>安装</title><indexterm>
-   <primary> Apache</primary>
-   <secondary> 安装</secondary></indexterm> 
+   <title>安装</title>
    <para>
     <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 中的 Apache 默认不会安装到系统中。要用<quote>即装即用</quote>的标准预定义配置来安装它，请按如下所示继续：
    </para>
@@ -129,11 +122,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-apache2-configuration">
-  <title>配置 Apache</title><indexterm>
-
-  <primary> Apache</primary>
-
-  <secondary> 配置</secondary></indexterm> 
+  <title>配置 Apache</title>
 
   <para>
    <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 提供了两个配置选项：
@@ -167,10 +156,7 @@
   </important>
 
   <sect2 xml:id="sec-apache2-configuration-manually-configfiles">
-   <title>Apache 配置文件</title><indexterm>
-   <primary> Apache</primary>
-   <secondary> 配置</secondary>
-   <tertiary>文件</tertiary></indexterm> 
+   <title>Apache 配置文件</title>
    <para>
     本部分概述了 Apache 配置文件。如果使用 YaST 进行配置，则不需要使用这些文件；但如果以后要切换到手动配置，则此信息可能有用。
    </para>
@@ -362,18 +348,12 @@
   </sect2>
 
   <sect2 xml:id="sec-apache2-configuration-manually">
-   <title>手动配置 Apache</title><indexterm class="startofrange" xml:id="idx-apache2-configuration-manually">
-   <primary> Apache</primary>
-   <secondary> 配置</secondary>
-   <tertiary> 手动</tertiary></indexterm> 
+   <title>手动配置 Apache</title>
    <para>
     手动配置 Apache 包括作为 <systemitem class="username">root</systemitem> 用户来编辑纯文本配置文件。
    </para>
    <sect3 xml:id="sec-apache2-configuration-manually-vhost">
-    <title>虚拟主机配置</title><indexterm>
-    <primary> Apache</primary>
-    <secondary>配置</secondary>
-    <tertiary>虚拟主机</tertiary></indexterm> 
+    <title>虚拟主机配置</title>
     <para>
      术语<emphasis>虚拟主机</emphasis>指的是 Apache 在一台物理计算机上为多个统一资源标识符 (URI) 提供服务的能力。这意味着在一个物理计算机上的一个 Web 服务器可以运行几个域（例如 www.example.com 和 www.example.net）。
     </para>
@@ -559,7 +539,7 @@ Allow from all</screen>
   Require all granted
   &lt;/Directory&gt;
 &lt;/VirtualHost&gt;</screen>
-     </example><indexterm class="endofrange" startref="idx-apache2-configuration-manually"/>
+     </example>
     </sect4>
    </sect3>
   </sect2>
@@ -571,15 +551,7 @@ Allow from all</screen>
 
  </sect1>
  <sect1 xml:id="sec-apache2-start-stop">
-  <title>启动和停止 Apache</title><indexterm>
-
-  <primary>Apache</primary>
-
-  <secondary>启动</secondary></indexterm><indexterm>
-
-  <primary>Apache</primary>
-
-  <secondary>停止</secondary></indexterm>
+  <title>启动和停止 Apache</title>
 
   <remark>taroth 2014-02-11: @file-maintainer: please give the following a
  thorough check - so far I only replaced the rc* commands by the systemctl
@@ -708,11 +680,7 @@ Allow from all</screen>
   </tip>
  </sect1>
  <sect1 xml:id="sec-apache2-modules">
-  <title>安装、激活和配置模块</title><indexterm class="startofrange" xml:id="idx-apache2-modules">
-
-  <primary> Apache</primary>
-
-  <secondary> 模块</secondary></indexterm> 
+  <title>安装、激活和配置模块</title>
 
   <para>
    Apache 软件是以模块化方式构建的：除某些核心任务外的所有功能都是通过模块处理的。这方面的发展很快，甚至连 HTTP 都是由模块 (<systemitem>http_core</systemitem>) 处理的。
@@ -762,10 +730,7 @@ Allow from all</screen>
   </variablelist>
 
   <sect2 xml:id="sec-apache2-modules-installing">
-   <title>模块安装</title><indexterm>
-   <primary> Apache</primary>
-   <secondary> 模块</secondary>
-   <tertiary>安装</tertiary></indexterm> 
+   <title>模块安装</title>
    <para>
     如果您按<xref linkend="sec-apache2-quickstart-installation"/>中所述执行了默认安装，那么以下模块已经安装：所有基本和扩展模块、多处理模块 Prefork MPM 以及外部模块 <systemitem>mod_python</systemitem>。
    </para>
@@ -791,10 +756,7 @@ Allow from all</screen>
   </sect2>
 
   <sect2 xml:id="sec-apache2-modules-base-extension">
-   <title>基础模块和扩展模块</title><indexterm>
-   <primary> Apache</primary>
-   <secondary>模块</secondary>
-   <tertiary>可用</tertiary></indexterm> 
+   <title>基础模块和扩展模块</title>
    <para>
     Apache 文档中对所有基础模块和扩展模块均进行了详细的描述。此处仅提供大多数重要模块的简短描述。请参见 <link xlink:href="http://httpd.apache.org/docs/2.4/mod/">http://httpd.apache.org/docs/2.4/mod/</link> 以了解有关每个模块的详细信息。
    </para>
@@ -1011,10 +973,7 @@ Allow from all</screen>
   </sect2>
 
   <sect2 xml:id="sec-apache2-modules-mpm">
-   <title>多处理模块</title><indexterm>
-   <primary> Apache</primary>
-   <secondary>模块</secondary>
-   <tertiary>多处理</tertiary></indexterm> 
+   <title>多处理模块</title>
    <para>
     <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 提供了两个不同的多处理模块 (MPM) 来结合 Apache 使用：
    </para>
@@ -1063,10 +1022,7 @@ Allow from all</screen>
   </sect2>
 
   <sect2 xml:id="sec-apache2-modules-external">
-   <title>外部模块</title><indexterm>
-   <primary> Apache</primary>
-   <secondary>模块</secondary>
-   <tertiary>外部</tertiary></indexterm> 
+   <title>外部模块</title>
    <para>
     此处提供了 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 随附的所有外部模块的列表。在列出的目录中查找模块的文档。
    </para>
@@ -1158,10 +1114,7 @@ Allow from all</screen>
   </sect2>
 
   <sect2 xml:id="sec-apache2-modules-building-modules">
-   <title>编译</title><indexterm>
-   <primary> Apache</primary>
-   <secondary>模块</secondary>
-   <tertiary>构建</tertiary></indexterm> 
+   <title>编译</title>
    <para>
     高级用户可以通过编写自定义模块来扩展 Apache。要开发 Apache 模块或编译第三方模块，就需要 <systemitem>apache2-devel</systemitem> 包以及相应的开发工具。<systemitem>apache2-devel</systemitem> 还包含 <command>apxs2</command> 工具，此工具是编译其他 Apache 模块所必需的。
    </para>
@@ -1195,15 +1148,11 @@ Allow from all</screen>
 apxs2 -cia <replaceable>MODULE</replaceable>.c</screen>
    <para>
     其中，<option>-c</option> 编译该模块，<option>-i</option> 安装该模块，<option>-a</option> 激活该模块。<command>apxs2</command> 的其他选项在 <systemitem>apxs2(1)</systemitem> 手册页中有描述。
-   </para><indexterm class="endofrange" startref="idx-apache2-modules"/>
+   </para>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-apache2-cgi">
-  <title>启用 CGI 脚本</title><indexterm>
-
-  <primary> Apache</primary>
-
-  <secondary>CGI 脚本</secondary></indexterm> 
+  <title>启用 CGI 脚本</title>
 
   <para>
    Apache 的通用网关接口 (CGI) 允许您使用程序或脚本（通常称为 CGI 脚本）创建动态内容。可以用任何编程语言来编写 CGI 脚本。通常使用诸如 Perl 或 PHP 之类的脚本语言。
@@ -1307,11 +1256,7 @@ apxs2 -cia <replaceable>MODULE</replaceable>.c</screen>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-apache2-ssl">
-  <title>使用 SSL 设置安全性 Web 服务器</title><indexterm class="startofrange" xml:id="idx-apache2-ssl">
-
-  <primary> Apache</primary>
-
-  <secondary>SSL</secondary></indexterm> 
+  <title>使用 SSL 设置安全性 Web 服务器</title>
 
   <para>
    只要在 Web 服务器和客户端之间传送敏感数据（如信用卡信息），就需要具有带身份验证的安全的加密连接。<systemitem>mod_ssl</systemitem> 使用安全套接字层（SSL）和传输层安全（TLS）协议来为客户端和 Web 服务器之间的 HTTP 通信提供强有力的加密机制。使用 SSL/TLS 时，将在 Web 服务器和客户端之间建立专用连接。如此可确保数据完整性，并且客户端和服务器能够彼此验证。
@@ -1330,10 +1275,7 @@ apxs2 -cia <replaceable>MODULE</replaceable>.c</screen>
   </para>
 
   <sect2 xml:id="sec-apache2-ssl-certificate">
-   <title>创建 SSL 证书</title><indexterm>
-   <primary> Apache</primary>
-   <secondary>SSL</secondary>
-   <tertiary>创建 SSL 证书</tertiary></indexterm> 
+   <title>创建 SSL 证书</title>
    <para>
     要将 SSL/TLS 与 Web 服务器搭配使用，您需要创建 SSL 证书。在 Web 服务器和客户端之间授权时需要此证书，以便每一方都能明确地识别另一方。为了确保证书的完整性，证书必须由所有用户都信任的一方签署。
    </para>
@@ -1538,10 +1480,7 @@ sudo cp new.cert.key /etc/apache2/ssl.key/server.key</screen>
   </sect2>
 
   <sect2 xml:id="sec-apache2-ssl-configuration">
-   <title>使用 SSL 配置 Apache</title><indexterm>
-   <primary> Apache</primary>
-   <secondary>SSL</secondary>
-   <tertiary>使用 SSL 配置 Apache</tertiary></indexterm> 
+   <title>使用 SSL 配置 Apache</title>
    <para>
     Web 服务器端的 SSL 和 TLS 请求的默认端口是 443。在端口 80 上的<quote>普通</quote> Apache 侦听和端口 443 上支持 SSL/TLS 的 Apache 侦听之间没有冲突。事实上，HTTP 和 HTTPS 可以使用相同的 Apache 实例运行。通常使用一个虚拟主机将请求发送到端口 80 和端口 443 以区分虚拟服务器。
    </para>
@@ -1609,7 +1548,7 @@ sudo cp new.cert.key /etc/apache2/ssl.key/server.key</screen>
      <para>
       在服务器配置中设置为 <literal>off</literal> 时，服务器的行为类似于不支持 SNI。SSL 请求将由定义的<emphasis>第一个</emphasis>虚拟主机（端口 443）处理。
      </para>
-    </important><indexterm class="endofrange" startref="idx-apache2-ssl"/>
+    </important>
    </sect3>
   </sect2>
  </sect1>
@@ -1780,11 +1719,7 @@ apachectl start</screen>
   </itemizedlist>
  </sect1>
  <sect1 xml:id="sec-apache2-security">
-  <title>避免安全性问题</title><indexterm>
-
-  <primary> Apache</primary>
-
-  <secondary>安全性</secondary></indexterm> 
+  <title>避免安全性问题</title>
 
   <para>
    对公共因特网开放的 Web 服务器需要不断加强管理。对于软件和意外的错误配置，安全问题似乎都是不可避免的。有关如何处理这些问题，在此有一些提示。
@@ -1858,11 +1793,7 @@ apachectl start</screen>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-apache2-troubleeshooting">
-  <title>查错</title><indexterm>
-
-  <primary> Apache</primary>
-
-  <secondary>查错</secondary></indexterm> 
+  <title>查错</title>
 
   <para>
    如果 Apache 不启动、网页不可访问或用户无法连接到 Web 服务器，那么找出问题的原因是很重要的。下面是几处查找错误描述的常见位置和需要检查的重要事项：
@@ -2011,7 +1942,7 @@ apachectl start</screen>
    <title>其他来源</title>
    <para>
     如果遇到特定于 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 中的 Apache 的问题，请查看“技术信息搜索”，网址为：<link xlink:href="http://www.suse.com/support"/>。<link xlink:href="http://httpd.apache.org/ABOUT_APACHE.html"/> 提供了对 Apache 历史的介绍。此页还解释此服务器为什么被称为 Apache。
-   </para><indexterm class="endofrange" startref="idx-apache2"/>
+   </para>
   </sect2>
  </sect1>
 </chapter>

--- a/l10n/sles/zh-cn/xml/apache2_yast_i.xml
+++ b/l10n/sles/zh-cn/xml/apache2_yast_i.xml
@@ -6,10 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm class="startofrange" xml:id="idx-apache2-configuration-yast">
- <primary>Apache</primary>
- <secondary> 配置</secondary>
- <tertiary> YaST</tertiary></indexterm>
+ </info>
  <para>
   要使用 YaST 配置 Web 服务器，请启动 YaST，并选择<menuchoice> <guimenu>网络服务</guimenu> <guimenu> HTTP 服务器</guimenu> </menuchoice>。第一次启动此模块时，<guimenu>HTTP 服务器向导</guimenu>会启动，提示您做出一些有关服务器管理的基本决定。完成向导后，在您每次调用 <guimenu>HTTP 服务器</guimenu>模块时，<guimenu>HTTP 服务器配置</guimenu>对话框都会启动。有关详细信息，请参见<xref linkend="sec-apache2-configuration-yast-server-configuration"/>。
  </para>
@@ -221,7 +218,7 @@
    <title>主要主机</title>
    <para>
     这些对话框与上述对话框相同。请参见<xref linkend="sec-apache2-configuration-yast-wizard-default-host"/>和<xref linkend="sec-apache2-configuration-yast-wizard-virtual-hosts"/>。
-   </para><indexterm class="endofrange" startref="idx-apache2-configuration-yast"/>
+   </para>
   </sect4>
  </sect3>
 </sect2>

--- a/l10n/sles/zh-cn/xml/apps_brasero.xml
+++ b/l10n/sles/zh-cn/xml/apps_brasero.xml
@@ -15,26 +15,9 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-brasero" class="startofrange">
- <primary> Brasero</primary></indexterm> 
+ </info>
  <sect1 xml:id="sec-brasero-creating">
-  <title>创建数据 CD 或 DVD</title><indexterm>
-
-  <primary>CD</primary>
-
-  <secondary>创建</secondary>
-
-  <tertiary>数据</tertiary></indexterm><indexterm>
-
-  <primary>K3b</primary>
-
-  <secondary>数据 CD</secondary></indexterm><indexterm>
-
-  <primary>DVD</primary>
-
-  <secondary>创建</secondary>
-
-  <tertiary>数据</tertiary></indexterm>
+  <title>创建数据 CD 或 DVD</title>
 
   <para>
    首次启动 Brasero 后，会显示如<xref linkend="fig-brasero-main" xrefstyle="select:label nopage"/>中所示的主窗口。
@@ -116,17 +99,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-brasero-creatingaudiocd">
-  <title>创建音频 CD</title><indexterm>
-
-  <primary>CD</primary>
-
-  <secondary>创建</secondary>
-
-  <tertiary>音频</tertiary></indexterm><indexterm>
-
-  <primary>Brasero</primary>
-
-  <secondary>音频 CD</secondary></indexterm> 
+  <title>创建音频 CD</title>
 
   <para>
    创建音频 CD 和创建数据 CD 并没有太大的差别。按如下所示继续：
@@ -168,19 +141,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-brasero-copying">
-  <title>拷贝 CD 或 DVD</title><indexterm>
-
-  <primary>CD</primary>
-
-  <secondary>复制</secondary></indexterm><indexterm>
-
-  <primary>Brasero</primary>
-
-  <secondary>复制 CD</secondary></indexterm><indexterm>
-
-  <primary>DVD</primary>
-
-  <secondary>复制</secondary></indexterm>
+  <title>拷贝 CD 或 DVD</title>
 
   <para>
    要复制 CD 或 DVD，请执行如下操作：
@@ -216,15 +177,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-gnome-writingiso">
-  <title>刻录 ISO 映像</title><indexterm>
-
-  <primary>CD</primary>
-
-  <secondary> ISO 映像</secondary></indexterm><indexterm>
-
-  <primary> DVD</primary>
-
-  <secondary> ISO 映像</secondary></indexterm>
+  <title>刻录 ISO 映像</title>
 
   <para>
    如果已有 ISO 映像，请单击<guimenu>刻录映像</guimenu>或转到<menuchoice> <guimenu> 项目</guimenu> <guimenu> 新建项目</guimenu>
@@ -232,11 +185,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-brasero-multisession">
-  <title>创建多记录片段 CD 或 DVD</title><indexterm>
-
-  <primary>CD</primary>
-
-  <secondary>多记录片断</secondary></indexterm>
+  <title>创建多记录片段 CD 或 DVD</title>
 
   <para>
    多记录片段磁盘可以在多个刻录片段中刻录数据。例如，它可用于刻录比媒体小的备份。在每个片段中可以添加其他备份文件。有趣的是，数据刻录不仅仅局限于 CD 或 DVD。您还可以在多记录片段磁盘中添加音频片段。
@@ -274,6 +223,6 @@
 
   <para>
    您可以在 <link xlink:href="https://wiki.gnome.org/Apps/Brasero"/> 上找到有关 Brasero 的详细信息。
-  </para><indexterm class="endofrange" startref="idx-brasero"/>
+  </para>
  </sect1>
 </chapter>

--- a/l10n/sles/zh-cn/xml/apps_ekiga.xml
+++ b/l10n/sles/zh-cn/xml/apps_ekiga.xml
@@ -11,12 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-voip" class="startofrange">
- <primary>voice over IP</primary></indexterm><indexterm>
- <primary>应用程序</primary>
- <secondary>网络</secondary>
- <tertiary>Ekiga</tertiary></indexterm><indexterm xml:id="idx-ekiga" class="startofrange">
- <primary>Ekiga</primary></indexterm>
+ </info>
  <note>
   <title>Ekiga 可能未安装</title>
   <para>
@@ -387,11 +382,7 @@
   </table>
  </sect1>
  <sect1 xml:id="sec-ekiga-firstcall">
-  <title>致电</title><indexterm>
-
-  <primary>Ekiga</primary>
-
-  <secondary>呼叫</secondary></indexterm>
+  <title>致电</title>
 
   <para>
    正确配置 Ekiga 后，打电话就变得十分容易。
@@ -531,8 +522,8 @@
   </para>
 
   <para>
-   要设置私用电话网络，您可能对 <literal>PBX </literal>软件 Asterisk <link xlink:href="http://www.asterisk.org/"/> 感兴趣。在 <link xlink:href="http://www.voip-info.org/wiki-Asterisk"/> 中可找到相关信息。<indexterm startref="idx-ekiga" class="endofrange"/>
-   <indexterm startref="idx-voip" class="endofrange"/> 
+   要设置私用电话网络，您可能对 <literal>PBX </literal>软件 Asterisk <link xlink:href="http://www.asterisk.org/"/> 感兴趣。在 <link xlink:href="http://www.voip-info.org/wiki-Asterisk"/> 中可找到相关信息。
+    
   </para>
  </sect1>
 </chapter>

--- a/l10n/sles/zh-cn/xml/apps_firefox.xml
+++ b/l10n/sles/zh-cn/xml/apps_firefox.xml
@@ -11,13 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm class="startofrange" xml:id="idx-firefox">
- <primary>Firefox</primary></indexterm><indexterm class="startofrange" xml:id="idx-browsers-firefox">
- <primary>万维网浏览器</primary>
- <secondary>Firefox</secondary></indexterm><indexterm>
- <primary>应用程序</primary>
- <secondary>网络</secondary>
- <tertiary>Firefox</tertiary></indexterm>
+ </info>
  <sect1 xml:id="sec-firefox-start">
   <title>启动 Firefox</title>
 
@@ -27,11 +21,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-firefox-navigating">
-  <title>网站导航</title><indexterm>
-
-  <primary> Firefox</primary>
-
-  <secondary> 浏览</secondary></indexterm> 
+  <title>网站导航</title>
 
   <para>
    Firefox 的外观与其他浏览器类似。<xref linkend="fig-firefox-main"/>中显示了这一工具。窗口顶部是地址栏（用于输入网址）和搜索栏。也可从书签工具栏使用书签，以进行快速访问。有关 Firefox 各种功能的详细信息，请使用菜单栏中的<guimenu>帮助</guimenu>菜单。
@@ -72,9 +62,7 @@
   </figure>
 
   <sect2 xml:id="sec-firefox-locationbar">
-   <title>地址栏</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> 地址栏</secondary></indexterm> 
+   <title>地址栏</title>
    <para>
     在地址栏中键入信息时，自动补全下拉框将会打开。其中会显示含有您所键入的字符的所有先前位置地址和书签。匹配的词语将以粗体高亮显示。最常和最近访问的项会列在前面。
    </para>
@@ -87,9 +75,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-zoom">
-   <title>缩放</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> 缩放</secondary></indexterm> 
+   <title>缩放</title>
    <para>
     Firefox 提供了两种缩放选项：页面缩放（默认）和文本缩放。页面缩放可将整个页面连同其所有元素（包括图形）同比例扩大，而文本缩放仅限于更改文本大小。
    </para>
@@ -102,11 +88,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-tabbedbrowsing">
-   <title>标签式浏览</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary>标签</secondary></indexterm><indexterm>
-   <primary>Firefox</primary>
-   <secondary>标签式浏览</secondary></indexterm>
+   <title>标签式浏览</title>
    <para>
     使用标签页浏览可在单个窗口中装载多个网站。要在使用的页面之间切换，请使用窗口顶部的标签页。如果您经常同时使用多个网页，则标签页式浏览可以让您在页面之间轻松地进行切换。
    </para>
@@ -153,9 +135,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-sidebar">
-   <title>使用侧栏</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> 侧栏</secondary></indexterm> 
+   <title>使用侧栏</title>
    <para>
     使用浏览器窗口的左侧可查看书签或浏览历史记录。用扩展件还可以通过新的方式使用侧栏。要显示侧栏，请从菜单栏中选择<menuchoice> <guimenu>查看</guimenu>
     <guimenu>侧栏</guimenu> </menuchoice>，然后选择所需的内容。
@@ -170,13 +150,7 @@
   </para>
 
   <sect2 xml:id="sec-firefox-searchengine">
-   <title>在 Web 上查找信息</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary> 搜索方式</secondary></indexterm><indexterm>
-   <primary> Firefox</primary>
-   <secondary> 搜索栏</secondary></indexterm><indexterm>
-   <primary> Firefox</primary>
-   <secondary> Web 搜索</secondary></indexterm>
+   <title>在 Web 上查找信息</title>
    <para>
     Firefox 包含一个搜索栏，它可以访问不同的引擎，如 Google、Yahoo 或 Amazon。例如，如果您希望使用当前引擎来查找有关 SUSE 的信息，请在搜索栏中单击，键入 <literal>SUSE</literal>，然后按 <keycap function="enter"/>。结果将显示在窗口中。
    </para>
@@ -231,9 +205,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-searchengine-smartkeywords">
-    <title>向联机搜索添加关键词</title><indexterm>
-    <primary>Firefox</primary>
-    <secondary> 关键词</secondary></indexterm>
+    <title>向联机搜索添加关键词</title>
     <para>
      Firefox 允许您定义自己的<emphasis>关键词</emphasis>：用作特定搜索引擎的 URL 快捷方式的缩写。例如，如果您已将 <literal>ws</literal> 定义为 Wikipedia 搜索的关键词，那么只要在地址栏中键入 <literal>ws <replaceable>搜索词</replaceable></literal>即可在 Wikipedia 中搜索<replaceable>搜索词</replaceable>。
     </para>
@@ -275,26 +247,18 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-findinfo-page">
-   <title>在当前页面中搜索</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> 在页面上查找</secondary></indexterm> 
+   <title>在当前页面中搜索</title>
    <para>
     要在网页中搜索，请在菜单栏中单击<menuchoice>
     <guimenu>编辑</guimenu> <guimenu>查找</guimenu> </menuchoice>，或者按<keycombo> <keycap function="control"/> <keycap>F</keycap> </keycombo>。此时，查找栏会打开。它通常显示在窗口的底部。在文本框中键入您的查询。Firefox 会查找第一个出现您所输入短语的位置。可以按 <keycap>F3</keycap> 或在查找栏中单击<guimenu>查找语句在页面中的下一个位置</guimenu>按钮，来查找此短语的其他位置。单击<guimenu>高亮所有</guimenu>按钮将高亮显示出现此短语的全部位置。选中<guimenu>区分大小写</guimenu>选项，则查询时会区分大小写。
-   </para><indexterm>
-   <primary>Firefox</primary>
-   <secondary> 快速查找</secondary></indexterm>
+   </para>
    <para>
     Firefox 还提供两个快速查找选项。在网页上单击要开始搜索的任意位置，输入键 <keycap>/</keycap>，后面紧跟搜索项。第一个出现所输入的搜索项的位置将会高亮显示。使用 <keycap>F3</keycap> 查找下一个位置。也可以将快速查找限制为仅查找链接。输入键 <keycap>'</keycap> 可使用此搜索选项。
    </para>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-firefox-bookmarks">
-  <title>管理书签</title><indexterm>
-
-  <primary> Firefox</primary>
-
-  <secondary> 书签</secondary></indexterm> 
+  <title>管理书签</title>
 
   <para>
    通过书签，可以方便地保存指向您喜爱的网站的链接。Firefox 不仅使添加新书签变得非常容易（只需单击一下鼠标），还可提供多种方式，方便您管理大量书签收藏。您可以将书签整理到各文件夹中，使用标签将其分类，或者使用智能书签文件夹对其过滤。
@@ -313,13 +277,7 @@
   </para>
 
   <sect2 xml:id="sec-firefox-bookmarks-organise">
-   <title>管理书签</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary>书签</secondary>
-   <tertiary>管理</tertiary></indexterm><indexterm>
-   <primary>Firefox</primary>
-   <secondary>书签</secondary>
-   <tertiary>库</tertiary></indexterm>
+   <title>管理书签</title>
    <para>
     <guimenu>书签库</guimenu>可用于管理每个书签的属性（名称和地址位置），以及将书签整理成文件夹和部分。它与 <xref linkend="fig-firefox-library"/> 类似。
    </para>
@@ -400,10 +358,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-tags">
-   <title>标签</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary> 书签</secondary>
-   <tertiary> 标签</tertiary></indexterm>
+   <title>标签</title>
    <para>
     标签提供了一种将一个书签归档到多个类别下的简便方法。您可以根据需要为书签添加任意数量的标签。例如，要访问标签为 <literal>suse</literal> 的全部站点，可在地址栏中输入 <literal>suse</literal>。系统会自动为每个标签在库中<systemitem>最近使用的标签</systemitem>文件夹内自动创建一个项目。将标签对应的项目拖放到书签工具栏可以轻松访问该项目。
    </para>
@@ -413,13 +368,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-imexport">
-   <title>导入和导出书签</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary>书签</secondary>
-   <tertiary>导入</tertiary></indexterm><indexterm>
-   <primary>Firefox</primary>
-   <secondary>书签</secondary>
-   <tertiary>导出</tertiary></indexterm>
+   <title>导入和导出书签</title>
 
    <para>
     要从其他浏览器或 HTML 格式的文件导入书签，可在菜单栏中选择<menuchoice>
@@ -436,10 +385,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-live">
-   <title>在线书签</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary> 书签</secondary>
-   <tertiary>在线书签</tertiary></indexterm>
+   <title>在线书签</title>
    <para>
     在线书签显示书签菜单中的标题并为您显示最新的新闻。这节省了您的时间，因为您只需一览收藏的站点就能够获得最新新闻。在线书签会自动更新。许多站点和博客支持此格式。
    </para>
@@ -450,20 +396,14 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-smart">
-   <title>智能书签文件夹</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary> 书签</secondary>
-   <tertiary> 智能书签</tertiary></indexterm>
+   <title>智能书签文件夹</title>
    <para>
     智能书签文件夹是会动态更新的虚拟书签文件夹。智能书签文件夹共有三个：<guimenu>访问最多</guimenu>链接显示于书签工具栏中。<guimenu>最近使用的书签</guimenu>链接和<guimenu>最近使用的标签</guimenu>位于书签菜单中。
    </para>
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-toolbar">
-   <title>书签工具栏</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary> 书签</secondary>
-   <tertiary> 工具栏</tertiary></indexterm>
+   <title>书签工具栏</title>
    <para>
     <literal>书签工具栏</literal>显示在地址栏下方，使您能够快速访问书签。您也可以直接添加、组织和编辑书签。默认情况下，<literal>书签工具栏</literal>中填入了预定义的一组书签，并组织进若干文件夹（请参见<xref linkend="fig-firefox-main"/>）。
    </para>
@@ -476,15 +416,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-firefox-downloadmanager">
-  <title>使用下载管理器</title><indexterm>
-
-  <primary>Firefox</primary>
-
-  <secondary> 下载管理器</secondary></indexterm><indexterm>
-
-  <primary>下载管理器</primary>
-
-  <secondary>Firefox</secondary></indexterm>
+  <title>使用下载管理器</title>
 
   <para>
    用下载管理器可跟踪当前和历史下载。要启动下载管理器，请在菜单栏中单击<menuchoice>
@@ -504,20 +436,14 @@
   </tip>
  </sect1>
  <sect1 xml:id="sec-firefox-security">
-  <title>安全性</title><indexterm>
-
-  <primary>Firefox</primary>
-
-  <secondary> 安全性</secondary></indexterm>
+  <title>安全性</title>
 
   <para>
    由于浏览因特网的风险越来越高，Firefox 提供了各种措施以使浏览更安全。它会自动检查您正尝试访问的站点是否包含有害软件 (malware) 或是否已链接到窃取敏感数据 (phishing) 的站点，并阻止您进入这些站点。即时网站 ID 使您能够轻松检查站点的合法性，密码管理器和弹出窗口拦截程序则提供了更多安全性。通过隐私浏览模式，您可以进行网上冲浪，而 Firefox 不会在您的计算机上记录数据。
   </para>
 
   <sect2 xml:id="sec-firefox-security-instant-id">
-   <title>即时网站 ID</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary> 站点标识</secondary></indexterm>
+   <title>即时网站 ID</title>
    <para>
     Firefox 使您对网页标识一目了然。地址栏中地址旁边的图标指示可以使用哪些身份信息，以及通讯是否已加密。
    </para>
@@ -630,11 +556,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-firefox-customizing">
-  <title>自定义 Firefox</title><indexterm>
-
-  <primary> Firefox</primary>
-
-  <secondary>配置</secondary></indexterm> 
+  <title>自定义 Firefox</title>
 
   <para>
    可以对 Firefox 进行范围广泛的自定义。
@@ -663,9 +585,7 @@
   </para>
 
   <sect2 xml:id="sec-firefox-preferences">
-   <title>选项</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary> 选项</secondary></indexterm>
+   <title>选项</title>
    <para>
     Firefox 提供了丰富的配置选项。可以通过在菜单栏中选择<menuchoice> <guimenu> 编辑</guimenu>
     <guimenu> 选项</guimenu> </menuchoice> 来使用这些选项。在对话框中单击问号图标可以访问联机帮助，其中对每个选项都做了详细描述。
@@ -682,9 +602,7 @@
     </mediaobject>
    </figure>
    <sect3 xml:id="sec-firefox-preferences-sessions">
-    <title>会话管理</title><indexterm>
-    <primary>Firefox</primary>
-    <secondary> 会话管理</secondary></indexterm>
+    <title>会话管理</title>
     <para>
      默认情况下，Firefox 只有在崩溃后或由于安装扩展而重启动之后才会自动恢复会话（窗口和标签页）。但也可以将其配置为每次启动时都恢复会话：按<xref linkend="sec-firefox-preferences"/>中所述打开“选项”对话框并转到<guimenu>常规</guimenu>类别。将<guimenu>启动 Firefox 时:</guimenu> 选项设置为<guimenu>显示上次打开的窗口和标签页</guimenu>。
     </para>
@@ -695,17 +613,13 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-preferences-language">
-    <title>网站的语言首选项</title><indexterm>
-    <primary>Firefox</primary>
-    <secondary> 语言</secondary></indexterm>
+    <title>网站的语言首选项</title>
     <para>
      在向 Web 服务器发送请求时，浏览器总是会发送用户首选语言的信息。能以多种语言显示的网站（且已配置为评估此语言参数）将以浏览器请求的语言显示其页面。在 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 上，首选语言已预先配置为使用与桌面相同的语言。要更改此设置，请按<xref linkend="sec-firefox-preferences"/>中所述打开<guimenu>选项</guimenu>窗口，转到<guimenu>内容</guimenu>类别并<guimenu>选择</guimenu>您的首选语言。
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-preferences-spelling">
-    <title>拼写检查</title><indexterm>
-    <primary>Firefox</primary>
-    <secondary> 拼写检查</secondary></indexterm>
+    <title>拼写检查</title>
     <para>
      默认情况下，当您在多行文本框中键入文本时，Firefox 会对您键入的内容进行拼写检查。拼写错误的词会以红色下划线标注。要更正某个词，可右键单击它并从上下文菜单中选择正确的拼写。还可以将正确的词添加到字典中。
     </para>
@@ -716,13 +630,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-extensions">
-   <title>附加组件</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary>附加组件</secondary></indexterm><indexterm>
-   <primary>Firefox</primary>
-   <secondary>扩展</secondary></indexterm><indexterm>
-   <primary>Firefox</primary>
-   <secondary>主题</secondary></indexterm>
+   <title>附加组件</title>
    <para>
     您可以用扩展来个性化 Firefox，以满足您的需要。使用扩展可以更改 Firefox 的外观，增强现有功能，以及添加功能。例如，扩展可以增强下载管理器功能，显示天气或控制 Web 音乐播放器。其他扩展可以阻止广告或脚本等内容，从而为 Web 开发人员提供协助或提高安全性。
    </para>
@@ -733,10 +641,7 @@
     如果您不喜欢 Firefox 的标准外观，请安装新的<emphasis>主题</emphasis>。主题只影响浏览器的外观，而不会更改其功能。
    </para>
    <sect3 xml:id="sec-firefox-extensions-install">
-    <title>安装附加组件</title><indexterm>
-    <primary>Firefox</primary>
-    <secondary> 附加组件</secondary>
-    <tertiary>安装</tertiary></indexterm>
+    <title>安装附加组件</title>
     <para>
      要添加扩展或主题，请在菜单栏中使用<menuchoice>
      <guimenu> 工具</guimenu> <guimenu> 附加组件</guimenu> </menuchoice> 启动附加组件管理器。它打开后会显示<guimenu>获取附加组件</guimenu>选项卡，其中显示推荐的附加组件选择或上次搜索的结果。
@@ -761,10 +666,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-extensions-manage">
-    <title>管理附加组件</title><indexterm>
-    <primary>Firefox</primary>
-    <secondary> 附加组件</secondary>
-    <tertiary>管理</tertiary></indexterm>
+    <title>管理附加组件</title>
     <para>
      附加产品管理器还提供了方便管理扩展、主题和插件的界面。可以启用、禁用或卸载<guimenu>扩展</guimenu>。如果扩展可配置，则可以通过<guimenu>选项</guimenu>按钮访问其配置选项。在<guimenu>外观</guimenu>选项卡中，可以<guimenu>卸载</guimenu>主题或通过单击<guimenu>启用</guimenu>激活其他主题。还会列出待发扩展和主题安装。选择<guimenu>取消</guimenu>可停止安装。虽然不能以用户身份安装<guimenu>插件</guimenu>，但通过附加组件管理器可以禁用或启用它们。
     </para>
@@ -777,15 +679,7 @@
 
  </sect1>
  <sect1 xml:id="sec-firefox-printing">
-  <title>从 Firefox 打印</title><indexterm>
-
-  <primary>Firefox</primary>
-
-  <secondary>打印</secondary></indexterm><indexterm>
-
-  <primary>打印</primary>
-
-  <secondary>Firefox</secondary></indexterm>
+  <title>从 Firefox 打印</title>
 
   <para>
    实际打印网页前，您可以用打印预览功能控制打印出来的页面的外观。在菜单栏中，选择<menuchoice> <guimenu>文件</guimenu> <guimenu>打印预览</guimenu>
@@ -821,6 +715,6 @@
    </member>
    <member><emphasis>键盘快捷键</emphasis>：<link xlink:href="http://support.mozilla.org/kb/Keyboard+shortcuts"/>
    </member>
-  </simplelist><indexterm startref="idx-firefox" class="endofrange"/><indexterm class="endofrange" startref="idx-browsers-firefox"/>
+  </simplelist>
  </sect1>
 </chapter>

--- a/l10n/sles/zh-cn/xml/apps_gimp.xml
+++ b/l10n/sles/zh-cn/xml/apps_gimp.xml
@@ -11,26 +11,12 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-gimp" class="startofrange">
- <primary>GIMP</primary></indexterm><indexterm xml:id="idx-graphics-editing" class="startofrange">
- <primary>图形</primary>
- <secondary>编辑</secondary></indexterm><indexterm>
- <primary>应用程序</primary>
- <secondary>图形</secondary>
- <tertiary>GIMP</tertiary></indexterm>
+ </info>
  <para>
   GIMP 是极其复杂的程序。本章只讨论其中的一小部分功能、工具和菜单项。要了解如何查找有关此程序的详细信息，请参见<xref linkend="sec-gimp-moreinfo"/>。
  </para>
  <sect1 xml:id="sec-gimp-graphics">
-  <title>图形格式</title><indexterm>
-
-  <primary>图形</primary>
-
-  <secondary>像素</secondary></indexterm><indexterm>
-
-  <primary>图形</primary>
-
-  <secondary>矢量</secondary></indexterm>
+  <title>图形格式</title>
 
   <para>
    主要有两种类型的数字图形：光栅和矢量。GIMP 用于处理光栅图形，它是数码照片或扫描图像最常用的格式。
@@ -87,11 +73,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-gimp-starting">
-  <title>启动 GIMP</title><indexterm>
-
-  <primary> GIMP</primary>
-
-  <secondary> 启动</secondary></indexterm> 
+  <title>启动 GIMP</title>
 
   <para>
    要启动 GIMP，请选择<menuchoice><guimenu>应用程序</guimenu>
@@ -129,10 +111,7 @@
     <guimenu>文件</guimenu>菜单提供标准文件操作，如<guimenu>新建</guimenu>、<guimenu>打开</guimenu>、<guimenu>保存</guimenu>、<guimenu>打印</guimenu>和<guimenu>关闭</guimenu>。单击<guimenu>退出</guimenu>可退出应用程序。
    </para>
    <para>
-    <indexterm>
-    <primary>GIMP</primary>
-    <secondary>视图</secondary>
-    </indexterm>通过<guimenu>视图</guimenu>菜单中的项目，可以控制图像和图像窗口的显示。<guimenu>新建视图</guimenu>将打开当前图像的另一个显示窗口。在一个视图中所做的更改将在该图像的其他所有视图中得到反映。通过备用视图，可以在放大图像的某一部分进行操纵的同时在另一个视图中查看整个图像。使用<guimenu>缩放</guimenu>可调整当前窗口的放大级别。如果选中<guimenu>在窗口中调整图像</guimenu>，则系统会重新调整图像窗口的大小，以完全显示当前图像。
+    通过<guimenu>视图</guimenu>菜单中的项目，可以控制图像和图像窗口的显示。<guimenu>新建视图</guimenu>将打开当前图像的另一个显示窗口。在一个视图中所做的更改将在该图像的其他所有视图中得到反映。通过备用视图，可以在放大图像的某一部分进行操纵的同时在另一个视图中查看整个图像。使用<guimenu>缩放</guimenu>可调整当前窗口的放大级别。如果选中<guimenu>在窗口中调整图像</guimenu>，则系统会重新调整图像窗口的大小，以完全显示当前图像。
    </para>
   </sect2>
 
@@ -185,9 +164,7 @@
   </para>
 
   <sect2 xml:id="sec-gimp-getstart-creating">
-   <title>创建新图像</title><indexterm>
-   <primary> GIMP</primary>
-   <secondary> 创建图像</secondary></indexterm> 
+   <title>创建新图像</title>
    <procedure>
     <step>
      <para>
@@ -198,9 +175,7 @@
     <step>
      <para>
       如果愿意，请选择称为<guimenu>模板</guimenu>的预定义设置。
-     </para><indexterm>
-     <primary> GIMP</primary>
-     <secondary> 模板</secondary></indexterm> 
+     </para>
      <note>
       <title>自定义模板</title>
       <para>
@@ -238,9 +213,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-getstart-open">
-   <title>打开现有图像</title><indexterm>
-   <primary> GIMP</primary>
-   <secondary> 打开图像</secondary></indexterm> 
+   <title>打开现有图像</title>
    <para>
     要打开现有图像，请选择<menuchoice> <guimenu> 文件</guimenu>
     <guimenu> 打开</guimenu></menuchoice>。
@@ -251,11 +224,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gimp-saving">
-  <title>保存和导出图像</title><indexterm>
-
-  <primary> GIMP</primary>
-
-  <secondary> 保存图像</secondary></indexterm> 
+  <title>保存和导出图像</title>
 
   <para>
    在 GIMP 中，保存和导出图像是有差别的。
@@ -287,10 +256,7 @@
 
 
    <varlistentry>
-    <term>JPEG<indexterm>
-     <primary> 文件</primary>
-     <secondary> 格式</secondary>
-     <tertiary> JPG</tertiary></indexterm> 
+    <term>JPEG 
     </term>
     <listitem>
      <para>
@@ -299,10 +265,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>GIF<indexterm>
-     <primary> 文件</primary>
-     <secondary>格式</secondary>
-     <tertiary> GIF</tertiary></indexterm> 
+    <term>GIF 
     </term>
     <listitem>
      <para>
@@ -311,10 +274,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>PNG<indexterm>
-     <primary> 文件</primary>
-     <secondary>格式</secondary>
-     <tertiary> PNG</tertiary></indexterm> 
+    <term>PNG 
     </term>
     <listitem>
      <para>
@@ -325,20 +285,14 @@
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-gimp-basics">
-  <title>编辑图像</title><indexterm xml:id="idx-gimp-editing-images" class="startofrange">
-
-  <primary> GIMP</primary>
-
-  <secondary> 编辑图像</secondary></indexterm> 
+  <title>编辑图像</title>
 
   <para>
    GIMP 提供了若干个用于对图像进行更改的工具。此处所述的功能是小幅改动最常用到的功能。
   </para>
 
   <sect2 xml:id="sec-gimp-basics-size">
-   <title>更改图像的大小</title><indexterm xml:id="idx-graphics-resizing" class="startofrange">
-   <primary> 图形</primary>
-   <secondary>大小调整</secondary></indexterm> 
+   <title>更改图像的大小</title>
    <para>
     在扫描图像或从相机装载数码照片后，通常有必要为在网页显示或进行打印而修改大小。通过缩小或截去图像部分区域，可以轻松将减少图像大小。
    </para>
@@ -346,9 +300,7 @@
     将图像放大会出现较多问题。由于光栅图形的性质，在放大图像时将造成质量损失。在缩放或剪切之前，最好保存原始图像的副本。
    </para>
    <sect3 xml:id="sec-gimp-basics-size-cropping">
-    <title>剪切图像</title><indexterm>
-    <primary> GIMP</primary>
-    <secondary> 剪切</secondary></indexterm> 
+    <title>剪切图像</title>
     <procedure>
      <step>
       <para>
@@ -374,9 +326,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-size-scaling">
-    <title>缩放图像</title><indexterm>
-    <primary> GIMP</primary>
-    <secondary> 调整图像大小</secondary></indexterm> 
+    <title>缩放图像</title>
     <procedure>
      <step>
       <para>
@@ -427,14 +377,12 @@
        完成后，单击<guimenu>调整大小</guimenu>。
       </para>
      </step>
-    </procedure><indexterm startref="idx-graphics-resizing" class="endofrange"/>
+    </procedure>
    </sect3>
   </sect2>
 
   <sect2 xml:id="sec-gimp-basics-select">
-   <title>选择图像部分区域</title><indexterm xml:id="idx-gimp-selecting" class="startofrange">
-   <primary> GIMP</primary>
-   <secondary> 选择</secondary></indexterm> 
+   <title>选择图像部分区域</title>
    <para>
     许多时候需要只对图像的一部分执行图像操作。为此，必须选择要处理的图像部分。您可以使用工具箱中提供的选择工具、使用快速蒙板或者组合不同的选项，来选择图像区域。使用<guimenu>选择</guimenu>下的项目也可以修改选择区域。选择区域周围带有虚轮廓线，称作<emphasis>行进中的蚂蚁</emphasis>。
    </para>
@@ -543,9 +491,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-select-quickmask">
-    <title>使用快速蒙板</title><indexterm>
-    <primary> GIMP</primary>
-    <secondary> 快速蒙板</secondary></indexterm> 
+    <title>使用快速蒙板</title>
     <para>
      快速蒙板是使用绘画工具选取图像各个部分的一种方法。最好的做法是使用<guimenu>剪刀</guimenu>或<guimenu>自由选择</guimenu>工具进行大致选择。然后开始使用<guimenu>快速蒙板</guimenu>。
     </para>
@@ -577,7 +523,7 @@
        完成后，单击图像窗口左下角的图标返回到正常选择视图。然后，该选区将以行进中的蚂蚁形式显示。
       </para>
      </step>
-    </procedure><indexterm startref="idx-gimp-selecting" class="endofrange"/>
+    </procedure>
    </sect3>
   </sect2>
 
@@ -590,9 +536,7 @@
     在许多工具中，当前所用工具的图标会与箭头一同显示。对于涂画工具，会显示当前画笔的轮廓，让您清楚看到图像中要涂画的位置以及要涂画区域的大小。
    </para>
    <sect3 xml:id="sec-gimp-basics-color-selecting">
-    <title>选择颜色</title><indexterm>
-    <primary> GIMP</primary>
-    <secondary> 颜色</secondary></indexterm> 
+    <title>选择颜色</title>
     <para>
      GIMP 工具箱始终显示两个色样。前景色由绘图工具使用。背景色的使用要少见得多，但可以轻松切换为前景色。
     </para>
@@ -650,9 +594,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-color-text">
-    <title>添加文字</title><indexterm>
-    <primary> GIMP</primary>
-    <secondary> 文本</secondary></indexterm> 
+    <title>添加文字</title>
     <para>
      要添加文本，请使用文本工具。使用工具选项选择所需的字体和文本属性。在图像中单击，然后开始编写。
     </para>
@@ -661,9 +603,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-color-clone">
-    <title>修饰图像 － 克隆工具</title><indexterm>
-    <primary> GIMP</primary>
-    <secondary> 修饰图像</secondary></indexterm> 
+    <title>修饰图像 － 克隆工具</title>
     <para>
      克隆工具是很理想的图像修饰工具。它支持使用图像另一部分的信息来绘图图像。如果需要，该工具还可以从图案中提取信息。
     </para>
@@ -680,9 +620,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-basics-levels">
-   <title>调整色阶</title><indexterm>
-   <primary> GIMP</primary>
-   <secondary> 级别</secondary></indexterm> 
+   <title>调整色阶</title>
    <para>
     图像经常需要略微调整才能获得理想的打印或显示效果。
    </para>
@@ -713,9 +651,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-basics-undo">
-   <title>撤销错误</title><indexterm>
-   <primary> GIMP</primary>
-   <secondary> 撤销</secondary></indexterm> 
+   <title>撤销错误</title>
    <para>
     在 GIMP 中所做的大部分修改都可以撤销。要查看修改历史记录，请使用包含在默认窗口布局中的撤销对话框，或使用<menuchoice>
     <guimenu> 窗口</guimenu> <guimenu> 可靠接对话框</guimenu>
@@ -732,9 +668,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-advanced-layers">
-   <title>图层</title><indexterm>
-   <primary> GIMP</primary>
-   <secondary> 图层</secondary></indexterm> 
+   <title>图层</title>
    <para>
     图层是 GIMP 中的一个很重要的特性。通过在不同的图层中绘制图像的各个部分，您可以更改、移动或删除这些部分而不影响图像的其余部分。
    </para>
@@ -747,9 +681,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-advanced-modes">
-   <title>图像模式</title><indexterm>
-   <primary> GIMP</primary>
-   <secondary> 图像模式</secondary></indexterm> 
+   <title>图像模式</title>
    <para>
     GIMP 有三种图像模式：
    </para>
@@ -776,24 +708,14 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-advanced-effects">
-   <title>特殊效果</title><indexterm>
-   <primary> GIMP</primary>
-   <secondary> 效果</secondary></indexterm> 
+   <title>特殊效果</title>
    <para>
     GIMP 包含大量过滤器和脚本，可增强图像、为图像添加特殊效果或做艺术处理。可在<guimenu>过滤器</guimenu>中找到它们。要了解具体的功能，亲身体验是最佳方式。
-   </para><indexterm startref="idx-gimp-editing-images" class="endofrange"/>
+   </para>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gimp-printing">
-  <title>打印图像</title><indexterm>
-
-  <primary>GIMP</primary>
-
-  <secondary>打印</secondary></indexterm><indexterm>
-
-  <primary>打印</primary>
-
-  <secondary>GIMP</secondary></indexterm>
+  <title>打印图像</title>
 
   <para>
    要打印图像，请从图像菜单中选择<menuchoice> <guimenu>文件</guimenu>
@@ -866,6 +788,6 @@
      有一个整个专用于 GIMP 和 GNOME 桌面环境的 IRC 网络 - GIMPNet。您可以将喜爱的 IRC 客户端指向 <literal>irc.gimp.org</literal> 服务器，用该客户端来连接到 GIMPNet。<literal>#gimp-users</literal> 通道适合提出有关如何使用 GIMP 的问题。如果要旁听开发人员的讨论，请加入 <literal>#gimp</literal> 通道。
     </para>
    </listitem>
-  </itemizedlist><indexterm class="endofrange" startref="idx-gimp"/><indexterm class="endofrange" startref="idx-graphics-editing"/>
+  </itemizedlist>
  </sect1>
 </chapter>

--- a/l10n/sles/zh-cn/xml/autofs.xml
+++ b/l10n/sles/zh-cn/xml/autofs.xml
@@ -11,8 +11,7 @@
     <systemitem>autofs</systemitem> 是一个可根据需要自动装入指定目录的程序。它基于一个内核模块运行以实现高效率，并且可以同时管理本地目录和网络共享。这些自动安装点仅会在被访问时装入，一定时间内不活动后即会被卸载。这种按需行为可节省带宽，并实现比 <filename>/etc/fstab</filename> 管理的静态装入更高的性能。虽然 <systemitem>autofs</systemitem> 是控制脚本，但 <command>automount</command> 才是实际执行自动装入的命令（守护程序）。
    </para>
   </abstract>
- </info><indexterm>
- <primary>AutoFS</primary></indexterm>
+ </info>
  <sect1 xml:id="sec-autofs-installation">
   <title>安装</title>
 

--- a/l10n/sles/zh-cn/xml/common_intro_available_doc_i.xml
+++ b/l10n/sles/zh-cn/xml/common_intro_available_doc_i.xml
@@ -9,13 +9,7 @@
    </dm:bugtracker>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>帮助</primary>
-
- <secondary> SUSE 手册</secondary></indexterm><indexterm>
-
- <primary> SUSE 手册</primary></indexterm>
+ </info>
 
  <note>
   <title>在线文档和最新更新</title>

--- a/l10n/sles/zh-cn/xml/fs_structure_i.xml
+++ b/l10n/sles/zh-cn/xml/fs_structure_i.xml
@@ -6,9 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary> 目录</primary>
- <secondary>结构</secondary></indexterm> 
+ </info>
  <para>
   下表简要介绍 Linux 系统上最重要的较高级别目录。以下列表中是关于这些目录和重要子目录的更多详细信息。
  </para>
@@ -244,9 +242,7 @@
  </para>
  <variablelist>
   <varlistentry>
-   <term><filename>/bin</filename><indexterm>
-    <primary>目录</primary>
-    <secondary>/bin</secondary></indexterm> 
+   <term><filename>/bin</filename> 
    </term>
    <listitem>
     <para>
@@ -255,9 +251,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/boot</filename><indexterm>
-    <primary>目录</primary>
-    <secondary>/boot</secondary></indexterm> 
+   <term><filename>/boot</filename> 
    </term>
    <listitem>
     <para>
@@ -266,9 +260,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/dev</filename><indexterm>
-    <primary>目录</primary>
-    <secondary>/dev</secondary></indexterm> 
+   <term><filename>/dev</filename> 
    </term>
    <listitem>
     <para>
@@ -277,9 +269,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/etc</filename><indexterm>
-    <primary>目录</primary>
-    <secondary>/etc</secondary></indexterm> 
+   <term><filename>/etc</filename> 
    </term>
    <listitem>
     <para>
@@ -288,9 +278,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/home/<replaceable>USERNAME</replaceable></filename><indexterm>
-    <primary>directories</primary>
-    <secondary>/home</secondary></indexterm>
+   <term><filename>/home/<replaceable>USERNAME</replaceable></filename>
    </term>
    <listitem>
     <para>
@@ -305,9 +293,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/lib</filename><indexterm>
-    <primary>目录</primary>
-    <secondary>/lib</secondary></indexterm> 
+   <term><filename>/lib</filename> 
    </term>
    <listitem>
     <para>
@@ -316,9 +302,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/media</filename><indexterm>
-    <primary>目录</primary>
-    <secondary>/media</secondary></indexterm> 
+   <term><filename>/media</filename> 
    </term>
    <listitem>
     <para>
@@ -329,9 +313,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/mnt</filename><indexterm>
-    <primary>目录</primary>
-    <secondary>/mnt</secondary></indexterm> 
+   <term><filename>/mnt</filename> 
    </term>
    <listitem>
     <para>
@@ -340,9 +322,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/opt</filename><indexterm>
-    <primary>目录</primary>
-    <secondary>/opt</secondary></indexterm> 
+   <term><filename>/opt</filename> 
    </term>
    <listitem>
     <para>
@@ -351,9 +331,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/root</filename><indexterm>
-    <primary>目录</primary>
-    <secondary>/root</secondary></indexterm> 
+   <term><filename>/root</filename> 
    </term>
    <listitem>
     <para>
@@ -362,9 +340,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/run</filename><indexterm>
-    <primary> 目录</primary>
-    <secondary> /run</secondary></indexterm>
+   <term><filename>/run</filename>
    </term>
    <listitem>
     <para>
@@ -373,9 +349,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/sbin</filename><indexterm>
-    <primary>目录</primary>
-    <secondary>/sbin</secondary></indexterm> 
+   <term><filename>/sbin</filename> 
    </term>
    <listitem>
     <para>
@@ -384,9 +358,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/srv</filename><indexterm>
-    <primary>目录</primary>
-    <secondary>/srv</secondary></indexterm> 
+   <term><filename>/srv</filename> 
    </term>
    <listitem>
     <para>
@@ -395,9 +367,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/tmp</filename><indexterm>
-    <primary>目录</primary>
-    <secondary>/tmp</secondary></indexterm> 
+   <term><filename>/tmp</filename> 
    </term>
    <listitem>
     <para>
@@ -412,9 +382,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/usr</filename><indexterm>
-    <primary>目录</primary>
-    <secondary>/usr</secondary></indexterm> 
+   <term><filename>/usr</filename> 
    </term>
    <listitem>
     <para>
@@ -465,9 +433,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/var</filename><indexterm>
-    <primary>目录</primary>
-    <secondary>/var</secondary></indexterm> 
+   <term><filename>/var</filename> 
    </term>
    <listitem>
     <para>

--- a/l10n/sles/zh-cn/xml/fuse.xml
+++ b/l10n/sles/zh-cn/xml/fuse.xml
@@ -12,15 +12,10 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>FUSE</primary></indexterm> 
+ </info>
 
  <sect1 xml:id="sec-fuse-config">
-  <title>配置 FUSE</title><indexterm>
-
-  <primary>FUSE</primary>
-
-  <secondary>配置</secondary></indexterm>
+  <title>配置 FUSE</title>
 
   <para>
    需要安装 <systemitem class="resource">fuse</systemitem> 包才能使用 FUSE。根据要使用的文件系统，您需要作为独立包提供的附加插件。 
@@ -31,13 +26,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-fuse-ntfs">
-  <title>装入 NTFS 分区</title><indexterm>
-
-  <primary>FUSE</primary>
-
-  <secondary>ntfs-3g</secondary></indexterm><indexterm>
-
-  <primary>ntfs-3g</primary></indexterm> 
+  <title>装入 NTFS 分区</title>
 
   <para>
    NTFS（<emphasis>新技术文件系统</emphasis>）是 Windows 的默认文件系统。在一般情况下，由于非特权用户无法使用外部 FUSE 库装入 NTFS 块设备，因此下文所述的 Windows 分区装入过程需要 root 特权。

--- a/l10n/sles/zh-cn/xml/grub2.xml
+++ b/l10n/sles/zh-cn/xml/grub2.xml
@@ -11,10 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>引导</primary>
- <secondary>GRUB 2</secondary></indexterm><indexterm>
- <primary>GRUB 2</primary></indexterm>
+ </info>
  <sect1 xml:id="sec-grub2-new-features">
   <title>GRUB Legacy 与 GRUB 2 之间的主要差异</title>
 
@@ -67,9 +64,7 @@
    <varlistentry>
     <term><filename>/boot/grub2/grub.cfg</filename>
     </term>
-    <listitem><indexterm>
-     <primary>GRUB 2</primary>
-     <secondary> grub.cfg</secondary></indexterm>
+    <listitem>
      <para>
       此文件包含 GRUB 2 菜单项的配置。它替代了 GRUB Legacy 中的 <filename>menu.lst</filename>。不要编辑 <filename>grub.cfg</filename> — 它是由命令 <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command> 自动生成的。
      </para>
@@ -78,9 +73,7 @@
    <varlistentry>
     <term><filename>/boot/grub2/custom.cfg</filename>
     </term>
-    <listitem><indexterm>
-     <primary>GRUB 2</primary>
-     <secondary> custom.cfg</secondary></indexterm>
+    <listitem>
      <para>
       此可选文件在引导时由 <filename>grub.cfg</filename> 直接检索，可用于向引导菜单添加自定义项。从 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 开始，使用 <command>grub-once</command> 时也将分析这些项目。
      </para>
@@ -89,9 +82,7 @@
    <varlistentry>
     <term><filename>/etc/default/grub</filename>
     </term>
-    <listitem><indexterm>
-     <primary>GRUB 2</primary>
-     <secondary> /etc/default/grub</secondary></indexterm>
+    <listitem>
      <para>
       此文件控制 GRUB 2 的用户设置，通常包含背景和主题等其他环境设置。
      </para>
@@ -100,9 +91,7 @@
    <varlistentry>
     <term><filename>/etc/grub.d/</filename> 下的脚本
     </term>
-    <listitem><indexterm>
-     <primary>GRUB 2</primary>
-     <secondary> /etc/grub.d/</secondary></indexterm>
+    <listitem>
      <para>
       在执行 <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command> 命令期间，将读取此目录中的脚本。主配置文件 <filename>/boot/grub/grub.cfg</filename> 中集成了这些脚本的说明。
      </para>
@@ -111,9 +100,7 @@
    <varlistentry xml:id="vle-grub2-sysconfig">
     <term><filename>/etc/sysconfig/bootloader</filename>
     </term>
-    <listitem><indexterm>
-     <primary>GRUB 2</primary>
-     <secondary> sysconfig/bootloader</secondary></indexterm>
+    <listitem>
      <para>
       此配置文件保存一些基本设置，例如引导加载程序类型，或者是否要启用 UEFI 安全引导支持。
      </para>
@@ -142,13 +129,7 @@
   </note>
 
   <sect2 xml:id="sec-grub2-cfg">
-   <title>文件 <filename>/boot/grub2/grub.cfg</filename></title><indexterm>
-   <primary>配置文件</primary>
-   <secondary>grub.cfg</secondary></indexterm><indexterm>
-   <primary>GRUB 2</primary>
-   <secondary>引导菜单</secondary></indexterm><indexterm>
-   <primary>GRUB 2</primary>
-   <secondary>grub.cfg</secondary></indexterm>
+   <title>文件 <filename>/boot/grub2/grub.cfg</filename></title>
    <para>
     带有引导菜单的图形启动屏幕内容由 GRUB 2 配置文件 <filename>/boot/grub2/grub.cfg</filename> 控制，该文件包含有关可以通过菜单引导的所有分区或操作系统的信息。
    </para>
@@ -161,11 +142,7 @@
   </sect2>
 
   <sect2 xml:id="sec-grub2-etc-default-grub">
-   <title>文件 <filename>/etc/default/grub</filename></title><indexterm>
-   <primary>配置文件</primary>
-   <secondary> /etc/default/grub</secondary></indexterm><indexterm>
-   <primary> GRUB 2</primary>
-   <secondary> /etc/default/grub</secondary></indexterm>
+   <title>文件 <filename>/etc/default/grub</filename></title>
    <para>
     此文件包含 GRUB 2 的其他常规选项，例如，显示菜单的时间，或者要引导的默认操作系统。要列出所有可用选项，请查看以下命令的输出：
    </para>
@@ -422,9 +399,7 @@
   </sect2>
 
   <sect2 xml:id="sec-grub2-map">
-   <title>BIOS 驱动器与 Linux 设备之间的映射</title><indexterm>
-   <primary>GRUB 2</primary>
-   <secondary> device.map</secondary></indexterm>
+   <title>BIOS 驱动器与 Linux 设备之间的映射</title>
    <para>
     在 GRUB Legacy 中，<filename>device.map</filename> 配置文件用于基于 BIOS 驱动器号派生 Linux 设备名称。不一定总能正确猜测出 BIOS 驱动器与 Linux 设备之间的映射。例如，如果 IDE 和 SCSI 驱动器的引导顺序在 BIOS 配置中被交换，则 GRUB Legacy 就会发生顺序错误。
    </para>
@@ -440,9 +415,7 @@
   </sect2>
 
   <sect2 xml:id="sec-grub2-menu-change">
-   <title>在引导过程中编辑菜单项</title><indexterm>
-   <primary>GRUB 2</primary>
-   <secondary> 菜单编辑器</secondary></indexterm>
+   <title>在引导过程中编辑菜单项</title>
    <para>
     当系统由于配置错误而不再能够引导时，如果能够直接编辑菜单项，就会很有帮助。使用菜单编辑器还可以在不更改系统配置的情况下测试新设置。
    </para>
@@ -518,9 +491,7 @@
   </sect2>
 
   <sect2 xml:id="sec-grub2-password">
-   <title>设置引导口令</title><indexterm>
-   <primary>GRUB 2</primary>
-   <secondary> 引导口令</secondary></indexterm>
+   <title>设置引导口令</title>
    <para>
     即使在操作系统引导之前，GRUB 2 也支持对文件系统的访问。没有 root 权限的用户可以访问 Linux 系统中的文件，而在引导系统后，他们将无权访问这些文件。要阻止此类访问或防止用户引导某些菜单项，请设置引导口令。
    </para>

--- a/l10n/sles/zh-cn/xml/help_admin.xml
+++ b/l10n/sles/zh-cn/xml/help_admin.xml
@@ -6,10 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>帮助</primary></indexterm><indexterm>
- <primary>文档</primary>
- <see>帮助</see></indexterm>
+ </info>
  <para>
   <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> 提供了各种信息和文档来源，其中绝大部分已经集成在您的已安装系统中。
  </para>
@@ -32,9 +29,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>桌面帮助中心<indexterm>
-    <primary> 帮助</primary>
-    <secondary> 帮助中心</secondary></indexterm>
+   <term>桌面帮助中心
    </term>
    <listitem>
     <para>
@@ -55,10 +50,7 @@
   <title>文档目录</title>
 
   <para>
-   <indexterm>
-   <primary>帮助</primary>
-   <secondary>/usr/share/doc</secondary>
-   </indexterm> 在您安装的 Linux 系统上查找文档的传统目录是 <filename>/usr/share/doc</filename>。目录通常包含有关您的系统上已安装的包和发行说明、手册等等的信息。
+    在您安装的 Linux 系统上查找文档的传统目录是 <filename>/usr/share/doc</filename>。目录通常包含有关您的系统上已安装的包和发行说明、手册等等的信息。
   </para>
 
   <note>
@@ -71,12 +63,7 @@
   <sect2 xml:id="sec-help-onboard-docdir-manual">
    <title>SUSE 手册</title>
    <para>
-    <indexterm>
-    <primary>帮助</primary>
-    <secondary>SUSE 手册</secondary>
-    </indexterm> <indexterm>
-    <primary>SUSE 手册</primary>
-    </indexterm> 我们的手册提供了不同语言的 HTML 和 PDF 版本。在 <filename>manual</filename> 子目录下有您的产品适用的大多数 HTML 版 SUSE 手册。有关对您的产品可用的所有文档的概述，请参见这些手册的前言。
+      我们的手册提供了不同语言的 HTML 和 PDF 版本。在 <filename>manual</filename> 子目录下有您的产品适用的大多数 HTML 版 SUSE 手册。有关对您的产品可用的所有文档的概述，请参见这些手册的前言。
    </para>
    <para>
     如果安装了多种语言，<filename>/usr/share/doc/manual</filename> 可能包含这些手册的不同语言版本。两个桌面的帮助中心内也提供 HTML 版本的 SUSE 手册。有关在安装媒体的何处能找到这些书的 PDF 和 HTML 版本的信息，请参见 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 发行说明。它们位于所安装系统的 <filename>/usr/share/doc/release-notes/</filename> 下，或者也可以联机访问您的产品专属网站：<link os="sles;sled" xlink:href="http://www.suse.com/releasenotes/"/>。
@@ -87,10 +74,7 @@
   <sect2 xml:id="sec-help-onboard-docdir-pkg">
    <title>包文档</title>
    <para>
-    <indexterm>
-    <primary>帮助</primary>
-    <secondary>包文档</secondary>
-    </indexterm> 在 <filename>packages</filename> 下可找到系统上安装的软件包中包含的文档。对每个包，都会创建子目录 <filename>/usr/share/doc/packages/<replaceable>PACKAGENAME</replaceable></filename>。它经常包含该包的自述文件，有时还包含示例、配置文件或其他脚本。下表列出了 <filename>/usr/share/doc/packages</filename> 下常见的文件。以下每项不一定都存在，许多包中可能只包含其中的一部分。
+     在 <filename>packages</filename> 下可找到系统上安装的软件包中包含的文档。对每个包，都会创建子目录 <filename>/usr/share/doc/packages/<replaceable>PACKAGENAME</replaceable></filename>。它经常包含该包的自述文件，有时还包含示例、配置文件或其他脚本。下表列出了 <filename>/usr/share/doc/packages</filename> 下常见的文件。以下每项不一定都存在，许多包中可能只包含其中的一部分。
    </para>
    <variablelist>
     <varlistentry>
@@ -191,11 +175,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-help-onboard-manpages">
-  <title>手册页</title><indexterm>
-
-  <primary> 帮助</primary>
-
-  <secondary> 手册页</secondary></indexterm> 
+  <title>手册页</title>
 
   <para>
    手册页是任何 Linux 系统的基本组成部分。它们介绍命令的用法以及所有可用的选项和参数。许多页面都可以用 <command>man</command> 后面跟命令名来访问，例如 <command>man ls</command>。
@@ -340,22 +320,14 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-help-onboard-infopages">
-  <title>信息页</title><indexterm>
-
-  <primary>帮助</primary>
-
-  <secondary>信息页</secondary></indexterm>
+  <title>信息页</title>
 
   <para>
    信息页是系统上另一个重要的信息来源。它们通常比手册页更为详细。它们包含多个命令行选项，有时还包含完整的教学课程或参考文档。要查看特定命令的信息页，请输入 <command>info</command> 后面跟命令名，例如 <command>info ls</command>。您可以在外壳中直接用查看器浏览信息页，并显示名为<quote>节点</quote>的各个部分。使用 <keycap function="space"/> 可前移，使用 <keycap function="backspace"/> 可后移。在节点内，您也可以用 <keycap function="pageup"/> 和 <keycap function="pagedown"/> 浏览，但只有 <keycap function="space"/> 和 <keycap function="backspace"/> 仍会带您到上个或下个节点。按 <keycap>Q</keycap> 结束查看模式。并非每个命令都有对应的信息页，反之亦然。
   </para>
  </sect1>
  <sect1 xml:id="sec-help-online">
-  <title>联机资源</title><indexterm>
-
-  <primary>帮助</primary>
-
-  <secondary> 联机文档</secondary></indexterm>
+  <title>联机资源</title>
 
   <para>
    除了安装在 <filename>/usr/share/doc</filename> 下的联机版 SUSE 手册之外，您还可以访问网上的产品特定手册和文档。有关 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 所有适用文档的概述，请查看产品特定的文档网页，网址为：<phrase os="sles;sled"><link xlink:href="http://www.suse.com/doc/"/></phrase>。

--- a/l10n/sles/zh-cn/xml/help_user.xml
+++ b/l10n/sles/zh-cn/xml/help_user.xml
@@ -12,16 +12,11 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-help">
- <primary>帮助</primary></indexterm><indexterm>
- <primary>文档</primary>
- <see>帮助</see></indexterm>
+ </info>
 
  <variablelist>
   <varlistentry>
-   <term>桌面帮助中心<indexterm>
-    <primary> 帮助</primary>
-    <secondary> 帮助中心</secondary></indexterm>
+   <term>桌面帮助中心
    </term>
    <listitem>
     <para>
@@ -56,11 +51,7 @@
   </varlistentry>
  </variablelist>
  <sect1 xml:id="sec-help-onboard-yelp">
-  <title>使用 GNOME 帮助</title><indexterm>
-
-  <primary>帮助</primary>
-
-  <secondary> 帮助</secondary></indexterm>
+  <title>使用 GNOME 帮助</title>
 
   <para>
    要在 GNOME 桌面上直接从应用程序启动帮助，可单击<guimenu>帮助</guimenu>按钮，或者按 <keycap>F1</keycap>。两种方法都会直接打开帮助中心的该应用程序文档。不过，您也可以通过打开终端并输入 <command>yelp</command> 或在主菜单中单击<menuchoice><guimenu>应用程序</guimenu>
@@ -91,9 +82,7 @@
   <title>更多帮助资源</title>
 
   <para>
-   <indexterm>
-   <primary> 帮助</primary>
-   <secondary> 联机文档</secondary> </indexterm> 除了 <filename>/usr/share/doc</filename> 下安装的 SUSE 手册外，您还可以访问 Web 上的产品特定的手册和文档。有关 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 所有适用文档的概述，请查看产品特定的文档网页，网址为：<link os="sles;sled" xlink:href="https://documentation.suse.com/"/>。
+    除了 <filename>/usr/share/doc</filename> 下安装的 SUSE 手册外，您还可以访问 Web 上的产品特定的手册和文档。有关 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 所有适用文档的概述，请查看产品特定的文档网页，网址为：<link os="sles;sled" xlink:href="https://documentation.suse.com/"/>。
   </para>
 
   <para>
@@ -141,29 +130,20 @@
   </para>
 
   <sect2 xml:id="sec-help-more-tldp">
-   <title>Linux 文档计划</title><indexterm>
-   <primary>TLDP</primary></indexterm><indexterm>
-   <primary>帮助</primary>
-   <secondary> Linux 文档 (TLDP)</secondary></indexterm>
+   <title>Linux 文档计划</title>
    <para>
     Linux 文档计划（Linux Documentation Project，TLDP）由编写 Linux 相关文档的志愿者团队负责管理（请参见 <link xlink:href="http://www.tldp.org"/>）。这套文档包括初学者教程，但主要侧重于有经验的用户和职业系统管理员。TLDP 发布了免费的操作指南、常见问题和其他指南（手册）。<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 上也有来自 TLDP 的部分文档。
    </para>
 
 
    <sect3 xml:id="sec-helpmore-tldp-faq">
-    <title>常见问题 (FAQ)</title><indexterm>
-    <primary>帮助</primary>
-    <secondary> TLDP</secondary>
-    <tertiary> 常见问题</tertiary></indexterm>
+    <title>常见问题 (FAQ)</title>
     <para>
      FAQ（常见问题）是一系列问题和解答。它们来自 Usenet 新闻组，该新闻组的目的是减少连续重复粘贴相同基本问题的情况。
     </para>
    </sect3>
    <sect3 xml:id="sec-helpmore-tldp-guides">
-    <title>指南</title><indexterm>
-    <primary>帮助</primary>
-    <secondary> TLDP</secondary>
-    <tertiary> 指南</tertiary></indexterm>
+    <title>指南</title>
     <para>
      有关各主题或程序的手册和指南，请参见 <link xlink:href="http://www.tldp.org/guides.html"/>。其中包括《<citetitle>Bash Guide for Beginners</citetitle>》（Bash 初学者指南）、《<citetitle>Linux Filesystem Hierarchy</citetitle>》（Linux 文件系统层次）和《<citetitle>Linux Administrator's Security Guide</citetitle>》（Linux 管理员安全指南）。指南通常比操作指南或常见问题更为详尽。它们一般是由专家为专家编写的。
     </para>
@@ -175,9 +155,7 @@
 
 
   <sect2 xml:id="sec-help-more-wikipedia">
-   <title>Wikipedia：免费的联机百科全书</title><indexterm>
-   <primary> 帮助</primary>
-   <secondary> Wikipedia</secondary></indexterm>
+   <title>Wikipedia：免费的联机百科全书</title>
    <remark>Translators: Translate the link http://en.wikipedia.org into your language: Replace "en"
     with your ISO language code.</remark> 
    <para>
@@ -186,11 +164,7 @@
   </sect2>
 
   <sect2 xml:id="sec-help-more-standards">
-   <title>标准和规范</title><indexterm>
-   <primary>帮助</primary>
-   <secondary>标准</secondary></indexterm><indexterm>
-   <primary>帮助</primary>
-   <secondary>规范</secondary></indexterm>
+   <title>标准和规范</title>
    <para>
     有很多信息源都提供有关标准和规范的信息。
    </para>

--- a/l10n/sles/zh-cn/xml/lvm.xml
+++ b/l10n/sles/zh-cn/xml/lvm.xml
@@ -7,19 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>YaST</primary>
-
- <secondary>LVM</secondary></indexterm><indexterm>
-
- <primary>LVM</primary>
-
- <secondary>YaST</secondary></indexterm><indexterm>
-
- <primary>逻辑卷管理器</primary>
-
- <see>LVM</see></indexterm>
+ </info>
 
  <para>
   本节说明配置 LVM 时要执行的特定步骤。<phrase os="sles">如需逻辑卷管理器的总体信息，请参见<xref linkend="sec-lvm-explained"/>。</phrase>

--- a/l10n/sles/zh-cn/xml/mobile.xml
+++ b/l10n/sles/zh-cn/xml/mobile.xml
@@ -11,36 +11,16 @@
     移动计算主要与便携式计算机、PDA 和手提电话（以及它们之间的数据交换）关联。移动硬件部件（如外部硬盘、闪存盘或数码相机）可连接到便携式计算机或台式机。移动计算方案中涉及了许多软件组件，一些应用程序是专门为移动定制的。
    </para>
   </abstract>
- </info><indexterm xml:id="idx-mobility" class="startofrange">
- <primary> 移动能力</primary></indexterm> 
+ </info>
  <sect1 xml:id="sec-mobile-nbook">
-  <title>便携式计算机</title><indexterm class="startofrange" xml:id="idx-notebook">
-
-  <primary>便携式计算机</primary></indexterm><indexterm>
-
-  <primary>便携式计算机</primary>
-
-  <secondary>硬件</secondary></indexterm><indexterm>
-
-  <primary>便携式计算机</primary>
-
-  <secondary>PCMCIA</secondary></indexterm><indexterm>
-
-  <primary>PCMCIA</primary></indexterm><indexterm>
-
-  <primary>移动能力</primary>
-
-  <secondary>便携式计算机</secondary></indexterm>
+  <title>便携式计算机</title>
 
   <para>
    便携式计算机的硬件不同于普通台式机的硬件。这是因为必须考虑可交换性、空间要求和能耗等条件。移动硬件的制造商已开发了标准接口，如可用于扩展便携式计算机硬件的 PCMCIA（个人计算机内存卡国际协会）、迷你 PCI 和迷你 PCIe。这些标准涉及内存卡、网络接口卡和外部硬盘。
   </para>
 
   <sect2 xml:id="sec-mobile-powerm">
-   <title>省电</title><indexterm>
-   <primary>便携式计算机</primary>
-   <secondary>电源管理</secondary></indexterm><indexterm>
-   <primary> 电源管理</primary></indexterm>
+   <title>省电</title>
    <para>
     由于在制造便携式计算机时加入了能量优化系统组件，这使得不必连接电源线即可使用便携式计算机。这些部件在省电方面所起的作用并不亚于操作系统。<phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> 支持各种控制便携式计算机能耗的方法，在使用电池供电时，这些方法对计算机运行时间的影响各不相同。下面的列表按照省电作用从高到低排列：
    </para>
@@ -77,8 +57,7 @@
   </sect2>
 
   <sect2 xml:id="sec-mobile-nbook-change">
-   <title>在变化的操作环境中集成</title><indexterm>
-   <primary>便携式计算机</primary></indexterm>
+   <title>在变化的操作环境中集成</title>
    <para>
     在用于移动计算时，您的系统需要适应变化的操作环境。很多服务都依赖于环境，而且必须重配置底层客户端。<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 将为您处理这项任务。
    </para>
@@ -138,12 +117,7 @@
      <term>NetworkManager</term>
      <listitem>
       <para>
-       <indexterm>
-       <primary>NetworkManager</primary>
-       </indexterm> <indexterm>
-       <primary>便携式计算机NetworkManager</primary>
-       <secondary> NetworkManager 特别为在便携式计算机上联网移动而设计。</secondary>
-       </indexterm>它让您能够轻松地在网络环境之间或不同网络类型之间进行自动切换，例如，移动宽带（如 GPRS、EDGE 或 3G）、无线 LAN 和以太网。NetworkManager 在无线 LAN 中支持 WEP 和 WPA-PSK 加密。它也支持拨号连接。GNOME 桌面包含 NetworkManager 的前端。有关详细信息，请参见<xref linkend="sec-nm-configure"/>。
+        它让您能够轻松地在网络环境之间或不同网络类型之间进行自动切换，例如，移动宽带（如 GPRS、EDGE 或 3G）、无线 LAN 和以太网。NetworkManager 在无线 LAN 中支持 WEP 和 WPA-PSK 加密。它也支持拨号连接。GNOME 桌面包含 NetworkManager 的前端。有关详细信息，请参见<xref linkend="sec-nm-configure"/>。
       </para>
       <table>
        <title>NetworkManager 的用例</title>
@@ -229,12 +203,7 @@
      <term>SLP</term>
      <listitem>
       <para>
-       <indexterm>
-       <primary>便携式计算机</primary>
-       <secondary> SLP</secondary>
-       </indexterm> <indexterm>
-       <primary> SLP</primary>
-       </indexterm> 服务位置协议 (SLP) 简化了便携式计算机与现有网络的连接。没有 SLP，便携式计算机的管理员通常需要详细了解网络中可用的服务。使用 SLP 则可以向本地网络中的所有客户端广播某种服务是否可用。支持 SLP 的应用程序可以处理 SLP 发送的信息，并进行自动配置。SLP 还可用于安装系统，从而最大限度地减少搜索合适安装源的工作量。<phrase os="sles;osuse">有关 SLP 的更多详细信息，请参见<xref linkend="cha-slp"/>。</phrase>
+         服务位置协议 (SLP) 简化了便携式计算机与现有网络的连接。没有 SLP，便携式计算机的管理员通常需要详细了解网络中可用的服务。使用 SLP 则可以向本地网络中的所有客户端广播某种服务是否可用。支持 SLP 的应用程序可以处理 SLP 发送的信息，并进行自动配置。SLP 还可用于安装系统，从而最大限度地减少搜索合适安装源的工作量。<phrase os="sles;osuse">有关 SLP 的更多详细信息，请参见<xref linkend="cha-slp"/>。</phrase>
       </para>
      </listitem>
     </varlistentry>
@@ -247,8 +216,7 @@
     在移动使用场合有各种任务领域，它们由专用软件实现：系统监控（特别是电池充电）、数据同步和与外围设备及因特网的无线通讯。以下章节介绍了 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 为各项任务提供的最为重要的应用程序。
    </para>
    <sect3 xml:id="sec-mobile-nbook-soft-mon">
-    <title>系统监视</title><indexterm>
-    <primary> 系统监视</primary></indexterm> 
+    <title>系统监视</title>
     <para>
      <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 提供了两个系统监视工具：
     </para>
@@ -257,12 +225,7 @@
       <term>电源管理</term>
       <listitem>
        <para>
-        <indexterm>
-        <primary>系统监视</primary>
-        <secondary>电源管理</secondary>
-        </indexterm> <indexterm>
-        <primary>电源管理</primary>
-        </indexterm> <guimenu> 电源管理</guimenu>是可让您调整 GNOME 桌面的节能行为的应用程序。通常您可以通过<menuchoice><guimenu>计算机</guimenu> <guimenu> 控制中心</guimenu> <guimenu> 系统</guimenu> <guimenu> 电源管理</guimenu></menuchoice>来访问该应用程序。
+          <guimenu> 电源管理</guimenu>是可让您调整 GNOME 桌面的节能行为的应用程序。通常您可以通过<menuchoice><guimenu>计算机</guimenu> <guimenu> 控制中心</guimenu> <guimenu> 系统</guimenu> <guimenu> 电源管理</guimenu></menuchoice>来访问该应用程序。
        </para>
       </listitem>
      </varlistentry>
@@ -270,10 +233,7 @@
       <term>系统监视程序</term>
       <listitem>
        <para>
-        <indexterm>
-        <primary> 系统监视</primary>
-        <secondary> 系统监视器</secondary>
-        </indexterm> <guimenu>系统监视器</guimenu>将可测量的系统参数收集到一个监视环境中。它默认会在三个选项卡中显示输出信息。<guimenu>进程</guimenu>提供有关当前正在运行的进程的详细信息，比如，CPU 负载、内存使用情况或进程 ID 号和优先级。您可以自定义所收集数据的显示和过滤方式 — 要添加新类型的进程信息，请左键单击进程表标题，并选择要隐藏或要添加到视图中的列。也可以监视不同数据页中的不同系统参数，或跨网络并行收集不同计算机上的数据。<guimenu>资源</guimenu>选项卡显示 CPU、内存和网络历史的图表，<guimenu>文件系统</guimenu>选项卡列出所有分区及其使用情况。
+         <guimenu>系统监视器</guimenu>将可测量的系统参数收集到一个监视环境中。它默认会在三个选项卡中显示输出信息。<guimenu>进程</guimenu>提供有关当前正在运行的进程的详细信息，比如，CPU 负载、内存使用情况或进程 ID 号和优先级。您可以自定义所收集数据的显示和过滤方式 — 要添加新类型的进程信息，请左键单击进程表标题，并选择要隐藏或要添加到视图中的列。也可以监视不同数据页中的不同系统参数，或跨网络并行收集不同计算机上的数据。<guimenu>资源</guimenu>选项卡显示 CPU、内存和网络历史的图表，<guimenu>文件系统</guimenu>选项卡列出所有分区及其使用情况。
        </para>
       </listitem>
      </varlistentry>
@@ -289,13 +249,7 @@
       <term>同步电子邮件</term>
       <listitem>
        <para>
-        <indexterm>
-        <primary>同步数据</primary>
-        <secondary>电子邮件</secondary>
-        </indexterm> <indexterm>
-        <primary>电子邮件</primary>
-        <secondary>同步</secondary>
-        </indexterm> 在办公室网络中使用 IMAP 帐户储存电子邮件。随后可以从工作站使用任意断开连接但支持 IMAP 的电子邮件客户端（如 Mozilla Thunderbird 或 Evolution）来访问这些电子邮件，如<xref linkend="book-gnomeuser"/>中所述。必须对电子邮件客户端进行配置，以便始终从同一文件夹访问<literal>已发送邮件</literal>。这样能确保在完成同步过程之后可以提供所有信件及其状态信息。使用邮件客户端中实施的 SMTP 服务器（而非系统范围的 MTA Postfix 或 Sendmail）来发送邮件，从而可收到有关未发送邮件的可靠反馈。
+          在办公室网络中使用 IMAP 帐户储存电子邮件。随后可以从工作站使用任意断开连接但支持 IMAP 的电子邮件客户端（如 Mozilla Thunderbird 或 Evolution）来访问这些电子邮件，如<xref linkend="book-gnomeuser"/>中所述。必须对电子邮件客户端进行配置，以便始终从同一文件夹访问<literal>已发送邮件</literal>。这样能确保在完成同步过程之后可以提供所有信件及其状态信息。使用邮件客户端中实施的 SMTP 服务器（而非系统范围的 MTA Postfix 或 Sendmail）来发送邮件，从而可收到有关未发送邮件的可靠反馈。
        </para>
       </listitem>
      </varlistentry>
@@ -303,18 +257,14 @@
       <term>同步文件和目录</term>
       <listitem>
        <para>
-        <indexterm>
-        <primary>同步数据</primary>
-        </indexterm> 有多个实用程序适合在便携式计算机和工作站之间同步数据。使用最广泛的一种实用程序是称为 <command>rsync</command> 的命令行工具。有关更多信息，请参见其手册页 (<command>man 1 rsync</command>)。
+         有多个实用程序适合在便携式计算机和工作站之间同步数据。使用最广泛的一种实用程序是称为 <command>rsync</command> 的命令行工具。有关更多信息，请参见其手册页 (<command>man 1 rsync</command>)。
        </para>
       </listitem>
      </varlistentry>
     </variablelist>
    </sect3>
    <sect3 xml:id="sec-mobile-nbook-soft-wifi">
-    <title>无线通讯：Wi-Fi</title><indexterm>
-    <primary>网络</primary>
-    <secondary> Wi-Fi</secondary></indexterm>
+    <title>无线通讯：Wi-Fi</title>
     <para>
      Wi-Fi 在这三种无线技术中覆盖范围最广，是唯一一种适用于大型网络（有时甚至是在空间上分离的网络）的操作技术。单独的计算机可以通过互连形成独立的无线网络或访问因特网。称为<emphasis>接入点</emphasis>的设备是作为支持 Wi-Fi 的设备的基站，而且充当着访问因特网的中介角色。移动用户可以在多个接入点之间切换，这取决于所在位置以及哪个接入点提供的连接最佳。类似移动电话的情况，Wi-Fi 用户可以访问一个大型网络，而不必被集中到某个位置来访问这个网络。
     </para>
@@ -579,34 +529,19 @@
    <sect3 xml:id="sec-mobile-nbook-soft-bluetooth">
     <title>无线通讯：蓝牙</title>
     <para>
-     <indexterm>
-     <primary>网络</primary>
-     <secondary>蓝牙</secondary>
-     </indexterm> <indexterm>
-     <primary>蓝牙</primary>
-     </indexterm> 蓝牙技术是所有无线技术中应用范围最广的技术。与 IrDA 一样，蓝牙技术可用于计算机（便携式计算机）和 PDA 或手提电话之间的通信。它还可用于连接一定范围内的多台计算机。蓝牙技术还可用于连接键盘或鼠标之类的无线系统组件。但这种技术的覆盖范围还不够大，无法将远程系统连接到网络中。此时就可选用 Wi-Fi 技术来穿越墙壁之类的有形障碍物进行通讯。
+       蓝牙技术是所有无线技术中应用范围最广的技术。与 IrDA 一样，蓝牙技术可用于计算机（便携式计算机）和 PDA 或手提电话之间的通信。它还可用于连接一定范围内的多台计算机。蓝牙技术还可用于连接键盘或鼠标之类的无线系统组件。但这种技术的覆盖范围还不够大，无法将远程系统连接到网络中。此时就可选用 Wi-Fi 技术来穿越墙壁之类的有形障碍物进行通讯。
     </para>
    </sect3>
    <sect3 xml:id="sec-mobile-nbook-soft-irda">
     <title>无线通讯：IrDA</title>
     <para>
-     <indexterm>
-     <primary>网络</primary>
-     <secondary> IrDA</secondary>
-     </indexterm> <indexterm>
-     <primary> IrDA</primary>
-     </indexterm> IrDA 是覆盖范围最小的无线技术。通讯双方必须在彼此的视线范围之内。无法穿越墙壁这样的障碍物。将文件从便携式计算机传送到手提电话就是 IrDA 的一种应用方式。使用 IrDA 即可覆盖由便携式计算机到手提电话之间的较短路径。向收件人远距离传输文件的任务由移动网络来处理。IrDA 的另一种应用方式就是在办公室中无线传送打印任务。
+       IrDA 是覆盖范围最小的无线技术。通讯双方必须在彼此的视线范围之内。无法穿越墙壁这样的障碍物。将文件从便携式计算机传送到手提电话就是 IrDA 的一种应用方式。使用 IrDA 即可覆盖由便携式计算机到手提电话之间的较短路径。向收件人远距离传输文件的任务由移动网络来处理。IrDA 的另一种应用方式就是在办公室中无线传送打印任务。
     </para>
    </sect3>
   </sect2>
 
   <sect2 xml:id="sec-mobile-nbook-sec">
-   <title>数据安全性</title><indexterm>
-   <primary>移动性</primary>
-   <secondary>数据安全性</secondary></indexterm><indexterm>
-   <primary>安全性</primary>
-   <secondary>加密文件系统</secondary></indexterm><indexterm>
-   <primary>数据安全性</primary></indexterm>
+   <title>数据安全性</title>
    <para>
     要防止他人未经授权访问您的便携式计算机上的数据，您最好同时采用多种方式。可以在以下方面采取各种可能的安全措施：
    </para>
@@ -649,43 +584,11 @@
       </para>
      </listitem>
     </varlistentry>
-   </variablelist><indexterm class="endofrange" startref="idx-notebook"/>
+   </variablelist>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-mobile-hw">
-  <title>移动硬件</title><indexterm>
-
-  <primary>移动能力</primary>
-
-  <secondary>USB</secondary></indexterm><indexterm>
-
-  <primary>移动能力</primary>
-
-  <secondary>防火墙 (IEEE1394)</secondary></indexterm><indexterm>
-
-  <primary>防火墙 (IEEE1394)</primary>
-
-  <secondary>硬盘</secondary></indexterm><indexterm>
-
-  <primary>USB</primary>
-
-  <secondary>硬盘</secondary></indexterm><indexterm>
-
-  <primary>USB</primary>
-
-  <secondary>闪存盘</secondary></indexterm><indexterm>
-
-  <primary>闪存盘</primary></indexterm><indexterm>
-
-  <primary>移动能力</primary>
-
-  <secondary>外部硬盘</secondary></indexterm><indexterm>
-
-  <primary>移动能力</primary>
-
-  <secondary>数码相机</secondary></indexterm><indexterm>
-
-  <primary>数码相机</primary></indexterm>
+  <title>移动硬件</title>
 
   <para>
    <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 支持自动检测 FireWire (IEEE 1394) 或 USB 上的移动储存设备。术语<emphasis>移动储存设备</emphasis>适用于任何种类的防火墙或 USB 硬盘、闪存盘或数码相机。这些设备在通过相应的接口与系统连接后，系统将会自动检测并配置这些设备。GNOME 的文件管理器提供了灵活的移动硬件项目处理方式。要安全卸载任何此类媒体，请使用文件管理器的<guimenu>卸载卷</guimenu> (GNOME) 功能。有关详细信息，请参见<xref linkend="book-gnomeuser"/>。
@@ -717,19 +620,7 @@
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-mobile-comm">
-  <title>移动设备（智能手机和平板电脑）</title><indexterm>
-
-  <primary>移动性</primary>
-
-  <secondary>智能手机</secondary></indexterm><indexterm>
-
-  <primary>移动性</primary>
-
-  <secondary>平板电脑</secondary></indexterm><indexterm>
-
-  <primary>智能手机</primary></indexterm><indexterm>
-
-  <primary>平板电脑</primary></indexterm>
+  <title>移动设备（智能手机和平板电脑）</title>
 
   <para>
    桌面系统或便携式计算机可通过蓝牙、Wi-Fi 或 USB 直接连接与移动设备进行通讯。根据移动设备型号和您的特定需求选择一种连接方法。通常，通过 USB 将移动设备连接到台式计算机或便携式计算机时，可将 USB 作为常规外部储存使用。通过设置蓝牙或 Wi-Fi 连接，您可以与移动设备交互，并直接从台式计算机或便携式计算机中控制其功能。您可以使用若干个开源图形实用程序（特别是 <link xlink:href="https://community.kde.org/KDEConnect">KDE Connect</link> 和 <link xlink:href="https://extensions.gnome.org/extension/1319/gsconnect/">GSConnect</link>）控制连接的移动设备。

--- a/l10n/sles/zh-cn/xml/net_config_files.xml
+++ b/l10n/sles/zh-cn/xml/net_config_files.xml
@@ -7,10 +7,7 @@
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
-<indexterm>
- <primary>配置文件</primary></indexterm><indexterm xml:id="idx-networks-configuration-files" class="startofrange">
- <primary>网络</primary>
- <secondary>配置文件</secondary></indexterm>
+
  <para>
   本节对网络配置文件进行了概述并解释了它们的作用和所使用的格式。
  </para>
@@ -82,21 +79,13 @@ MACVLAN_DEVICE='eth0'
   <para>
    有关 <filename>ifcfg.template</filename> 的信息，请参见<xref linkend="sec-basicnet-manconf-files-config-etc"/>。
   </para>
-<indexterm>
-  <primary> 配置文件</primary>
-  <secondary>ifcfg-*</secondary></indexterm> 
+ 
   <para arch="zseries" os="sles">
    IBM Z 不支持 USB。接口文件的名称和网络别名包含专用于 IBM Z 的元素，例如 <literal>qeth</literal>。
   </para>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-config-etc">
-  <title><filename>/etc/sysconfig/network/config</filename>、<filename>/etc/sysconfig/network/dhcp</filename> 和 <filename>/etc/sysconfig/network/wireless</filename></title><indexterm>
-  <primary>配置文件</primary>
-  <secondary>网络</secondary></indexterm><indexterm>
-  <primary>配置文件</primary>
-  <secondary>dhcp</secondary></indexterm><indexterm>
-  <primary>配置文件</primary>
-  <secondary>wireless</secondary></indexterm>
+  <title><filename>/etc/sysconfig/network/config</filename>、<filename>/etc/sysconfig/network/dhcp</filename> 和 <filename>/etc/sysconfig/network/wireless</filename></title>
   <para>
    文件 <filename>config</filename> 包含 <command>ifup</command>、<command>ifdown</command> 和 <command>ifstatus</command> 行为的常规设置。<filename>dhcp</filename> 包含用于无线 LAN 卡的 DHCP 和 <filename>wireless</filename> 设置。所有三个配置文件中的变量均已注释掉。<filename>/etc/sysconfig/network/config</filename> 中的一些变量也可用于 <filename>ifcfg-*</filename> 文件，在这些文件中它们具有更高优先级。<filename>/etc/sysconfig/network/ifcfg.template</filename> 文件列出可以按接口指定的变量。但是，<filename>/etc/sysconfig/network/config</filename> 中的大多数变量是全局变量，不能在 ifcfg-files 中被覆盖。例如，<systemitem>NETWORKMANAGER</systemitem> 或 <systemitem>NETCONFIG_*</systemitem> 变量是全局变量。
   </para>
@@ -115,19 +104,9 @@ MACVLAN_DEVICE='eth0'
 
  <sect3 xml:id="sec-basicnet-manconf-files-routes">
   <title><filename>/etc/sysconfig/network/routes</filename> 和 <filename>/etc/sysconfig/network/ifroute-*</filename></title>
-<indexterm xml:id="idx-routing" class="startofrange">
-  <primary>路由选择</primary></indexterm><indexterm>
-  <primary>路由选择</primary>
-  <secondary>路由</secondary></indexterm><indexterm>
-  <primary>配置文件</primary>
-  <secondary>路由</secondary></indexterm><indexterm>
-  <primary>配置</primary>
-  <secondary>路由选择</secondary></indexterm>
+
   <para>
-   TCP/IP 包的静态路由是 <filename>/etc/sysconfig/network/routes</filename> 和 <filename>/etc/sysconfig/network/ifroute-*</filename> 文件确定的。可以在 <filename>/etc/sysconfig/network/routes</filename> 中指定各种系统任务所需的所有静态路由：主机的路由、主机通过网关的路由以及网络的路由。对于需要个别路由的每个接口，定义另一个配置文件：<filename>/etc/sysconfig/network/ifroute-*</filename>。将通配符 (<literal>*</literal>) 替换为接口名称。路由选择配置文件中的项如下所示：<indexterm>
-   <primary>路由</primary>
-   <secondary>静态</secondary>
-   </indexterm>
+   TCP/IP 包的静态路由是 <filename>/etc/sysconfig/network/routes</filename> 和 <filename>/etc/sysconfig/network/ifroute-*</filename> 文件确定的。可以在 <filename>/etc/sysconfig/network/routes</filename> 中指定各种系统任务所需的所有静态路由：主机的路由、主机通过网关的路由以及网络的路由。对于需要个别路由的每个接口，定义另一个配置文件：<filename>/etc/sysconfig/network/ifroute-*</filename>。将通配符 (<literal>*</literal>) 替换为接口名称。路由选择配置文件中的项如下所示：
   </para>
 <screen># Destination     Gateway           Netmask            Interface  Options</screen>
 
@@ -170,21 +149,13 @@ default           204.127.235.41    0.0.0.0            eth0
 # Destination     [Gateway]                -           Interface
 2001:DB8:100::/64 -                        -           eth0
 2001:DB8:100::/32 fe80::216:3eff:fe6d:c042 -           eth0</screen>
-  </example><indexterm class="endofrange" startref="idx-routing"/>
+  </example>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-resolv">
   <title><filename>/etc/resolv.conf</filename></title>
-<indexterm>
-  <primary> 配置文件</primary>
-  <secondary>resolv.conf</secondary></indexterm> 
+ 
   <para>
-   主机所属的域在 <filename>/etc/resolv.conf</filename> 中指定（关键字 <systemitem>search</systemitem>）。使用 <systemitem>search</systemitem> 选项最多可以指定六个域，总共 256 个字符。当解析不是完全限定的名称时，将尝试通过附加单独的 <systemitem>search</systemitem> 项生成一个完全限定的名称。使用 <systemitem>nameserver</systemitem> 选项最多可以指定 3 个名称服务器，每行指定一个。注释以井号或分号（<literal>#</literal> 或 <literal>;</literal>）开头。有关示例，请参见<xref linkend="dat-netz-etc-resolv-conf"/>。<indexterm>
-   <primary>DNS</primary>
-   <secondary>域</secondary>
-   </indexterm> <indexterm>
-   <primary>DNS</primary>
-   <secondary>名称服务器</secondary>
-   </indexterm>
+   主机所属的域在 <filename>/etc/resolv.conf</filename> 中指定（关键字 <systemitem>search</systemitem>）。使用 <systemitem>search</systemitem> 选项最多可以指定六个域，总共 256 个字符。当解析不是完全限定的名称时，将尝试通过附加单独的 <systemitem>search</systemitem> 项生成一个完全限定的名称。使用 <systemitem>nameserver</systemitem> 选项最多可以指定 3 个名称服务器，每行指定一个。注释以井号或分号（<literal>#</literal> 或 <literal>;</literal>）开头。有关示例，请参见<xref linkend="dat-netz-etc-resolv-conf"/>。 
   </para>
   <para>
    但是，<filename>/etc/resolv.conf</filename> 不应手动编辑。而是由 <command>netconfig</command> 脚本生成。要定义静态 DNS 配置而不使用 YaST，请手动编辑 <filename>/etc/sysconfig/network/config</filename> 文件中的相应变量：
@@ -307,9 +278,7 @@ nameserver 192.168.1.116</screen>
 
  <sect3 xml:id="sec-basicnet-manconf-hosts">
   <title><filename>/etc/hosts</filename></title>
-<indexterm>
-  <primary> 配置文件</primary>
-  <secondary>主机</secondary></indexterm> 
+ 
   <para>
    在此文件中，如<xref linkend="dat-netz-etc-hosts"/>中所示，将为主机名指派 IP 地址。如果未实施名称服务器，则将与其建立 IP 连接的所有主机必须列在此处。在此文件中为每个主机输入一行数据，包含 IP 地址、完全限定的主机名和主机名。IP 地址必须在每行的开头，各项用空格和制表符隔开。注释总是以 <literal>#</literal> 符号开头。
   </para>
@@ -321,9 +290,7 @@ nameserver 192.168.1.116</screen>
   </example>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-networks">
-  <title><filename>/etc/networks</filename></title><indexterm>
-  <primary>配置文件</primary>
-  <secondary>网络</secondary></indexterm>
+  <title><filename>/etc/networks</filename></title>
   <para>
    在这里，网络名称被转换为网络地址。格式类似于 <filename>hosts</filename> 文件的格式，只是网络名称在地址的前面。请参见<xref linkend="dat-netz-networks"/>。
   </para>
@@ -334,9 +301,7 @@ localnet     192.168.0.0</screen>
   </example>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-host">
-  <title><filename>/etc/host.conf</filename></title><indexterm>
-  <primary> 配置文件</primary>
-  <secondary>host.conf</secondary></indexterm> 
+  <title><filename>/etc/host.conf</filename></title>
   <para>
    此文件控制名称解析，即通过<emphasis>解析程序</emphasis>库转换主机名和网络名称。此文件只用于链接到 libc4 或 libc5 的程序。对于当前的 glibc 程序，请参见 <filename>/etc/nsswitch.conf</filename> 中的设置。每个参数都必须始终在单独的一行中输入。注释以 <literal>#</literal> 符号开头。<xref linkend="tab-netz-param-hostconf"/> 显示了可用的参数。<xref linkend="dat-netz-etc-hostconf"/> 中显示了 <filename>/etc/host.conf</filename> 的示例。
   </para>
@@ -434,13 +399,9 @@ multi on</screen>
   </example>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-nsswitch">
-  <title><filename>/etc/nsswitch.conf</filename></title><indexterm>
-  <primary> 配置文件</primary>
-  <secondary> nsswitch.conf</secondary></indexterm> 
+  <title><filename>/etc/nsswitch.conf</filename></title>
   <para>
-   GNU C Library 2.0 的引入与 <emphasis>名称服务转换</emphasis> (NNS) 的引入是同时进行的。有关详细信息，请参见 <systemitem>nsswitch.conf(5)</systemitem> 手册页和《<emphasis>GNU C 库参考手册</emphasis>》。<indexterm>
-   <primary>NSS</primary>
-   </indexterm>
+   GNU C Library 2.0 的引入与 <emphasis>名称服务转换</emphasis> (NNS) 的引入是同时进行的。有关详细信息，请参见 <systemitem>nsswitch.conf(5)</systemitem> 手册页和《<emphasis>GNU C 库参考手册</emphasis>》。
   </para>
   <para>
    查询的顺序是在文件 <filename>/etc/nsswitch.conf</filename> 中定义的。<xref linkend="dat-netz-nsswitchconf"/> 中显示了 <filename>nsswitch.conf</filename> 的示例。注释以 <literal>#</literal> 符号开头。在本例中，<filename>hosts</filename> 数据库下的项意味着通过 DNS<phrase os="sles;osuse">（请参见<xref linkend="cha-dns"/>）</phrase>将请求发送到 <filename>/etc/hosts</filename> (<option>files</option>)。
@@ -468,10 +429,7 @@ shadow:     compat
 </screen>
   </example>
   <para>
-   <xref linkend="tab-netz-nnswitch-db"/> 中列出了 NSS 上可用的<quote>数据库</quote>。<indexterm>
-   <primary>NSS</primary>
-   <secondary>数据库</secondary>
-   </indexterm><xref linkend="tab-netz-nnswitch-conf"/> 中列出了 NSS 数据库的配置选项。
+   <xref linkend="tab-netz-nnswitch-db"/> 中列出了 NSS 上可用的<quote>数据库</quote>。<xref linkend="tab-netz-nnswitch-conf"/> 中列出了 NSS 数据库的配置选项。
   </para>
   <table xml:id="tab-netz-nnswitch-db">
    <title>通过 /etc/nsswitch.conf 可用的数据库</title>
@@ -706,9 +664,7 @@ shadow:     compat
   </table>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-nscd">
-  <title><filename>/etc/nscd.conf</filename></title><indexterm>
-  <primary> 配置文件</primary>
-  <secondary>nscd.conf</secondary></indexterm> 
+  <title><filename>/etc/nscd.conf</filename></title>
   <para>
    此文件用于配置 nscd（名称服务缓存守护程序）。请参见 <systemitem>nscd(8)</systemitem> 和 <systemitem>nscd.conf(5)</systemitem> 手册页。默认情况下，<option>passwd</option>、<option>groups</option> 和 <option>hosts</option> 的系统项由 nscd 进行缓存。这对 NIS 和 LDAP 等目录服务的性能而言非常重要，否则，每次访问名称、组或主机都需要网络连接。
    
@@ -720,12 +676,10 @@ shadow:     compat
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-hostname">
   <title><filename>/etc/HOSTNAME </filename></title>
-<indexterm>
-  <primary>配置文件</primary>
-  <secondary>主机名</secondary></indexterm>
+
   <para>
    <filename>/etc/HOSTNAME</filename> 包含完全限定的主机名 (FQHN)。完全限定的主机名是附有域名的主机名。此文件只能包含一行（在此行中设置主机名）。计算机引导时会读取此文件。
   </para>
-<indexterm class="endofrange" startref="idx-networks-configuration-files"/>
+
  </sect3>
 </sect2>

--- a/l10n/sles/zh-cn/xml/net_dhcp.xml
+++ b/l10n/sles/zh-cn/xml/net_dhcp.xml
@@ -13,12 +13,7 @@
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
-<indexterm class="startofrange" xml:id="idx-DHCP">
- <primary>DHCP</primary></indexterm><indexterm>
- <primary>网络</primary>
- <secondary>DHCP</secondary></indexterm><indexterm>
- <primary>IP 地址</primary>
- <secondary>动态指派</secondary></indexterm>
+
  <tip arch="zseries" os="sles">
   <title>IBM Z：DHCP 支持</title>
   <para>
@@ -40,15 +35,7 @@
  <sect1 xml:id="sec-dhcp-yast">
   <title>使用 YaST 配置 DHCP 服务器</title>
 
-<indexterm>
 
-  <primary>YaST</primary>
-
-  <secondary>DHCP</secondary></indexterm><indexterm>
-
-  <primary>DHCP使用 YaST 配置</primary>
-
-  <secondary/></indexterm>
 
   <para>
    要安装 DHCP 服务器，请启动 YaST 并选择<menuchoice><guimenu>软件</guimenu> <guimenu> 软件管理</guimenu></menuchoice>。选择<menuchoice><guimenu>过滤器</guimenu>
@@ -292,39 +279,20 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-dhcp-soft">
-  <title>DHCP 软件包</title><indexterm>
-
-  <primary> DHCP</primary>
-
-  <secondary>包</secondary></indexterm> 
+  <title>DHCP 软件包</title>
 
   <para>
    DHCP 服务器和 DHCP 客户端都适用于 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>。可用的 DHCP 服务器是 <systemitem class="daemon">dhcpd</systemitem>（由因特网系统联盟发布）。客户端提供了 <systemitem>dhcp-client</systemitem>（ISC 中也有提供）及 <systemitem>wicked</systemitem> 包附带的工具。
   </para>
 
   <para>
-   默认情况下，<systemitem>wicked</systemitem> 工具会连同 <systemitem>wickedd-dhcp4</systemitem> 和 <systemitem>wickedd-dhcp6</systemitem> 服务一起安装。系统每次引导时，会自动启动它们，以监视 DHCP 服务器。它们不需要配置文件来执行操作，可以直接用在大多数标准设置中。对于更复杂的情况，请使用 ISC <systemitem>dhcp-client</systemitem>，它是通过配置文件 <filename>/etc/dhclient.conf</filename> 和 <filename>/etc/dhclient6.conf</filename> 来控制的。<indexterm>
-   <primary>配置文件</primary>
-   <secondary> dhclient.conf</secondary>
-   </indexterm>
+   默认情况下，<systemitem>wicked</systemitem> 工具会连同 <systemitem>wickedd-dhcp4</systemitem> 和 <systemitem>wickedd-dhcp6</systemitem> 服务一起安装。系统每次引导时，会自动启动它们，以监视 DHCP 服务器。它们不需要配置文件来执行操作，可以直接用在大多数标准设置中。对于更复杂的情况，请使用 ISC <systemitem>dhcp-client</systemitem>，它是通过配置文件 <filename>/etc/dhclient.conf</filename> 和 <filename>/etc/dhclient6.conf</filename> 来控制的。
   </para>
  </sect1>
  <sect1 xml:id="sec-dhcp-server">
   <title>DHCP 服务器 dhcpd</title>
 
-<indexterm>
 
-  <primary>配置文件</primary>
-
-  <secondary>dhcpd.conf</secondary></indexterm><indexterm class="startofrange" xml:id="idx-dhcp-server">
-
-  <primary>DHCP</primary>
-
-  <secondary>服务器</secondary></indexterm><indexterm class="startofrange" xml:id="idx-dhcp-dhcpd">
-
-  <primary>DHCP</primary>
-
-  <secondary>dhcpd</secondary></indexterm>
 
   <para>
    任何 DHCP 系统的核心都是动态主机配置协议守护程序。根据配置文件 <filename>/etc/dhcpd.conf</filename> 中定义的设置，此服务器<emphasis>租出</emphasis>地址并监视它们的使用。通过更改此文件中的参数和值，系统管理员可以在许多方面影响程序的行为。让我们看一下<xref linkend="dat-dhcp-conf"/>中的基本示例 <filename>/etc/dhcpd.conf</filename> 文件。
@@ -400,12 +368,10 @@ subnet 192.168.2.0 netmask 255.255.255.0
 
   <para>
    在默认的 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 系统上，出于安全考虑，将在 chroot 环境中启动 DHCP 守护程序。必须将配置文件复制到 chroot 环境，以便守护程序能够找到它们。通常情况下无需担心这一点，因为命令 <command>systemctl start dhcpd</command> 会自动复制这些文件。
-  </para><indexterm class="endofrange" startref="idx-dhcp-server"/><indexterm class="endofrange" startref="idx-dhcp-dhcpd"/>
+  </para>
 
   <sect2 xml:id="sec-dhcp-statip">
-   <title>具有固定 IP 地址的客户端</title><indexterm>
-   <primary> DHCP</primary>
-   <secondary>静态地址指派</secondary></indexterm> 
+   <title>具有固定 IP 地址的客户端</title>
    <para>
     DHCP 可用来向特定客户端指派预定义的静态地址。显式指派的地址始终优先于来自地址池的动态地址。静态地址永远不会像动态地址那样过期。例如，对于动态地址而言，如果没有足够的地址可用，服务器需要在客户端之间重新分发这些地址。
    </para>
@@ -476,6 +442,6 @@ fixed-address 192.168.2.100;
 
   <para>
    有关 DHCP 的更多信息，请访问<emphasis>因特网系统联盟</emphasis>网站 (<link xlink:href="https://www.isc.org/dhcp/"/>)。也可在 <option>dhcpd</option>、<option>dhcpd.conf</option>、<option>dhcpd.leases</option> 和 <option>dhcp-options</option> 手册页中获得相关信息。
-  </para><indexterm class="endofrange" startref="idx-DHCP"/>
+  </para>
  </sect1>
 </chapter>

--- a/l10n/sles/zh-cn/xml/net_dns.xml
+++ b/l10n/sles/zh-cn/xml/net_dns.xml
@@ -16,21 +16,9 @@
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
-<indexterm>
- <primary>域名系统</primary>
- <see>DNS</see></indexterm><indexterm>
- <primary>DNS</primary>
- <secondary>配置</secondary></indexterm><indexterm>
- <primary>配置</primary>
- <secondary>DNS</secondary></indexterm><indexterm>
- <primary>名称服务器</primary>
- <see>DNS</see></indexterm>
+
  <sect1 xml:id="sec-dns-basic">
-  <title>DNS 术语</title><indexterm>
-
-  <primary> DNS</primary>
-
-  <secondary>术语</secondary></indexterm> 
+  <title>DNS 术语</title>
 
   <variablelist>
    <varlistentry>
@@ -489,25 +477,11 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-dns-bind">
-  <title>启动 BIND 名称服务器</title><indexterm xml:id="idx-DNS-BIND" class="startofrange">
-
-  <primary>DNS</primary>
-
-  <secondary>BIND</secondary></indexterm><indexterm xml:id="idx-BIND" class="startofrange">
-
-  <primary>BIND</primary></indexterm>
+  <title>启动 BIND 名称服务器</title>
 
   <para>
    在 <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> 系统上，已预先配置名称服务器 BIND（<emphasis>Berkeley 因特网名称域</emphasis>），因此在安装后可以立即启动此名称服务器，而不会出现任何问题。一般而言，如果您已有因特网连接，并在 <systemitem class="ipaddress">/etc/resolv.conf</systemitem> 中输入了 <systemitem class="domainname">127.0.0.1</systemitem> 作为 <filename>localhost</filename> 的名称服务器地址，则表示您已经有正常工作的名称解析功能，因而无需知道提供商的 DNS。BIND 通过 root 名称服务器执行名称解析，这个过程非常慢。通常，应将提供商的 DNS 及其 IP 地址输入配置文件 <filename>/etc/named.conf</filename> 的 <systemitem>forwarders</systemitem> 下，以确保能进行有效而安全的名称解析。如果到目前为止是这种情况，则该名称服务器将作为<emphasis>仅用于缓存</emphasis>的纯名称服务器运行。只有在配置了该名称服务器自己的区域后，它才能成为正确的 DNS。在 <filename>/usr/share/doc/packages/bind/config</filename> 中可找到简单的示例。
-  </para><indexterm>
-
-  <primary>配置文件</primary>
-
-  <secondary>resolv.conf</secondary></indexterm><indexterm>
-
-  <primary>配置文件</primary>
-
-  <secondary>named.conf</secondary></indexterm>
+  </para>
 
   <tip>
    <title>名称服务器信息的自动适应</title>
@@ -524,25 +498,10 @@
    要启动名称服务器，请以 <systemitem class="username">root</systemitem> 身份输入命令 <command>systemctl start named</command>。使用 <command>systemctl status named</command> 检查 named（当调用名称服务器进程时）是否已成功启动。请用 <command>host</command> 或 <command>dig</command> 程序立即在本地系统上测试名称服务器，该测试应返回 <systemitem class="domainname">localhost</systemitem> 作为默认服务器，地址为 <systemitem class="ipaddress">127.0.0.1</systemitem>。如果未返回所需的结果，则表明 <filename>/etc/resolv.conf</filename> 可能包含不正确的名称服务器项或此文件不存在。如果是第一次测试，请输入 <command>host</command> <option>127.0.0.1</option>，此命令应始终有效。如果收到错误讯息，请使用 <command>systemctl status named</command> 查看服务器是否确实在运行。如果该名称服务器未启动或者出现意外的行为，请检查 <command>journalctl -e</command> 的输出。
   </para>
 
-<indexterm>
 
-  <primary>日志文件</primary>
-
-  <secondary>讯息</secondary></indexterm><indexterm>
-
-  <primary>DNS</primary>
-
-  <secondary>启动</secondary></indexterm><indexterm>
-
-  <primary>DNS</primary>
-
-  <secondary>查错</secondary></indexterm>
 
   <para>
-   要将提供商的名称服务器（或网络上正在运行的名称服务器）用作转发器，请在 <systemitem>options</systemitem> 部分的 <systemitem>forwarders</systemitem> 下输入相应的一个或多个 IP 地址。<xref linkend="ex-forward"/>中包含的地址仅用作示例。请根据您自己的设置调整这些项。<indexterm>
-   <primary>DNS</primary>
-   <secondary>转发</secondary>
-   </indexterm>
+   要将提供商的名称服务器（或网络上正在运行的名称服务器）用作转发器，请在 <systemitem>options</systemitem> 部分的 <systemitem>forwarders</systemitem> 下输入相应的一个或多个 IP 地址。<xref linkend="ex-forward"/>中包含的地址仅用作示例。请根据您自己的设置调整这些项。
   </para>
 
   <example xml:id="ex-forward">
@@ -563,11 +522,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-dns-named">
-  <title>/etc/named.conf 配置文件</title><indexterm xml:id="idx-configuration-files-named-conf" class="startofrange">
-
-  <primary> 配置文件</primary>
-
-  <secondary>named.conf</secondary></indexterm> 
+  <title>/etc/named.conf 配置文件</title>
 
   <para>
    BIND 名称服务器本身的所有设置都储存在文件 <filename>/etc/named.conf</filename> 中。但是，将要处理的域的区域数据（由主机名、IP 地址等组成）储存在目录 <filename>/var/lib/named</filename> 下单独的文件中。稍后将介绍其详细信息。
@@ -602,9 +557,7 @@ zone "." in {
   </example>
 
   <sect2 xml:id="sec-dns-named-options">
-   <title>重要的配置选项</title><indexterm>
-   <primary> DNS</primary>
-   <secondary>选项</secondary></indexterm> 
+   <title>重要的配置选项</title>
    <variablelist>
     <varlistentry>
      <term>directory "<replaceable>FILENAME</replaceable>";</term>
@@ -632,9 +585,7 @@ zone "." in {
     </varlistentry>
     <varlistentry>
      <term>listen-on port 53 { 127.0.0.1; <replaceable>IP-ADDRESS</replaceable>; };</term>
-     <listitem><indexterm>
-      <primary>端口</primary>
-      <secondary>53</secondary></indexterm>
+     <listitem>
       <para>
        指示 BIND 通过哪些网络接口和哪个端口来接受客户端查询。不需要显式指定 <literal>port 53</literal>，因为 <literal>53</literal> 是默认端口。输入 <literal>127.0.0.1</literal> 允许接收来自 Localhost 的请求。如果完全省略此项，则在默认情况下使用所有接口。
       </para>
@@ -719,9 +670,7 @@ zone "." in {
   </sect2>
 
   <sect2 xml:id="sec-dns-named-log">
-   <title>日志记录</title><indexterm>
-   <primary> DNS</primary>
-   <secondary>日志记录</secondary></indexterm> 
+   <title>日志记录</title>
    <para>
     可以在 BIND 中详细配置日志记录的内容、方式和位置。通常，默认设置就已足够。<xref linkend="ex-no-log"/>显示了此项最简单的形式，并完全抑制任何日志记录。
    </para>
@@ -810,13 +759,7 @@ zone "." in {
   </sect2>
  </sect1>
  <sect1 xml:id="sec-dns-zonefile">
-  <title>区域文件</title><indexterm>
-
-  <primary> DNS</primary>
-
-  <secondary>区域</secondary>
-
-  <tertiary>文件</tertiary></indexterm> 
+  <title>区域文件</title>
 
   <para>
    所需的区域文件有两种类型。一种类型将 IP 地址指派给主机名，另一种类型则正好相反：为 IP 地址提供主机名。
@@ -994,10 +937,7 @@ pluto     AAAA 2345:00D2:DA11::1234:5678:9ABC:DEF0</screen>
 
 
   <para>
-   伪域 <literal>in-addr.arpa</literal> 用于 IP 地址到主机名的反向查找。它被追加到采用反向表示法的地址的网络部分。因此，将 <systemitem class="ipaddress">192.168</systemitem> 解析成 <systemitem>168.192.in-addr.arpa</systemitem>。参见 <xref linkend="dat-arpa"/>。<indexterm>
-   <primary>DNS</primary>
-   <secondary>反向查找</secondary>
-   </indexterm>
+   伪域 <literal>in-addr.arpa</literal> 用于 IP 地址到主机名的反向查找。它被追加到采用反向表示法的地址的网络部分。因此，将 <systemitem class="ipaddress">192.168</systemitem> 解析成 <systemitem>168.192.in-addr.arpa</systemitem>。参见 <xref linkend="dat-arpa"/>。
   </para>
 
 
@@ -1064,9 +1004,9 @@ pluto     AAAA 2345:00D2:DA11::1234:5678:9ABC:DEF0</screen>
   </variablelist>
 
   <para>
-   通常，可以在 BIND 的不同版本间传输区域，不会产生任何问题。<indexterm class="endofrange" startref="idx-DNS-BIND"/>
-   <indexterm class="endofrange" startref="idx-BIND"/>
-   <indexterm class="endofrange" startref="idx-configuration-files-named-conf"/>
+   通常，可以在 BIND 的不同版本间传输区域，不会产生任何问题。
+   
+   
 
   </para>
  </sect1>

--- a/l10n/sles/zh-cn/xml/net_samba.xml
+++ b/l10n/sles/zh-cn/xml/net_samba.xml
@@ -11,16 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-Samba" class="startofrange">
- <primary>Samba</primary></indexterm><indexterm>
- <primary>SMB</primary>
- <see>Samba</see></indexterm><indexterm>
- <primary>macOS</primary>
- <secondary>共享文件</secondary></indexterm><indexterm>
- <primary>Windows</primary>
- <secondary>共享文件</secondary></indexterm><indexterm>
- <primary>Linux</primary>
- <secondary>与其他操作系统共享文件</secondary></indexterm>
+ </info>
  <sect1 xml:id="sec-samba-term">
   <title>术语</title>
 
@@ -33,18 +24,7 @@
     <term>SMB 协议</term>
     <listitem>
      <para>
-      <indexterm>
-      <primary>Samba</primary>
-      <secondary>SMB</secondary>
-      </indexterm> <indexterm>
-      <primary>协议</primary>
-      <secondary>SMB</secondary>
-      </indexterm> <indexterm>
-      <primary>smbd</primary>
-      </indexterm>Samba 使用基于 <phrase role="productname">NetBIOS</phrase> 服务的 SMB（服务器消息块）协议。Microsoft 发布该协议以便其他软件制造商能够与 Microsoft 域网络建立连接。使用 Samba 时，SMB 协议在 TCP/IP 协议之上工作，所以必须在所有客户端上安装 TCP/IP 协议。<indexterm>
-      <primary>Samba</primary>
-      <secondary> TCP/IP</secondary>
-      </indexterm>
+        Samba 使用基于 <phrase role="productname">NetBIOS</phrase> 服务的 SMB（服务器消息块）协议。Microsoft 发布该协议以便其他软件制造商能够与 Microsoft 域网络建立连接。使用 Samba 时，SMB 协议在 TCP/IP 协议之上工作，所以必须在所有客户端上安装 TCP/IP 协议。
      </para>
      <tip arch="zseries" os="sles">
       <title>IBM Z：NetBIOS 支持</title>
@@ -58,13 +38,7 @@
     <term>CIFS 协议</term>
     <listitem>
      <para>
-      <indexterm>
-      <primary>Samba</primary>
-      <secondary>CIFS</secondary>
-      </indexterm> <indexterm>
-      <primary>协议</primary>
-      <secondary>CIFS</secondary>
-      </indexterm>（常用因特网文件系统）协议是 Samba 支持的另一种协议。CIFS 定义网络中使用的标准远程文件系统访问协议，使用户组能够一起工作并在网络中共享文档。
+       （常用因特网文件系统）协议是 Samba 支持的另一种协议。CIFS 定义网络中使用的标准远程文件系统访问协议，使用户组能够一起工作并在网络中共享文档。
      </para>
     </listitem>
    </varlistentry>
@@ -72,22 +46,16 @@
     <term>NetBIOS</term>
     <listitem>
      <para>
-      <indexterm>
-      <primary>NetBIOS</primary>
-      </indexterm> NetBIOS 是为用于提供名称服务的计算机之间进行通讯而设计的软件接口 (API)。它使连接到网络的计算机能够为自己保留名称。之后便可以根据名称对这些计算机进行寻址。没有任何中心进程来检查这些名称。网络上的任何计算机均可以保留所需数量的名称，前提是这些名称均未使用。可以为不同的网络体系结构实施 NetBIOS 接口。<phrase role="productname">NetBEUI</phrase> 是与网络硬件结合相对密切的一种实施，但它常被称为 <phrase role="productname">NetBIOS</phrase>。使用 NetBIOS 实施的网络协议包括 Novell 的 IPX（通过 TCP/IP 的 NetBIOS）和 TCP/IP。
+       NetBIOS 是为用于提供名称服务的计算机之间进行通讯而设计的软件接口 (API)。它使连接到网络的计算机能够为自己保留名称。之后便可以根据名称对这些计算机进行寻址。没有任何中心进程来检查这些名称。网络上的任何计算机均可以保留所需数量的名称，前提是这些名称均未使用。可以为不同的网络体系结构实施 NetBIOS 接口。<phrase role="productname">NetBEUI</phrase> 是与网络硬件结合相对密切的一种实施，但它常被称为 <phrase role="productname">NetBIOS</phrase>。使用 NetBIOS 实施的网络协议包括 Novell 的 IPX（通过 TCP/IP 的 NetBIOS）和 TCP/IP。
      </para>
      <para>
       通过 TCP/IP 发送的 NetBIOS 名称与 <filename>/etc/hosts</filename> 中使用的名称或 DNS 定义的名称没有相同之处。NetBIOS 使用它自己的、完全独立的命名约定。但为了方便管理，建议您使用与 DNS 主机名对应的名称，或本机使用 DNS。Samba 默认采用这种方式。
-     </para><indexterm>
-     <primary>Samba</primary>
-     <secondary>名称</secondary></indexterm>
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>Samba 服务器</term>
-    <listitem><indexterm>
-     <primary>Samba</primary>
-     <secondary> 服务器</secondary></indexterm>
+    <listitem>
      <para>
       Samba 服务器向客户端提供 SMB/CIFS 服务和 NetBIOS over IP 命名服务。对于 Linux，Samba 服务器有三个守护程序：smbd 用于 SMB/CIFS 服务，nmbd 用于命名服务，winbind 用于身份验证。
      </para>
@@ -95,9 +63,7 @@
    </varlistentry>
    <varlistentry>
     <term>Samba 客户端</term>
-    <listitem><indexterm xml:id="idx-Samba-clients" class="startofrange">
-     <primary> Samba</primary>
-     <secondary> 客户端</secondary></indexterm> 
+    <listitem> 
      <para>
       Samba 客户端是一种能够通过 SMB 协议从 Samba 服务器使用 Samba 服务的系统。常见操作系统（例如 Windows 和 macOS）都支持 SMB 协议。必须在所有计算机上安装 TCP/IP 协议。Samba 提供适用于多种不同类型 UNIX 的客户端。对于 Linux，有一个用于 SMB 的内核模块，它允许在 Linux 系统级别上集成 SMB 资源。不需要对 Samba 客户端运行任何守护程序。
      </para>
@@ -107,16 +73,7 @@
     <term>共享</term>
     <listitem>
      <para>
-      <indexterm>
-      <primary>Samba</primary>
-      <secondary>共享</secondary>
-      </indexterm>SMB 服务器通过共享为其客户端提供资源。共享就是服务器上的打印机和目录及其子目录。可以通过名称来导出并访问共享。可以将共享名称设置为任何名称 — 不一定是导出目录的名称。也可以为打印机指派一个名称。客户端可以根据打印机的名称来访问打印机。<indexterm>
-      <primary>打印</primary>
-      <secondary>Samba</secondary>
-      </indexterm> <indexterm>
-      <primary>Samba</primary>
-      <secondary>打印机 </secondary>
-      </indexterm> <indexterm class="endofrange" startref="idx-Samba-clients"/>
+      SMB 服务器通过共享为其客户端提供资源。共享就是服务器上的打印机和目录及其子目录。可以通过名称来导出并访问共享。可以将共享名称设置为任何名称 — 不一定是导出目录的名称。也可以为打印机指派一个名称。客户端可以根据打印机的名称来访问打印机。  
      </para>
     </listitem>
    </varlistentry>
@@ -124,10 +81,7 @@
     <term>DC</term>
     <listitem>
      <para>
-      <indexterm>
-      <primary>Samba</primary>
-      <secondary>DC</secondary>
-      </indexterm> 域控制器 (DC) 是处理域中帐户的服务器。为了复制数据，一个域中可有更多域控制器可用。
+       域控制器 (DC) 是处理域中帐户的服务器。为了复制数据，一个域中可有更多域控制器可用。
      </para>
     </listitem>
    </varlistentry>
@@ -156,34 +110,10 @@
    <para>
     <systemitem>winbind</systemitem> 是一项独立服务，同样也是以单独的 <systemitem>samba-winbind</systemitem> 包提供。
    </para>
-  </tip><indexterm>
-
-  <primary>Samba</primary>
-
-  <secondary>启动</secondary></indexterm><indexterm>
-
-  <primary>Samba</primary>
-
-  <secondary>停止</secondary></indexterm>
+  </tip>
  </sect1>
  <sect1 xml:id="sec-samba-serv-inst">
-  <title>配置 Samba 服务器</title><indexterm>
-
-  <primary>Samba</primary>
-
-  <secondary>安装</secondary></indexterm><indexterm>
-
-  <primary>Samba</primary>
-
-  <secondary>服务器</secondary></indexterm><indexterm>
-
-  <primary>Samba</primary>
-
-  <secondary>配置</secondary></indexterm><indexterm>
-
-  <primary>配置</primary>
-
-  <secondary>Samba</secondary></indexterm>
+  <title>配置 Samba 服务器</title>
 
   <para os="sles;osuse">
    <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> 中的 Samba 服务器可通过两种不同方式进行配置：用 YaST 或手动方式。手工配置可提供更详细的信息，但没有 YaST GUI 方便。
@@ -288,16 +218,7 @@
   <sect2 xml:id="sec-samba-serv-inst-manual" os="sles;osuse">
    <title>手动配置服务器</title>
    <para>
-    <indexterm>
-    <primary>Samba</primary>
-    <secondary>配置</secondary>
-    </indexterm> <indexterm>
-    <primary>配置</primary>
-    <secondary>Samba</secondary>
-    </indexterm> <indexterm>
-    <primary>配置文件</primary>
-    <secondary>smb.conf</secondary>
-    </indexterm> 如果想将 Samba 用作服务器，请安装 <systemitem class="resource">samba</systemitem>。Samba 的主配置文件是 <filename>/etc/samba/smb.conf</filename>。可以将此文件分为两个逻辑部分。<literal>[global]</literal> 部分包含中央和全局设置。以下默认部分包含各个文件和打印机共享：
+       如果想将 Samba 用作服务器，请安装 <systemitem class="resource">samba</systemitem>。Samba 的主配置文件是 <filename>/etc/samba/smb.conf</filename>。可以将此文件分为两个逻辑部分。<literal>[global]</literal> 部分包含中央和全局设置。以下默认部分包含各个文件和打印机共享：
    </para>
    <itemizedlist mark="bullet" spacing="normal">
     <listitem>
@@ -380,9 +301,7 @@
     </variablelist>
    </sect3>
    <sect3 xml:id="sec-samba-smb-conf-shares">
-    <title>共享</title><indexterm>
-    <primary> Samba</primary>
-    <secondary> 共享</secondary></indexterm> 
+    <title>共享</title>
     <para>
      以下示例描述了如何使 CD-ROM 驱动器和用户目录 (<literal>homes</literal>) 对 SMB 客户端可用。
     </para>
@@ -498,13 +417,7 @@
     </warning>
    </sect3>
    <sect3 xml:id="sec-samba-rechte">
-    <title>安全性级别</title><indexterm xml:id="idx-Samba-security" class="startofrange">
-    <primary>Samba</primary>
-    <secondary>安全性</secondary></indexterm><indexterm>
-    <primary>安全性</primary>
-    <secondary>Samba</secondary></indexterm><indexterm>
-    <primary>Samba</primary>
-    <secondary>许可权限</secondary></indexterm>
+    <title>安全性级别</title>
     <para>
      要提高安全性，可以使用口令来保护每个共享访问。SMB 提供以下检查许可权限的方式：
     </para>
@@ -540,31 +453,19 @@
     </para>
     <para>
      有关此主题的更多信息，可以在《Samba 3 操作指南》中找到。对于一个系统上的多个服务器，应注意选项 <option>interfaces</option> 和 <option>bind interfaces only</option>。
-    </para><indexterm class="endofrange" startref="idx-Samba-security"/>
+    </para>
    </sect3>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-samba-client-inst">
-  <title>配置客户端</title><indexterm>
-
-  <primary> Samba</primary>
-
-  <secondary> 客户端</secondary></indexterm> 
+  <title>配置客户端</title>
 
   <para>
    客户端只能通过 TCP/IP 访问 Samba 服务器。NetBEUI 和通过 IPX 的 NetBIOS 不能与 Samba 共用。
   </para>
 
   <sect2 xml:id="sec-samba-client-inst-yast">
-   <title>使用 YaST 配置 Samba 客户端</title><indexterm>
-   <primary>YaST</primary>
-   <secondary>Samba</secondary>
-   <tertiary>客户机</tertiary></indexterm><indexterm>
-   <primary>Samba</primary>
-   <secondary>客户机</secondary></indexterm><indexterm>
-   <primary>配置</primary>
-   <secondary>Samba</secondary>
-   <tertiary>客户机</tertiary></indexterm>
+   <title>使用 YaST 配置 Samba 客户端</title>
    <para>
     配置 Samba 客户端来访问 Samba 或 Windows 服务器上的资源（文件或打印机）。在<menuchoice> <guimenu> 网络服务</guimenu>
     <guimenu> Windows 域成员资格</guimenu></menuchoice>对话框中输入 NT 或 Active Directory 域或工作组。如果激活<guimenu>将 SMB 信息也用于 Linux 身份验证</guimenu>，则用户身份验证将在 Samba、NT 或 Kerberos 服务器上运行。
@@ -578,11 +479,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-samba-anmeld-serv">
-  <title>将 Samba 用作登录服务器</title><indexterm>
-
-  <primary> Samba</primary>
-
-  <secondary> 登录</secondary></indexterm> 
+  <title>将 Samba 用作登录服务器</title>
 
   <para>
    在主要由 Windows 客户端组成的网络中，使用户只能使用有效帐户和口令进行注册通常是最好的选择。在基于 Windows 的网络中，此任务由主域控制器 (PDC) 来处理。您可以使用配置为 PDC 的 Windows NT 服务器，但是此任务也可以借助 Samba 服务器来完成。<xref linkend="dat-samba-smb-conf-dom"/>中显示了必须在 <filename>smb.conf</filename> 的 <literal>[global]</literal> 部分设置的项。
@@ -601,11 +498,7 @@
   </para>
 
 <screen>useradd hostname\$
-smbpasswd -a -m hostname</screen><indexterm>
-
-  <primary> 命令</primary>
-
-  <secondary> smbpasswd</secondary></indexterm> 
+smbpasswd -a -m hostname</screen> 
 
   <para>
    使用 <command>useradd</command> 命令可添加一个美元符号。命令 <command>smbpasswd</command> 在使用参数 <option>-m</option> 时自动插入此符号。带注释的配置示例 (<filename>/usr/share/doc/packages/samba/examples/smb.conf.SUSE</filename>) 包含自动执行此任务的设置。
@@ -1075,14 +968,11 @@ No shadow copies found in system.</screen>
 
   <para>
    Samba 文档包含在 <systemitem>samba-doc</systemitem> 包中，默认情况下不会安装该包。您可以使用 <command>zypper install samba-doc</command> 进行安装。在命令行中输入 <command>apropos</command>
-   <option> samba</option> 可显示一些手册页；或浏览 <filename>/usr/share/doc/packages/samba</filename> 目录以获取更多的联机文档和示例。<filename>examples</filename> 子目录中提供了一个带注释的示例配置 (<filename>smb.conf.SUSE</filename>)。另一个可以查看 Samba 相关信息的文件是 <filename>/usr/share/doc/packages/samba/README.SUSE</filename>。<indexterm>
-   <primary>配置文件</primary>
-   <secondary> smb.conf</secondary>
-   </indexterm>
+   <option> samba</option> 可显示一些手册页；或浏览 <filename>/usr/share/doc/packages/samba</filename> 目录以获取更多的联机文档和示例。<filename>examples</filename> 子目录中提供了一个带注释的示例配置 (<filename>smb.conf.SUSE</filename>)。另一个可以查看 Samba 相关信息的文件是 <filename>/usr/share/doc/packages/samba/README.SUSE</filename>。
   </para>
 
   <para>
    Samba 小组提供的《Samba 操作指南》（请参见 <link xlink:href="https://wiki.samba.org"/>）中有一节专门介绍查错。此外，文档的第 V 部分提供了检查配置的逐步指南。
-  </para><indexterm class="endofrange" startref="idx-Samba"/>
+  </para>
  </sect1>
 </chapter>

--- a/l10n/sles/zh-cn/xml/net_slp.xml
+++ b/l10n/sles/zh-cn/xml/net_slp.xml
@@ -11,14 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>网络</primary>
- <secondary>SLP</secondary></indexterm><indexterm>
- <primary>服务位置协议</primary>
- <see>SLP</see></indexterm><indexterm>
- <primary>SLP</primary></indexterm><indexterm>
- <primary>协议</primary>
- <secondary>SLP</secondary></indexterm>
+ </info>
  <para>
   <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> 支持使用 SLP 提供的安装源进行安装，并且包含许多集成了 SLP 支持的系统服务。您可以使用 SLP 为联网客户端（如系统上的安装服务器、文件服务器或打印服务器）提供核心功能。提供 SLP 支持的服务包括 cupsd、login、ntp、openldap2、postfix、rpasswd、rsyncd、saned、sshd（通过 fish）、vnc 和 ypserv。
  </para>

--- a/l10n/sles/zh-cn/xml/net_yast.xml
+++ b/l10n/sles/zh-cn/xml/net_yast.xml
@@ -9,15 +9,7 @@
   </dm:docmanager>
  </info>
 
-<indexterm xml:id="idx-networks-integrating" class="startofrange">
 
- <primary>网络</primary>
-
- <secondary>配置</secondary></indexterm><indexterm>
-
- <primary>卡</primary>
-
- <secondary>网络</secondary></indexterm>
 
  <para>
   Linux 上有多个支持的联网类型。其中多数使用不同的设备名，配置文件分布在文件系统上的多个位置。关于手动网络配置方面的详细概述，请参见<xref linkend="sec-basicnet-manconf"/>。
@@ -37,13 +29,7 @@
 
  <sect2 xml:id="sec-basicnet-yast-netcard">
   <title>使用 YaST 配置网卡</title>
-<indexterm>
-  <primary>卡</primary>
-  <secondary>网络</secondary></indexterm><indexterm>
-  <primary>网络</primary>
-  <secondary>YaST</secondary></indexterm><indexterm>
-  <primary>YaST</primary>
-  <secondary>网卡</secondary></indexterm><indexterm/>
+
   <para>
    要在 YaST 中配置以太网卡或 Wi-Fi/蓝牙卡，请选择<menuchoice> <guimenu>系统</guimenu> <guimenu> 网络设置</guimenu>
    </menuchoice>。启动模块后，YaST 将显示<guimenu>网络设置</guimenu>对话框，其中包括四个选项卡：<guimenu>全局选项</guimenu>、<guimenu>概述</guimenu>、<guimenu>主机名/DNS</guimenu> 和<guimenu>路由选择</guimenu>。
@@ -107,10 +93,7 @@
    </para>
    <sect4 xml:id="sec-basicnet-yast-change-address">
     <title>配置 IP 地址</title>
-<indexterm>
-    <primary>网络</primary>
-    <secondary>YaST</secondary>
-    <tertiary>IP 地址</tertiary></indexterm>
+
     <para>
      您可在<guimenu>网卡设置</guimenu>对话框的<guimenu>地址</guimenu>选项卡中设置网卡的 IP 地址或 IP 地址的确定方法。同时支持 IPv4 和 IPv6 地址。网卡可设置为<guimenu>无 IP 地址</guimenu>（对于绑定设备很有用）、<guimenu>静态指派的 IP 地址</guimenu>（IPv4 或 IPv6）或通过 <guimenu>DHCP</guimenu>和/或 <guimenu>Zeroconf</guimenu> 指派的<guimenu>动态地址</guimenu>。
     </para>
@@ -181,13 +164,7 @@
     </para>
    </sect4>
    <sect4 xml:id="sec-basicnet-yast-configure-addresses">
-    <title>配置多个地址</title><indexterm>
-    <primary>网络</primary>
-    <secondary>YaST</secondary>
-    <tertiary>别名</tertiary></indexterm><indexterm>
-    <primary>网络</primary>
-    <secondary>YaST</secondary>
-    <tertiary>地址</tertiary></indexterm>
+    <title>配置多个地址</title>
     <para>
      一个网络设备可以有多个 IP 地址。
     </para>
@@ -287,10 +264,7 @@
    </sect4>
    <sect4 xml:id="sec-basicnet-yast-change-start">
     <title>激活网络设备</title>
-<indexterm>
-    <primary>网络</primary>
-    <secondary> YaST</secondary>
-    <tertiary> 激活</tertiary></indexterm>
+
     <para>
      如果使用结合 <command>wicked</command> 的方法，便可以将设备配置为在引导期间、连接电缆时或检测到网卡时启动、以手动方式启动或永不启动设备。要更改设备启动，请如下继续操作：
     </para>
@@ -503,10 +477,7 @@
    </procedure>
   </sect3>
   <sect3 xml:id="sec-basicnet-yast-change-host">
-   <title>配置主机名和 DNS</title><indexterm>
-   <primary>网络</primary>
-   <secondary> YaST</secondary>
-   <tertiary> 主机名</tertiary></indexterm>
+   <title>配置主机名和 DNS</title>
    <para>
     如果您在安装期间未更改网络配置，并且已有以太网卡可用，则系统会自动为您的计算机生成主机名并激活 DHCP。这同样适用于主机连接到网络环境所需的名称服务信息。如果网络地址设置使用了 DHCP，则会向域名服务器列表自动填充相应数据。如果希望使用静态设置，则手动设置这些值。
    </para>
@@ -593,10 +564,7 @@ yast dns edit nameserver3=192.168.1.118</screen>
 
   <sect3 xml:id="sec-basicnet-yast-change-route">
    <title>配置路由选择</title>
-<indexterm>
-   <primary>网关</primary>
-   <secondary>YaST</secondary>
-   <tertiary>网关</tertiary></indexterm>
+
    <para>
     要使计算机能够与其他计算机和其他网络进行通信，必须提供路由选择信息以使网络流量使用正确的路径。如果使用 DHCP，则将自动提供此信息。如果使用静态设置，则必须手动添加此数据。
    </para>

--- a/l10n/sles/zh-cn/xml/nm.xml
+++ b/l10n/sles/zh-cn/xml/nm.xml
@@ -6,10 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>因特网</primary>
- <secondary>连接到</secondary></indexterm><indexterm>
- <primary>NetworkManager</primary></indexterm>
+ </info>
  <para>
   NetworkManager 是用于便携式计算机和其他可移动计算机的理想解决方案。它支持网络连接的顶级加密类型和标准，包括 802.1x 保护的网络的连接。802.1X 是<quote>基于端口的网络访问控制的本地和城域网 IEEE 标准</quote>。使用 NetworkManager，在外出时，您就无需担心配置网络接口以及在有线或无线网络之间切换的问题。NetworkManager 可自动连接到已知无线网络或并行管理多个网络连接 － 然后将最快的连接用作默认连接。而且，您还可手动在可用网络之间切换，并使用系统盘中的小程序管理网络连接。
 
@@ -38,11 +35,7 @@
   </itemizedlist>
  </sect1>
  <sect1 xml:id="sec-nm-activate">
-  <title>启用或禁用 NetworkManager</title><indexterm>
-
-  <primary> NetworkManager</primary>
-
-  <secondary> 启用</secondary></indexterm>
+  <title>启用或禁用 NetworkManager</title>
 
   <para>
    在便携式计算机上，默认情况下 NetworkManager 处于启用状态。但是，任何时候都可以在 YaST 网络设置模块中启用或禁用它。
@@ -110,11 +103,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-nm-configure">
-  <title>配置网络连接</title><indexterm>
-
-  <primary> NetworkManager</primary>
-
-  <secondary> 配置</secondary></indexterm>
+  <title>配置网络连接</title>
 
   <para>
    在 YaST 中启用 NetworkManager 后，使用 GNOME 中提供的 NetworkManager 前端配置网络连接。它会显示所有网络连接类型对应的选项卡，例如有线、无线、移动宽带、DSL 和 VPN 连接。
@@ -318,10 +307,7 @@
   </sect2>
 
   <sect2 xml:id="sec-nm-vpn">
-   <title>NetworkManager 和 VPN</title><indexterm>
-   <primary>NetworkManager</primary>
-   <secondary>VPN</secondary></indexterm><indexterm>
-   <primary>VPN</primary></indexterm>
+   <title>NetworkManager 和 VPN</title>
    <para>
     NetworkManager 支持多种虚拟专用网 (VPN) 技术。对于每种技术，<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 都随附了提供 NetworkManager 常规支持的基础包。此外，还需要为您的小程序安装特定于桌面的包。
    </para>
@@ -517,11 +503,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-nm-security">
-  <title>NetworkManager 和安全性</title><indexterm>
-
-  <primary> NetworkManager</primary>
-
-  <secondary> 安全性</secondary></indexterm>
+  <title>NetworkManager 和安全性</title>
 
   <para>
    NetworkManager 区分两种类型的无线连接，即可信和不可信。可信连接是您过去明确选择的任何网络。所有其他连接均为不可信连接。可信连接用接入点的名称和 MAC 地址识别。使用 MAC 地址可以确保带有可信连接名称的不同接入点不可使用。
@@ -651,11 +633,7 @@
   </qandaset>
  </sect1>
  <sect1 xml:id="sec-nm-trouble">
-  <title>查错</title><indexterm>
-
-  <primary> NetworkManager</primary>
-
-  <secondary> 查错</secondary></indexterm>
+  <title>查错</title>
 
   <para>
    可能出现连接问题。与 NetworkManager 相关的一些常见问题包括小程序不启动或缺少 VPN 选项。解决方法和预防这些问题的方法随使用的工具而定。

--- a/l10n/sles/zh-cn/xml/pcmcia_apm.xml
+++ b/l10n/sles/zh-cn/xml/pcmcia_apm.xml
@@ -39,9 +39,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>休眠（暂挂到磁盘）<indexterm>
-     <primary>电源管理</primary>
-     <secondary>休眠</secondary></indexterm> 
+    <term>休眠（暂挂到磁盘） 
     </term>
     <listitem>
      <para>
@@ -55,9 +53,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>电池监视<indexterm>
-     <primary>电源管理</primary>
-     <secondary>电池监视</secondary></indexterm> 
+    <term>电池监视 
     </term>
     <listitem>
      <para>
@@ -84,11 +80,7 @@
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-pmanage-acpi">
-  <title>高级配置和电源接口 (ACPI)</title><indexterm xml:id="idx-power-management-ACPI" class="startofrange">
-
-  <primary>电源管理</primary>
-
-  <secondary>ACPI</secondary></indexterm> 
+  <title>高级配置和电源接口 (ACPI)</title>
 
   <para>
    ACPI 旨在支持操作系统设置和控制各个硬件组件。ACPI 取代即插即用电源管理 (PnP) 和高级电源管理 (APM)。它提供有关电池、AC 适配器、温度、风扇和系统事件（例如<quote>合上机盖</quote>或<quote>电池电量低</quote>）的信息。
@@ -205,7 +197,7 @@
        <link xlink:href="http://acpi.sourceforge.net/dsdt/index.php"/>（Bruno Ducrot 开发的 DSDT 增补程序）
       </para>
      </listitem>
-    </itemizedlist><indexterm class="endofrange" startref="idx-power-management-ACPI"/>
+    </itemizedlist>
    </sect3>
   </sect2>
  </sect1>

--- a/l10n/sles/zh-cn/xml/printing.xml
+++ b/l10n/sles/zh-cn/xml/printing.xml
@@ -6,8 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>打印</primary></indexterm>
+ </info>
  <para>
   <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> 支持使用多种类型的打印机进行打印，其中包括远程网络打印机。可以手动或使用 YaST 配置打印机。有关配置描述，请参见<xref linkend="sec-y2-hw-print"/>。启动和管理打印任务时既可以使用图形实用程序，也可以使用命令行实用程序。如果打印机未能按预期正常工作，请参见<xref linkend="sec-drucken-prob"/>。
  </para>
@@ -266,15 +265,7 @@ Resolution/Output Resolution: 150dpi 300dpi *600dpi</screen>
   </para>
  </sect1>
  <sect1 xml:id="sec-p-appl-commandline">
-  <title>从命令行打印</title><indexterm>
-
-  <primary>打印</primary>
-
-  <secondary>命令行</secondary></indexterm><indexterm>
-
-  <primary>命令</primary>
-
-  <secondary>lp</secondary></indexterm>
+  <title>从命令行打印</title>
 
   <para>
    要从命令行打印，请输入 <command>lp -d</command>
@@ -367,9 +358,7 @@ Resolution/Output Resolution: 150dpi 300dpi *600dpi</screen>
   </para>
 
   <sect2 xml:id="sec-drucken-gdi">
-   <title>打印机没有标准打印机语言支持</title><indexterm>
-   <primary>打印</primary>
-   <secondary> GDI 打印机</secondary></indexterm>
+   <title>打印机没有标准打印机语言支持</title>
    <para>
     这些打印机不支持任何常见的打印机语言，只能使用专门的专有控制系列来进行寻址。因此这些打印机只能用于制造商提供了驱动程序的操作系统版本。GDI 是 Microsoft* 为图形设备开发的编程接口。通常制造商只提供 Windows 的驱动程序，而因为 Windows 驱动程序使用 GDI 界面，所以这些打印机也称作 <emphasis>GDI 打印机</emphasis>。问题实际并不是出在编程接口上，而是因这些打印机只能通过相应打印机型号的专用打印机语言来寻址所造成。
    </para>
@@ -395,12 +384,7 @@ Resolution/Output Resolution: 150dpi 300dpi *600dpi</screen>
   </sect2>
 
   <sect2 xml:id="sec-drucken-prob-netconnect">
-   <title>网络打印机连接</title><indexterm>
-   <primary>打印</primary>
-   <secondary>网络</secondary></indexterm><indexterm>
-   <primary>打印</primary>
-   <secondary>查错</secondary>
-   <tertiary>网络</tertiary></indexterm>
+   <title>网络打印机连接</title>
    <para/>
    <variablelist>
     <varlistentry>

--- a/l10n/sles/zh-cn/xml/raid.xml
+++ b/l10n/sles/zh-cn/xml/raid.xml
@@ -7,19 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>YaST</primary>
-
- <secondary>RAID</secondary></indexterm><indexterm>
-
- <primary>RAID</primary>
-
- <secondary>YaST</secondary></indexterm><indexterm>
-
- <primary>软 RAID</primary>
-
- <see>RAID</see></indexterm>
+ </info>
 
  <para>
   本节介绍创建和配置各种类型的 RAID 所需执行的操作。<phrase os="sles">如果您需要有关 RAID 的背景信息，请参见<xref linkend="sec-raid-intro"/></phrase>。

--- a/l10n/sles/zh-cn/xml/suse_emacs.xml
+++ b/l10n/sles/zh-cn/xml/suse_emacs.xml
@@ -6,28 +6,19 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-Emacs" class="startofrange">
- <primary>Emacs</primary></indexterm><indexterm xml:id="idx-editors-Emacs" class="startofrange">
- <primary>编辑器</primary>
- <secondary>Emacs</secondary></indexterm>
+ </info>
  <para>
   GNU Emacs 是一个复杂的工作环境。下面几节介绍当启动 GNU Emacs 时处理的配置文件。有关详细信息，请参见 <link xlink:href="http://www.gnu.org/software/emacs/"/>。
  </para>
  <para>
   启动时，Emacs 会读取包含用户、系统管理员和经销商的设置的多个文件以进行自定义或预配置。初始化文件 <filename>~/.emacs</filename> 被安装到 <filename>/etc/skel</filename> 中各个用户的主目录中。<filename>.emacs</filename> 又会读取文件 <filename>/etc/skel/.gnu-emacs</filename>。要自定义程序，请（通过 <command>cp /etc/skel/.gnu-emacs ~/.gnu-emacs</command>）将 <filename>.gnu-emacs</filename> 复制到用户主目录并在那里进行所需的设置。
- </para><indexterm>
- <primary>配置文件</primary>
- <secondary>.emacs</secondary></indexterm><indexterm>
- <primary>Emacs</primary>
- <secondary>.emacs</secondary></indexterm>
+ </para>
  <para>
   <filename>.gnu-emacs</filename> 将文件 <filename>~/.gnu-emacs-custom</filename> 定义为 <literal>custom-file</literal>。如果用户通过 Emacs 中的 <literal>customize</literal> 选项进行设置，则这些设置将保存到 <filename>~/.gnu-emacs-custom</filename> 中。
  </para>
  <para>
   通过 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>，<systemitem class="resource">emacs</systemitem> 包将文件 <filename>site-start.el</filename> 安装在目录 <filename>/usr/share/emacs/site-lisp</filename> 中。文件 <filename>site-start.el</filename> 在初始化文件 <filename>~/.emacs</filename> 之前进行装载。除其他作用之外，<filename>site-start.el</filename> 确保自动装载通过 Emacs 扩充包分发的特殊配置文件（例如 <systemitem class="resource">psgml</systemitem>）。此类型的配置文件也位于 <filename>/usr/share/emacs/site-lisp</filename> 中，总是以 <filename>suse-start-</filename> 开头。本地系统管理员可以在 <filename>default.el</filename> 中指定整个系统范围的设置。
- </para><indexterm>
- <primary> Emacs</primary>
- <secondary> default.el</secondary></indexterm> 
+ </para>
  <para>
   <emphasis>初始化文件</emphasis>下的 EMACS 信息文件中提供了有关这些文件的更多信息：<literal>info:/emacs/InitFile</literal>。此位置还提供了有关如何禁止装载这些文件（如果需要）的信息。
  </para>
@@ -65,5 +56,5 @@
     如果需要，可安装众多附加产品包：<systemitem class="resource">emacs-auctex</systemitem> (LaTeX)、<systemitem class="resource">psgml</systemitem>（SGML 和 XML）、<systemitem class="resource">gnuserv</systemitem>（客户端和服务器操作）等。
    </para>
   </listitem>
- </itemizedlist><indexterm class="endofrange" startref="idx-Emacs"/><indexterm class="endofrange" startref="idx-editors-Emacs"/>
+ </itemizedlist>
 </sect2>

--- a/l10n/sles/zh-cn/xml/suse_kb.xml
+++ b/l10n/sles/zh-cn/xml/suse_kb.xml
@@ -7,15 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>键盘</primary>
-
- <secondary>布局</secondary></indexterm><indexterm>
-
- <primary>键盘</primary>
-
- <secondary>映射</secondary></indexterm>
+ </info>
 
  <para>
   为了标准化程序的键盘映射，对以下文件进行了更改：
@@ -30,51 +22,15 @@
 /etc/termcap
 /usr/share/terminfo/x/xterm
 /usr/share/X11/app-defaults/XTerm
-/usr/share/emacs/<replaceable>VERSION</replaceable>/site-lisp/term/*.el</screen><indexterm>
-
- <primary>配置文件</primary>
-
- <secondary>termcap</secondary></indexterm><indexterm>
-
- <primary>配置文件</primary>
-
- <secondary>inputrc</secondary></indexterm>
+/usr/share/emacs/<replaceable>VERSION</replaceable>/site-lisp/term/*.el</screen>
 
  <para>
   这些更改只影响使用 <command>terminfo</command> 项的应用程序或其配置文件被直接更改（<command>vi</command>、<command>less</command> 等）的应用程序。不是系统附带的应用程序应该根据这些默认设置进行调整。
- </para><indexterm>
-
- <primary>键盘</primary>
-
- <secondary>映射</secondary>
-
- <tertiary>组合</tertiary></indexterm><indexterm>
-
- <primary>键盘</primary>
-
- <secondary>映射</secondary>
-
- <tertiary>multikey</tertiary></indexterm>
+ </para>
 
  <para>
   在 X 下，可以如 <filename>/etc/X11/Xmodmap</filename> 中所说明的启用 Compose 键（多键）。
- </para><indexterm>
-
- <primary>键盘</primary>
-
- <secondary>X 键盘扩展</secondary></indexterm><indexterm>
-
- <primary>键盘</primary>
-
- <secondary>XKB</secondary></indexterm><indexterm>
-
- <primary>X 键盘扩展</primary>
-
- <see>键盘，XKB</see></indexterm><indexterm>
-
- <primary>XKB</primary>
-
- <see>键盘，XKB</see></indexterm>
+ </para>
 
  <para>
   可以通过“X 键盘扩展”(XKB) 进行进一步的设置。桌面环境 GNOME (gswitchit) 也使用此扩展。

--- a/l10n/sles/zh-cn/xml/suse_l10n.xml
+++ b/l10n/sles/zh-cn/xml/suse_l10n.xml
@@ -7,36 +7,19 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>系统</primary>
-
- <secondary>本地化</secondary></indexterm><indexterm>
-
- <primary>I18N</primary></indexterm><indexterm>
-
- <primary>L10N</primary></indexterm><indexterm>
-
- <primary>国际化</primary></indexterm><indexterm>
-
- <primary>本地化</primary></indexterm>
+ </info>
 
  <para>
   该系统在很大程度上实现了国际化，可修改以满足本地需要。国际化 (<emphasis>I18N</emphasis>) 允许特定的本地化 (<emphasis>L10N</emphasis>)。I18N 和 L10N 这两个缩写词使用原单词的第一个和最后一个字母，中间的数字表示省略的字母数。
  </para>
 
  <para>
-  设置是通过文件 <filename>/etc/sysconfig/language</filename> 中定义的 <systemitem>LC_ </systemitem>变量进行的。这不仅指<emphasis>本地语言支持</emphasis>，还指<emphasis>消息</emphasis>（语言）、<emphasis>字符集</emphasis>、<emphasis>排序顺序</emphasis>、<emphasis>时间和日期</emphasis>、<emphasis>数字</emphasis>和<emphasis>货币</emphasis>等类别。这些类别中的每一种都可以使用自己的变量直接定义，或使用 <filename>language</filename> 文件中的主变量间接定义（请参见 <command>locale</command> 手册页）。<indexterm>
-  <primary>配置文件</primary>
-  <secondary>语言</secondary>
-  </indexterm>
+  设置是通过文件 <filename>/etc/sysconfig/language</filename> 中定义的 <systemitem>LC_ </systemitem>变量进行的。这不仅指<emphasis>本地语言支持</emphasis>，还指<emphasis>消息</emphasis>（语言）、<emphasis>字符集</emphasis>、<emphasis>排序顺序</emphasis>、<emphasis>时间和日期</emphasis>、<emphasis>数字</emphasis>和<emphasis>货币</emphasis>等类别。这些类别中的每一种都可以使用自己的变量直接定义，或使用 <filename>language</filename> 文件中的主变量间接定义（请参见 <command>locale</command> 手册页）。
  </para>
 
  <variablelist>
   <varlistentry>
-   <term><systemitem>RC_LC_MESSAGES</systemitem>、<systemitem>RC_LC_CTYPE</systemitem>、<systemitem>RC_LC_COLLATE</systemitem>、<systemitem>RC_LC_TIME</systemitem>、<systemitem>RC_LC_NUMERIC</systemitem>、 <systemitem>RC_LC_MONETARY</systemitem><indexterm>
-    <primary>变量</primary>
-    <secondary>环境</secondary></indexterm> 
+   <term><systemitem>RC_LC_MESSAGES</systemitem>、<systemitem>RC_LC_CTYPE</systemitem>、<systemitem>RC_LC_COLLATE</systemitem>、<systemitem>RC_LC_TIME</systemitem>、<systemitem>RC_LC_NUMERIC</systemitem>、 <systemitem>RC_LC_MONETARY</systemitem> 
    </term>
    <listitem>
     <para>
@@ -110,9 +93,7 @@ localedef -i en_US -f UTF-8 en_US.UTF-8
    </varlistentry>
    <varlistentry>
     <term>
-<systemitem>LANG=en_US.ISO-8859-1</systemitem><indexterm>
-     <primary>编码</primary>
-     <secondary>ISO-8859-1</secondary></indexterm> 
+<systemitem>LANG=en_US.ISO-8859-1</systemitem> 
     </term>
     <listitem>
      <para>
@@ -147,16 +128,7 @@ localedef -i en_US -f UTF-8 en_US.UTF-8
    </listitem>
   </itemizedlist>
   <para>
-   这确保了对 <filename>/etc/sysconfig/language</filename> 所做的任何更改在下次登录到相应外壳时均可用，而无需手动将其激活。<indexterm>
-   <primary>配置文件</primary>
-   <secondary>语言</secondary>
-   </indexterm><indexterm>
-   <primary>配置文件</primary>
-   <secondary>配置文件</secondary>
-   </indexterm> <indexterm>
-   <primary> 配置文件</primary>
-   <secondary> /etc/profile.d/lang.sh</secondary>
-   </indexterm>
+   这确保了对 <filename>/etc/sysconfig/language</filename> 所做的任何更改在下次登录到相应外壳时均可用，而无需手动将其激活。 
   </para>
   <para>
    用户可以通过相应地编译他们的 <filename>~/.bashrc</filename> 覆盖系统默认值。例如，如果不想对程序讯息使用系统范围的 <literal>en_US</literal>，请加入 <systemitem>LC_MESSAGES=es_ES</systemitem>，这样讯息将以西班牙语显示。

--- a/l10n/sles/zh-cn/xml/suse_logfiles.xml
+++ b/l10n/sles/zh-cn/xml/suse_logfiles.xml
@@ -6,10 +6,8 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>日志文件</primary></indexterm><indexterm>
- <primary>logrotate</primary></indexterm>
+ </info>
  <para>
   多个系统服务（<emphasis>守护程序</emphasis>）以及内核本身会定期将系统状态和特定事件记录到日志文件中。这样，管理员可以定期检查系统在某一时刻的状态，识别错误或故障功能，并精确诊断它们。这些日志文件通常储存在 FHS 指定的 <filename>/var/log</filename> 中，文件大小每天都会增长。<systemitem>logrotate</systemitem> 包可以帮助控制这些文件的增长。有关详细信息，请参见<xref linkend="sec-tuning-logfiles-logrotate"/>。
- </para> 
+ </para>
 </sect2>

--- a/l10n/sles/zh-cn/xml/suse_vc.xml
+++ b/l10n/sles/zh-cn/xml/suse_vc.xml
@@ -7,24 +7,12 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>控制台</primary>
-
- <secondary>切换</secondary></indexterm>
+ </info>
 
  <para>
   Linux 是一个多用户和多任务的系统。即使是在独立计算机系统上也可以感受到这些功能的好处。在文本方式下，提供了 6 个虚拟控制台。可以使用 <keycombo> <keycap function="alt"/> <keycap>F1</keycap> </keycombo> 到 <keycombo> <keycap function="alt"/> <keycap>F6</keycap> </keycombo> 在这些控制台间切换。第 7 个控制台是为 X 保留的，而第 10 个控制台显示内核消息。
 
- </para><indexterm>
-
- <primary>控制台</primary>
-
- <secondary>指派</secondary></indexterm><indexterm>
-
- <primary>配置文件</primary>
-
-</indexterm>
+ </para>
 
  <para>
   要从 x 切换到控制台而不将其关闭，请使用 <keycombo>

--- a/l10n/sles/zh-cn/xml/sw_managing_commandline.xml
+++ b/l10n/sles/zh-cn/xml/sw_managing_commandline.xml
@@ -11,9 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary> 安装</primary>
- <secondary>软件</secondary></indexterm> 
+ </info>
  <xi:include href="zypper.xml"/>
  <xi:include href="rpm.xml"/>
 </chapter>

--- a/l10n/sles/zh-cn/xml/x86_inst_problem.xml
+++ b/l10n/sles/zh-cn/xml/x86_inst_problem.xml
@@ -7,9 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary> 问题解决</primary></indexterm> 
+ </info>
 
  <para>
   交付之前，<phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> 经过了大量的测试。尽管如此，在引导或安装期间还是会偶然发生问题。

--- a/l10n/sles/zh-cn/xml/yast2_gui.xml
+++ b/l10n/sles/zh-cn/xml/yast2_gui.xml
@@ -6,8 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-YaST-gui" class="startofrange">
- <primary>YaST</primary></indexterm>
+ </info>
  <para>
   YaST 是 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 的安装和配置工具。它具有图形界面，并且能够在安装期间和安装之后快速自定义系统。它可用于设置硬件、配置网络、系统服务和调整安全性设置。
  </para>

--- a/l10n/sles/zh-cn/xml/yast2_lang.xml
+++ b/l10n/sles/zh-cn/xml/yast2_lang.xml
@@ -6,14 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>系统</primary>
- <secondary>语言</secondary></indexterm><indexterm>
- <primary>YaST</primary>
- <secondary>语言</secondary></indexterm><indexterm>
- <primary>语言</primary></indexterm><indexterm>
- <primary>配置</primary>
- <secondary>语言</secondary></indexterm>
+ </info>
  <para>
   如果在其他国家/地区工作或必须在多语环境中工作，则需要设置计算机以支持该要求。<phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> 可以同时处理不同的<literal>区域设置</literal>。区域设置代表一组参数，这些参数定义在用户界面中反映的语言和国家/地区设置。
  </para>

--- a/l10n/sles/zh-cn/xml/yast2_ncurses.xml
+++ b/l10n/sles/zh-cn/xml/yast2_ncurses.xml
@@ -7,14 +7,10 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-YaST-text-mode" class="startofrange">
- <primary> YaST</primary>
- <secondary> 文本方式</secondary></indexterm> 
+ </info>
  <para>
   本章所针对的读者是在其系统上不运行 X 服务器而依赖于基于文本的安装工具的系统管理员和专家。它提供了与以文本方式启动和操作 YaST 有关的基本信息。
- </para><indexterm>
- <primary> YaST</primary>
- <secondary> ncurses</secondary></indexterm> 
+ </para>
  <para>
   文本模式的 YaST 使用 ncurses 库提供简单的伪图形用户界面。默认情况下已安装 ncurses 库。用于运行 YaST 的终端仿真器支持的最小大小为 80x25 个字符。
  </para>
@@ -245,11 +241,7 @@
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-yast-ncurses-commands">
-  <title>YaST 命令行选项</title><indexterm>
-
-  <primary> YaST</primary>
-
-  <secondary> 命令行</secondary></indexterm> 
+  <title>YaST 命令行选项</title>
 
   <para>
    除了文本模式界面以外，YaST 还提供了一个纯命令行界面。要获取 YaST 命令行选项列表，请输入：
@@ -258,10 +250,7 @@
 <screen>yast -h</screen>
 
   <sect2 xml:id="sec-yast-ncurses-modulaufruf">
-   <title>启动单个模块</title><indexterm>
-   <primary>YaST</primary>
-   <secondary>文本方式</secondary>
-   <tertiary>模块</tertiary></indexterm>
+   <title>启动单个模块</title>
    <para>
     为了节省时间，可以直接启动单个 YaST 模块。要启动模块，请输入：
    </para>
@@ -298,7 +287,7 @@
    <para>
     如果模块不提供命令行支持，将以文本方式启动，并显示以下消息：
    </para>
-<screen>This YaST module does not support the command line interface.</screen><indexterm class="endofrange" startref="idx-YaST-text-mode"/>
+<screen>This YaST module does not support the command line interface.</screen>
   </sect2>
  </sect1>
 </chapter>

--- a/l10n/sles/zh-cn/xml/yast2_sound.xml
+++ b/l10n/sles/zh-cn/xml/yast2_sound.xml
@@ -7,23 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>配置</primary>
-
- <secondary>声卡</secondary></indexterm><indexterm>
-
- <primary>YaST</primary>
-
- <secondary>声卡</secondary></indexterm><indexterm>
-
- <primary>声音</primary>
-
- <secondary>在 YaST 中配置</secondary></indexterm><indexterm>
-
- <primary>卡</primary>
-
- <secondary>声音</secondary></indexterm>
+ </info>
 
  <para>
   YaST 可以自动检测大多数声卡，并使用相应的值配置它们。要更改默认设置，或者需要设置不能自动配置的声卡，可以使用 YaST 声音模块。在其中，还可以设置附加声卡或切换它们的顺序。
@@ -167,13 +151,7 @@
   </step>
   <step>
    <para>
-    <indexterm>
-    <primary>声音</primary>
-    <secondary>字体</secondary>
-    </indexterm> <indexterm>
-    <primary>声音</primary>
-    <secondary>MIDI</secondary>
-    </indexterm>检测到支持的声卡时，您可以安装 SoundFonts 来播放 MIDI 文件：
+     检测到支持的声卡时，您可以安装 SoundFonts 来播放 MIDI 文件：
    </para>
    <substeps performance="required">
     <step>
@@ -203,12 +181,6 @@
  </procedure>
 
  <para>
-  单击<guimenu>确定</guimenu>并退出 YaST 声音模块时，将会保存所有声卡的音量和配置。混音器设置保存到文件 <filename>/etc/asound.state</filename> 中。ALSA 配置数据追加到文件 <filename>/etc/modprobe.d/sound</filename> 的末尾，并写入 <filename>/etc/sysconfig/sound</filename>。<indexterm>
-  <primary>配置文件</primary>
-  <secondary> asound.state</secondary>
-  </indexterm> <indexterm>
-  <primary>配置文件</primary>
-  <secondary> modprobe.d/sound</secondary>
-  </indexterm>
+  单击<guimenu>确定</guimenu>并退出 YaST 声音模块时，将会保存所有声卡的音量和配置。混音器设置保存到文件 <filename>/etc/asound.state</filename> 中。ALSA 配置数据追加到文件 <filename>/etc/modprobe.d/sound</filename> 的末尾，并写入 <filename>/etc/sysconfig/sound</filename>。 
  </para>
 </sect1>

--- a/l10n/sles/zh-cn/xml/yast2_sw.xml
+++ b/l10n/sles/zh-cn/xml/yast2_sw.xml
@@ -11,11 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>YaST</primary>
- <secondary>软件</secondary></indexterm><indexterm>
- <primary>配置</primary>
- <secondary>软件</secondary></indexterm>
+ </info>
  <para>
   使用 YaST 软件管理器更改系统的软件集合。此 YaST 模块有两种形式：一种是 X Window 的图形变体，另一种是命令行上使用的基于文本的变体。本章介绍图形变体 — 有关基于文本的 YaST 的细节，请参见<xref linkend="cha-yast-text"/>。
  </para>

--- a/l10n/sles/zh-cn/xml/yast2_userman.xml
+++ b/l10n/sles/zh-cn/xml/yast2_userman.xml
@@ -99,13 +99,7 @@
   <title>管理用户帐户</title>
 
   <para>
-   <indexterm>
-   <primary>用户</primary>
-   <secondary>创建帐户</secondary>
-   </indexterm> <indexterm>
-   <primary> 用户</primary>
-   <secondary>修改帐户</secondary>
-   </indexterm> YaST 可让您创建、修改、删除或临时禁用用户帐户。除非您是有经验的用户或管理员，否则不要修改用户帐户。
+     YaST 可让您创建、修改、删除或临时禁用用户帐户。除非您是有经验的用户或管理员，否则不要修改用户帐户。
   </para>
 
   <note>
@@ -189,11 +183,7 @@
   </tip>
 
   <procedure>
-   <title>禁用或删除用户帐户</title><indexterm>
-   <primary>用户</primary>
-   <secondary>禁用帐户</secondary></indexterm><indexterm>
-   <primary>用户</primary>
-   <secondary>删除帐户</secondary></indexterm>
+   <title>禁用或删除用户帐户</title>
    <step>
     <para>
      打开 YaST <guimenu>用户和组管理</guimenu>对话框并单击<guimenu>用户</guimenu>选项卡。
@@ -241,9 +231,7 @@
 
    </para>
    <procedure>
-    <title>配置口令设置</title><indexterm>
-    <primary>用户</primary>
-    <secondary>口令设置</secondary></indexterm>
+    <title>配置口令设置</title>
     <step>
      <para>
       打开 YaST <guimenu>用户和组管理</guimenu>对话框并选择<guimenu>用户</guimenu>选项卡。
@@ -298,11 +286,7 @@
   </sect2>
 
   <sect2 xml:id="sec-y2-userman-adv-crypto">
-   <title>管理加密的用户主目录</title><indexterm>
-   <primary>用户主目录</primary>
-   <secondary>加密</secondary></indexterm><indexterm>
-   <primary>用户</primary>
-   <secondary>加密的用户主目录</secondary></indexterm>
+   <title>管理加密的用户主目录</title>
    <para>
     要在失窃和硬盘被卸下的情况下保护用户主目录中的数据，可为用户创建加密的用户主目录。这些用户主目录是用 LUKS（Linux 统一密钥设置）加密的，这会为用户生成映像和映像密钥。映像密钥受用户的登录口令保护。用户登录系统时，会装入加密的用户主目录，且该用户可以使用内容。
    </para>
@@ -414,11 +398,7 @@
   </sect2>
 
   <sect2 xml:id="sec-y2-userman-adv-quota">
-   <title>管理定额</title><indexterm>
-   <primary>用户</primary>
-   <secondary>定额</secondary></indexterm><indexterm>
-   <primary>定额</primary>
-   <secondary>用户, 组</secondary></indexterm>
+   <title>管理定额</title>
    <para>
     为了防止系统容量在没有通知的情况下耗尽，系统管理员可以为用户或组设置定额。可以为一个或多个文件系统定义定额，该定额限制可使用的磁盘空间量和可在该处创建的 inode（索引节点）数。Inode 是文件系统上储存有关普通文件、目录或其他文件系统对象的基本信息的数据结构。其会储存文件系统对象的所有属性（如：用户和组所有权、读权限、写权限或执行权限），但不会储存文件名和内容。
    </para>
@@ -564,11 +544,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-y2-userman-defaults">
-  <title>更改本地用户的默认设置</title><indexterm>
-
-  <primary>用户</primary>
-
-  <secondary>默认设置</secondary></indexterm>
+  <title>更改本地用户的默认设置</title>
 
   <para>
    创建新的本地用户时，YaST 将使用几个默认设置。例如，这些设置包括用户所属的主组和次组或用户的用户主目录访问权限。您可以更改这些默认设置来满足要求：
@@ -616,10 +592,7 @@
   <title>将用户指派到组</title>
 
   <para>
-   <indexterm>
-   <primary>用户</primary>
-   <secondary>组指派</secondary>
-   </indexterm>根据可从<guimenu>用户和组管理</guimenu>对话框的<guimenu>新用户默认值</guimenu>选项卡中访问的默认设置，会将本地用户指派到若干个组中。通过以下内容可以了解到修改单个用户的组指派的方法。如需更改新用户的默认组指派，请参见<xref linkend="sec-y2-userman-defaults"/>。
+   根据可从<guimenu>用户和组管理</guimenu>对话框的<guimenu>新用户默认值</guimenu>选项卡中访问的默认设置，会将本地用户指派到若干个组中。通过以下内容可以了解到修改单个用户的组指派的方法。如需更改新用户的默认组指派，请参见<xref linkend="sec-y2-userman-defaults"/>。
   </para>
 
   <procedure>
@@ -660,19 +633,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-y2-userman-groups">
-  <title>管理组</title><indexterm>
-
-  <primary>组</primary>
-
-  <secondary>管理</secondary></indexterm><indexterm>
-
-  <primary>YaST</primary>
-
-  <secondary>组管理</secondary></indexterm><indexterm>
-
-  <primary>配置</primary>
-
-  <secondary>组</secondary></indexterm>
+  <title>管理组</title>
 
   <para>
    使用 YaST 还能轻松添加、修改或删除组。
@@ -744,11 +705,7 @@
   </para>
  </sect1>
  <sect1 xml:id="cha-y2-userman-authent">
-  <title>更改用户身份验证方法</title><indexterm>
-
-  <primary>用户</primary>
-
-  <secondary>身份验证</secondary></indexterm>
+  <title>更改用户身份验证方法</title>
 
   <para>
    如果计算机已连接到网络，您可以更改身份验证方法。下列选项可用：

--- a/l10n/sles/zh-cn/xml/yast2_you.xml
+++ b/l10n/sles/zh-cn/xml/yast2_you.xml
@@ -6,11 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>更新</primary>
- <secondary>联机</secondary></indexterm><indexterm>
- <primary>YaST</primary>
- <secondary>联机更新</secondary></indexterm>
+ </info>
  <para>
   SUSE 持续为您的产品提供软件安全更新。默认情况下，用更新小程序来保持您的系统是最新的。有关更新小程序的更多信息请参考<xref linkend="sec-updater"/>。本章介绍用于更新软件包的备用工具：YaST 联机更新。
  </para>

--- a/l10n/sles/zh-tw/xml/64bit_issues.xml
+++ b/l10n/sles/zh-tw/xml/64bit_issues.xml
@@ -6,8 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>64 位元 Linux</primary></indexterm> 
+ </info>
  <para>
   <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> 可用於<phrase os="sles">多種</phrase> 64 位元平台。但這並不表示所有包含的應用程式都已移植到 64 位元平台。<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 支援在 64 位元系統環境中使用 32 位元應用程式。本章簡略說明這項支援在 64 位元 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 平台上的執行方式。
  </para>
@@ -25,11 +24,7 @@
 
 
  <sect1 xml:id="sec-64bit-runt">
-  <title>執行期間支援</title><indexterm>
-
-  <primary> 64 位元 Linux</primary>
-
-  <secondary>執行期間支援</secondary></indexterm> 
+  <title>執行期間支援</title>
 
   <important>
    <title>不同應用程式版本之間的衝突</title>
@@ -58,11 +53,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-64bit-kernel">
-  <title>核心規格</title><indexterm>
-
-  <primary> 64 位元 Linux</primary>
-
-  <secondary>核心規格</secondary></indexterm> 
+  <title>核心規格</title>
 
   <para>
    適用於 AMD64/Intel 64<phrase os="sles">、IBM POWER 和 IBM Z</phrase> 的 64 位元核心提供 64 位元和 32 位元兩種核心 ABI (應用程式二進位介面)。後者與相對應 32 位元核心的 ABI 是相同的。這表示 32 位元應用程式可以用與 32 位元核心溝通相同的方式，來與 64 位元核心溝通。

--- a/l10n/sles/zh-tw/xml/aarch64_inst_problem.xml
+++ b/l10n/sles/zh-tw/xml/aarch64_inst_problem.xml
@@ -7,9 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary> 問題解決方案</primary></indexterm> 
+ </info>
 
  <para>
   出廠之前，<phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> 已經過大量的程式測試。如果忽略該處理，在開機或安裝期間會偶爾發生問題。

--- a/l10n/sles/zh-tw/xml/adm_shell.xml
+++ b/l10n/sles/zh-tw/xml/adm_shell.xml
@@ -13,10 +13,7 @@
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
-<indexterm>
- <primary>外圍程序</primary></indexterm><indexterm>
- <primary>Bash</primary>
- <see>外圍程序</see></indexterm>
+
  <sect1 xml:id="sec-adm-whatistheshell">
   <title>什麼是<quote>外圍程序</quote>？</title>
 
@@ -27,9 +24,7 @@
   </para>
 
   <sect2 xml:id="sec-adm-configfiles">
-   <title>瞭解 Bash 組態檔案</title><indexterm>
-   <primary>組態檔案</primary>
-   <see> Bash</see></indexterm>
+   <title>瞭解 Bash 組態檔案</title>
    <para>
     外圍程序可啟用為︰
    </para>
@@ -243,9 +238,7 @@
   <xi:include href="fs_structure_i.xml"/>
  </sect1>
  <sect1 xml:id="sec-adm-shellscripts">
-  <title>寫入外圍程序程序檔</title><indexterm>
-
-  <primary>外圍程序檔</primary></indexterm>
+  <title>寫入外圍程序程序檔</title>
 
   <para>
    使用外圍程序程序檔可以方便地完成各種任務︰收集資料、搜尋文字中的單字或片語，以及執行其他有用的操作。以下範例顯示了一個列印文字的小型外圍程序程序檔︰
@@ -259,9 +252,7 @@ echo "Hello World" <co xml:id="co-adm-shell-echo"/></screen>
    <calloutlist>
     <callout arearefs="co-adm-shell-shebang">
      <para>
-      第一行以 <emphasis>Shebang</emphasis> <indexterm>
-      <primary>Shebang</primary>
-      </indexterm> 字元 (<literal>#!</literal>) 開頭，指出此檔案為程序檔。程序檔透過 Shebang 後面指定的解譯器執行，在此例中為 <command>/bin/sh</command>。
+      第一行以 <emphasis>Shebang</emphasis>  字元 (<literal>#!</literal>) 開頭，指出此檔案為程序檔。程序檔透過 Shebang 後面指定的解譯器執行，在此例中為 <command>/bin/sh</command>。
      </para>
     </callout>
     <callout arearefs="co-adm-shell-comment">
@@ -411,9 +402,7 @@ echo "Hello World" <co xml:id="co-adm-shell-echo"/></screen>
 <screen>find / -name "foo*" 2&gt;/dev/null</screen>
  </sect1>
  <sect1 xml:id="sec-adm-alias">
-  <title>使用別名</title><indexterm>
-
-  <primary>aliases</primary></indexterm>
+  <title>使用別名</title>
 
   <para>
    別名為一或多條指令的簡短定義。別名的語法為︰

--- a/l10n/sles/zh-tw/xml/adm_support.xml
+++ b/l10n/sles/zh-tw/xml/adm_support.xml
@@ -22,9 +22,7 @@
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
-<indexterm>
- <primary>支援</primary></indexterm><indexterm>
- <primary>系統資訊</primary></indexterm>
+
  <sect1 xml:id="sec-admsupport-hostinfo">
   <title>顯示目前系統資訊</title>
 

--- a/l10n/sles/zh-tw/xml/apache2.xml
+++ b/l10n/sles/zh-tw/xml/apache2.xml
@@ -11,14 +11,9 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm class="startofrange" xml:id="idx-apache2">
- <primary> Apache</primary></indexterm> 
+ </info>
  <sect1 xml:id="sec-apache2-quickstart">
-  <title>快速入門</title><indexterm>
-
-  <primary> Apache</primary>
-
-  <secondary> 快速入門</secondary></indexterm> 
+  <title>快速入門</title>
 
   <para>
    本節中的說明可協助您快速設定和啟動 Apache。您必須登入為 <systemitem class="username">root</systemitem> 身分，才能安裝和設定 Apache。
@@ -54,9 +49,7 @@
   </sect2>
 
   <sect2 xml:id="sec-apache2-quickstart-installation">
-   <title>安裝</title><indexterm>
-   <primary> Apache</primary>
-   <secondary> 安裝</secondary></indexterm> 
+   <title>安裝</title>
    <para>
     <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 中的 Apache 預設不會安裝到系統。若要以可<quote>直接</quote>執行的預先定義標準組態進行安裝，請按照以下步驟操作︰
    </para>
@@ -129,11 +122,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-apache2-configuration">
-  <title>設定 Apache</title><indexterm>
-
-  <primary> Apache</primary>
-
-  <secondary> 設定</secondary></indexterm> 
+  <title>設定 Apache</title>
 
   <para>
    <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 提供了兩個組態選項︰
@@ -167,10 +156,7 @@
   </important>
 
   <sect2 xml:id="sec-apache2-configuration-manually-configfiles">
-   <title>Apache 組態檔案</title><indexterm>
-   <primary> Apache</primary>
-   <secondary> 設定</secondary>
-   <tertiary>檔案</tertiary></indexterm> 
+   <title>Apache 組態檔案</title>
    <para>
     本節提供 Apache 組態檔案的綜覽。如果使用 YaST 設定組態，則無需變更這些檔案。不過，如果您要在以後改為以手動方式設定組態，該資訊可能會對您有用。
    </para>
@@ -362,18 +348,12 @@
   </sect2>
 
   <sect2 xml:id="sec-apache2-configuration-manually">
-   <title>手動設定 Apache</title><indexterm class="startofrange" xml:id="idx-apache2-configuration-manually">
-   <primary> Apache</primary>
-   <secondary> 設定</secondary>
-   <tertiary>手動</tertiary></indexterm> 
+   <title>手動設定 Apache</title>
    <para>
     以手動方式設定 Apache 是指以 <systemitem class="username">root</systemitem> 使用者身分來編輯純文字組態檔案。
    </para>
    <sect3 xml:id="sec-apache2-configuration-manually-vhost">
-    <title>虛擬主機組態</title><indexterm>
-    <primary> Apache</primary>
-    <secondary> 設定</secondary>
-    <tertiary>虛擬主機</tertiary></indexterm> 
+    <title>虛擬主機組態</title>
     <para>
      <emphasis>「虛擬主機」</emphasis>一詞，是形容 Apache 從同一部實體機器提供多個通用資源識別字串 (URI，Universal Resource Identifier) 的能力。這是指同時由一部實體電腦的單一網頁伺服器來執行多個領域 (例如，www.example.com 和 www.example.net)。
     </para>
@@ -558,7 +538,7 @@ Allow from all</screen>
   Require all granted
   &lt;/Directory&gt;
 &lt;/VirtualHost&gt;</screen>
-     </example><indexterm class="endofrange" startref="idx-apache2-configuration-manually"/>
+     </example>
     </sect4>
    </sect3>
   </sect2>
@@ -570,15 +550,7 @@ Allow from all</screen>
 
  </sect1>
  <sect1 xml:id="sec-apache2-start-stop">
-  <title>啟動和停止 Apache</title><indexterm>
-
-  <primary>Apache</primary>
-
-  <secondary>啟動</secondary></indexterm><indexterm>
-
-  <primary>Apache</primary>
-
-  <secondary>停止</secondary></indexterm>
+  <title>啟動和停止 Apache</title>
 
   <remark>taroth 2014-02-11: @file-maintainer: please give the following a
  thorough check - so far I only replaced the rc* commands by the systemctl
@@ -707,11 +679,7 @@ Allow from all</screen>
   </tip>
  </sect1>
  <sect1 xml:id="sec-apache2-modules">
-  <title>安裝、啟用和設定模組</title><indexterm class="startofrange" xml:id="idx-apache2-modules">
-
-  <primary> Apache</primary>
-
-  <secondary> 模組</secondary></indexterm> 
+  <title>安裝、啟用和設定模組</title>
 
   <para>
    Apache 軟體採用了模組化設計︰除了部分核心任務，其餘所有功能皆由模組處理。這方面的發展很快，甚至連 HTTP 都是由模組 (<systemitem/>http_core) 處理。
@@ -761,10 +729,7 @@ Allow from all</screen>
   </variablelist>
 
   <sect2 xml:id="sec-apache2-modules-installing">
-   <title>模組安裝</title><indexterm>
-   <primary> Apache</primary>
-   <secondary> 模組</secondary>
-   <tertiary>安裝</tertiary></indexterm> 
+   <title>模組安裝</title>
    <para>
     如果您已依照<xref linkend="sec-apache2-quickstart-installation"/> 中所述完成預設安裝，則下列模組此時都已安裝︰所有基礎模組與延伸模組、多重處理模組 Prefork MPM 以及外部模組 <systemitem>mod_python</systemitem>。
    </para>
@@ -790,10 +755,7 @@ Allow from all</screen>
   </sect2>
 
   <sect2 xml:id="sec-apache2-modules-base-extension">
-   <title>基本和延伸模組</title><indexterm>
-   <primary> Apache</primary>
-   <secondary> 模組</secondary>
-   <tertiary> 適用的</tertiary></indexterm> 
+   <title>基本和延伸模組</title>
    <para>
     Apache 說明文件中詳細介紹了所有的基本模組和延伸模組。本文件只提供最重要模組的概要說明。如需關於每個模組的詳細資訊，請參閱 <link xlink:href="http://httpd.apache.org/docs/2.4/mod/">http://httpd.apache.org/docs/2.4/mod/</link>。
    </para>
@@ -1010,10 +972,7 @@ Allow from all</screen>
   </sect2>
 
   <sect2 xml:id="sec-apache2-modules-mpm">
-   <title>多重處理模組</title><indexterm>
-   <primary> Apache</primary>
-   <secondary> 模組</secondary>
-   <tertiary> 多重處理</tertiary></indexterm> 
+   <title>多重處理模組</title>
    <para>
     <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 提供了兩種不同的多重處理模組 (MPM) 來搭配 Apache 使用。
    </para>
@@ -1062,10 +1021,7 @@ Allow from all</screen>
   </sect2>
 
   <sect2 xml:id="sec-apache2-modules-external">
-   <title>外部模組</title><indexterm>
-   <primary> Apache</primary>
-   <secondary> 模組</secondary>
-   <tertiary> 外部</tertiary></indexterm> 
+   <title>外部模組</title>
    <para>
     此處提供了 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 隨附的所有外部模組的清單。在列出目錄中找出模組的說明文件。
    </para>
@@ -1157,10 +1113,7 @@ Allow from all</screen>
   </sect2>
 
   <sect2 xml:id="sec-apache2-modules-building-modules">
-   <title>編譯</title><indexterm>
-   <primary> Apache</primary>
-   <secondary> 模組</secondary>
-   <tertiary> 建立</tertiary></indexterm> 
+   <title>編譯</title>
    <para>
     Apache 允許進階使用者編寫自訂模組進行延伸。若要開發 Apache 模組或編譯協力廠商模組，除了相對應開發工具外，還需要套件 <systemitem>apache2-devel</systemitem>。<systemitem>apache2-devel</systemitem> 也包含了 <command>apxs2</command> 工具，這是在編譯 Apache 其他模組時，需要用到的工具。
    </para>
@@ -1194,15 +1147,11 @@ Allow from all</screen>
 apxs2 -cia <replaceable>MODULE</replaceable>.c</screen>
    <para>
     其中，<option>-c</option> 用於編譯模組，<option>-i</option> 用於安裝模組，<option>-a</option> 用於啟用模組。如需有關 <command>apxs2</command> 的其他選項資訊，請參閱 <systemitem>apxs2(1)</systemitem> man 頁面。
-   </para><indexterm class="endofrange" startref="idx-apache2-modules"/>
+   </para>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-apache2-cgi">
-  <title>啟用 CGI 程序檔</title><indexterm>
-
-  <primary> Apache</primary>
-
-  <secondary>CGI 程序檔</secondary></indexterm> 
+  <title>啟用 CGI 程序檔</title>
 
   <para>
    Apache 的通用閘道介面 (CGI) 可讓您使用程式或程序檔 (通常稱 CGI 程序檔) 建立動態內容。CGI 程序檔可以用任何程式設計語言來編寫。通常會使用類似 Perl 或 PHP 等程式檔設計語言。
@@ -1306,11 +1255,7 @@ apxs2 -cia <replaceable>MODULE</replaceable>.c</screen>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-apache2-ssl">
-  <title>設定提供 SSL 的安全網頁伺服器</title><indexterm class="startofrange" xml:id="idx-apache2-ssl">
-
-  <primary> Apache</primary>
-
-  <secondary>SSL</secondary></indexterm> 
+  <title>設定提供 SSL 的安全網頁伺服器</title>
 
   <para>
    如果 Web 伺服器和用戶端之間會傳輸信用卡資訊等敏感性資料，最好使用需經過驗證的安全加密連接。<systemitem>mod_ssl</systemitem> 會為用戶端和網頁伺服器之間的 HTTP 通訊，提供使用安全通訊端層 (Secure Sockets Layer, SSL)、以及傳輸層安全性 (Transport Layer Security, TLS) 通訊協定的強式加密。使用 SSL/TLS 時，Web 伺服器和用戶端之間會建立私人連接。如此便可確保資料完整性，使用戶端與伺服器可以彼此進行驗證。
@@ -1329,10 +1274,7 @@ apxs2 -cia <replaceable>MODULE</replaceable>.c</screen>
   </para>
 
   <sect2 xml:id="sec-apache2-ssl-certificate">
-   <title>建立 SSL 憑證</title><indexterm>
-   <primary> Apache</primary>
-   <secondary> SSL</secondary>
-   <tertiary> 建立 SSL 憑證</tertiary></indexterm> 
+   <title>建立 SSL 憑證</title>
    <para>
     您必須建立 SSL 證書，才能在 Web 伺服器上使用 SSL/TLS 功能。網頁伺服器和用戶端在彼此驗證時要用到這項證書，以便讓任一方可以清楚識別對方。為了確保證書的完整性，其必須由每位使用者信任的一方加以簽章。
    </para>
@@ -1537,10 +1479,7 @@ sudo cp new.cert.key /etc/apache2/ssl.key/server.key</screen>
   </sect2>
 
   <sect2 xml:id="sec-apache2-ssl-configuration">
-   <title>設定提供 SSL 的 Apache</title><indexterm>
-   <primary> Apache</primary>
-   <secondary> SSL</secondary>
-   <tertiary> 設定提供 SSL 的 Apache</tertiary></indexterm> 
+   <title>設定提供 SSL 的 Apache</title>
    <para>
     在網頁伺服器端上，SSL 和 TLS 要求的預設連接埠是 443。同時有傾聽連接埠 80 的<quote>一般</quote>Apache 和傾聽連接埠 443 之已啟用 SSL/TLS 的 Apache，並不會產生衝突。事實上，HTTP 和 HTTPS 可以執行相同的 Apache 例項。通常這時會使用不同的虛擬主機，將連接埠 80 和連接埠 443 的要求分派到不同的虛擬伺服器。
    </para>
@@ -1608,7 +1547,7 @@ sudo cp new.cert.key /etc/apache2/ssl.key/server.key</screen>
      <para>
       若在伺服器組態中設定為 <literal>off</literal>，則伺服器將表現為不支援 SNI。將由定義的<emphasis>第一個</emphasis>虛擬主機 (連接埠 443) 來處理 SSL 要求。
      </para>
-    </important><indexterm class="endofrange" startref="idx-apache2-ssl"/>
+    </important>
    </sect3>
   </sect2>
  </sect1>
@@ -1779,11 +1718,7 @@ apachectl start</screen>
   </itemizedlist>
  </sect1>
  <sect1 xml:id="sec-apache2-security">
-  <title>避免安全性問題</title><indexterm>
-
-  <primary> Apache</primary>
-
-  <secondary> 安全性</secondary></indexterm> 
+  <title>避免安全性問題</title>
 
   <para>
    向公用網際網路公開的網頁伺服器，必須持續進行系統管理。軟體和意外的錯誤設定不可避免地會產生安全性問題。下面是可用來處理這些問題的幾項秘訣。
@@ -1857,11 +1792,7 @@ apachectl start</screen>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-apache2-troubleeshooting">
-  <title>疑難排解</title><indexterm>
-
-  <primary> Apache</primary>
-
-  <secondary> 疑難排解</secondary></indexterm> 
+  <title>疑難排解</title>
 
   <para>
    如果 Apache 未啟動，網頁就無法存取，或者使用者無法連接網頁伺服器，因此找出問題的根源是很重要的工作。下面是您可在其中尋找錯誤原因的幾個常見位置以及需要檢查的重點︰
@@ -2010,7 +1941,7 @@ apachectl start</screen>
    <title>其他資源</title>
    <para>
     如果您在 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 中遇到與 Apache 有關的問題，請查閱「技術資訊搜尋」，網址為︰<link xlink:href="http://www.suse.com/support"/>。關於 Apache 的歷程，請參閱 <link xlink:href="http://httpd.apache.org/ABOUT_APACHE.html"/>。此頁面也說明稱伺服器為 Apache 的原因。
-   </para><indexterm class="endofrange" startref="idx-apache2"/>
+   </para>
   </sect2>
  </sect1>
 </chapter>

--- a/l10n/sles/zh-tw/xml/apache2_yast_i.xml
+++ b/l10n/sles/zh-tw/xml/apache2_yast_i.xml
@@ -6,10 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm class="startofrange" xml:id="idx-apache2-configuration-yast">
- <primary>Apache</primary>
- <secondary> 設定</secondary>
- <tertiary> YaST</tertiary></indexterm>
+ </info>
  <para>
   若要使用 YaST 來設定您的 Web 伺服器，請啟動 YaST 並選取<menuchoice> <guimenu>網路服務</guimenu> <guimenu>HTTP 伺服器</guimenu> </menuchoice>。第一次啟動模組時，<guimenu>HTTP 伺服器精靈</guimenu>會啟動，提示您對伺服器管理進行一些基本設定。完成精靈之後，每當您呼叫<guimenu>HTTP 伺服器</guimenu>模組時，<guimenu>HTTP 伺服器組態</guimenu>對話方塊就會啟動。如需詳細資訊，請參閱<xref linkend="sec-apache2-configuration-yast-server-configuration"/>。
  </para>
@@ -222,7 +219,7 @@
    <title>主要主機</title>
    <para>
     這些對話方塊相同於前面已介紹過的對話方塊。請參閱<xref linkend="sec-apache2-configuration-yast-wizard-default-host"/>和<xref linkend="sec-apache2-configuration-yast-wizard-virtual-hosts"/>。
-   </para><indexterm class="endofrange" startref="idx-apache2-configuration-yast"/>
+   </para>
   </sect4>
  </sect3>
 </sect2>

--- a/l10n/sles/zh-tw/xml/apps_brasero.xml
+++ b/l10n/sles/zh-tw/xml/apps_brasero.xml
@@ -15,26 +15,9 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-brasero" class="startofrange">
- <primary> Brasero</primary></indexterm> 
+ </info>
  <sect1 xml:id="sec-brasero-creating">
-  <title>建立多區段的資料 CD 或 DVD</title><indexterm>
-
-  <primary>CD</primary>
-
-  <secondary>建立</secondary>
-
-  <tertiary>資料</tertiary></indexterm><indexterm>
-
-  <primary>K3b</primary>
-
-  <secondary>資料 CD</secondary></indexterm><indexterm>
-
-  <primary>DVD</primary>
-
-  <secondary>建立</secondary>
-
-  <tertiary>資料</tertiary></indexterm>
+  <title>建立多區段的資料 CD 或 DVD</title>
 
   <para>
    第一次啟動 Brasero 後，主視窗的外觀如<xref linkend="fig-brasero-main" xrefstyle="select:label nopage"/> 中所示。
@@ -116,17 +99,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-brasero-creatingaudiocd">
-  <title>建立音樂 CD</title><indexterm>
-
-  <primary>CD</primary>
-
-  <secondary>建立</secondary>
-
-  <tertiary>音訊</tertiary></indexterm><indexterm>
-
-  <primary>Brasero</primary>
-
-  <secondary>音訊 CD</secondary></indexterm> 
+  <title>建立音樂 CD</title>
 
   <para>
    建立音樂 CD 與建立資料 CD 並無很大差別。請執行下列步驟︰
@@ -168,19 +141,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-brasero-copying">
-  <title>複製 CD 或 DVD</title><indexterm>
-
-  <primary>CD</primary>
-
-  <secondary>複製</secondary></indexterm><indexterm>
-
-  <primary>Brasero</primary>
-
-  <secondary>複製 CD</secondary></indexterm><indexterm>
-
-  <primary>DVD</primary>
-
-  <secondary>複製</secondary></indexterm>
+  <title>複製 CD 或 DVD</title>
 
   <para>
    若要複製 CD 或 DVD，請按照下列步驟進行︰
@@ -216,15 +177,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-gnome-writingiso">
-  <title>燒錄 ISO 影像</title><indexterm>
-
-  <primary>CD</primary>
-
-  <secondary> ISO 影像</secondary></indexterm><indexterm>
-
-  <primary> DVD</primary>
-
-  <secondary> ISO 影像</secondary></indexterm>
+  <title>燒錄 ISO 影像</title>
 
   <para>
    如果已有 ISO 影像，請按一下<guimenu>燒錄影像</guimenu>或移至<menuchoice> <guimenu>專案</guimenu> <guimenu>新的專案</guimenu>
@@ -232,11 +185,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-brasero-multisession">
-  <title>建立多區段 CD 或 DVD</title><indexterm>
-
-  <primary>CD</primary>
-
-  <secondary>多區段</secondary></indexterm>
+  <title>建立多區段 CD 或 DVD</title>
 
   <para>
    多工作業光碟適用於多個燒錄作業進行資料寫入的工作。例如，在寫入比媒體小很多的備份資料時，這種多工作業就很有用。您可以在每個寫入區段加入其他的備份檔案。值得一提的是，這種燒錄作業並不限於資料 CD 或 DVD。您也可以在多工作業光碟中加入音訊燒錄作業。
@@ -274,6 +223,6 @@
 
   <para>
    如需 Brasero 的詳細資訊，請造訪 <link xlink:href="https://wiki.gnome.org/Apps/Brasero"/>。
-  </para><indexterm class="endofrange" startref="idx-brasero"/>
+  </para>
  </sect1>
 </chapter>

--- a/l10n/sles/zh-tw/xml/apps_ekiga.xml
+++ b/l10n/sles/zh-tw/xml/apps_ekiga.xml
@@ -11,12 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-voip" class="startofrange">
- <primary>VoIP</primary></indexterm><indexterm>
- <primary>應用程式</primary>
- <secondary>網路</secondary>
- <tertiary>Ekiga</tertiary></indexterm><indexterm xml:id="idx-ekiga" class="startofrange">
- <primary>Ekiga</primary></indexterm>
+ </info>
  <note>
   <title>Ekiga 可能未安裝</title>
   <para>
@@ -387,11 +382,7 @@
   </table>
  </sect1>
  <sect1 xml:id="sec-ekiga-firstcall">
-  <title>進行通話</title><indexterm>
-
-  <primary> Ekiga</primary>
-
-  <secondary> 呼叫</secondary></indexterm> 
+  <title>進行通話</title>
 
   <para>
    正確設定 Ekiga 後，即可輕鬆撥打電話。
@@ -531,8 +522,8 @@
   </para>
 
   <para>
-   若要安裝私人電話網路，您可能需要瞭解 <literal>PBX</literal> 軟體 Asterisk <link xlink:href="http://www.asterisk.org/"/>。相關資訊請造訪 <link xlink:href="http://www.voip-info.org/wiki-Asterisk"/>。<indexterm startref="idx-ekiga" class="endofrange"/>
-   <indexterm startref="idx-voip" class="endofrange"/> 
+   若要安裝私人電話網路，您可能需要瞭解 <literal>PBX</literal> 軟體 Asterisk <link xlink:href="http://www.asterisk.org/"/>。相關資訊請造訪 <link xlink:href="http://www.voip-info.org/wiki-Asterisk"/>。
+    
   </para>
  </sect1>
 </chapter>

--- a/l10n/sles/zh-tw/xml/apps_firefox.xml
+++ b/l10n/sles/zh-tw/xml/apps_firefox.xml
@@ -11,13 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm class="startofrange" xml:id="idx-firefox">
- <primary>Firefox</primary></indexterm><indexterm class="startofrange" xml:id="idx-browsers-firefox">
- <primary>網頁瀏覽器</primary>
- <secondary>Firefox</secondary></indexterm><indexterm>
- <primary>應用程式</primary>
- <secondary>網路</secondary>
- <tertiary>Firefox</tertiary></indexterm>
+ </info>
  <sect1 xml:id="sec-firefox-start">
   <title>啟動 Firefox</title>
 
@@ -27,11 +21,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-firefox-navigating">
-  <title>瀏覽網站</title><indexterm>
-
-  <primary> Firefox</primary>
-
-  <secondary> 瀏覽</secondary></indexterm> 
+  <title>瀏覽網站</title>
 
   <para>
    Firefox 的外觀與其他瀏覽器相似。如<xref linkend="fig-firefox-main"/>所示。視窗的頂部有一個用於輸入網址的網址列，以及搜尋列。書籤工具列中的書籤也可用於快速存取。如需各種 Firefox 功能的詳細資訊，請使用選單列中的<guimenu>說明</guimenu>選單。
@@ -72,9 +62,7 @@
   </figure>
 
   <sect2 xml:id="sec-firefox-locationbar">
-   <title>網址列</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> 網址列</secondary></indexterm> 
+   <title>網址列</title>
    <para>
     在網址列中輸入時，會開啟自動填寫下拉式方塊。其中會顯示包含您所輸入字元的所有先前網址和書籤。相符的詞語將以粗體反白顯示。最近的且造訪最頻繁的項目會首先列出。
    </para>
@@ -87,9 +75,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-zoom">
-   <title>縮放</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> 縮放</secondary></indexterm> 
+   <title>縮放</title>
    <para>
     Firefox 提供兩種縮放選項︰頁面縮放 (預設) 與文字縮放。頁面縮放功能可放大整個頁面，頁面的所有元素 (包括圖形) 都會同等程度的擴大，而文字縮放只會變更文字大小。
    </para>
@@ -102,11 +88,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-tabbedbrowsing">
-   <title>分頁式瀏覽</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary>分頁</secondary></indexterm><indexterm>
-   <primary>Firefox</primary>
-   <secondary>分頁式瀏覽</secondary></indexterm>
+   <title>分頁式瀏覽</title>
    <para>
     使用分頁式瀏覽可在單一視窗中載入多個網站。若要在使用的頁面之間切換，請使用視窗頂部的分頁。如果您經常一次使用一個以上的網頁，分頁式瀏覽可讓您更方便地在網頁間切換。
    </para>
@@ -153,9 +135,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-sidebar">
-   <title>使用提要欄位</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> 提要欄位</secondary></indexterm> 
+   <title>使用提要欄位</title>
    <para>
     使用瀏覽器視窗左面的側邊欄可以檢視書籤或瀏覽歷史。延伸程式可能也會加入新的使用方式來使用提要欄位。若要顯示側邊欄，請從選單列中選取<menuchoice> <guimenu>檢視</guimenu>
     <guimenu>側邊欄</guimenu> </menuchoice>，然後選取所需的內容。
@@ -170,13 +150,7 @@
   </para>
 
   <sect2 xml:id="sec-firefox-searchengine">
-   <title>在網路上尋找資訊</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary>搜尋工具</secondary></indexterm><indexterm>
-   <primary> Firefox</primary>
-   <secondary>搜尋列</secondary></indexterm><indexterm>
-   <primary>Firefox</primary>
-   <secondary>網路搜尋</secondary></indexterm>
+   <title>在網路上尋找資訊</title>
    <para>
     Firefox 提供了一個搜尋列，可以存取各種引擎，例如，Google、Yahoo 或 Amazon。例如，如果您想使用目前的引擎尋找 SUSE 的相關資訊，請按一下搜尋列並輸入 <literal>SUSE</literal>，然後按 <keycap function="enter"/>。結果將顯示在視窗中。
    </para>
@@ -231,9 +205,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-searchengine-smartkeywords">
-    <title>新增關鍵字至線上搜尋</title><indexterm>
-    <primary>Firefox</primary>
-    <secondary> 關鍵字</secondary></indexterm>
+    <title>新增關鍵字至線上搜尋</title>
     <para>
      Firefox 可讓您定義自己的<emphasis>關鍵字</emphasis>，那是一種縮寫，可當成特定搜索引擎的 URL 捷徑。例如，若您已將 <literal>ws</literal> 定義為 Wikipedia 搜尋的關鍵字，便可在網址列中輸入 <literal>ws <replaceable>搜尋詞彙</replaceable></literal>以在 Wikipedia 中搜尋<replaceable>搜尋詞彙</replaceable>。
     </para>
@@ -275,26 +247,18 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-findinfo-page">
-   <title>在目前的頁面中搜尋</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> 尋找頁面</secondary></indexterm> 
+   <title>在目前的頁面中搜尋</title>
    <para>
     若要在網頁內搜尋，請在選單列中按一下<menuchoice>
     <guimenu>編輯</guimenu> <guimenu>尋找</guimenu> </menuchoice>，或按 <keycombo> <keycap function="control"/> <keycap>F</keycap> </keycombo>。尋找列便會開啟。它通常顯示在視窗的底部。在文字方塊中輸入查詢。當您輸入時，Firefox 會找到此片語出現的第一個位置。您可以按 <keycap>F3</keycap> 或尋找列中的<guimenu>下一個</guimenu>按鈕來尋找這個字詞的其他出現點。按一下<guimenu>全部高亮度標示</guimenu>按鈕將高亮度標示片語所有出現的位置。核取<guimenu>符合大小寫</guimenu>選項會使查詢區分大小寫。
-   </para><indexterm>
-   <primary> Firefox</primary>
-   <secondary> 快速尋找</secondary></indexterm> 
+   </para>
    <para>
     另外，Firefox 還提供了兩個快速尋找選項。在網頁內的任意位置上按一下以開始搜尋，然後輸入 <keycap>/</keycap> 鍵，並在其後緊跟搜尋詞彙。當您輸入時，搜尋詞彙出現的第一個位置將會高亮度標示。使用 <keycap>F3</keycap> 可以尋找下一個出現的位置。也可將快速尋找的範圍限定為僅針對連結。輸入 <keycap>'</keycap> 鍵便可使用此搜尋選項。
    </para>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-firefox-bookmarks">
-  <title>管理書籤</title><indexterm>
-
-  <primary> Firefox</primary>
-
-  <secondary> 書籤</secondary></indexterm> 
+  <title>管理書籤</title>
 
   <para>
    書籤是提供儲存我的最愛網站連結的便捷方法。Firefox 不但讓您只按一下滑鼠就能輕輕鬆鬆新增新的書籤，還提供了多種管理大量書籤收藏的方法。您可以將書籤排序成資料夾，使用標籤將其分類，或者使用智慧型書籤資料夾對其進行過濾。
@@ -313,13 +277,7 @@
   </para>
 
   <sect2 xml:id="sec-firefox-bookmarks-organise">
-   <title>組織書籤</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary>書籤</secondary>
-   <tertiary>管理</tertiary></indexterm><indexterm>
-   <primary>Firefox</primary>
-   <secondary>書籤</secondary>
-   <tertiary>收藏庫</tertiary></indexterm>
+   <title>組織書籤</title>
    <para>
     <guimenu>收藏庫</guimenu>可用來管理每個書籤的屬性 (名稱與位址的位置) 以及依資料夾與區段整理書籤。它和 <xref linkend="fig-firefox-library"/> 類似。
    </para>
@@ -400,10 +358,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-tags">
-   <title>標籤</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> 書籤</secondary>
-   <tertiary> 標籤</tertiary></indexterm> 
+   <title>標籤</title>
    <para>
     標籤提供了一種便捷的方法，讓您將一個書籤歸入數個類別。您在為書籤指定標籤時可以使用儘可能多的詞彙。例如，若要存取所有指定了 <literal>suse</literal> 標籤的網站，請在網址列中輸入 <literal>suse</literal>。對於每個標籤，將在收藏庫的<systemitem>最近使用的標籤</systemitem>資料夾中自動建立一個項目。將標籤的項目拖放到書籤工具列便可輕易存取該項目。
    </para>
@@ -413,13 +368,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-imexport">
-   <title>匯入及匯出書籤</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary>書籤</secondary>
-   <tertiary>匯入</tertiary></indexterm><indexterm>
-   <primary>Firefox</primary>
-   <secondary>書籤</secondary>
-   <tertiary>匯出</tertiary></indexterm>
+   <title>匯入及匯出書籤</title>
 
    <para>
     若要從其他瀏覽器或 HTML 格式的檔案匯入書籤，可在選單列中選取<menuchoice>
@@ -436,10 +385,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-live">
-   <title>即時書籤</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> 書籤</secondary>
-   <tertiary> 即時書籤</tertiary></indexterm> 
+   <title>即時書籤</title>
    <para>
     即時書籤可在書籤選單中顯示標題，並讓您隨時得知最新消息。這可讓您快速瀏覽喜歡的站台，以節省時間。即時書籤會自動更新。許多站點和部落格都支援此格式。
    </para>
@@ -450,20 +396,14 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-smart">
-   <title>智慧型書籤資料夾</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> 書籤</secondary>
-   <tertiary> 智慧型書籤</tertiary></indexterm> 
+   <title>智慧型書籤資料夾</title>
    <para>
     智慧型書籤資料夾是可動態更新的虛擬書籤資料夾。有三個智慧型書籤資料夾︰<guimenu>瀏覽最多</guimenu>連結位於書籤工具列。<guimenu>最近使用的書籤</guimenu>連結和<guimenu>最近使用的標籤</guimenu>位於書籤選單中。
    </para>
   </sect2>
 
   <sect2 xml:id="sec-firefox-bookmarks-toolbar">
-   <title>書籤工具列</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> 書籤</secondary>
-   <tertiary> 工具列</tertiary></indexterm> 
+   <title>書籤工具列</title>
    <para>
     「<literal>書籤工具列</literal>」顯示在網址列的下方，可讓您快速存取書籤。您也可以直接新增、組織和編輯書籤。依預設，「<literal>書籤工具列</literal>」中將填入位於多個資料夾中預先定義的書籤集 (請參閱<xref linkend="fig-firefox-main"/>)。
    </para>
@@ -476,15 +416,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-firefox-downloadmanager">
-  <title>使用下載管理員</title><indexterm>
-
-  <primary> Firefox</primary>
-
-  <secondary>下載管理員</secondary></indexterm><indexterm>
-
-  <primary>下載管理員</primary>
-
-  <secondary>Firefox </secondary></indexterm>
+  <title>使用下載管理員</title>
 
   <para>
    您可以使用下載管理員來追蹤您目前和先前下載的項目。若要啟動下載管理員，請在選單列中，按一下<menuchoice>
@@ -504,20 +436,14 @@
   </tip>
  </sect1>
  <sect1 xml:id="sec-firefox-security">
-  <title>安全性</title><indexterm>
-
-  <primary> Firefox</primary>
-
-  <secondary> 安全</secondary></indexterm> 
+  <title>安全性</title>
 
   <para>
    瀏覽網際網路的風險日益增高，因此，Firefox 提供了各種方法以使瀏覽更加安全。它會自動檢查您是否正在嘗試存取包含有害軟體 (間諜軟體) 或竊取敏感性資料 (網路釣魚) 的網站，並會阻止您進入這些網站。即時網站 ID 可讓您輕鬆檢查網站的合法性，而密碼管理員與彈出型視窗封鎖程式則提供了額外的安全保護。私密瀏覽讓您在暢游網際網路的同時不在電腦上留下資料。
   </para>
 
   <sect2 xml:id="sec-firefox-security-instant-id">
-   <title>即時網站 ID</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> 網站身分識別</secondary></indexterm> 
+   <title>即時網站 ID</title>
    <para>
     Firefox 可讓您快速檢查網頁的身分識別。網址列中地址旁邊的圖示指示可以使用哪些身分資訊，以及通訊是否已加密︰
    </para>
@@ -630,11 +556,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-firefox-customizing">
-  <title>自訂 Firefox</title><indexterm>
-
-  <primary> Firefox</primary>
-
-  <secondary> 設定</secondary></indexterm> 
+  <title>自訂 Firefox</title>
 
   <para>
    Firefox 的自訂彈性很高。
@@ -663,9 +585,7 @@
   </para>
 
   <sect2 xml:id="sec-firefox-preferences">
-   <title>選項</title><indexterm>
-   <primary> Firefox</primary>
-   <secondary> 選項</secondary></indexterm> 
+   <title>選項</title>
    <para>
     Firefox 提供許多組態選項。在選單列中選擇<menuchoice> <guimenu>編輯</guimenu>
     <guimenu>選項</guimenu> </menuchoice>即可使用這些選項。線上說明中對每個選項都做了詳細描述，您可以在對話方塊中按一下問號來存取線上說明。
@@ -682,9 +602,7 @@
     </mediaobject>
    </figure>
    <sect3 xml:id="sec-firefox-preferences-sessions">
-    <title>工作階段管理</title><indexterm>
-    <primary> Firefox</primary>
-    <secondary> 工作階段管理</secondary></indexterm> 
+    <title>工作階段管理</title>
     <para>
      依預設，Firefox 只會在當機後或在安裝擴充套件而引起的重新啟動之後，才會自還原您的工作階段 (視窗和分頁)。但是，也可以將 Firefox 設定為在每次啟動時還原工作階段︰如<xref linkend="sec-firefox-preferences"/>中所述開啟「選項」對話方塊，然後移至<guimenu>一般</guimenu>類別。將<guimenu>當 Firefox 啟動時:</guimenu> 選項設定為<guimenu>顯示上次瀏覽的視窗和分頁</guimenu>。
     </para>
@@ -695,17 +613,13 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-preferences-language">
-    <title>網站的語言優先設定</title><indexterm>
-    <primary> Firefox</primary>
-    <secondary> 語言</secondary></indexterm> 
+    <title>網站的語言優先設定</title>
     <para>
      當您向 Web 伺服器傳送請求時，瀏覽器始終會傳送使用者所偏好之語言的資訊。支援多種語言並設定為分析此語言參數的網站將以瀏覽器請求的語言顯示頁面。在 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 中，偏好語言預先設定為使用與桌面相同的語言。若要變更此設定，請依<xref linkend="sec-firefox-preferences"/>中所述開啟<guimenu>選項</guimenu>視窗，移至<guimenu>內容</guimenu>類別，並<guimenu>選擇</guimenu>您的偏好語言。
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-preferences-spelling">
-    <title>拚字檢查</title><indexterm>
-    <primary> Firefox</primary>
-    <secondary> 拼字檢查</secondary></indexterm> 
+    <title>拚字檢查</title>
     <para>
      Firefox 預設會於您在多行文字方塊中輸入時對輸入的內容進行拼字檢查。拼錯的字會加上紅色底線。若要校正單字，請在其上按一下滑鼠右鍵，然後從內容選單中選取正確的拼字。若該單字正確，也可以將其新增至字典。
     </para>
@@ -716,13 +630,7 @@
   </sect2>
 
   <sect2 xml:id="sec-firefox-extensions">
-   <title>附加元件</title><indexterm>
-   <primary>Firefox</primary>
-   <secondary>附加元件</secondary></indexterm><indexterm>
-   <primary>Firefox</primary>
-   <secondary>擴充套件</secondary></indexterm><indexterm>
-   <primary>Firefox</primary>
-   <secondary>佈景主題</secondary></indexterm>
+   <title>附加元件</title>
    <para>
     擴充套件可讓您根據自己的需求個人化 Firefox。使用擴充套件您可以變更 Firefox 的外觀、增強現有功能，以及新增功能。例如，擴充套件可以增強下載管理員功能，顯示天氣或控制 Web 音樂播放器。其他擴充套件可以阻擋廣告或程序檔等內容，為 Web 開發人員提供協助或提高安全性。
    </para>
@@ -733,10 +641,7 @@
     如果您不喜歡 Firefox 的標準外觀，請安裝新的<emphasis>主題</emphasis>。佈景主題只會改變瀏覽器的外觀，不會改變功能。
    </para>
    <sect3 xml:id="sec-firefox-extensions-install">
-    <title>安裝附加元件</title><indexterm>
-    <primary> Firefox</primary>
-    <secondary> 附加元件</secondary>
-    <tertiary> 安裝</tertiary></indexterm> 
+    <title>安裝附加元件</title>
     <para>
      若要新增擴充套件或佈景主題，請在選單列中使用<menuchoice>
      <guimenu>工具</guimenu> <guimenu>附加元件</guimenu> </menuchoice>啟動附加元件管理員。它會開啟到<guimenu>取得元件</guimenu>分頁中，顯示精選附加元件或上次的搜尋結果以供您選擇。
@@ -761,10 +666,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-firefox-extensions-manage">
-    <title>管理附加元件</title><indexterm>
-    <primary> Firefox</primary>
-    <secondary> 附加元件</secondary>
-    <tertiary> 管理</tertiary></indexterm> 
+    <title>管理附加元件</title>
     <para>
      附加產品管理員還可以提供管理延伸、主題與外掛程式的便捷介面。您可以啟用、停用或移除<guimenu>擴充套件</guimenu>。若擴充套件屬於可設定套件，您可透過<guimenu>選項</guimenu>按鈕存取其組態選項。在<guimenu>外觀設定</guimenu>索引標籤中，您可以<guimenu>解除安裝</guimenu>佈景主題，或對其他佈景主題按一下<guimenu>啟用</guimenu>來啟用該佈景主題。待處理的擴充套件和佈景主題安裝也會列出。選取<guimenu>取消</guimenu>可停止安裝。雖然您無法以使用者身分安裝<guimenu>外掛程式</guimenu>，但可以使用附加元件管理員將其停用或啟用。
     </para>
@@ -777,15 +679,7 @@
 
  </sect1>
  <sect1 xml:id="sec-firefox-printing">
-  <title>從 Firefox 中列印</title><indexterm>
-
-  <primary>Firefox</primary>
-
-  <secondary>列印</secondary></indexterm><indexterm>
-
-  <primary>列印</primary>
-
-  <secondary>Firefox</secondary></indexterm>
+  <title>從 Firefox 中列印</title>
 
   <para>
    在真正列印網頁之前，可以使用預覽列印功能來控制列印頁面的外觀。在選單列中，選擇<menuchoice> <guimenu>檔案</guimenu> <guimenu>預覽列印</guimenu>
@@ -821,6 +715,6 @@
    </member>
    <member><emphasis>鍵盤捷徑</emphasis>︰<link xlink:href="http://support.mozilla.org/kb/Keyboard+shortcuts"/>
    </member>
-  </simplelist><indexterm startref="idx-firefox" class="endofrange"/><indexterm class="endofrange" startref="idx-browsers-firefox"/>
+  </simplelist>
  </sect1>
 </chapter>

--- a/l10n/sles/zh-tw/xml/apps_gimp.xml
+++ b/l10n/sles/zh-tw/xml/apps_gimp.xml
@@ -11,26 +11,12 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-gimp" class="startofrange">
- <primary>GIMP</primary></indexterm><indexterm xml:id="idx-graphics-editing" class="startofrange">
- <primary>繪圖</primary>
- <secondary>編輯</secondary></indexterm><indexterm>
- <primary>應用程式</primary>
- <secondary>繪圖</secondary>
- <tertiary>GIMP</tertiary></indexterm>
+ </info>
  <para>
   GIMP 是非常複雜的程式。本章僅討論小範圍的功能、工具及選單項目。請參閱<xref linkend="sec-gimp-moreinfo"/>，得知可以找到更多有關此程式資訊的地方。
  </para>
  <sect1 xml:id="sec-gimp-graphics">
-  <title>繪圖格式</title><indexterm>
-
-  <primary>繪圖</primary>
-
-  <secondary>點陣圖形</secondary></indexterm><indexterm>
-
-  <primary>繪圖</primary>
-
-  <secondary>向量圖形</secondary></indexterm>
+  <title>繪圖格式</title>
 
   <para>
    主要有兩種類型的數位圖形︰點陣圖形和向量圖形。GIMP 專用於處理點陣圖形，這是數位相片或掃描影像的最常用格式。
@@ -87,11 +73,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-gimp-starting">
-  <title>啟動 GIMP</title><indexterm>
-
-  <primary>GIMP</primary>
-
-  <secondary>啟動</secondary></indexterm>
+  <title>啟動 GIMP</title>
 
   <para>
    要啟動 GIMP，請選取<menuchoice><guimenu>應用程式</guimenu>
@@ -129,10 +111,7 @@
     <guimenu>檔案</guimenu>選單提供標準檔案操作，如<guimenu>新增</guimenu>、<guimenu>開啟</guimenu>、<guimenu>儲存</guimenu>、<guimenu>列印</guimenu>和<guimenu>關閉</guimenu>。按一下<guimenu>結束</guimenu>可結束應用程式。
    </para>
    <para>
-    <indexterm>
-    <primary>GIMP</primary>
-    <secondary>檢視</secondary>
-    </indexterm>利用<guimenu>檢視</guimenu>選單中的項目，控制影像及影像視窗的顯示。<guimenu>新增檢視</guimenu> 會開啟目前影像的第二個顯示視窗。在某個檢視中進行的變更會反映在該影像的所有其他檢視中。對於放大要操作的局部影像，同時在另一個檢視中查看完整影像，替代檢視是非常有用的。使用 <guimenu>縮放</guimenu> 來調整目前視窗的放大倍率。當選取<guimenu>依影像調整視窗大小</guimenu>時，影像視窗就會調整大小以恰好容納目前的影像。
+    利用<guimenu>檢視</guimenu>選單中的項目，控制影像及影像視窗的顯示。<guimenu>新增檢視</guimenu> 會開啟目前影像的第二個顯示視窗。在某個檢視中進行的變更會反映在該影像的所有其他檢視中。對於放大要操作的局部影像，同時在另一個檢視中查看完整影像，替代檢視是非常有用的。使用 <guimenu>縮放</guimenu> 來調整目前視窗的放大倍率。當選取<guimenu>依影像調整視窗大小</guimenu>時，影像視窗就會調整大小以恰好容納目前的影像。
    </para>
   </sect2>
 
@@ -185,9 +164,7 @@
   </para>
 
   <sect2 xml:id="sec-gimp-getstart-creating">
-   <title>建立新影像</title><indexterm>
-   <primary>GIMP</primary>
-   <secondary>建立影像</secondary></indexterm>
+   <title>建立新影像</title>
    <procedure>
     <step>
      <para>
@@ -198,9 +175,7 @@
     <step>
      <para>
       如有需要，請選取名為<guimenu>範本</guimenu>的預先定義設定。
-     </para><indexterm>
-     <primary> GIMP</primary>
-     <secondary> 範本</secondary></indexterm> 
+     </para>
      <note>
       <title>自訂範本</title>
       <para>
@@ -238,9 +213,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-getstart-open">
-   <title>開啟現有的影像</title><indexterm>
-   <primary>GIMP</primary>
-   <secondary>開啟影像</secondary></indexterm>
+   <title>開啟現有的影像</title>
    <para>
     若要開啟現有影像，請選取<menuchoice> <guimenu>檔案</guimenu>
     <guimenu>開啟</guimenu></menuchoice>。
@@ -251,11 +224,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gimp-saving">
-  <title>儲存與輸出影像</title><indexterm>
-
-  <primary>GIMP</primary>
-
-  <secondary>儲存影像</secondary></indexterm>
+  <title>儲存與輸出影像</title>
 
   <para>
    在 GIMP 中，儲存和輸出影像是有差別的。
@@ -287,10 +256,7 @@
 
 
    <varlistentry>
-    <term>JPEG<indexterm>
-     <primary> 檔案</primary>
-     <secondary> 格式</secondary>
-     <tertiary> JPG</tertiary></indexterm> 
+    <term>JPEG 
     </term>
     <listitem>
      <para>
@@ -299,10 +265,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>GIF<indexterm>
-     <primary> 檔案</primary>
-     <secondary> 格式</secondary>
-     <tertiary> GIF</tertiary></indexterm> 
+    <term>GIF 
     </term>
     <listitem>
      <para>
@@ -311,10 +274,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>PNG<indexterm>
-     <primary> 檔案</primary>
-     <secondary> 格式</secondary>
-     <tertiary> PNG</tertiary></indexterm> 
+    <term>PNG 
     </term>
     <listitem>
      <para>
@@ -325,20 +285,14 @@
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-gimp-basics">
-  <title>編輯影像</title><indexterm xml:id="idx-gimp-editing-images" class="startofrange">
-
-  <primary>GIMP</primary>
-
-  <secondary>編輯影像</secondary></indexterm>
+  <title>編輯影像</title>
 
   <para>
    GIMP 提供了數個用於編輯影像的工具。此處描述的是一些小幅改動最常用的功能。
   </para>
 
   <sect2 xml:id="sec-gimp-basics-size">
-   <title>變更影像的大小</title><indexterm xml:id="idx-graphics-resizing" class="startofrange">
-   <primary>圖形</primary>
-   <secondary>調整大小</secondary></indexterm>
+   <title>變更影像的大小</title>
    <para>
     在掃描影像或者從相機中載入數位相片後，通常需要修改它們的大小，才能顯示於網頁或者對其進行列印。利用縮小影像或剪下影像的某些部分，就可以輕易地變得更小。
    </para>
@@ -346,9 +300,7 @@
     放大影像相對麻煩很多。因為點陣圖形所固有的特性，放大影像會降低品質。建議在縮放或裁切之前，保留一份原始影像的複本。
    </para>
    <sect3 xml:id="sec-gimp-basics-size-cropping">
-    <title>裁切影像</title><indexterm>
-    <primary>GIMP</primary>
-    <secondary>裁切</secondary></indexterm>
+    <title>裁切影像</title>
     <procedure>
      <step>
       <para>
@@ -374,9 +326,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-size-scaling">
-    <title>縮放影像</title><indexterm>
-    <primary>GIMP</primary>
-    <secondary>縮放影像</secondary></indexterm>
+    <title>縮放影像</title>
     <procedure>
      <step>
       <para>
@@ -427,14 +377,12 @@
        完成後，按一下<guimenu>調整大小</guimenu>。
       </para>
      </step>
-    </procedure><indexterm startref="idx-graphics-resizing" class="endofrange"/>
+    </procedure>
    </sect3>
   </sect2>
 
   <sect2 xml:id="sec-gimp-basics-select">
-   <title>選取部分影像</title><indexterm xml:id="idx-gimp-selecting" class="startofrange">
-   <primary>GIMP</primary>
-   <secondary>選取</secondary></indexterm>
+   <title>選取部分影像</title>
    <para>
     只在部分影像上執行影像操作通常是很有用的。若要這樣做，必須選取要進行操作的部分影像。可以使用工具箱中可用的選取工具、使用快速遮色片、或結合不同選項來選取區域。也可以利用 <guimenu>選取</guimenu> 下的項目來修改選取區域。選取區域會以虛線外框來表示，稱為<emphasis>行軍中的螞蟻</emphasis>。
    </para>
@@ -543,9 +491,7 @@
     </procedure>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-select-quickmask">
-    <title>使用快速遮色片</title><indexterm>
-    <primary>GIMP</primary>
-    <secondary>快速遮色片</secondary></indexterm>
+    <title>使用快速遮色片</title>
     <para>
      快速遮色片是一個使用繪圖工具選取部分影像的方法。最好的做法是先使用<guimenu>剪刀</guimenu>或<guimenu>自由選取</guimenu>工具進行粗略選擇。然後開始使用<guimenu>快速遮色片</guimenu>︰
     </para>
@@ -577,7 +523,7 @@
        完成後，按一下影像視窗左下角的圖示回到正常選取檢視窗。然後，該選取區域將以行軍中的螞蟻顯示。
       </para>
      </step>
-    </procedure><indexterm startref="idx-gimp-selecting" class="endofrange"/>
+    </procedure>
    </sect3>
   </sect2>
 
@@ -590,9 +536,7 @@
     使用許多工具時，目前工具的圖示會與箭號一起顯示。若為繪圖工具，則會顯示目前筆刷的外形，允許您精確地查看將在影像中繪圖的位置及將要繪圖的區域大小。
    </para>
    <sect3 xml:id="sec-gimp-basics-color-selecting">
-    <title>選取色彩</title><indexterm>
-    <primary>GIMP</primary>
-    <secondary>色彩</secondary></indexterm>
+    <title>選取色彩</title>
     <para>
      GIMP 工具箱總是顯示兩個色卡。前景色彩由繪製工具使用。背景色彩的使用要少見得多，但可以輕易切換為前景色彩。
     </para>
@@ -650,9 +594,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-color-text">
-    <title>加入文字</title><indexterm>
-    <primary>GIMP</primary>
-    <secondary>文字</secondary></indexterm>
+    <title>加入文字</title>
     <para>
      若要新增文字，請使用文字工具。使用工具選項選取所需的字型和文字內容。按一下影像，然後開始撰寫。
     </para>
@@ -661,9 +603,7 @@
     </para>
    </sect3>
    <sect3 xml:id="sec-gimp-basics-color-clone">
-    <title>修整影像 -- 複製工具</title><indexterm>
-    <primary>GIMP</primary>
-    <secondary>修飾影像</secondary></indexterm>
+    <title>修整影像 -- 複製工具</title>
     <para>
      複製工具對於修飾影像是非常理想的。它可以讓您使用影像其他部分的資訊，在影像中繪圖。如果想要的話，它也可以取代從圖樣中取得資訊。
     </para>
@@ -680,9 +620,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-basics-levels">
-   <title>調整色階</title><indexterm>
-   <primary>GIMP</primary>
-   <secondary>層級</secondary></indexterm>
+   <title>調整色階</title>
    <para>
     影像通常需要一點調整以得到理想的列印或顯示效果。
    </para>
@@ -713,9 +651,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-basics-undo">
-   <title>復原錯誤</title><indexterm>
-   <primary>GIMP</primary>
-   <secondary>復原</secondary></indexterm>
+   <title>復原錯誤</title>
    <para>
     GIMP 中進行的修改大多數都可以復原。若要檢視修改歷程，請使用預設視窗配置中包含的復原對話方塊，或者使用<menuchoice>
     <guimenu>Windows</guimenu> <guimenu>可停駐的對話方塊</guimenu>
@@ -732,9 +668,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-advanced-layers">
-   <title>圖層</title><indexterm>
-   <primary>GIMP</primary>
-   <secondary>圖層</secondary></indexterm>
+   <title>圖層</title>
    <para>
     圖層是 GIMP 中非常重要的觀念。利用在您部分影像的個別圖層上繪圖，可以變更、移動或刪除那些部分而不會損害到影像的其他部分。
    </para>
@@ -747,9 +681,7 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-advanced-modes">
-   <title>影像模式</title><indexterm>
-   <primary>GIMP</primary>
-   <secondary>影像模式</secondary></indexterm>
+   <title>影像模式</title>
    <para>
     GIMP 有三種影像模式︰
    </para>
@@ -776,24 +708,14 @@
   </sect2>
 
   <sect2 xml:id="sec-gimp-advanced-effects">
-   <title>特殊效果</title><indexterm>
-   <primary>GIMP</primary>
-   <secondary>效果</secondary></indexterm>
+   <title>特殊效果</title>
    <para>
      GIMP 包含廣泛增強影像用的濾鏡和指令碼，可以在影像中加入特殊效果，或進行藝術操作。您可以在<guimenu>過濾器</guimenu>中找到它們。試驗是找出可以利用功能的最好方法。
-   </para><indexterm startref="idx-gimp-editing-images" class="endofrange"/>
+   </para>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-gimp-printing">
-  <title>列印影像</title><indexterm>
-
-  <primary>GIMP</primary>
-
-  <secondary>列印</secondary></indexterm><indexterm>
-
-  <primary>列印</primary>
-
-  <secondary>GIMP</secondary></indexterm>
+  <title>列印影像</title>
 
   <para>
    要列印影像，可以從影像選單中選取<menuchoice> <guimenu>檔案</guimenu>
@@ -866,6 +788,6 @@
      GIMP 與 GNOME 桌面環境有一整個專用的 IRC 網路 — GIMPNet。您可以將您喜愛的 IRC 用戶端指向 <literal>irc.gimp.org</literal> 伺服器，透過該用戶端連接到 GIMPNet。若要詢問有關使用 GIMP 的問題，可以前往 <literal>#gimp-使用者</literal>聊天頻道。如果要旁聽開發人員的討論，請加入 <literal>#gimp</literal> 聊天頻道。
     </para>
    </listitem>
-  </itemizedlist><indexterm class="endofrange" startref="idx-gimp"/><indexterm class="endofrange" startref="idx-graphics-editing"/>
+  </itemizedlist>
  </sect1>
 </chapter>

--- a/l10n/sles/zh-tw/xml/autofs.xml
+++ b/l10n/sles/zh-tw/xml/autofs.xml
@@ -11,8 +11,7 @@
     <systemitem>autofs</systemitem> 是一個程式，可以根據需要掛接指定的目錄。它以核心模組為基礎，效率很高，並且可以管理本地目錄和網路共用。這些自動掛接點僅在存取時掛接，一段時間不使用後即會卸載。這種按需行為可節省頻寬，在效能上優於 <filename>/etc/fstab</filename> 管理的靜態掛接。雖然 <systemitem>autofs</systemitem> 是一個控制程序檔，但是 <command>automount</command> 才是執行實際自動掛接的指令 (精靈)。
    </para>
   </abstract>
- </info><indexterm>
- <primary>AutoFS</primary></indexterm>
+ </info>
  <sect1 xml:id="sec-autofs-installation">
   <title>安裝</title>
 

--- a/l10n/sles/zh-tw/xml/common_intro_available_doc_i.xml
+++ b/l10n/sles/zh-tw/xml/common_intro_available_doc_i.xml
@@ -9,13 +9,7 @@
    </dm:bugtracker>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>說明</primary>
-
- <secondary> SUSE 手冊</secondary></indexterm><indexterm>
-
- <primary> SUSE 手冊</primary></indexterm>
+ </info>
 
  <note>
   <title>線上文件和最新更新</title>

--- a/l10n/sles/zh-tw/xml/fs_structure_i.xml
+++ b/l10n/sles/zh-tw/xml/fs_structure_i.xml
@@ -6,9 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary> 目錄</primary>
- <secondary> 結構</secondary></indexterm> 
+ </info>
  <para>
   下表概述了 Linux 系統中最重要的較高層級目錄。下列清單中提供了關於目錄與重要子目錄的更多詳細資訊。
  </para>
@@ -244,9 +242,7 @@
  </para>
  <variablelist>
   <varlistentry>
-   <term><filename>/bin</filename><indexterm>
-    <primary>目錄</primary>
-    <secondary>/bin</secondary></indexterm> 
+   <term><filename>/bin</filename> 
    </term>
    <listitem>
     <para>
@@ -255,9 +251,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/boot</filename><indexterm>
-    <primary>目錄</primary>
-    <secondary>/boot</secondary></indexterm>
+   <term><filename>/boot</filename>
    </term>
    <listitem>
     <para>
@@ -266,9 +260,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/dev</filename><indexterm>
-    <primary>目錄</primary>
-    <secondary>/dev</secondary></indexterm>
+   <term><filename>/dev</filename>
    </term>
    <listitem>
     <para>
@@ -277,9 +269,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/etc</filename><indexterm>
-    <primary>目錄</primary>
-    <secondary>/etc</secondary></indexterm>
+   <term><filename>/etc</filename>
    </term>
    <listitem>
     <para>
@@ -288,9 +278,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/home/<replaceable>USERNAME</replaceable></filename><indexterm>
-    <primary>directories</primary>
-    <secondary>/home</secondary></indexterm>
+   <term><filename>/home/<replaceable>USERNAME</replaceable></filename>
    </term>
    <listitem>
     <para>
@@ -305,9 +293,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/lib</filename><indexterm>
-    <primary>目錄</primary>
-    <secondary>/lib</secondary></indexterm>
+   <term><filename>/lib</filename>
    </term>
    <listitem>
     <para>
@@ -316,9 +302,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/media</filename><indexterm>
-    <primary>目錄</primary>
-    <secondary>/media</secondary></indexterm>
+   <term><filename>/media</filename>
    </term>
    <listitem>
     <para>
@@ -329,9 +313,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/mnt</filename><indexterm>
-    <primary>目錄</primary>
-    <secondary>/mnt</secondary></indexterm>
+   <term><filename>/mnt</filename>
    </term>
    <listitem>
     <para>
@@ -340,9 +322,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/opt</filename><indexterm>
-    <primary>目錄</primary>
-    <secondary>/opt</secondary></indexterm>
+   <term><filename>/opt</filename>
    </term>
    <listitem>
     <para>
@@ -351,9 +331,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/root</filename><indexterm>
-    <primary>目錄</primary>
-    <secondary>/root</secondary></indexterm>
+   <term><filename>/root</filename>
    </term>
    <listitem>
     <para>
@@ -362,9 +340,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/run</filename><indexterm>
-    <primary>目錄</primary>
-    <secondary>/run</secondary></indexterm>
+   <term><filename>/run</filename>
    </term>
    <listitem>
     <para>
@@ -373,9 +349,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/sbin</filename><indexterm>
-    <primary>目錄</primary>
-    <secondary>/sbin</secondary></indexterm>
+   <term><filename>/sbin</filename>
    </term>
    <listitem>
     <para>
@@ -384,9 +358,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/srv</filename><indexterm>
-    <primary>目錄</primary>
-    <secondary>/srv</secondary></indexterm>
+   <term><filename>/srv</filename>
    </term>
    <listitem>
     <para>
@@ -395,9 +367,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/tmp</filename><indexterm>
-    <primary>目錄</primary>
-    <secondary>/tmp</secondary></indexterm>
+   <term><filename>/tmp</filename>
    </term>
    <listitem>
     <para>
@@ -412,9 +382,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/usr</filename><indexterm>
-    <primary>目錄</primary>
-    <secondary>/usr</secondary></indexterm>
+   <term><filename>/usr</filename>
    </term>
    <listitem>
     <para>
@@ -465,9 +433,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term><filename>/var</filename><indexterm>
-    <primary>目錄</primary>
-    <secondary>/var</secondary></indexterm>
+   <term><filename>/var</filename>
    </term>
    <listitem>
     <para>

--- a/l10n/sles/zh-tw/xml/fuse.xml
+++ b/l10n/sles/zh-tw/xml/fuse.xml
@@ -12,15 +12,10 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary> FUSE</primary></indexterm> 
+ </info>
 
  <sect1 xml:id="sec-fuse-config">
-  <title>設定 FUSE</title><indexterm>
-
-  <primary> FUSE</primary>
-
-  <secondary> 設定</secondary></indexterm> 
+  <title>設定 FUSE</title>
 
   <para>
    您必須先安裝套件 <systemitem class="resource">fuse</systemitem> 才能使用 FUSE。是否需要以獨立套件形式提供的其他外掛程式，取決於要使用的檔案系統。 
@@ -31,13 +26,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-fuse-ntfs">
-  <title>裝載 NTFS 分割區</title><indexterm>
-
-  <primary>FUSE</primary>
-
-  <secondary>ntfs-3g</secondary></indexterm><indexterm>
-
-  <primary>ntfs-3g</primary></indexterm>
+  <title>裝載 NTFS 分割區</title>
 
   <para>
    <emphasis>新技術檔案系統</emphasis> (NTFS，New Technology File System) 是 Windows 的預設檔案系統。在一般情況下，由於非特權使用者無法使用外部 FUSE 程式庫掛接 NTFS 區塊裝置，因此下文所述的 Windows 分割區掛接程序需要 root 特權。

--- a/l10n/sles/zh-tw/xml/grub2.xml
+++ b/l10n/sles/zh-tw/xml/grub2.xml
@@ -11,10 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>開機</primary>
- <secondary>GRUB 2</secondary></indexterm><indexterm>
- <primary>GRUB 2</primary></indexterm>
+ </info>
  <sect1 xml:id="sec-grub2-new-features">
   <title>GRUB Legacy 與 GRUB 2 之間的主要差異</title>
 
@@ -67,9 +64,7 @@
    <varlistentry>
     <term><filename>/boot/grub2/grub.cfg</filename>
     </term>
-    <listitem><indexterm>
-     <primary>GRUB 2</primary>
-     <secondary> grub.cfg</secondary></indexterm>
+    <listitem>
      <para>
       此檔案包含 GRUB 2 功能表項目的組態。它取代了 GRUB Legacy 中的 <filename>menu.lst</filename>。不要編輯 <filename>grub.cfg</filename> — 它是由指令 <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command> 自動產生的。
      </para>
@@ -78,9 +73,7 @@
    <varlistentry>
     <term><filename>/boot/grub2/custom.cfg</filename>
     </term>
-    <listitem><indexterm>
-     <primary>GRUB 2</primary>
-     <secondary> custom.cfg</secondary></indexterm>
+    <listitem>
      <para>
       這個可選用檔案在開機時由 <filename>grub.cfg</filename> 直接獲取，可用於將自訂項目新增至開機功能表。從 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 開始，這些項目也將會在使用 <command>grub-once</command> 時進行剖析。
      </para>
@@ -89,9 +82,7 @@
    <varlistentry>
     <term><filename>/etc/default/grub</filename>
     </term>
-    <listitem><indexterm>
-     <primary>GRUB 2</primary>
-     <secondary> /etc/default/grub</secondary></indexterm>
+    <listitem>
      <para>
       此檔案控制 GRUB 2 的使用者設定，通常包含背景和主題等其他環境設定。
      </para>
@@ -100,9 +91,7 @@
    <varlistentry>
     <term><filename>/etc/grub.d/</filename> 下的程序檔
     </term>
-    <listitem><indexterm>
-     <primary>GRUB 2</primary>
-     <secondary> /etc/grub.d/</secondary></indexterm>
+    <listitem>
      <para>
       在執行 <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command> 指令期間，系統會讀取此目錄中的程序檔。主要組態檔案 <filename>/boot/grub/grub.cfg</filename> 中整合了這些程序檔的指示。
      </para>
@@ -111,9 +100,7 @@
    <varlistentry xml:id="vle-grub2-sysconfig">
     <term><filename>/etc/sysconfig/bootloader</filename>
     </term>
-    <listitem><indexterm>
-     <primary>GRUB 2</primary>
-     <secondary> sysconfig/bootloader</secondary></indexterm>
+    <listitem>
      <para>
       此組態檔案儲存一些基本設定，例如開機載入程式類型，或者是否要啟用 UEFI 安全開機支援。
      </para>
@@ -142,13 +129,7 @@
   </note>
 
   <sect2 xml:id="sec-grub2-cfg">
-   <title>檔案 <filename>/boot/grub2/grub.cfg</filename></title><indexterm>
-   <primary>組態檔案</primary>
-   <secondary>grub.cfg</secondary></indexterm><indexterm>
-   <primary>GRUB 2</primary>
-   <secondary>開機功能表</secondary></indexterm><indexterm>
-   <primary>GRUB 2</primary>
-   <secondary>grub.cfg</secondary></indexterm>
+   <title>檔案 <filename>/boot/grub2/grub.cfg</filename></title>
    <para>
     帶有開機功能表的圖形開頭顯示畫面以 GRUB 2 組態檔案 <filename>/boot/grub2/grub.cfg</filename> 為基礎，它包含關於可以透過功能表開機之所有分割區或作業系統的資訊。
    </para>
@@ -161,11 +142,7 @@
   </sect2>
 
   <sect2 xml:id="sec-grub2-etc-default-grub">
-   <title>檔案 <filename>/etc/default/grub</filename></title><indexterm>
-   <primary>組態檔案</primary>
-   <secondary> /etc/default/grub</secondary></indexterm><indexterm>
-   <primary> GRUB 2</primary>
-   <secondary> /etc/default/grub</secondary></indexterm>
+   <title>檔案 <filename>/etc/default/grub</filename></title>
    <para>
     此檔案包含 GRUB 2 的更多一般選項，例如，顯示功能表的時間，或者要開機的預設作業系統。若要列出所有可用選項，請查看以下指令的輸出︰
    </para>
@@ -422,9 +399,7 @@
   </sect2>
 
   <sect2 xml:id="sec-grub2-map">
-   <title>BIOS 磁碟機與 Linux 裝置之間的映射</title><indexterm>
-   <primary>GRUB 2</primary>
-   <secondary> device.map</secondary></indexterm>
+   <title>BIOS 磁碟機與 Linux 裝置之間的映射</title>
    <para>
     在 GRUB Legacy 中，<filename>device.map</filename> 組態檔案用於依據 BIOS 磁碟機代號衍生 Linux 裝置名稱。不一定總能猜對 BIOS 磁碟機與 Linux 裝置之間的映射。例如，如果在 BIOS 組態中交換了 IDE 和 SCSI 驅動器的開機順序，那麼 GRUB Legacy 就會使用錯誤的順序。
    </para>
@@ -440,9 +415,7 @@
   </sect2>
 
   <sect2 xml:id="sec-grub2-menu-change">
-   <title>在開機程序期間編輯功能表項目</title><indexterm>
-   <primary>GRUB 2</primary>
-   <secondary> 功能表編輯器</secondary></indexterm>
+   <title>在開機程序期間編輯功能表項目</title>
    <para>
     當系統由於組態錯誤而不再能夠開機時，如果能夠直接編輯功能表項目，就會很有幫助。使用功能表編輯器還可以在不變更系統組態的情況下測試新設定。
    </para>
@@ -518,9 +491,7 @@
   </sect2>
 
   <sect2 xml:id="sec-grub2-password">
-   <title>設定啟動密碼</title><indexterm>
-   <primary>GRUB 2</primary>
-   <secondary> 開機密碼</secondary></indexterm>
+   <title>設定啟動密碼</title>
    <para>
     即使在作業系統開機之前，GRUB 2 也支援對檔案系統的存取。沒有 root 許可權的使用者可以存取 Linux 系統中的檔案，而在系統開機後，他們將無權存取這些檔案。若要阻擋此類型的存取，或防止使用者啟動特定的功能表項目，請設定開機密碼。
    </para>

--- a/l10n/sles/zh-tw/xml/help_admin.xml
+++ b/l10n/sles/zh-tw/xml/help_admin.xml
@@ -6,10 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>說明</primary></indexterm><indexterm>
- <primary>文件</primary>
- <see>說明</see></indexterm>
+ </info>
  <para>
   <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> 隨附了各種來源的資訊和文件，其中有許多已整合到安裝的系統中。
  </para>
@@ -32,9 +29,7 @@
    </listitem>
   </varlistentry>
   <varlistentry>
-   <term>桌面說明中心<indexterm>
-    <primary> 說明</primary>
-    <secondary> 說明中心</secondary></indexterm>
+   <term>桌面說明中心
    </term>
    <listitem>
     <para>
@@ -55,10 +50,7 @@
   <title>文件目錄</title>
 
   <para>
-   <indexterm>
-   <primary>說明</primary>
-   <secondary> /usr/share/doc</secondary>
-   </indexterm> 安裝 Linux 系統後，可以在 <filename>/usr/share/doc</filename> 這個傳統目錄中找到文件。該目錄通常包含系統上已安裝之套件的相關資訊，以及版本說明和手冊等。
+    安裝 Linux 系統後，可以在 <filename>/usr/share/doc</filename> 這個傳統目錄中找到文件。該目錄通常包含系統上已安裝之套件的相關資訊，以及版本說明和手冊等。
   </para>
 
   <note>
@@ -71,12 +63,7 @@
   <sect2 xml:id="sec-help-onboard-docdir-manual">
    <title>SUSE 手冊</title>
    <para>
-    <indexterm>
-    <primary>說明</primary>
-    <secondary>SUSE 手冊</secondary>
-    </indexterm> <indexterm>
-    <primary>SUSE 手冊</primary>
-    </indexterm> 我們提供了不同語言的手冊，有 HTML 和 PDF 兩種版本。在 <filename>manual</filename> 子目錄下，可以找到您產品適用的大多數 HTML 版 SUSE 手冊。如需您產品適用的所有文件的綜覽，請參閱手冊的序。
+      我們提供了不同語言的手冊，有 HTML 和 PDF 兩種版本。在 <filename>manual</filename> 子目錄下，可以找到您產品適用的大多數 HTML 版 SUSE 手冊。如需您產品適用的所有文件的綜覽，請參閱手冊的序。
    </para>
    <para>
     如果安裝了多種語言，<filename>/usr/share/doc/manual</filename> 可能會包含不同語言版本的手冊。HTML 版本的 SUSE 手冊也可以在兩種桌面系統的說明中心內找到。若想瞭解 PDF 和 HTML 版手冊在安裝媒體上的位置，請參閱 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 的版本說明。這些手冊位於所安裝系統的 <filename>/usr/share/doc/release-notes/</filename> 目錄內，也可以在 <link os="sles;sled" xlink:href="http://www.suse.com/releasenotes/"/> 中產品特定的網頁內找到其線上版本。
@@ -87,10 +74,7 @@
   <sect2 xml:id="sec-help-onboard-docdir-pkg">
    <title>套件文件</title>
    <para>
-    <indexterm>
-    <primary>說明</primary>
-    <secondary>套件文件</secondary>
-    </indexterm> 在 <filename>packages</filename> 下面，可找到系統上已安裝之軟體套件中所包含的文件。對每個套件都會建立子目錄 <filename>/usr/share/doc/packages/<replaceable>PACKAGENAME</replaceable></filename>。其中通常包含套件的讀我檔案，有時還包含範例、組態檔案或其他程序檔。以下清單介紹了 <filename>/usr/share/doc/packages</filename> 下包含的一般檔案。以下每個項目不一定都存在，許多套件可能只包含其中的一部分。
+     在 <filename>packages</filename> 下面，可找到系統上已安裝之軟體套件中所包含的文件。對每個套件都會建立子目錄 <filename>/usr/share/doc/packages/<replaceable>PACKAGENAME</replaceable></filename>。其中通常包含套件的讀我檔案，有時還包含範例、組態檔案或其他程序檔。以下清單介紹了 <filename>/usr/share/doc/packages</filename> 下包含的一般檔案。以下每個項目不一定都存在，許多套件可能只包含其中的一部分。
    </para>
    <variablelist>
     <varlistentry>
@@ -191,11 +175,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-help-onboard-manpages">
-  <title>線上文件</title><indexterm>
-
-  <primary> 說明</primary>
-
-  <secondary> 線上文件</secondary></indexterm> 
+  <title>線上文件</title>
 
   <para>
    man 頁面 Linux 系統的重要部分。它們提供指令用法以及所有可用選項與參數的說明。man 頁面可以使用 <command>man</command> 後接指令名稱的方式進行存取，例如 <command>man ls</command>。
@@ -340,22 +320,14 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-help-onboard-infopages">
-  <title>Info 頁面</title><indexterm>
-
-  <primary> 說明</primary>
-
-  <secondary> Info 頁面</secondary></indexterm> 
+  <title>Info 頁面</title>
 
   <para>
    Info 頁面是您系統上另一個重要的資訊來源。它們所提供的資訊通常比 man 頁面更為詳盡。這些頁面中的內容不止指令行選項，有時還包含完整的教學課程或參考文件。若要檢視特定指令的資訊頁面，請輸入 <command>info</command>，後接指令名稱，例如 <command>info ls</command>。您可以直接在外圍程序中使用檢視器瀏覽資訊頁面，並可顯示不同的區段 (稱為<quote>節點</quote>)。使用 <keycap function="space"/> 和 <keycap function="backspace"/> 分別可以向前和向後移動。在節點內，您也可以使用 <keycap function="pageup"/> 和 <keycap function="pagedown"/> 進行瀏覽，但要前往上一個或下一個節點，只能使用 <keycap function="space"/> 和 <keycap function="backspace"/>。按 <keycap>Q</keycap> 可以結束檢視模式。並不是所有指令都隨附資訊頁面，反之亦然。
   </para>
  </sect1>
  <sect1 xml:id="sec-help-online">
-  <title>線上資源</title><indexterm>
-
-  <primary>說明</primary>
-
-  <secondary> 線上文件</secondary></indexterm>
+  <title>線上資源</title>
 
   <para>
    除了 <filename>/usr/share/doc</filename> 下所安裝之 SUSE 手冊的線上版本外，您還可以在 Web 上存取產品專屬的手冊與文件。如需關於 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 所有可用文件的綜覽，請查看產品專屬文件網頁 <phrase os="sles;sled"><link xlink:href="http://www.suse.com/doc/"/></phrase>。

--- a/l10n/sles/zh-tw/xml/help_user.xml
+++ b/l10n/sles/zh-tw/xml/help_user.xml
@@ -12,16 +12,11 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-help">
- <primary>說明</primary></indexterm><indexterm>
- <primary>文件</primary>
- <see>說明</see></indexterm>
+ </info>
 
  <variablelist>
   <varlistentry>
-   <term>桌面說明中心<indexterm>
-    <primary> 說明</primary>
-    <secondary> 說明中心</secondary></indexterm>
+   <term>桌面說明中心
    </term>
    <listitem>
     <para>
@@ -56,11 +51,7 @@
   </varlistentry>
  </variablelist>
  <sect1 xml:id="sec-help-onboard-yelp">
-  <title>使用 GNOME 說明</title><indexterm>
-
-  <primary>說明</primary>
-
-  <secondary> 說明</secondary></indexterm>
+  <title>使用 GNOME 說明</title>
 
   <para>
    在 GNOME 桌面上，若要從應用程式直接啟動說明，請按一下<guimenu>說明</guimenu>按鈕，或按 <keycap>F1</keycap>。使用這兩種方法都可以在說明中心內直接開啟該應用程式的文件。不過，您也可以開啟終端機並輸入 <command>yelp</command>，或者在主功能表中按一下<menuchoice><guimenu>應用程式</guimenu>
@@ -91,9 +82,7 @@
   <title>其他說明資源</title>
 
   <para>
-   <indexterm>
-   <primary> 說明</primary>
-   <secondary> 線上文件</secondary> </indexterm> 除了 <filename>/usr/share/doc</filename> 下所安裝之 SUSE 手冊外，您還可以在 Web 上存取產品專屬的手冊與文件。如需關於 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 所有可用文件的綜覽，請查看產品專屬文件網頁 <link os="sles;sled" xlink:href="https://documentation.suse.com/"/>。
+    除了 <filename>/usr/share/doc</filename> 下所安裝之 SUSE 手冊外，您還可以在 Web 上存取產品專屬的手冊與文件。如需關於 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 所有可用文件的綜覽，請查看產品專屬文件網頁 <link os="sles;sled" xlink:href="https://documentation.suse.com/"/>。
   </para>
 
   <para>
@@ -141,29 +130,20 @@
   </para>
 
   <sect2 xml:id="sec-help-more-tldp">
-   <title>The Linux Documentation Project</title><indexterm>
-   <primary>TLDP</primary></indexterm><indexterm>
-   <primary> 說明</primary>
-   <secondary> Linux 文件計畫 (TLDP)</secondary></indexterm>
+   <title>The Linux Documentation Project</title>
    <para>
     The Linux Documentation Project (TLDP) 由志願者組成的團體運營，該團體負責撰寫 Linux 相關文件 (請參閱 <link xlink:href="http://www.tldp.org"/>)。這組文件包含入門者的教學課程，但主要是針對有經驗的使用者和專業系統管理員。TLDP 發佈了免費的 HOWTO、常見問題集和指南 (手冊)。<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 中也隨附了一部分來自 TLDP 的文件。
    </para>
 
 
    <sect3 xml:id="sec-helpmore-tldp-faq">
-    <title>常見問答集</title><indexterm>
-    <primary>說明</primary>
-    <secondary> TLDP</secondary>
-    <tertiary> 常見問題</tertiary></indexterm>
+    <title>常見問答集</title>
     <para>
      FAQ (常見問題集) 是一系列的問題與解答。源於 Usenet 新聞群組，目的是為了減少連續張貼相同的基本問題。
     </para>
    </sect3>
    <sect3 xml:id="sec-helpmore-tldp-guides">
-    <title>指南</title><indexterm>
-    <primary>說明</primary>
-    <secondary> TLDP</secondary>
-    <tertiary> 指南</tertiary></indexterm>
+    <title>指南</title>
     <para>
      各種主題或程式的手冊和指南可在 <link xlink:href="http://www.tldp.org/guides.html"/> 中找到。範圍從《<citetitle>Bash Guide for Beginners</citetitle>》(Bash 初學者指南)、《<citetitle>Linux Filesystem Hierarchy</citetitle>》(Linux 檔案系統階層) 到《<citetitle>Linux Administrator's Security Guide</citetitle>》(Linux 管理員安全性指南)。指南通常比 HOWTO 或常見問題集更為詳盡。它們通常是由進階使用者針對進階使用者而撰寫的。
     </para>
@@ -175,9 +155,7 @@
 
 
   <sect2 xml:id="sec-help-more-wikipedia">
-   <title>Wikipedia︰免費線上百科全書</title><indexterm>
-   <primary> 說明</primary>
-   <secondary> Wikipedia</secondary></indexterm>
+   <title>Wikipedia︰免費線上百科全書</title>
    <remark>Translators: Translate the link http://en.wikipedia.org into your language: Replace "en"
     with your ISO language code.</remark> 
    <para>
@@ -186,11 +164,7 @@
   </sect2>
 
   <sect2 xml:id="sec-help-more-standards">
-   <title>標準和規格</title><indexterm>
-   <primary>說明</primary>
-   <secondary>標準</secondary></indexterm><indexterm>
-   <primary>說明</primary>
-   <secondary>規格</secondary></indexterm>
+   <title>標準和規格</title>
    <para>
     目前有各種來源，提供關於標準或規格的資訊。
    </para>

--- a/l10n/sles/zh-tw/xml/lvm.xml
+++ b/l10n/sles/zh-tw/xml/lvm.xml
@@ -7,19 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>YaST</primary>
-
- <secondary>LVM</secondary></indexterm><indexterm>
-
- <primary>LVM</primary>
-
- <secondary>YaST</secondary></indexterm><indexterm>
-
- <primary>邏輯磁碟區管理</primary>
-
- <see>LVM</see></indexterm>
+ </info>
 
  <para>
   本節介紹設定 LVM 時要執行的特定步驟。<phrase os="sles">如果您需要邏輯磁碟區管理員的一般資訊，請參閱<xref linkend="sec-lvm-explained"/>。</phrase>

--- a/l10n/sles/zh-tw/xml/mobile.xml
+++ b/l10n/sles/zh-tw/xml/mobile.xml
@@ -11,36 +11,16 @@
     人們多半會將行動計算與筆記型電腦、PDA、行動電話以及它們彼此間的資料交換聯想在一起。行動硬體元件 (如外接硬碟、隨身碟或數位相機) 可以連接到筆記型電腦或桌上電腦系統。行動計算環境需要許多軟體元件，而且有些應用程式是專為行動用途量身訂製的。
    </para>
   </abstract>
- </info><indexterm xml:id="idx-mobility" class="startofrange">
- <primary> 行動性</primary></indexterm> 
+ </info>
  <sect1 xml:id="sec-mobile-nbook">
-  <title>筆記型電腦</title><indexterm class="startofrange" xml:id="idx-notebook">
-
-  <primary>筆記型電腦</primary></indexterm><indexterm>
-
-  <primary>筆記型電腦</primary>
-
-  <secondary>硬體</secondary></indexterm><indexterm>
-
-  <primary>筆記型電腦</primary>
-
-  <secondary>PCMCIA</secondary></indexterm><indexterm>
-
-  <primary>PCMCIA</primary></indexterm><indexterm>
-
-  <primary>行動性</primary>
-
-  <secondary>筆記型電腦</secondary></indexterm>
+  <title>筆記型電腦</title>
 
   <para>
    筆記型電腦的硬體與一般桌上電腦系統不同。因為可交換性、空間要求和耗電量之類的準則必須考慮在內。行動硬體的製造廠商開發了一些標準介面，例如 PCMCIA (國際個人電腦記憶卡協會)、Mini PCI 和 Mini PCIe，可以使用它們來擴充筆記型電腦的硬體。這些標準涵蓋了記憶卡、網路介面卡和外接硬碟。
   </para>
 
   <sect2 xml:id="sec-mobile-powerm">
-   <title>省電</title><indexterm>
-   <primary>筆記型電腦</primary>
-   <secondary>電源管理</secondary></indexterm><indexterm>
-   <primary>電源管理</primary></indexterm>
+   <title>省電</title>
    <para>
     製造筆記型電腦時採用了電能優化系統元件，因此不必靠電力系統就可以使用該類電腦。它們在省電方面的功效不亞於作業系統。<phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> 支援各種控制筆記型電腦電源消耗的方法，在使用電池電源時，這些方法對電腦運作時間的影響各不相同。下表按照省電作用從高到低排列︰
    </para>
@@ -77,8 +57,7 @@
   </sect2>
 
   <sect2 xml:id="sec-mobile-nbook-change">
-   <title>與變動作業環境的整合</title><indexterm>
-   <primary>筆記型電腦</primary></indexterm>
+   <title>與變動作業環境的整合</title>
    <para>
     您的系統在用於行動計算時，常需與變動的作業環境搭配。許多服務與環境息息相關，因而基礎用戶端必須經過重新設定。<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 會為您處理此工作。
    </para>
@@ -138,12 +117,7 @@
      <term>NetworkManager</term>
      <listitem>
       <para>
-       <indexterm>
-       <primary>NetworkManager</primary>
-       </indexterm> <indexterm>
-       <primary>筆記型電腦NetworkManager</primary>
-       <secondary> NetworkManager 是專為筆記型電腦的行動網路功能特別量身訂製的。</secondary>
-       </indexterm>它能讓您在多種網路環境或不同類型的網路 (例如 GPRS、EDGE 或 3G 等行動寬頻、無線 LAN 和乙太網路) 之間輕鬆地自動切換。NetworkManager 支援無線 LAN 中的 WEP 與 WPA-PSK 加密，還支援撥號連接。GNOME 桌面包含 NetworkManager 的前端。如需詳細資訊，請參閱<xref linkend="sec-nm-configure"/>。
+        它能讓您在多種網路環境或不同類型的網路 (例如 GPRS、EDGE 或 3G 等行動寬頻、無線 LAN 和乙太網路) 之間輕鬆地自動切換。NetworkManager 支援無線 LAN 中的 WEP 與 WPA-PSK 加密，還支援撥號連接。GNOME 桌面包含 NetworkManager 的前端。如需詳細資訊，請參閱<xref linkend="sec-nm-configure"/>。
       </para>
       <table>
        <title>NetworkManager 的使用案例</title>
@@ -229,12 +203,7 @@
      <term>SLP</term>
      <listitem>
       <para>
-       <indexterm>
-       <primary>筆記型電腦</primary>
-       <secondary>SLP</secondary>
-       </indexterm> <indexterm>
-       <primary>SLP</primary>
-       </indexterm> 服務位置通訊協定 (SLP) 簡化了筆記型電腦到現有網路的連接。沒有 SLP，筆記型電腦的管理員通常需要熟知網路中的可用服務。SLP 廣播特定類型服務的可用性到本地網路中的所有用戶端。支援 SLP 的應用程式可以處理由 SLP 分派出來的資訊，而且能夠自動設定。SLP 還可用來安裝系統，縮短對適用安裝來源的搜尋時間。<phrase os="sles;osuse">如需有關 SLP 的詳細資訊，請參閱<xref linkend="cha-slp"/>。</phrase>
+         服務位置通訊協定 (SLP) 簡化了筆記型電腦到現有網路的連接。沒有 SLP，筆記型電腦的管理員通常需要熟知網路中的可用服務。SLP 廣播特定類型服務的可用性到本地網路中的所有用戶端。支援 SLP 的應用程式可以處理由 SLP 分派出來的資訊，而且能夠自動設定。SLP 還可用來安裝系統，縮短對適用安裝來源的搜尋時間。<phrase os="sles;osuse">如需有關 SLP 的詳細資訊，請參閱<xref linkend="cha-slp"/>。</phrase>
       </para>
      </listitem>
     </varlistentry>
@@ -247,8 +216,7 @@
     在行動使用場合有各種任務領域，它們由專屬軟體實現︰系統監控 (特別是電池充電)、資料同步化，以及與週邊和網際網路的無線通訊。以下幾節涵蓋了 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 為每項任務提供的最重要的應用程式。
    </para>
    <sect3 xml:id="sec-mobile-nbook-soft-mon">
-    <title>系統監控</title><indexterm>
-    <primary> 系統監控</primary></indexterm> 
+    <title>系統監控</title>
     <para>
      <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 提供了兩種系統監控工具︰
     </para>
@@ -257,12 +225,7 @@
       <term>電源管理</term>
       <listitem>
        <para>
-        <indexterm>
-        <primary>系統監控</primary>
-        <secondary>電源管理</secondary>
-        </indexterm> <indexterm>
-        <primary>電源管理</primary>
-        </indexterm> <guimenu>電源管理</guimenu>是一款可讓您調整與 GNOME 桌面行為關聯之節能的應用程式。通常，您可以透過<menuchoice><guimenu>電腦</guimenu> <guimenu>控制中心</guimenu> <guimenu>系統</guimenu> <guimenu>電源管理</guimenu></menuchoice>來存取該應用程式。
+          <guimenu>電源管理</guimenu>是一款可讓您調整與 GNOME 桌面行為關聯之節能的應用程式。通常，您可以透過<menuchoice><guimenu>電腦</guimenu> <guimenu>控制中心</guimenu> <guimenu>系統</guimenu> <guimenu>電源管理</guimenu></menuchoice>來存取該應用程式。
        </para>
       </listitem>
      </varlistentry>
@@ -270,10 +233,7 @@
       <term>系統監視器</term>
       <listitem>
        <para>
-        <indexterm>
-        <primary> 系統監控</primary>
-        <secondary> 系統監視器</secondary>
-        </indexterm> <guimenu>系統監視器</guimenu>會將度量系統參數收集到一個監控環境中。依預設，它會在三個索引標籤中顯示輸出資訊。<guimenu>程序</guimenu>提供目前執行之程序的詳細資訊，例如 CPU 負載、記憶體使用率，或程序 ID 編號及優先程度。您可以自訂收集之資料的顯示和過濾方式。若要新增新類型的程序資訊，請按一下程序表的標題，然後選擇要隱藏或新增至檢視窗的欄。還可以在各資料頁監控不同的系統參數，或透過網路同時收集各種機器的資料。<guimenu>資源</guimenu>索引標籤顯示 CPU、記憶體和網路歷程的圖表，<guimenu>檔案系統</guimenu>索引標籤列出所有分割區及其使用情況。
+         <guimenu>系統監視器</guimenu>會將度量系統參數收集到一個監控環境中。依預設，它會在三個索引標籤中顯示輸出資訊。<guimenu>程序</guimenu>提供目前執行之程序的詳細資訊，例如 CPU 負載、記憶體使用率，或程序 ID 編號及優先程度。您可以自訂收集之資料的顯示和過濾方式。若要新增新類型的程序資訊，請按一下程序表的標題，然後選擇要隱藏或新增至檢視窗的欄。還可以在各資料頁監控不同的系統參數，或透過網路同時收集各種機器的資料。<guimenu>資源</guimenu>索引標籤顯示 CPU、記憶體和網路歷程的圖表，<guimenu>檔案系統</guimenu>索引標籤列出所有分割區及其使用情況。
        </para>
       </listitem>
      </varlistentry>
@@ -289,13 +249,7 @@
       <term>同步化電子郵件</term>
       <listitem>
        <para>
-        <indexterm>
-        <primary>同步化資料</primary>
-        <secondary>電子郵件</secondary>
-        </indexterm> <indexterm>
-        <primary>電子郵件</primary>
-        <secondary>同步化</secondary>
-        </indexterm> 使用 IMAP 帳戶在公司網路中儲存您的電子郵件。然後可以從工作站使用任何中斷連接但支援 IMAP 的電子郵件用戶端 (如 Mozilla Thunderbird 或 Evolution) 存取這些電子郵件，如<xref linkend="book-gnomeuser"/>中所述。電子郵件用戶端需要設定，如此「<literal>傳送郵件</literal>」會永遠存取相同的資料夾。這樣可確保完成同步化程序後，所有訊息及其狀態資訊都能使用。使用郵件用戶端中實作的用於傳送郵件的 SMTP 伺服器，代替全系統 MTA postfix 或 sendmail 來接收有關未傳送郵件的可靠回應。
+          使用 IMAP 帳戶在公司網路中儲存您的電子郵件。然後可以從工作站使用任何中斷連接但支援 IMAP 的電子郵件用戶端 (如 Mozilla Thunderbird 或 Evolution) 存取這些電子郵件，如<xref linkend="book-gnomeuser"/>中所述。電子郵件用戶端需要設定，如此「<literal>傳送郵件</literal>」會永遠存取相同的資料夾。這樣可確保完成同步化程序後，所有訊息及其狀態資訊都能使用。使用郵件用戶端中實作的用於傳送郵件的 SMTP 伺服器，代替全系統 MTA postfix 或 sendmail 來接收有關未傳送郵件的可靠回應。
        </para>
       </listitem>
      </varlistentry>
@@ -303,18 +257,14 @@
       <term>同步化檔案與目錄</term>
       <listitem>
        <para>
-        <indexterm>
-        <primary>同步化資料</primary>
-        </indexterm> 有數種公用程式適合用來同步化筆記型電腦與工作站之間的資料。使用最廣的是一項名為 <command>rsync</command> 的指令行工具。如需詳細資訊，請參閱其手冊頁 (<command>man 1 rsync</command>).
+         有數種公用程式適合用來同步化筆記型電腦與工作站之間的資料。使用最廣的是一項名為 <command>rsync</command> 的指令行工具。如需詳細資訊，請參閱其手冊頁 (<command>man 1 rsync</command>).
        </para>
       </listitem>
      </varlistentry>
     </variablelist>
    </sect3>
    <sect3 xml:id="sec-mobile-nbook-soft-wifi">
-    <title>無線通訊︰Wi-Fi</title><indexterm>
-    <primary>網路</primary>
-    <secondary> Wi-Fi</secondary></indexterm>
+    <title>無線通訊︰Wi-Fi</title>
     <para>
      Wi-Fi 在這幾種無線技術中覆蓋範圍最廣，是唯一一種適用於大型網路 (有時甚至是在空間上分離的網路) 的操作技術。個別機器可以彼此連接，形成一個獨立的無線網路或存取網際網路。稱為<emphasis>存取點</emphasis>的裝置，是做為啟用 Wi-Fi 裝置的基礎工作站，而且充當著存取網際網路的中介角色。行動使用者可以在存取點之間切換，端視所在位置及哪個存取點提供最佳連接而定。與行動電話的通訊方式類似，供 Wi-Fi 使用者使用的大型網路，不用將它們結合到特定位置就能存取。
     </para>
@@ -579,34 +529,19 @@
    <sect3 xml:id="sec-mobile-nbook-soft-bluetooth">
     <title>無線通訊︰藍芽</title>
     <para>
-     <indexterm>
-     <primary>網路</primary>
-     <secondary>藍芽</secondary>
-     </indexterm> <indexterm>
-     <primary>藍芽</primary>
-     </indexterm> 藍芽在所有無線技術中的應用範圍最廣泛。它可以用於電腦 (筆記型電腦) 與 PDA 或行動電話之間的通訊，像 IrDA 的功能一樣。也可以用來連接覆蓋範圍內的各台電腦。連接鍵盤或滑鼠等無線系統元件時，也可以使用藍芽。不過，此技術的範圍還不足以連接遠端系統與網路。此時就可選擇使用 Wi-Fi 技術來穿透實體障礙物 (如牆) 進行通訊。
+       藍芽在所有無線技術中的應用範圍最廣泛。它可以用於電腦 (筆記型電腦) 與 PDA 或行動電話之間的通訊，像 IrDA 的功能一樣。也可以用來連接覆蓋範圍內的各台電腦。連接鍵盤或滑鼠等無線系統元件時，也可以使用藍芽。不過，此技術的範圍還不足以連接遠端系統與網路。此時就可選擇使用 Wi-Fi 技術來穿透實體障礙物 (如牆) 進行通訊。
     </para>
    </sect3>
    <sect3 xml:id="sec-mobile-nbook-soft-irda">
     <title>無線通訊︰IrDA</title>
     <para>
-     <indexterm>
-     <primary>網路</primary>
-     <secondary>IrDA</secondary>
-     </indexterm> <indexterm>
-     <primary>IrDA</primary>
-     </indexterm> IrDA 是最短距離的無線技術。兩邊的通訊方必須位於彼此可見的距離內。無法克服如牆之類的障礙物。IrDA 的一個應用方式是從筆記型電腦傳輸檔案到行動電話。可使用 IrDA 來涵蓋筆記型電腦到行動電話的短距離。向收件人遠距離傳輸檔案的任務由行動網路來處理。IrDA 的另一種應用是在公司內以無線方式傳輸列印工作。
+       IrDA 是最短距離的無線技術。兩邊的通訊方必須位於彼此可見的距離內。無法克服如牆之類的障礙物。IrDA 的一個應用方式是從筆記型電腦傳輸檔案到行動電話。可使用 IrDA 來涵蓋筆記型電腦到行動電話的短距離。向收件人遠距離傳輸檔案的任務由行動網路來處理。IrDA 的另一種應用是在公司內以無線方式傳輸列印工作。
     </para>
    </sect3>
   </sect2>
 
   <sect2 xml:id="sec-mobile-nbook-sec">
-   <title>資料安全性</title><indexterm>
-   <primary>行動性</primary>
-   <secondary>資料安全性</secondary></indexterm><indexterm>
-   <primary>安全性</primary>
-   <secondary>加密檔案系統</secondary></indexterm><indexterm>
-   <primary>資料安全性</primary></indexterm>
+   <title>資料安全性</title>
    <para>
     理想而言，您應使用多種方式保護筆記型電腦上的資料，不受未授權的存取。可以從下列三大面向來採取適當的安全性措施︰
    </para>
@@ -649,43 +584,11 @@
       </para>
      </listitem>
     </varlistentry>
-   </variablelist><indexterm class="endofrange" startref="idx-notebook"/>
+   </variablelist>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-mobile-hw">
-  <title>行動硬體</title><indexterm>
-
-  <primary>行動性</primary>
-
-  <secondary>USB</secondary></indexterm><indexterm>
-
-  <primary>行動性</primary>
-
-  <secondary>防火牆 (IEEE1394)</secondary></indexterm><indexterm>
-
-  <primary>防火牆 (IEEE1394)</primary>
-
-  <secondary>硬碟</secondary></indexterm><indexterm>
-
-  <primary>USB</primary>
-
-  <secondary>硬碟</secondary></indexterm><indexterm>
-
-  <primary>USB</primary>
-
-  <secondary>隨身碟</secondary></indexterm><indexterm>
-
-  <primary>隨身碟</primary></indexterm><indexterm>
-
-  <primary>行動性</primary>
-
-  <secondary>外部硬碟</secondary></indexterm><indexterm>
-
-  <primary>行動性</primary>
-
-  <secondary>數位相機</secondary></indexterm><indexterm>
-
-  <primary>數位相機</primary></indexterm>
+  <title>行動硬體</title>
 
   <para>
    <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 能夠自動偵測 FireWire (IEEE 1394) 或 USB 上的行動儲存裝置。詞彙<emphasis>行動儲存裝置</emphasis>表示任何種類的 FireWire 或 USB 硬碟、快閃式磁碟或數位相機。當這些裝置透過對應介面與系統連接時，系統會自動予以偵測並設定。GNOME 的檔案管理員會提供靈活的行動硬體項目處理方式。若要安全卸載所有這些媒體，請使用檔案管理員的<guimenu>卸載磁碟區</guimenu>(GNOME) 功能。如需詳細資訊，請參閱<xref linkend="book-gnomeuser"/>。
@@ -717,19 +620,7 @@
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-mobile-comm">
-  <title>行動裝置 (智慧型電話和平板電腦)</title><indexterm>
-
-  <primary>行動性</primary>
-
-  <secondary>智慧型電話</secondary></indexterm><indexterm>
-
-  <primary>行動性</primary>
-
-  <secondary>平板電腦</secondary></indexterm><indexterm>
-
-  <primary>智慧型電話</primary></indexterm><indexterm>
-
-  <primary>平板電腦</primary></indexterm>
+  <title>行動裝置 (智慧型電話和平板電腦)</title>
 
   <para>
    桌上型電腦系統或筆記型電腦可透過藍芽、Wi-Fi 或 USB 直接連接與行動裝置進行通訊。依據行動裝置型號和您的特定需求選擇一種連接方法。通常，透過 USB 將行動裝置連接到桌上型電腦或筆記型電腦時，可將 USB 做為常設外部儲存使用。透過設定藍芽或 Wi-Fi 連接，您可以與行動裝置互動，並直接從桌上型電腦或筆記型電腦中控制其功能。您可以使用數個開放原始碼圖形公用程式 (特別是 <link xlink:href="https://community.kde.org/KDEConnect">KDE Connect</link> 和 <link xlink:href="https://extensions.gnome.org/extension/1319/gsconnect/">GSConnect</link>) 控制連接的行動裝置。

--- a/l10n/sles/zh-tw/xml/net_config_files.xml
+++ b/l10n/sles/zh-tw/xml/net_config_files.xml
@@ -7,10 +7,7 @@
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
-<indexterm>
- <primary>組態檔</primary></indexterm><indexterm xml:id="idx-networks-configuration-files" class="startofrange">
- <primary>網路</primary>
- <secondary>組態檔</secondary></indexterm>
+
  <para>
   本節提供網路組態檔的綜覽，並說明其用途和使用的格式。
  </para>
@@ -82,21 +79,13 @@ MACVLAN_DEVICE='eth0'
   <para>
    如需 <filename>ifcfg.template</filename> 的相關資訊，請參閱<xref linkend="sec-basicnet-manconf-files-config-etc"/>。
   </para>
-<indexterm>
-  <primary>組態檔</primary>
-  <secondary>ifcfg-*</secondary></indexterm>
+
   <para arch="zseries" os="sles">
    IBM Z 不支援 USB。介面檔案的名稱和網路別名包含專用於 IBM Z 的元素，例如 <literal>qeth</literal>。
   </para>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-config-etc">
-  <title><filename>/etc/sysconfig/network/config</filename>、<filename>/etc/sysconfig/network/dhcp</filename> 和 <filename>/etc/sysconfig/network/wireless</filename></title><indexterm>
-  <primary>組態檔</primary>
-  <secondary>網路</secondary></indexterm><indexterm>
-  <primary>組態檔</primary>
-  <secondary>dhcp</secondary></indexterm><indexterm>
-  <primary>組態檔</primary>
-  <secondary>無線</secondary></indexterm>
+  <title><filename>/etc/sysconfig/network/config</filename>、<filename>/etc/sysconfig/network/dhcp</filename> 和 <filename>/etc/sysconfig/network/wireless</filename></title>
   <para>
    檔案 <filename>config</filename> 包含 <command>ifup</command>、<command>ifdown</command> 和 <command>ifstatus</command> 行為的一般設定。<filename>dhcp</filename> 包含無線 LAN 卡之 DHCP 和 <filename>wireless</filename> 的設定。所有三個組態檔中的變數都已被註解。<filename>/etc/sysconfig/network/config</filename> 中的某些變數也可以在 <filename>ifcfg-*</filename> 檔案中使用，而且在這些檔案中它們的優先程度更高。<filename>/etc/sysconfig/network/ifcfg.template</filename> 檔案列出了可在永久介面中指定的變數。但是，大多數 <filename>/etc/sysconfig/network/config</filename> 變數都是全域變數，在 ifcfg 檔案中不能將它們覆寫。例如，<systemitem>NETWORKMANAGER</systemitem> 或 <systemitem>NETCONFIG_*</systemitem> 變數就是全域變數。
   </para>
@@ -115,19 +104,9 @@ MACVLAN_DEVICE='eth0'
 
  <sect3 xml:id="sec-basicnet-manconf-files-routes">
   <title><filename>/etc/sysconfig/network/routes</filename> 和 <filename>/etc/sysconfig/network/ifroute-*</filename></title>
-<indexterm xml:id="idx-routing" class="startofrange">
-  <primary>路由</primary></indexterm><indexterm>
-  <primary>路由</primary>
-  <secondary>路由</secondary></indexterm><indexterm>
-  <primary>組態檔案</primary>
-  <secondary>路由</secondary></indexterm><indexterm>
-  <primary>設定</primary>
-  <secondary>路由</secondary></indexterm>
+
   <para>
-   TCP/IP 封包的靜態路由是由 <filename>/etc/sysconfig/network/routes</filename> 和 <filename>/etc/sysconfig/network/ifroute-*</filename> 檔案確定的。您可在 <filename>/etc/sysconfig/network/routes</filename> 中指定各種系統任務所需的全部靜態路由，包括前往主機的路由、透過閘道前往主機的路由，以及前往網路的路由。對於需要個別路由的介面，請定義額外的組態檔案︰<filename>/etc/sysconfig/network/ifroute-*</filename>。以介面的名稱取代萬用字元 (<literal>*</literal>)。在路由組態檔中的項目看起來就像這樣︰<indexterm>
-   <primary> 路由</primary>
-   <secondary> 靜態</secondary>
-   </indexterm>
+   TCP/IP 封包的靜態路由是由 <filename>/etc/sysconfig/network/routes</filename> 和 <filename>/etc/sysconfig/network/ifroute-*</filename> 檔案確定的。您可在 <filename>/etc/sysconfig/network/routes</filename> 中指定各種系統任務所需的全部靜態路由，包括前往主機的路由、透過閘道前往主機的路由，以及前往網路的路由。對於需要個別路由的介面，請定義額外的組態檔案︰<filename>/etc/sysconfig/network/ifroute-*</filename>。以介面的名稱取代萬用字元 (<literal>*</literal>)。在路由組態檔中的項目看起來就像這樣︰
   </para>
 <screen># Destination     Gateway           Netmask            Interface  Options</screen>
 
@@ -170,21 +149,13 @@ default           204.127.235.41    0.0.0.0            eth0
 # Destination     [Gateway]                -           Interface
 2001:DB8:100::/64 -                        -           eth0
 2001:DB8:100::/32 fe80::216:3eff:fe6d:c042 -           eth0</screen>
-  </example><indexterm class="endofrange" startref="idx-routing"/>
+  </example>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-resolv">
   <title><filename>/etc/resolv.conf</filename></title>
-<indexterm>
-  <primary> 組態檔案</primary>
-  <secondary> resolv.conf</secondary></indexterm> 
+ 
   <para>
-   主機所屬的網域在 <filename>/etc/resolv.conf</filename> 中指定 (關鍵字 <systemitem>search</systemitem>)。使用 <systemitem>search</systemitem> 選項最多可以指定六個網域，總共 256 個字元。解析不完整的名稱時，會嘗試附加個別 <systemitem>search</systemitem> 項目產生一個名稱。使用 <systemitem>nameserver</systemitem> 選項最多可以指定 3 個名稱伺服器，一行指定一個。註解以井號或分號 (<literal>#</literal> 或 <literal>;</literal>) 開頭。如需取得範例說明，請參閱<xref linkend="dat-netz-etc-resolv-conf"/>。<indexterm>
-   <primary>DNS</primary>
-   <secondary>領域</secondary>
-   </indexterm> <indexterm>
-   <primary>DNS</primary>
-   <secondary>名稱伺服器</secondary>
-   </indexterm>
+   主機所屬的網域在 <filename>/etc/resolv.conf</filename> 中指定 (關鍵字 <systemitem>search</systemitem>)。使用 <systemitem>search</systemitem> 選項最多可以指定六個網域，總共 256 個字元。解析不完整的名稱時，會嘗試附加個別 <systemitem>search</systemitem> 項目產生一個名稱。使用 <systemitem>nameserver</systemitem> 選項最多可以指定 3 個名稱伺服器，一行指定一個。註解以井號或分號 (<literal>#</literal> 或 <literal>;</literal>) 開頭。如需取得範例說明，請參閱<xref linkend="dat-netz-etc-resolv-conf"/>。 
   </para>
   <para>
    不過，您不可手動編輯 <filename>/etc/resolv.conf</filename>。它是由 <command>netconfig</command> 程序檔產生的。若要定義靜態 DNS 組態而不使用 YaST，請在 <filename>/etc/sysconfig/network/config</filename> 檔案中手動編輯適當的變數︰
@@ -307,9 +278,7 @@ nameserver 192.168.1.116</screen>
 
  <sect3 xml:id="sec-basicnet-manconf-hosts">
   <title><filename>/etc/hosts</filename></title>
-<indexterm>
-  <primary> 組態檔案</primary>
-  <secondary> 主機</secondary></indexterm> 
+ 
   <para>
    在此檔案中 (請參閱<xref linkend="dat-netz-etc-hosts"/>)，將為主機名稱指定 IP 位址。如果沒有執行任何名稱伺服器，將使用此 IP 連接設定的所有主機將列示於此。對於每個主機，請在檔案中輸入一行資訊，其中包含 IP 位址、完全合格的主機名稱及主機名稱。IP 位址必須在行的開頭，然後以空格和定位點分隔這些項目。註解的前面永遠是 <literal>#</literal> 符號。
   </para>
@@ -321,9 +290,7 @@ nameserver 192.168.1.116</screen>
   </example>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-networks">
-  <title><filename>/etc/networks</filename></title><indexterm>
-  <primary> 組態檔案</primary>
-  <secondary> 網路</secondary></indexterm> 
+  <title><filename>/etc/networks</filename></title>
   <para>
    在此檔中，網路名稱會轉換為網路位址。格式與 <filename>hosts</filename> 檔案格式相似，但是網路名稱在位址前。請參閱<xref linkend="dat-netz-networks"/>。
   </para>
@@ -334,9 +301,7 @@ localnet     192.168.0.0</screen>
   </example>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-host">
-  <title><filename>/etc/host.conf</filename></title><indexterm>
-  <primary> 組態檔案</primary>
-  <secondary> host.conf</secondary></indexterm> 
+  <title><filename>/etc/host.conf</filename></title>
   <para>
    名稱解析--透過<emphasis>解析器</emphasis>庫分析主機和網路的名稱--由此檔案收集。該檔案僅用於與 libc4 或 libc5 連結的程式。對於目前的 glibc 程式，請參閱 <filename>/etc/nsswitch.conf</filename> 中的設定。每個參數都必須單獨佔用一行。註解的前面是 <literal>#</literal> 符號。<xref linkend="tab-netz-param-hostconf"/> 顯示出可用的參數。<filename>/etc/host.conf</filename> 範例是顯示在 <xref linkend="dat-netz-etc-hostconf"/>。
   </para>
@@ -434,13 +399,9 @@ multi on</screen>
   </example>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-nsswitch">
-  <title><filename>/etc/nsswitch.conf</filename></title><indexterm>
-  <primary> 組態檔案</primary>
-  <secondary> nsswitch.conf</secondary></indexterm> 
+  <title><filename>/etc/nsswitch.conf</filename></title>
   <para>
-   GNU C Library 2.0 的介紹隨附於<emphasis>名稱服務切換</emphasis> (NSS，Name Service Switch) 的介紹。詳細資訊請參閱 <systemitem>nsswitch.conf(5)</systemitem> man 頁面和 <emphasis>GNU C Library 參考手冊</emphasis>。<indexterm>
-   <primary>NSS</primary>
-   </indexterm>
+   GNU C Library 2.0 的介紹隨附於<emphasis>名稱服務切換</emphasis> (NSS，Name Service Switch) 的介紹。詳細資訊請參閱 <systemitem>nsswitch.conf(5)</systemitem> man 頁面和 <emphasis>GNU C Library 參考手冊</emphasis>。
   </para>
   <para>
    查詢的順序定義於檔案 <filename>/etc/nsswitch.conf</filename>。<filename>nsswitch.conf</filename> 範例是顯示在 <xref linkend="dat-netz-nsswitchconf"/>。備註前面標有 <literal>#</literal> 符號。在此範例中，<filename>hosts</filename> 資料庫下的項目表示要求是透過 DNS 傳送到 <filename>/etc/hosts</filename> (<option>files</option>)<phrase os="sles;osuse"> (請參閱<xref linkend="cha-dns"/>)</phrase>。
@@ -468,10 +429,7 @@ shadow:     compat
 </screen>
   </example>
   <para>
-   NSS 上可用的<quote>資料庫</quote>列示於 <xref linkend="tab-netz-nnswitch-db"/>。<indexterm>
-   <primary>NSS</primary>
-   <secondary> 資料庫</secondary>
-   </indexterm> NSS 資料庫的組態選項將列於<xref linkend="tab-netz-nnswitch-conf"/>。
+   NSS 上可用的<quote>資料庫</quote>列示於 <xref linkend="tab-netz-nnswitch-db"/>。 NSS 資料庫的組態選項將列於<xref linkend="tab-netz-nnswitch-conf"/>。
   </para>
   <table xml:id="tab-netz-nnswitch-db">
    <title>透過 /etc/nsswitch.conf 的可用資料庫</title>
@@ -706,9 +664,7 @@ shadow:     compat
   </table>
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-nscd">
-  <title><filename>/etc/nscd.conf</filename></title><indexterm>
-  <primary> 組態檔案</primary>
-  <secondary> nscd.conf</secondary></indexterm> 
+  <title><filename>/etc/nscd.conf</filename></title>
   <para>
    此檔案用來設定 nscd (名稱服務快取精靈)。請參閱 <systemitem>nscd(8)</systemitem> 與 <systemitem>nscd.conf(5)</systemitem> man 頁面。依預設，<option>passwd</option>、<option>groups</option> 與 <option>hosts</option> 的系統項目會由 nscd 快取。這對 NIS 與 LDAP 等目錄服務的效能而言十分重要，因為存取名稱、群組或主機都不再需要網路連接。
    
@@ -720,12 +676,10 @@ shadow:     compat
  </sect3>
  <sect3 xml:id="sec-basicnet-manconf-files-hostname">
   <title><filename>/etc/HOSTNAME </filename></title>
-<indexterm>
-  <primary> 組態檔案</primary>
-  <secondary> HOSTNAME</secondary></indexterm> 
+ 
   <para>
    <filename>/etc/HOSTNAME</filename> 包含完全合格的主機名稱 (FQHN)。完全合格的主機名稱是附加網域名稱的主機名稱。此檔案只能包含一行，其中設定了主機名稱。機器開機時會讀取此檔案。
   </para>
-<indexterm class="endofrange" startref="idx-networks-configuration-files"/>
+
  </sect3>
 </sect2>

--- a/l10n/sles/zh-tw/xml/net_dhcp.xml
+++ b/l10n/sles/zh-tw/xml/net_dhcp.xml
@@ -13,12 +13,7 @@
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
-<indexterm class="startofrange" xml:id="idx-DHCP">
- <primary>DHCP</primary></indexterm><indexterm>
- <primary>網路</primary>
- <secondary>DHCP</secondary></indexterm><indexterm>
- <primary>IP 位址</primary>
- <secondary>動態指定</secondary></indexterm>
+
  <tip arch="zseries" os="sles">
   <title>IBM Z：DHCP 支援</title>
   <para>
@@ -40,15 +35,7 @@
  <sect1 xml:id="sec-dhcp-yast">
   <title>使用 YaST 設定 DHCP 伺服器</title>
 
-<indexterm>
 
-  <primary>YaST</primary>
-
-  <secondary>DHCP</secondary></indexterm><indexterm>
-
-  <primary>DHCP使用 YaST 設定</primary>
-
-  <secondary/></indexterm>
 
   <para>
    若要安裝 DHCP 伺服器，請啟動 YaST 並選取<menuchoice><guimenu>軟體</guimenu> <guimenu>軟體管理</guimenu></menuchoice>。選擇<menuchoice><guimenu>過濾器</guimenu>
@@ -292,39 +279,20 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-dhcp-soft">
-  <title>DHCP 軟體套件</title><indexterm>
-
-  <primary> DHCP</primary>
-
-  <secondary> 套件</secondary></indexterm> 
+  <title>DHCP 軟體套件</title>
 
   <para>
    <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 可以使用 DHCP 伺服器，也可以使用 DHCP 用戶端。可用的 DHCP 伺服器是 <systemitem class="daemon">dhcpd</systemitem> (由 Internet Systems Consortium 發佈)。用戶端提供了 <systemitem>dhcp-client</systemitem> (ISC 也有提供) 及 <systemitem>wicked</systemitem> 套件附帶的工具。
   </para>
 
   <para>
-   依預設，<systemitem>wicked</systemitem> 工具會連同 <systemitem>wickedd-dhcp4</systemitem> 和 <systemitem>wickedd-dhcp6</systemitem> 服務一起安裝。系統每次開機時，會自動啟動它們，以監視 DHCP 伺服器。它們不需要組態檔來執行其工作，而且大部份的標準設定可以直接使用。如果情況較為複雜，請使用 ISC <systemitem>dhcp-client</systemitem>，此程式透過組態檔 <filename>/etc/dhclient.conf</filename> 和 <filename>/etc/dhclient6.conf</filename> 來控制。<indexterm>
-   <primary>組態檔</primary>
-   <secondary> dhclient.conf</secondary>
-   </indexterm>
+   依預設，<systemitem>wicked</systemitem> 工具會連同 <systemitem>wickedd-dhcp4</systemitem> 和 <systemitem>wickedd-dhcp6</systemitem> 服務一起安裝。系統每次開機時，會自動啟動它們，以監視 DHCP 伺服器。它們不需要組態檔來執行其工作，而且大部份的標準設定可以直接使用。如果情況較為複雜，請使用 ISC <systemitem>dhcp-client</systemitem>，此程式透過組態檔 <filename>/etc/dhclient.conf</filename> 和 <filename>/etc/dhclient6.conf</filename> 來控制。
   </para>
  </sect1>
  <sect1 xml:id="sec-dhcp-server">
   <title>DHCP 伺服器 dhcpd</title>
 
-<indexterm>
 
-  <primary>組態檔</primary>
-
-  <secondary>dhcpd.conf</secondary></indexterm><indexterm class="startofrange" xml:id="idx-dhcp-server">
-
-  <primary>DHCP</primary>
-
-  <secondary>伺服器</secondary></indexterm><indexterm class="startofrange" xml:id="idx-dhcp-dhcpd">
-
-  <primary>DHCP</primary>
-
-  <secondary>dhcpd</secondary></indexterm>
 
   <para>
    任何 DHCP 系統的核心都是動態主機組態通訊協定精靈。這個伺服器會依照組態檔 <filename>/etc/dhcpd.conf</filename> 中定義的設定，<emphasis>租用</emphasis>位址並監看其使用情形。藉由變更此檔案中的參數及值，系統管理員可以透過數種方式影響程式的行為。請參閱 <xref linkend="dat-dhcp-conf"/> 中的 <filename>/etc/dhcpd.conf</filename> 基本範例檔案。
@@ -400,12 +368,10 @@ subnet 192.168.2.0 netmask 255.255.255.0
 
   <para>
    在預設的 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 系統上，出於安全性考量，DHCP 精靈會在 chroot 環境中啟動。組態檔必須複製到 chroot 環境，如此精靈才可以找到這些檔案。通常情況下不需要擔心發生這種情形，因為指令 <command>systemctl start dhcpd</command> 會自動複製檔案。
-  </para><indexterm class="endofrange" startref="idx-dhcp-server"/><indexterm class="endofrange" startref="idx-dhcp-dhcpd"/>
+  </para>
 
   <sect2 xml:id="sec-dhcp-statip">
-   <title>使用固定 IP 位址的用戶端</title><indexterm>
-   <primary> DHCP</primary>
-   <secondary> 靜態位址指派</secondary></indexterm> 
+   <title>使用固定 IP 位址的用戶端</title>
    <para>
     DHCP 也可以用來指派預先定義的靜態位址給特定用戶端。明確指派的位址永遠比集區的動態位址優先。當可用位址不足，伺服器必須在用戶端之間重新分配位址時 (舉例而言)，動態位址便會過期，靜態位址則不同，它永遠不會過期。
    </para>
@@ -476,6 +442,6 @@ fixed-address 192.168.2.100;
 
   <para>
    如需有關 DHCP 的詳細資訊，請參閱 <emphasis>Internet Systems Consortium</emphasis> 的網站 <link xlink:href="https://www.isc.org/dhcp/"/>。在 <option>dhcpd</option>、<option>dhcpd.conf</option>、<option>dhcpd.leases</option> 和 <option>dhcp-options</option> man 頁面中也可以找到資訊。
-  </para><indexterm class="endofrange" startref="idx-DHCP"/>
+  </para>
  </sect1>
 </chapter>

--- a/l10n/sles/zh-tw/xml/net_dns.xml
+++ b/l10n/sles/zh-tw/xml/net_dns.xml
@@ -16,21 +16,9 @@
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
-<indexterm>
- <primary>領域名稱系統</primary>
- <see>DNS</see></indexterm><indexterm>
- <primary>DNS</primary>
- <secondary>設定</secondary></indexterm><indexterm>
- <primary>設定</primary>
- <secondary>DNS</secondary></indexterm><indexterm>
- <primary>名稱伺服器</primary>
- <see>DNS</see></indexterm>
+
  <sect1 xml:id="sec-dns-basic">
-  <title>DNS 詞彙</title><indexterm>
-
-  <primary> DNS</primary>
-
-  <secondary> 詞彙</secondary></indexterm> 
+  <title>DNS 詞彙</title>
 
   <variablelist>
    <varlistentry>
@@ -489,25 +477,11 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-dns-bind">
-  <title>啟動 BIND 名稱伺服器</title><indexterm xml:id="idx-DNS-BIND" class="startofrange">
-
-  <primary>DNS</primary>
-
-  <secondary>BIND</secondary></indexterm><indexterm xml:id="idx-BIND" class="startofrange">
-
-  <primary>BIND</primary></indexterm>
+  <title>啟動 BIND 名稱伺服器</title>
 
   <para>
    在 <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> 系統上，已預先設定名稱伺服器 BIND (<emphasis>Berkeley Internet Name Domain，柏克萊網際網路名稱網域</emphasis>)，因此在安裝後可以立即啟動此名稱伺服器，不會出現任何問題。一般而言，如果您能連接網際網路，並在 <systemitem class="ipaddress">/etc/resolv.conf</systemitem> 中輸入了 <systemitem class="domainname">127.0.0.1</systemitem> 做為 <filename>localhost</filename> 的名稱伺服器位址，則表示您已經有可以運作的名稱解析功能，因而無需知道提供者的 DNS。BIND 透過根名稱伺服器執行名稱解析，顯見處理程序較慢。一般而言，應該在 <systemitem>forwarders</systemitem> 下的組態檔 <filename>/etc/named.conf</filename> 中輸入提供者的 DNS 及其 IP 位址，以確保有效及安全的名稱解析。如果目前此辦法可行，名稱伺服器會當成純粹的「<emphasis>僅快取</emphasis>」名稱伺服器執行。只有在您設定了名稱伺服器自己的區域後，它才會成為真正的 DNS。<filename>/usr/share/doc/packages/bind/config</filename> 中提供了一個簡單範例。
-  </para><indexterm>
-
-  <primary>組態檔</primary>
-
-  <secondary>resolv.conf</secondary></indexterm><indexterm>
-
-  <primary>組態檔</primary>
-
-  <secondary>named.conf</secondary></indexterm>
+  </para>
 
   <tip>
    <title>自動使用名稱伺服器資訊</title>
@@ -524,25 +498,10 @@
    若要啟動名稱伺服器，請以 <systemitem class="username">root</systemitem> 身分輸入指令 <command>systemctl start named</command>。使用 <command>systemctl status named</command> 來檢查 named (在呼叫名稱伺服器程序時) 是否已成功啟動。使用 <command>host</command> 或 <command>dig</command> 程式立即測試本地系統上的名稱伺服器，應該會傳回 <systemitem class="domainname">localhost</systemitem> 做為預設伺服器，位址為 <systemitem class="ipaddress">127.0.0.1</systemitem>。如果沒有傳回所需的結果，<filename>/etc/resolv.conf</filename> 可能包含不正確的名稱伺服器項目，或是檔案不存在。如果是第一次測試，請輸入 <command>host</command> <option>127.0.0.1</option>，這通常都能成功。如果看到錯誤訊息，請使用 <command>systemctl status named</command> 檢查伺服器是否真的在執行。如果該名稱伺服器未啟動或者出現非預期的行為，請檢查 <command>journalctl -e</command> 的輸出。
   </para>
 
-<indexterm>
 
-  <primary>記錄檔</primary>
-
-  <secondary>訊息</secondary></indexterm><indexterm>
-
-  <primary>DNS</primary>
-
-  <secondary>啟動</secondary></indexterm><indexterm>
-
-  <primary>DNS</primary>
-
-  <secondary>疑難排解</secondary></indexterm>
 
   <para>
-   若要使用提供者的名稱伺服器或網路上正在執行的名稱伺服器做為轉遞者，請在 <systemitem>forwarders</systemitem> 下的 <systemitem>options</systemitem> 區段中輸入對應的 IP 位址。<xref linkend="ex-forward"/>中包含的位址只是範例。請根據您自己的設定調整這些項目。<indexterm>
-   <primary>DNS</primary>
-   <secondary> 轉遞</secondary>
-   </indexterm>
+   若要使用提供者的名稱伺服器或網路上正在執行的名稱伺服器做為轉遞者，請在 <systemitem>forwarders</systemitem> 下的 <systemitem>options</systemitem> 區段中輸入對應的 IP 位址。<xref linkend="ex-forward"/>中包含的位址只是範例。請根據您自己的設定調整這些項目。
   </para>
 
   <example xml:id="ex-forward">
@@ -563,11 +522,7 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-dns-named">
-  <title>/etc/named.conf 組態檔案</title><indexterm xml:id="idx-configuration-files-named-conf" class="startofrange">
-
-  <primary> 組態檔</primary>
-
-  <secondary> named.conf</secondary></indexterm> 
+  <title>/etc/named.conf 組態檔案</title>
 
   <para>
    BIND 名稱伺服器本身的所有設定都儲存於檔案 <filename>/etc/named.conf</filename> 中。不過，要處理之網域的區域資料 (包括主機名稱、IP 位址等) 儲存於 <filename>/var/lib/named</filename> 目錄中各自的檔案中。詳細資訊會在稍後說明 。
@@ -602,9 +557,7 @@ zone "." in {
   </example>
 
   <sect2 xml:id="sec-dns-named-options">
-   <title>重要組態選項</title><indexterm>
-   <primary> DNS</primary>
-   <secondary> 選項</secondary></indexterm> 
+   <title>重要組態選項</title>
    <variablelist>
     <varlistentry>
      <term>directory "<replaceable>FILENAME</replaceable>";</term>
@@ -632,9 +585,7 @@ zone "." in {
     </varlistentry>
     <varlistentry>
      <term>listen-on port 53 { 127.0.0.1; <replaceable>IP-ADDRESS</replaceable>; };</term>
-     <listitem><indexterm>
-      <primary>ports</primary>
-      <secondary>53</secondary></indexterm>
+     <listitem>
       <para>
        告訴 BIND 哪個網路介面和哪個連接埠要接受用戶端查詢。<literal>port 53</literal> 不需要明確指定，因為 <literal>53</literal> 是預設連接埠。輸入 <literal>127.0.0.1</literal> 將允許來自本地主機的要求。如果完全省略此項目，預設會使用所有介面。
       </para>
@@ -719,9 +670,7 @@ zone "." in {
   </sect2>
 
   <sect2 xml:id="sec-dns-named-log">
-   <title>記錄</title><indexterm>
-   <primary> DNS</primary>
-   <secondary> 記錄</secondary></indexterm> 
+   <title>記錄</title>
    <para>
     記錄的內容、方式及位置皆可在 BIND 中詳細設定。一般而言，預設設定應該足夠。<xref linkend="ex-no-log"/> 顯示了這類項目的最簡單格式，而且完全停用了記錄。
    </para>
@@ -810,13 +759,7 @@ zone "." in {
   </sect2>
  </sect1>
  <sect1 xml:id="sec-dns-zonefile">
-  <title>區域檔案</title><indexterm>
-
-  <primary> DNS</primary>
-
-  <secondary> 區域</secondary>
-
-  <tertiary> 檔案</tertiary></indexterm> 
+  <title>區域檔案</title>
 
   <para>
    需要兩種類型的區域檔案。一個會給主機名稱指定 IP 位址，另一個的作用恰恰相反︰為 IP 位址提供主機名稱。
@@ -994,10 +937,7 @@ pluto     AAAA 2345:00D2:DA11::1234:5678:9ABC:DEF0</screen>
 
 
   <para>
-   虛擬網域 <literal>in-addr.arpa</literal> 用來反向查詢 IP 位址到主機名稱。它會以反向標記法附加到位址的網路部分。因此 <systemitem class="ipaddress">192.168</systemitem> 會解析為 <systemitem>168.192.in-addr.arpa</systemitem>。請參閱<xref linkend="dat-arpa"/>。<indexterm>
-   <primary>DNS</primary>
-   <secondary> 反向查詢</secondary>
-   </indexterm>
+   虛擬網域 <literal>in-addr.arpa</literal> 用來反向查詢 IP 位址到主機名稱。它會以反向標記法附加到位址的網路部分。因此 <systemitem class="ipaddress">192.168</systemitem> 會解析為 <systemitem>168.192.in-addr.arpa</systemitem>。請參閱<xref linkend="dat-arpa"/>。
   </para>
 
 
@@ -1064,9 +1004,9 @@ pluto     AAAA 2345:00D2:DA11::1234:5678:9ABC:DEF0</screen>
   </variablelist>
 
   <para>
-   一般情況下，不同 BIND 版本之間的區域傳輸應該可以順利進行。<indexterm class="endofrange" startref="idx-DNS-BIND"/>
-   <indexterm class="endofrange" startref="idx-BIND"/>
-   <indexterm class="endofrange" startref="idx-configuration-files-named-conf"/>
+   一般情況下，不同 BIND 版本之間的區域傳輸應該可以順利進行。
+   
+   
 
   </para>
  </sect1>

--- a/l10n/sles/zh-tw/xml/net_samba.xml
+++ b/l10n/sles/zh-tw/xml/net_samba.xml
@@ -11,16 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-Samba" class="startofrange">
- <primary>Samba</primary></indexterm><indexterm>
- <primary>SMB</primary>
- <see>Samba</see></indexterm><indexterm>
- <primary>macOS</primary>
- <secondary>共用檔案</secondary></indexterm><indexterm>
- <primary>Windows</primary>
- <secondary>共用檔案</secondary></indexterm><indexterm>
- <primary>Linux</primary>
- <secondary>與另一個作業系統共用檔案</secondary></indexterm>
+ </info>
  <sect1 xml:id="sec-samba-term">
   <title>術語</title>
 
@@ -33,18 +24,7 @@
     <term>SMB 通訊協定</term>
     <listitem>
      <para>
-      <indexterm>
-      <primary>Samba</primary>
-      <secondary>SMB</secondary>
-      </indexterm> <indexterm>
-      <primary>通訊協定</primary>
-      <secondary>SMB</secondary>
-      </indexterm> <indexterm>
-      <primary>smbd</primary>
-      </indexterm> Samba 使用基於 <phrase role="productname">NetBIOS</phrase> 服務的 SMB (伺服器訊息區塊) 通訊協定。由於 Microsoft 發行了此通訊協定，因此其他的軟體製造商可以建立連接至 Microsoft 網域網路的連接。使用 Samba，SMB 通訊協定就可以在 TCP/IP 通訊協定上運作，因此 TCP/IP 通訊協定必須安裝在所有的用戶端上。<indexterm>
-      <primary>Samba</primary>
-      <secondary> TCP/IP 與</secondary>
-      </indexterm>
+         Samba 使用基於 <phrase role="productname">NetBIOS</phrase> 服務的 SMB (伺服器訊息區塊) 通訊協定。由於 Microsoft 發行了此通訊協定，因此其他的軟體製造商可以建立連接至 Microsoft 網域網路的連接。使用 Samba，SMB 通訊協定就可以在 TCP/IP 通訊協定上運作，因此 TCP/IP 通訊協定必須安裝在所有的用戶端上。
      </para>
      <tip arch="zseries" os="sles">
       <title>IBM Z：NetBIOS 支援</title>
@@ -58,13 +38,7 @@
     <term>CIFS 通訊協定</term>
     <listitem>
      <para>
-      <indexterm>
-      <primary>Samba</primary>
-      <secondary>CIFS</secondary>
-      </indexterm> <indexterm>
-      <primary>通訊協定</primary>
-      <secondary>CIFS</secondary>
-      </indexterm>CIFS (一般網際網路檔案系統) 通訊協定是 Samba 所支援的另一種通訊協定。CIFS 定義用於網路上的標準遠端檔案系統存取通訊協定，讓使用者群組可以透過網路分工合作和共享文件。
+       CIFS (一般網際網路檔案系統) 通訊協定是 Samba 所支援的另一種通訊協定。CIFS 定義用於網路上的標準遠端檔案系統存取通訊協定，讓使用者群組可以透過網路分工合作和共享文件。
      </para>
     </listitem>
    </varlistentry>
@@ -72,22 +46,16 @@
     <term>NetBIOS</term>
     <listitem>
      <para>
-      <indexterm>
-      <primary> NetBIOS</primary>
-      </indexterm> NetBIOS 是用來在提供名稱服務的機器之間進行通訊的軟體介面 (API)。它允許連接至網路的機器保留自己的名稱。在保留後，就可以使用名稱來定址這些機器。在此沒有檢查名稱的中央程序。在網路上的任何機器都可以保留它所需的任何數量名稱，只要這些名稱尚未使用。可以針對不同的網路結構實作 NetBIOS 介面。<phrase role="productname">NetBEUI</phrase> 是與網路硬體結合相對密切的一種實作，不過通常稱為 <phrase role="productname">NetBIOS</phrase>。與 NetBIOS 一起執行的網路通訊協定是 Novell 的 IPX (經由 TCP/IP 的 NetBIOS) 與 TCP/IP。
+       NetBIOS 是用來在提供名稱服務的機器之間進行通訊的軟體介面 (API)。它允許連接至網路的機器保留自己的名稱。在保留後，就可以使用名稱來定址這些機器。在此沒有檢查名稱的中央程序。在網路上的任何機器都可以保留它所需的任何數量名稱，只要這些名稱尚未使用。可以針對不同的網路結構實作 NetBIOS 介面。<phrase role="productname">NetBEUI</phrase> 是與網路硬體結合相對密切的一種實作，不過通常稱為 <phrase role="productname">NetBIOS</phrase>。與 NetBIOS 一起執行的網路通訊協定是 Novell 的 IPX (經由 TCP/IP 的 NetBIOS) 與 TCP/IP。
      </para>
      <para>
       經由 TCP/IP 所傳送的 NetBIOS 名稱，與 <filename>/etc/hosts</filename> 中所使用的名稱，或由 DNS 所定義的名稱完全不相同。NetBIOS 使用自己完全獨立的命名慣例。不過，為了方便管理，一般建議使用與 DNS 主機名稱相對應的名稱，或者在本地使用 DNS。Samba 預設是使用此對應名稱。
-     </para><indexterm>
-     <primary>Samba</primary>
-     <secondary>名稱。</secondary></indexterm>
+     </para>
     </listitem>
    </varlistentry>
    <varlistentry>
     <term>Samba 伺服器</term>
-    <listitem><indexterm>
-     <primary>Samba</primary>
-     <secondary> 伺服器</secondary></indexterm>
+    <listitem>
      <para>
       Samba 伺服器可為用戶端提供 SMB/CIFS 服務和 NetBIOS over IP 命名服務。對於 Linux 系統，Samba 伺服器有三種精靈可用︰smbd (用於 SMB/CIFS 服務)、nmbd (用於命名服務) 及 winbind (用於驗証)。
      </para>
@@ -95,9 +63,7 @@
    </varlistentry>
    <varlistentry>
     <term>Samba 用戶端</term>
-    <listitem><indexterm xml:id="idx-Samba-clients" class="startofrange">
-     <primary> Samba</primary>
-     <secondary> 用戶端</secondary></indexterm> 
+    <listitem> 
      <para>
       Samba 用戶端是透過 SMB 通訊協定，使用 Samba 伺服器所提供之 Samba 服務的系統。常用作業系統 (例如 Windows 和 macOS) 都支援 SMB 通訊協定。TCP/IP 通訊協定必須安裝在所有的電腦上。Samba 提供適用於不同 Unix 類別的用戶端。就 Linux 而言，有一個 SMB 的核心模組，允許在 Linux 系統層級上整合 SMB 資源。您不必為 Samba 用戶端執行任何精靈。
      </para>
@@ -107,16 +73,7 @@
     <term>共享</term>
     <listitem>
      <para>
-      <indexterm>
-      <primary> Samba</primary>
-      <secondary> 共享</secondary>
-      </indexterm> SMB 伺服器透過共享方式向用戶端提供資源。共享是指印表機和位在伺服器上的目錄及其子目錄。它是利用名稱來輸出，並且可藉由其名稱來存取。共用名稱可以設成任何名稱，它並不需要是輸出目錄的名稱。也會指定一個名稱給印表機。用戶端可以透過其名稱存取印表機。<indexterm>
-      <primary>列印</primary>
-      <secondary>Samba</secondary>
-      </indexterm> <indexterm>
-      <primary> Samba</primary>
-      <secondary>印表機</secondary>
-      </indexterm> <indexterm class="endofrange" startref="idx-Samba-clients"/>
+       SMB 伺服器透過共享方式向用戶端提供資源。共享是指印表機和位在伺服器上的目錄及其子目錄。它是利用名稱來輸出，並且可藉由其名稱來存取。共用名稱可以設成任何名稱，它並不需要是輸出目錄的名稱。也會指定一個名稱給印表機。用戶端可以透過其名稱存取印表機。  
      </para>
     </listitem>
    </varlistentry>
@@ -124,10 +81,7 @@
     <term>DC</term>
     <listitem>
      <para>
-      <indexterm>
-      <primary> Samba</primary>
-      <secondary> DC</secondary>
-      </indexterm> 網域控制器 (DC) 是處理網域中帳戶的伺服器。進行資料複製時，可在一個網域中使用其他領域控制器。
+       網域控制器 (DC) 是處理網域中帳戶的伺服器。進行資料複製時，可在一個網域中使用其他領域控制器。
      </para>
     </listitem>
    </varlistentry>
@@ -156,34 +110,10 @@
    <para>
     <systemitem>winbind</systemitem> 是一項獨立服務，同樣也是以單獨的 <systemitem>samba-winbind</systemitem> 套件提供。
    </para>
-  </tip><indexterm>
-
-  <primary>Samba</primary>
-
-  <secondary>啟動</secondary></indexterm><indexterm>
-
-  <primary>Samba</primary>
-
-  <secondary>停止</secondary></indexterm>
+  </tip>
  </sect1>
  <sect1 xml:id="sec-samba-serv-inst">
-  <title>設定 Samba 伺服器</title><indexterm>
-
-  <primary>Samba</primary>
-
-  <secondary>安裝</secondary></indexterm><indexterm>
-
-  <primary>Samba</primary>
-
-  <secondary>伺服器</secondary></indexterm><indexterm>
-
-  <primary>Samba</primary>
-
-  <secondary>設定</secondary></indexterm><indexterm>
-
-  <primary>設定</primary>
-
-  <secondary>Samba</secondary></indexterm>
+  <title>設定 Samba 伺服器</title>
 
   <para os="sles;osuse">
    <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> 中的 Samba 伺服器可以兩種方式設定︰使用 YaST 設定或手動設定。手動設定組態可以提供較詳細的設定，但是缺乏 YaST GUI 提供的方便性。
@@ -288,16 +218,7 @@
   <sect2 xml:id="sec-samba-serv-inst-manual" os="sles;osuse">
    <title>手動設定伺服器</title>
    <para>
-    <indexterm>
-    <primary>Samba</primary>
-    <secondary>設定</secondary>
-    </indexterm> <indexterm>
-    <primary>設定</primary>
-    <secondary>Samba</secondary>
-    </indexterm> <indexterm>
-    <primary> 組態檔</primary>
-    <secondary>smb.conf</secondary>
-    </indexterm>如果您想要使用 Samba 做為伺服器，請安裝 <systemitem class="resource">samba</systemitem>。Samba 的主要組態檔為 <filename>/etc/samba/smb.conf</filename>。這個檔案可以分成兩個邏輯部份。<literal>[global]</literal> 區段包含中央與全域設定值。以下預設區段包含個別檔案與印表機共享︰
+      如果您想要使用 Samba 做為伺服器，請安裝 <systemitem class="resource">samba</systemitem>。Samba 的主要組態檔為 <filename>/etc/samba/smb.conf</filename>。這個檔案可以分成兩個邏輯部份。<literal>[global]</literal> 區段包含中央與全域設定值。以下預設區段包含個別檔案與印表機共享︰
    </para>
    <itemizedlist mark="bullet" spacing="normal">
     <listitem>
@@ -380,9 +301,7 @@
     </variablelist>
    </sect3>
    <sect3 xml:id="sec-samba-smb-conf-shares">
-    <title>共享</title><indexterm>
-    <primary> Samba</primary>
-    <secondary> 共享</secondary></indexterm> 
+    <title>共享</title>
     <para>
      下列範例說明如何將 CD-ROM 光碟機與使用者目錄 (<literal>homes</literal>) 開放給 SMB 用戶端使用。
     </para>
@@ -498,13 +417,7 @@
     </warning>
    </sect3>
    <sect3 xml:id="sec-samba-rechte">
-    <title>安全性層級</title><indexterm xml:id="idx-Samba-security" class="startofrange">
-    <primary>Samba</primary>
-    <secondary>安全性</secondary></indexterm><indexterm>
-    <primary>安全性</primary>
-    <secondary>Samba</secondary></indexterm><indexterm>
-    <primary>Samba</primary>
-    <secondary>權限</secondary></indexterm>
+    <title>安全性層級</title>
     <para>
      為了提高安全性，每個共享存取權都以密碼保護。SMB 提供下列幾種權限檢查方式︰
     </para>
@@ -540,31 +453,19 @@
     </para>
     <para>
      在《Samba 3 HOWTO》中可以找到關於此主題的詳細資訊。至於在一個系統上的多個伺服器，請注意 <option>interfaces</option> 與 <option>bind interfaces only</option> 選項。
-    </para><indexterm class="endofrange" startref="idx-Samba-security"/>
+    </para>
    </sect3>
   </sect2>
  </sect1>
  <sect1 xml:id="sec-samba-client-inst">
-  <title>設定用戶端</title><indexterm>
-
-  <primary> Samba</primary>
-
-  <secondary> 用戶端</secondary></indexterm> 
+  <title>設定用戶端</title>
 
   <para>
    用戶端只能透過 TCP/IP 存取 Samba 伺服器。NetBEUI 與透過 IPX 的 NetBIOS 無法與 Samba 一起使用。
   </para>
 
   <sect2 xml:id="sec-samba-client-inst-yast">
-   <title>使用 YaST 設定 Samba 用戶端</title><indexterm>
-   <primary>YaST</primary>
-   <secondary>Samba</secondary>
-   <tertiary>用戶端</tertiary></indexterm><indexterm>
-   <primary>Samba</primary>
-   <secondary>用戶端</secondary></indexterm><indexterm>
-   <primary>設定</primary>
-   <secondary>Samba</secondary>
-   <tertiary>用戶端</tertiary></indexterm>
+   <title>使用 YaST 設定 Samba 用戶端</title>
    <para>
     設定 Samba 用戶端以存取 Samba 或 Windows 伺服器上的資源 (檔案或印表機)。在<menuchoice> <guimenu>網路服務</guimenu>
     <guimenu>Windows 網域成員</guimenu></menuchoice>對話方塊中輸入 NT 或 Active Directory 網域或工作群組。如果您啟用了<guimenu>Linux 驗證也使用 SMB 資訊</guimenu>，則使用者驗證將會在 Samba、NT 或 Kerberos 伺服器上執行。
@@ -578,11 +479,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-samba-anmeld-serv">
-  <title>做為登入伺服器的 Samba</title><indexterm>
-
-  <primary> Samba</primary>
-
-  <secondary> 登入</secondary></indexterm> 
+  <title>做為登入伺服器的 Samba</title>
 
   <para>
    在以 Windows 用戶端為主的網路中，通常會建議使用者只註冊一個有效的帳戶與密碼。在以 Windows 為基礎的網路中，這個任務是由主要網域控制器 (PDC) 來處理。您可以使用已設定為 PDC 的 Windows NT 伺服器，但也可借助 Samba 伺服器完成此任務。在 <filename>smb.conf</filename> 的 <literal>[global]</literal> 區段中必須編輯的項目如 <xref linkend="dat-samba-smb-conf-dom"/> 所示。
@@ -601,11 +498,7 @@
   </para>
 
 <screen>useradd hostname\$
-smbpasswd -a -m hostname</screen><indexterm>
-
-  <primary> 指令</primary>
-
-  <secondary> smbpasswd</secondary></indexterm> 
+smbpasswd -a -m hostname</screen> 
 
   <para>
    使用 <command>useradd</command> 指令，就會加上貨幣符號。當使用 <option>-m</option> 參數時，<command>smbpasswd</command> 指令就會自動插入這個符號。加備註的組態範例 (<filename>/usr/share/doc/packages/Samba/examples/smb.conf.SuSE</filename>) 包含一些設定，可讓此任務自動執行。
@@ -1075,14 +968,11 @@ No shadow copies found in system.</screen>
 
   <para>
    Samba 文件包含在 <systemitem>samba-doc</systemitem> 套件中，預設不會安裝該套件。您可以使用 <command>zypper install samba-doc</command> 來安裝。在指令行中輸入 <command>apropos</command>
-   <option> samba</option> 可顯示一些手冊頁，或者流覽 <filename>/usr/share/doc/packages/samba</filename> 目錄可取得更多的線上文件与範例。<filename>examples</filename> 子目錄中提供了一個帶有備註的範例組態 (<filename>smb.conf.SUSE</filename>)。另一個可以查看 Samba 相關資訊的檔案是 <filename>/usr/share/doc/packages/samba/README.SUSE</filename>。<indexterm>
-   <primary>組態檔案</primary>
-   <secondary> smb.conf</secondary>
-   </indexterm>
+   <option> samba</option> 可顯示一些手冊頁，或者流覽 <filename>/usr/share/doc/packages/samba</filename> 目錄可取得更多的線上文件与範例。<filename>examples</filename> 子目錄中提供了一個帶有備註的範例組態 (<filename>smb.conf.SUSE</filename>)。另一個可以查看 Samba 相關資訊的檔案是 <filename>/usr/share/doc/packages/samba/README.SUSE</filename>。
   </para>
 
   <para>
    由 Samba 團隊提供的《Samba  HOWTO》(請參閱 <link xlink:href="https://wiki.samba.org"/>) 包含了疑難排解一節。除此之外，文件的第五部份提供檢查組態的逐步指南。
-  </para><indexterm class="endofrange" startref="idx-Samba"/>
+  </para>
  </sect1>
 </chapter>

--- a/l10n/sles/zh-tw/xml/net_slp.xml
+++ b/l10n/sles/zh-tw/xml/net_slp.xml
@@ -11,14 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>網路</primary>
- <secondary>SLP</secondary></indexterm><indexterm>
- <primary>服務位置通訊協定</primary>
- <see>SLP</see></indexterm><indexterm>
- <primary>SLP</primary></indexterm><indexterm>
- <primary>通訊協定</primary>
- <secondary>SLP</secondary></indexterm>
+ </info>
  <para>
   <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> 支援使用 SLP 所提供的安裝來源進行安裝，並包含許多具有 SLP 整合支援的系統服務。您可以使用 SLP 以提供主要的功能給網路上的用戶端，例如系統上的安裝伺服器、檔案伺服器或是列印伺服器。提供 SLP 支援的服務包括 cupsd、login、ntp、openldap2、postfix、rpasswd、rsyncd、saned、sshd (透過 fish)、vnc 和 ypserv。
  </para>

--- a/l10n/sles/zh-tw/xml/net_yast.xml
+++ b/l10n/sles/zh-tw/xml/net_yast.xml
@@ -9,15 +9,7 @@
   </dm:docmanager>
  </info>
 
-<indexterm xml:id="idx-networks-integrating" class="startofrange">
 
- <primary>網路</primary>
-
- <secondary>設定</secondary></indexterm><indexterm>
-
- <primary>卡</primary>
-
- <secondary>網路</secondary></indexterm>
 
  <para>
   Linux 可支援多種網路類型。大多數使用不同的裝置名稱和組態檔，會分佈在檔案系統的不同位置。要更瞭解手動網路組態的綜覽，請參閱<xref linkend="sec-basicnet-manconf"/>。
@@ -37,13 +29,7 @@
 
  <sect2 xml:id="sec-basicnet-yast-netcard">
   <title>使用 YaST 設定網路卡</title>
-<indexterm>
-  <primary>卡</primary>
-  <secondary>網路</secondary></indexterm><indexterm>
-  <primary>網路</primary>
-  <secondary>YaST</secondary></indexterm><indexterm>
-  <primary>YaST</primary>
-  <secondary>網路卡</secondary></indexterm><indexterm/>
+
   <para>
    若要在 YaST 中設定以太網路卡或 Wi-Fi/藍芽卡，請選取<menuchoice> <guimenu>系統</guimenu> <guimenu>網路設定</guimenu>
    </menuchoice>。啟動模組後，YaST 將顯示<guimenu>網路設定</guimenu>對話方塊，其中包含四個索引標籤︰<guimenu>全域選項</guimenu>、<guimenu>綜覽</guimenu>、<guimenu>主機名稱/DNS</guimenu>和<guimenu>路由</guimenu>。
@@ -107,10 +93,7 @@
    </para>
    <sect4 xml:id="sec-basicnet-yast-change-address">
     <title>設定 IP 位址</title>
-<indexterm>
-    <primary> 網路</primary>
-    <secondary> YaST</secondary>
-    <tertiary> IP 位址</tertiary></indexterm> 
+ 
     <para>
      在<guimenu>網路卡設定</guimenu>對話方塊的<guimenu>位址</guimenu>索引標籤中，可以設定網路卡的 IP 位址或確定其 IP 位址的方式。系統支援 IPv4 和 IPv6 兩種位址。您可以為網路卡設定<guimenu>無 IP 位址</guimenu>(適用於 Bonding 裝置)、<guimenu>靜態指定的 IP 位址</guimenu>(IPv4 或 IPv6)，也可以透過<guimenu>DHCP</guimenu>或/與<guimenu>Zeroconf</guimenu>為其指定<guimenu>動態位址</guimenu>。
     </para>
@@ -181,13 +164,7 @@
     </para>
    </sect4>
    <sect4 xml:id="sec-basicnet-yast-configure-addresses">
-    <title>設定多個位址</title><indexterm>
-    <primary>網路</primary>
-    <secondary>YaST</secondary>
-    <tertiary>別名</tertiary></indexterm><indexterm>
-    <primary>網路</primary>
-    <secondary>YaST</secondary>
-    <tertiary>位址</tertiary></indexterm>
+    <title>設定多個位址</title>
     <para>
      一個網路裝置可擁有多個 IP 位址。
     </para>
@@ -287,10 +264,7 @@
    </sect4>
    <sect4 xml:id="sec-basicnet-yast-change-start">
     <title>啟動網路裝置</title>
-<indexterm>
-    <primary> 網路</primary>
-    <secondary> YaST</secondary>
-    <tertiary> 啟用</tertiary></indexterm> 
+ 
     <para>
      若使用結合 <command>wicked</command> 的方法，則可以將裝置設定為在開機時、連接纜線時、偵測到網路卡時啟動，或以手動方式啟動，或永不啟動。若要變更裝置啟動，請執行下列步驟︰
     </para>
@@ -503,10 +477,7 @@
    </procedure>
   </sect3>
   <sect3 xml:id="sec-basicnet-yast-change-host">
-   <title>設定主機名稱和 DNS</title><indexterm>
-   <primary>網路</primary>
-   <secondary> YaST</secondary>
-   <tertiary> 主機名稱</tertiary></indexterm>
+   <title>設定主機名稱和 DNS</title>
    <para>
     若您在安裝期間未變更網路組態，且已有乙太網路卡可用，則系統會自動為您的電腦產生主機名稱並啟動 DHCP。同時也會自動產生您主機要整合至網路環境所需的的名稱服務資訊。若網路位址設定使用 DHCP，則網域名稱伺服器清單會自動填入適當的資料。若您希望使用靜態設定，請手動設定數值。
    </para>
@@ -593,10 +564,7 @@ yast dns edit nameserver3=192.168.1.118</screen>
 
   <sect3 xml:id="sec-basicnet-yast-change-route">
    <title>設定路由</title>
-<indexterm>
-   <primary> 網路</primary>
-   <secondary> YaST</secondary>
-   <tertiary> 閘道</tertiary></indexterm> 
+ 
    <para>
     若要讓您的電腦與其他電腦和其他網路通訊，必須提供路由資訊，以讓網路流量採取正確的路徑。若使用 DHCP，會自動提供此資訊。若使用靜態設定，必須手動新增此資料。
    </para>

--- a/l10n/sles/zh-tw/xml/nm.xml
+++ b/l10n/sles/zh-tw/xml/nm.xml
@@ -6,10 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>網際網路</primary>
- <secondary>連接到</secondary></indexterm><indexterm>
- <primary>NetworkManager</primary></indexterm>
+ </info>
  <para>
   NetworkManager 是筆記型電腦與其他可攜式電腦的理想解決方案。它允許對網路連接使用一流的加密類型和標準，包括連至 802.1X 保護網路的連接。802.1X 是<quote>區域網路和都會區網路的 IEEE 標準 — 基於連接埠的網路存取控制</quote>。有了 NetworkManager，您在外出時，就不必顧慮網路介面的組態設定，也不必考慮如何在有線網路或無線網路之間進行切換。NetworkManager 可自動連接已知的無線網路，或是同時管理多個網路連接，然後按預設使用速度最快的連接。此外，您還可以手動在可用網路之間切換，並使用系統匣中的 Applet 管理網路連接。
 
@@ -38,11 +35,7 @@
   </itemizedlist>
  </sect1>
  <sect1 xml:id="sec-nm-activate">
-  <title>啟用或停用 NetworkManager</title><indexterm>
-
-  <primary> NetworkManager</primary>
-
-  <secondary> 啟用</secondary></indexterm>
+  <title>啟用或停用 NetworkManager</title>
 
   <para>
    對於筆記型電腦，NetworkManager 預設處於啟用狀態。但是您也可以在 YaST 網路設定模組中隨時將其啟用或停用。
@@ -110,11 +103,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-nm-configure">
-  <title>設定網路連線</title><indexterm>
-
-  <primary> NetworkManager</primary>
-
-  <secondary> 設定</secondary></indexterm>
+  <title>設定網路連線</title>
 
   <para>
    在 YaST 中啟用 NetworkManager 之後，使用 GNOME 中提供的 NetworkManager 前端設定網路連線。它會顯示所有類型網路連線的索引標籤，如有線、無線、行動寬頻、DSL 及 VPN 連線。
@@ -318,10 +307,7 @@
   </sect2>
 
   <sect2 xml:id="sec-nm-vpn">
-   <title>NetworkManager 和 VPN</title><indexterm>
-   <primary>NetworkManager</primary>
-   <secondary>VPN</secondary></indexterm><indexterm>
-   <primary>VPN</primary></indexterm>
+   <title>NetworkManager 和 VPN</title>
    <para>
     NetworkManager 支援多項虛擬私人網路 (VPN) 技術。對於每種技術，<phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 都附帶了可為 NetworkManager 提供一般支援的基礎套件。除此之外，您還需要為 Applet 安裝相應的桌面專屬套件。
    </para>
@@ -517,11 +503,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-nm-security">
-  <title>NetworkManager 和安全性</title><indexterm>
-
-  <primary> NetworkManager</primary>
-
-  <secondary> 安全性</secondary></indexterm>
+  <title>NetworkManager 和安全性</title>
 
   <para>
    NetworkManager 將無線連接分為受信任和不受信任兩種。受信任的連接是過去您明確選取過的任何網路，除此以外的連線都屬於不受信任。受信任的連接以存取點的名稱和 MAC 位址來識別。使用 MAC 位址可確保別的存取點不能使用受信任連接的名稱。
@@ -651,11 +633,7 @@
   </qandaset>
  </sect1>
  <sect1 xml:id="sec-nm-trouble">
-  <title>疑難排解</title><indexterm>
-
-  <primary> NetworkManager</primary>
-
-  <secondary> 疑難排解</secondary></indexterm>
+  <title>疑難排解</title>
 
   <para>
    可能發生連接問題。與 NetworkManager 相關的一些常見問題有︰Applet 未啟動或缺少 VPN 選項。解析和預防這些問題的方法會視使用的工具而定。

--- a/l10n/sles/zh-tw/xml/pcmcia_apm.xml
+++ b/l10n/sles/zh-tw/xml/pcmcia_apm.xml
@@ -39,9 +39,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>睡眠 (暫停磁碟)<indexterm>
-     <primary> 電源管理</primary>
-     <secondary> 睡眠</secondary></indexterm> 
+    <term>睡眠 (暫停磁碟) 
     </term>
     <listitem>
      <para>
@@ -55,9 +53,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>電池監視器<indexterm>
-     <primary> 電源管理</primary>
-     <secondary>電池監視器</secondary></indexterm> 
+    <term>電池監視器 
     </term>
     <listitem>
      <para>
@@ -84,11 +80,7 @@
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-pmanage-acpi">
-  <title>進階組態與電源介面 (ACPI)</title><indexterm xml:id="idx-power-management-ACPI" class="startofrange">
-
-  <primary> 電源管理</primary>
-
-  <secondary> ACPI</secondary></indexterm> 
+  <title>進階組態與電源介面 (ACPI)</title>
 
   <para>
    ACPI 主要用於讓作業系統設定和控制個別的硬體元件。ACPI 取代了「電源管理隨插即用 (PnP)」與「進階電源管理 (APM)」。它能提供一些資訊，包括電池、交流電轉接器、溫度、風扇以及<quote>關閉蓋子</quote>或<quote>電池電力不足</quote>等系統事件。
@@ -205,7 +197,7 @@
        <link xlink:href="http://acpi.sourceforge.net/dsdt/index.php"/> (Bruno Ducrot 的 DSDT 修補程式)
       </para>
      </listitem>
-    </itemizedlist><indexterm class="endofrange" startref="idx-power-management-ACPI"/>
+    </itemizedlist>
    </sect3>
   </sect2>
  </sect1>

--- a/l10n/sles/zh-tw/xml/printing.xml
+++ b/l10n/sles/zh-tw/xml/printing.xml
@@ -6,8 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary> 列印</primary></indexterm> 
+ </info>
  <para>
   <phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> 支援以多種類型的印表機進行列印，包括遠端網路印表機。您可以手動設定印表機，也可以使用 YaST 進行設定。如需組態設定指示，請參閱<xref linkend="sec-y2-hw-print"/>。圖形和指令行公用程式都可用來啟動和管理列印工作。如果您的印表機無法如預期般運作，請參閱<xref linkend="sec-drucken-prob"/>。
  </para>
@@ -266,15 +265,7 @@ Resolution/Output Resolution: 150dpi 300dpi *600dpi</screen>
   </para>
  </sect1>
  <sect1 xml:id="sec-p-appl-commandline">
-  <title>由指令行開始列印</title><indexterm>
-
-  <primary>列印</primary>
-
-  <secondary>指令行</secondary></indexterm><indexterm>
-
-  <primary>指令</primary>
-
-  <secondary>lp</secondary></indexterm>
+  <title>由指令行開始列印</title>
 
   <para>
    若要從指令行列印，請輸入 <command>lp -d</command>
@@ -367,9 +358,7 @@ Resolution/Output Resolution: 150dpi 300dpi *600dpi</screen>
   </para>
 
   <sect2 xml:id="sec-drucken-gdi">
-   <title>沒有標準印表機語言模式支援的印表機</title><indexterm>
-   <primary> 列印</primary>
-   <secondary> GDI 印表機</secondary></indexterm> 
+   <title>沒有標準印表機語言模式支援的印表機</title>
    <para>
     這些印表機不支援任何的一般印表機語言，且只有特殊的專屬控制序列才能處理。因此它們僅可在製造廠商針對其開發驅動程式的作業系統版本上使用。GDI 是 Microsoft* 為繪圖裝置所開發的程式設計介面。製造廠商通常只提供 Windows 適用的驅動程式，而由於 Windows 驅動程式使用 GDI 介面，因此這些印表機也稱為 <emphasis>GDI 印表機</emphasis>。問題實際並不是出在程式設計介面上，而是因這些印表機只能透過相應印表機型號的專用印表機語言來定址所造成。
    </para>
@@ -395,12 +384,7 @@ Resolution/Output Resolution: 150dpi 300dpi *600dpi</screen>
   </sect2>
 
   <sect2 xml:id="sec-drucken-prob-netconnect">
-   <title>網路印表機連接方式</title><indexterm>
-   <primary>列印</primary>
-   <secondary>網路</secondary></indexterm><indexterm>
-   <primary>列印</primary>
-   <secondary>疑難排解</secondary>
-   <tertiary>網路</tertiary></indexterm>
+   <title>網路印表機連接方式</title>
    <para/>
    <variablelist>
     <varlistentry>

--- a/l10n/sles/zh-tw/xml/raid.xml
+++ b/l10n/sles/zh-tw/xml/raid.xml
@@ -7,19 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>YaST</primary>
-
- <secondary>RAID</secondary></indexterm><indexterm>
-
- <primary>RAID</primary>
-
- <secondary>YaST</secondary></indexterm><indexterm>
-
- <primary>軟體 RAID</primary>
-
- <see>RAID</see></indexterm>
+ </info>
 
  <para>
   本節介紹建立和設定多種類型的 RAID 所需的動作。<phrase os="sles">如果您需要 RAID 的相關背景資訊，請參閱<xref linkend="sec-raid-intro"/></phrase>。

--- a/l10n/sles/zh-tw/xml/suse_emacs.xml
+++ b/l10n/sles/zh-tw/xml/suse_emacs.xml
@@ -6,28 +6,19 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-Emacs" class="startofrange">
- <primary>Emacs</primary></indexterm><indexterm xml:id="idx-editors-Emacs" class="startofrange">
- <primary>編輯器</primary>
- <secondary>Emacs</secondary></indexterm>
+ </info>
  <para>
   GNU Emacs 是個複雜的工作環境。以下幾個小節包含在 GNU Emacs 啟動時組態檔案的處理情形。更多相關資訊可在 <link xlink:href="http://www.gnu.org/software/emacs/"/> 取得。
  </para>
  <para>
   啟動時，Emacs 會讀取多個檔案，其中包含使用者、系統管理員以及供應商的自訂設定或預設組態設定。啟始化檔案 <filename>~/.emacs</filename> 會從 <filename>/etc/skel</filename> 安裝至個別使用者的主目錄。<filename>.emacs</filename> 接著會讀取 <filename>/etc/skel/.gnu-emacs</filename> 檔案。如果要自訂程式，請將 <filename>.gnu-emacs</filename> 複製到主目錄 (利用 <command>cp /etc/skel/.gnu-emacs ~/.gnu-emacs</command> 指令)，並依照您的需求來設定。
- </para><indexterm>
- <primary>組態檔案</primary>
- <secondary>.emacs</secondary></indexterm><indexterm>
- <primary>Emacs</primary>
- <secondary>.emacs</secondary></indexterm>
+ </para>
  <para>
   <filename>.gnu-emacs</filename> 定義 <filename>~/.gnu-emacs-custom</filename> 檔案為 <literal>自訂檔案</literal>。如果使用者是使用 Emacs 中的<literal>自訂</literal>選項來進行設定，這些設定會儲存至 <filename>~/.gnu-emacs-custom</filename> 中。
  </para>
  <para>
   透過 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase>，<systemitem class="resource">emacs</systemitem> 套件可將檔案 <filename>site-start.el</filename> 安裝至目錄 <filename>/usr/share/emacs/site-lisp</filename> 中。<filename>site-start.el</filename> 檔案會在啟始化檔案 <filename>~/.emacs</filename> 前載入。此外，<filename>site-start.el</filename> 會確保那些以 Emacs 附加套件來散佈的特定組態檔案皆能自動載入，例如 <systemitem class="resource">psgml</systemitem>。此類型的組態檔案也位於 <filename>/usr/share/emacs/site-lisp</filename> 中，並且會以 <filename>suse-start-</filename> 為開頭。本地系統管理員可在 <filename>default.el</filename> 中指定整個系統的設定。
- </para><indexterm>
- <primary> Emacs</primary>
- <secondary> default.el</secondary></indexterm> 
+ </para>
  <para>
   有關這些檔案的詳細資訊可在 <emphasis>Init File</emphasis> 下的 Emacs 資訊檔案中取得︰<literal>info:/emacs/InitFile</literal>。關於如何在需要時停止載入這些檔案的資訊，也可在此找到。
  </para>
@@ -65,5 +56,5 @@
     需要時可安裝多種附加產品套件︰<systemitem class="resource">emacs-auctex</systemitem> (LaTeX)、<systemitem class="resource">psgml</systemitem> (SGML 與 XML)、<systemitem class="resource">gnuserv</systemitem> (用戶端與伺服器作業) 以及其他。
    </para>
   </listitem>
- </itemizedlist><indexterm class="endofrange" startref="idx-Emacs"/><indexterm class="endofrange" startref="idx-editors-Emacs"/>
+ </itemizedlist>
 </sect2>

--- a/l10n/sles/zh-tw/xml/suse_kb.xml
+++ b/l10n/sles/zh-tw/xml/suse_kb.xml
@@ -7,15 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>鍵盤</primary>
-
- <secondary>配置</secondary></indexterm><indexterm>
-
- <primary>鍵盤</primary>
-
- <secondary>配置</secondary></indexterm>
+ </info>
 
  <para>
   若要標準化程式的鍵盤配置，請變更下列的檔案︰
@@ -30,51 +22,15 @@
 /etc/termcap
 /usr/share/terminfo/x/xterm
 /usr/share/X11/app-defaults/XTerm
-/usr/share/emacs/<replaceable>VERSION</replaceable>/site-lisp/term/*.el</screen><indexterm>
-
- <primary>組態檔案</primary>
-
- <secondary>termcap</secondary></indexterm><indexterm>
-
- <primary>組態檔案</primary>
-
- <secondary>inputrc</secondary></indexterm>
+/usr/share/emacs/<replaceable>VERSION</replaceable>/site-lisp/term/*.el</screen>
 
  <para>
   這些變更僅會影響使用 <command>terminfo</command> 項目的應用程式，或其組態檔是被直接變更的應用程式 (<command>vi</command>、<command>emacs</command> 等等)。未隨附於此系統的應用程式必須相容於這些預設值。
- </para><indexterm>
-
- <primary>鍵盤</primary>
-
- <secondary>配置</secondary>
-
- <tertiary>組合</tertiary></indexterm><indexterm>
-
- <primary>鍵盤</primary>
-
- <secondary>配置</secondary>
-
- <tertiary>組合鍵</tertiary></indexterm>
+ </para>
 
  <para>
   在 X 下，可以按照 <filename>/etc/X11/Xmodmap</filename> 中的說明啟用組合鍵 (複合鍵)。
- </para><indexterm>
-
- <primary>鍵盤</primary>
-
- <secondary>X 鍵盤延伸程式</secondary></indexterm><indexterm>
-
- <primary>鍵盤</primary>
-
- <secondary>XKB</secondary></indexterm><indexterm>
-
- <primary>X 鍵盤延伸程式</primary>
-
- <see>鍵盤、XKB</see></indexterm><indexterm>
-
- <primary>XKB</primary>
-
- <see>鍵盤、XKB</see></indexterm>
+ </para>
 
  <para>
   使用 X 鍵盤延伸程式 (XKB)，可以進行進一步的設定。桌面環境 GNOME (gswitchit) 也會使用此延伸。

--- a/l10n/sles/zh-tw/xml/suse_l10n.xml
+++ b/l10n/sles/zh-tw/xml/suse_l10n.xml
@@ -7,36 +7,19 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>系統</primary>
-
- <secondary>當地語系化</secondary></indexterm><indexterm>
-
- <primary>I18N</primary></indexterm><indexterm>
-
- <primary>L10N</primary></indexterm><indexterm>
-
- <primary>國際化</primary></indexterm><indexterm>
-
- <primary>當地語系化</primary></indexterm>
+ </info>
 
  <para>
   本系統已在很大程度上進行了國際化，可以根據當地的需求進行修改。國際化 (<emphasis>I18N</emphasis>) 允許特定的當地語系化 (<emphasis>L10N</emphasis>)。I18N 與 L10N 這兩個縮寫是取首尾兩個字母，兩字母中間再加上省略的字母數量。
  </para>
 
  <para>
-  設定位於 <filename>/etc/sysconfig/language</filename> 中所定義的 <systemitem>LC_</systemitem> 變數。這不僅是指<emphasis>本地語言支援</emphasis>，還包括<emphasis>訊息</emphasis> (語言)、<emphasis>字元集</emphasis>、<emphasis>排序順序</emphasis>、<emphasis>時間和日期</emphasis>、<emphasis>數字</emphasis>及<emphasis>貨幣</emphasis>等類別。這些類別中的每一種都可以使用自己的變數直接定義，或使用 <filename>language</filename> 檔案中的主變數間接定義 (請參閱 <command>locale</command> man 頁面)。<indexterm>
-  <primary>組態檔案</primary>
-  <secondary>語言</secondary>
-  </indexterm>
+  設定位於 <filename>/etc/sysconfig/language</filename> 中所定義的 <systemitem>LC_</systemitem> 變數。這不僅是指<emphasis>本地語言支援</emphasis>，還包括<emphasis>訊息</emphasis> (語言)、<emphasis>字元集</emphasis>、<emphasis>排序順序</emphasis>、<emphasis>時間和日期</emphasis>、<emphasis>數字</emphasis>及<emphasis>貨幣</emphasis>等類別。這些類別中的每一種都可以使用自己的變數直接定義，或使用 <filename>language</filename> 檔案中的主變數間接定義 (請參閱 <command>locale</command> man 頁面)。
  </para>
 
  <variablelist>
   <varlistentry>
-   <term><systemitem>RC_LC_MESSAGES</systemitem>、<systemitem>RC_LC_CTYPE</systemitem>、<systemitem>RC_LC_COLLATE</systemitem>、<systemitem>RC_LC_TIME</systemitem>、<systemitem>RC_LC_NUMERIC</systemitem>、<systemitem>RC_LC_MONETARY</systemitem><indexterm>
-    <primary>變數</primary>
-    <secondary> 環境</secondary></indexterm>
+   <term><systemitem>RC_LC_MESSAGES</systemitem>、<systemitem>RC_LC_CTYPE</systemitem>、<systemitem>RC_LC_COLLATE</systemitem>、<systemitem>RC_LC_TIME</systemitem>、<systemitem>RC_LC_NUMERIC</systemitem>、<systemitem>RC_LC_MONETARY</systemitem>
    </term>
    <listitem>
     <para>
@@ -110,9 +93,7 @@ localedef -i en_US -f UTF-8 en_US.UTF-8
    </varlistentry>
    <varlistentry>
     <term>
-<systemitem>LANG=en_US.ISO-8859-1</systemitem><indexterm>
-     <primary>編碼</primary>
-     <secondary> ISO-8859-1</secondary></indexterm>
+<systemitem>LANG=en_US.ISO-8859-1</systemitem>
     </term>
     <listitem>
      <para>
@@ -147,16 +128,7 @@ localedef -i en_US -f UTF-8 en_US.UTF-8
    </listitem>
   </itemizedlist>
   <para>
-   如此可以確保對 <filename>/etc/sysconfig/language</filename> 的任何變更在下次登入相應的外圍程序時即會生效，而不必手動將其啟用。<indexterm>
-   <primary>組態檔</primary>
-   <secondary>語言</secondary>
-   </indexterm><indexterm>
-   <primary>組態檔</primary>
-   <secondary>設定檔</secondary>
-   </indexterm> <indexterm>
-   <primary>組態檔</primary>
-   <secondary>/etc/profile.d/lang.sh</secondary>
-   </indexterm>
+   如此可以確保對 <filename>/etc/sysconfig/language</filename> 的任何變更在下次登入相應的外圍程序時即會生效，而不必手動將其啟用。 
   </para>
   <para>
    使用者可以適當地編輯自己的 <filename>~/.bashrc</filename> 來覆寫系統預設值。例如，如果不想對程式訊息使用系統範圍的 <literal>en_US</literal>，請加入 <systemitem>LC_MESSAGES=es_ES</systemitem>，這樣訊息將以西班牙語顯示。

--- a/l10n/sles/zh-tw/xml/suse_logfiles.xml
+++ b/l10n/sles/zh-tw/xml/suse_logfiles.xml
@@ -6,10 +6,8 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>記錄檔</primary></indexterm><indexterm>
- <primary>logrotate</primary></indexterm>
+ </info>
  <para>
   某些系統服務 (<emphasis>精靈</emphasis>) 以及核心本身，會定期將系統狀態與特定事件記錄到記錄檔案中。這樣，管理員可以定期檢查某個時間點的系統狀態、找出錯誤或有問題的功能，並用精確的方式來排除它們。這些記錄檔通常以 FHS 所指定的方式儲存於 <filename>/var/log</filename>，而且會日益增大。<systemitem>logrotate</systemitem> 套件有助於控制這些檔案增大的方式。如需詳細資訊，請參閱<xref linkend="sec-tuning-logfiles-logrotate"/>。
- </para> 
+ </para>
 </sect2>

--- a/l10n/sles/zh-tw/xml/suse_vc.xml
+++ b/l10n/sles/zh-tw/xml/suse_vc.xml
@@ -7,24 +7,12 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary> 主控台</primary>
-
- <secondary> 切換</secondary></indexterm> 
+ </info>
 
  <para>
   Linux 是多重使用者及多工的作業系統。這些功能的優點即使在獨立的個人電腦系統中一樣令人讚賞。在文字模式中，有六個虛擬主控台可用。使用 <keycombo> <keycap function="alt"/> <keycap>F1</keycap> </keycombo> 到 <keycombo> <keycap function="alt"/> <keycap>F6</keycap> </keycombo> 可以在虛擬主控台之間進行切換。第七個主控台保留給 X 使用，第十個主控台可以顯示核心訊息。
 
- </para><indexterm>
-
- <primary>主控台</primary>
-
- <secondary>指定</secondary></indexterm><indexterm>
-
- <primary>組態檔</primary>
-
-</indexterm>
+ </para>
 
  <para>
   若要在不關閉主控台的情況下，從 X 切換到主控台，請使用 <keycombo>

--- a/l10n/sles/zh-tw/xml/sw_managing_commandline.xml
+++ b/l10n/sles/zh-tw/xml/sw_managing_commandline.xml
@@ -11,9 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary> 安裝</primary>
- <secondary> 軟體</secondary></indexterm> 
+ </info>
  <xi:include href="zypper.xml"/>
  <xi:include href="rpm.xml"/>
 </chapter>

--- a/l10n/sles/zh-tw/xml/x86_inst_problem.xml
+++ b/l10n/sles/zh-tw/xml/x86_inst_problem.xml
@@ -7,9 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary> 問題解決方案</primary></indexterm> 
+ </info>
 
  <para>
   出廠之前，<phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> 已經過大量的程式測試。如果忽略該處理，在開機或安裝期間會偶爾發生問題。

--- a/l10n/sles/zh-tw/xml/yast2_gui.xml
+++ b/l10n/sles/zh-tw/xml/yast2_gui.xml
@@ -6,8 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-YaST-gui" class="startofrange">
- <primary>YaST</primary></indexterm>
+ </info>
  <para>
   YaST 是 <phrase role="productname"><phrase os="sles">SUSE Linux Enterprise Server</phrase></phrase> 的安裝和組態工具。它具有圖形介面，並且能夠在安裝期間和安裝之後快速自訂您的系統。它可用於設定硬體、設定網路、系統服務和調整安全性設定。
  </para>

--- a/l10n/sles/zh-tw/xml/yast2_lang.xml
+++ b/l10n/sles/zh-tw/xml/yast2_lang.xml
@@ -6,14 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>系統</primary>
- <secondary>語言</secondary></indexterm><indexterm>
- <primary>YaST</primary>
- <secondary>語言</secondary></indexterm><indexterm>
- <primary>語言</primary></indexterm><indexterm>
- <primary>設定</primary>
- <secondary>語言</secondary></indexterm>
+ </info>
  <para>
   若您在不同的國家/地區工作，或必須在多語言環境中工作，就需要對您的電腦進行設定，以支援這種情況。<phrase role="productname"><phrase os="sles">SUSE® Linux Enterprise Server</phrase></phrase> 可以同時處理不同的<literal>地區設定</literal>。地區設定是用於定義反映在使用者介面上之語言和國家/地區設定的一組參數。
  </para>

--- a/l10n/sles/zh-tw/xml/yast2_ncurses.xml
+++ b/l10n/sles/zh-tw/xml/yast2_ncurses.xml
@@ -7,14 +7,10 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm xml:id="idx-YaST-text-mode" class="startofrange">
- <primary> YaST</primary>
- <secondary> 文字模式</secondary></indexterm> 
+ </info>
  <para>
   本章適用對象為未在其系統上執行 X 伺服器，且依賴以文字為基礎的安裝工具的系統管理員及進階使用者。它提供了一些基本資訊，說明如何在文字模式中啟動與操作 YaST。
- </para><indexterm>
- <primary> YaST</primary>
- <secondary> ncurses</secondary></indexterm> 
+ </para>
  <para>
   文字模式下的 YaST 使用 ncurses 程式庫來提供簡單的虛擬圖形使用者介面。依預設，ncurses 程式庫已安裝。若要執行 YaST，終端模擬器的大小不能小於 80x25 個字元。
  </para>
@@ -245,11 +241,7 @@
   </variablelist>
  </sect1>
  <sect1 xml:id="sec-yast-ncurses-commands">
-  <title>YaST 指令行選項</title><indexterm>
-
-  <primary> YaST</primary>
-
-  <secondary> 指令行</secondary></indexterm> 
+  <title>YaST 指令行選項</title>
 
   <para>
    除文字模式介面之外，YaST 還提供了純指令行介面。若要取得 YaST 指令行選項的清單，請輸入︰
@@ -258,10 +250,7 @@
 <screen>yast -h</screen>
 
   <sect2 xml:id="sec-yast-ncurses-modulaufruf">
-   <title>啟動個別模組</title><indexterm>
-   <primary>YaST</primary>
-   <secondary>文字模式</secondary>
-   <tertiary>模組</tertiary></indexterm>
+   <title>啟動個別模組</title>
    <para>
     如果要節省時間，您可以直接啟動個別的 YaST 模組。若要啟動模組，請輸入︰
    </para>
@@ -298,7 +287,7 @@
    <para>
     如果某模組未提供指令行支援，則此模組將在文字模式中啟動，並且系統會顯示以下訊息︰
    </para>
-<screen>This YaST module does not support the command line interface.</screen><indexterm class="endofrange" startref="idx-YaST-text-mode"/>
+<screen>This YaST module does not support the command line interface.</screen>
   </sect2>
  </sect1>
 </chapter>

--- a/l10n/sles/zh-tw/xml/yast2_sound.xml
+++ b/l10n/sles/zh-tw/xml/yast2_sound.xml
@@ -7,23 +7,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
-
- <primary>設定</primary>
-
- <secondary>音效卡</secondary></indexterm><indexterm>
-
- <primary>YaST</primary>
-
- <secondary>音效卡</secondary></indexterm><indexterm>
-
- <primary>音效</primary>
-
- <secondary>使用 YaST 設定</secondary></indexterm><indexterm>
-
- <primary>介面卡</primary>
-
- <secondary>音效</secondary></indexterm>
+ </info>
 
  <para>
   YaST 可以自動偵測大多數音效卡，並為其設定適當的值。若要變更預設設定，或需要對無法自動設定的音效卡進行設定，請使用 YaST 音效模組。您還可以使用該模組設定其他音效卡或變換其順序。
@@ -167,13 +151,7 @@
   </step>
   <step>
    <para>
-    <indexterm>
-    <primary>音效</primary>
-    <secondary>字型</secondary>
-    </indexterm> <indexterm>
-    <primary>音效</primary>
-    <secondary>MIDI</secondary>
-    </indexterm>偵測到支援的音效卡時，您可以安裝 SoundFonts 來播放 MIDI 檔案︰
+     偵測到支援的音效卡時，您可以安裝 SoundFonts 來播放 MIDI 檔案︰
    </para>
    <substeps performance="required">
     <step>
@@ -203,12 +181,6 @@
  </procedure>
 
  <para>
-  按一下<guimenu>確定</guimenu>後會儲存所有音效卡的音量與組態，並結束 YaST 音效模組。混音器設定會儲存至檔案 <filename>/etc/asound.state</filename>。ALSA 組態資料會附加至 <filename>/etc/modprobe.d/sound</filename> 檔案的結尾並寫入 <filename>/etc/sysconfig/sound</filename>。<indexterm>
-  <primary>組態檔案</primary>
-  <secondary>asound.state</secondary>
-  </indexterm> <indexterm>
-  <primary>組態檔案</primary>
-  <secondary>modprobe.d/sound</secondary>
-  </indexterm>
+  按一下<guimenu>確定</guimenu>後會儲存所有音效卡的音量與組態，並結束 YaST 音效模組。混音器設定會儲存至檔案 <filename>/etc/asound.state</filename>。ALSA 組態資料會附加至 <filename>/etc/modprobe.d/sound</filename> 檔案的結尾並寫入 <filename>/etc/sysconfig/sound</filename>。 
  </para>
 </sect1>

--- a/l10n/sles/zh-tw/xml/yast2_sw.xml
+++ b/l10n/sles/zh-tw/xml/yast2_sw.xml
@@ -11,11 +11,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>YaST</primary>
- <secondary>軟體</secondary></indexterm><indexterm>
- <primary>設定</primary>
- <secondary>軟體</secondary></indexterm>
+ </info>
  <para>
   使用 YaST 軟體管理員可變更系統的軟體集合。此 YaST 模組有兩種類別︰一種是 X Window 的圖形變體，另一種是指令行上使用的文字式變體。本章介紹圖形變體 — 如需文字式 YaST 的詳細資料，請參閱<xref linkend="cha-yast-text"/>。
  </para>

--- a/l10n/sles/zh-tw/xml/yast2_userman.xml
+++ b/l10n/sles/zh-tw/xml/yast2_userman.xml
@@ -99,13 +99,7 @@
   <title>管理使用者帳戶</title>
 
   <para>
-   <indexterm>
-   <primary>使用者</primary>
-   <secondary>建立帳戶</secondary>
-   </indexterm> <indexterm>
-   <primary>使用者</primary>
-   <secondary>修改帳戶</secondary>
-   </indexterm> YaST 提供建立、修改、刪除或暫時停用使用者帳戶等功能。請勿修改使用者帳戶，除非您是有經驗的使用者或管理員。
+     YaST 提供建立、修改、刪除或暫時停用使用者帳戶等功能。請勿修改使用者帳戶，除非您是有經驗的使用者或管理員。
   </para>
 
   <note>
@@ -189,11 +183,7 @@
   </tip>
 
   <procedure>
-   <title>停用或刪除使用者帳戶</title><indexterm>
-   <primary>使用者</primary>
-   <secondary>停用帳戶</secondary></indexterm><indexterm>
-   <primary>使用者</primary>
-   <secondary>刪除帳戶</secondary></indexterm> 
+   <title>停用或刪除使用者帳戶</title>
    <step>
     <para>
      開啟 YaST 的<guimenu>使用者和群組管理</guimenu>對話方塊並按一下<guimenu>使用者</guimenu>索引標籤。
@@ -241,9 +231,7 @@
 
    </para>
    <procedure>
-    <title>設定密碼設定</title><indexterm>
-    <primary> 使用者</primary>
-    <secondary> 密碼設定</secondary></indexterm> 
+    <title>設定密碼設定</title>
     <step>
      <para>
       開啟 YaST 的<guimenu>使用者和群組管理</guimenu>對話方塊並選取<guimenu>使用者</guimenu>索引標籤。
@@ -298,11 +286,7 @@
   </sect2>
 
   <sect2 xml:id="sec-y2-userman-adv-crypto">
-   <title>管理加密的主目錄</title><indexterm>
-   <primary>主目錄</primary>
-   <secondary>加密</secondary></indexterm><indexterm>
-   <primary>使用者</primary>
-   <secondary>加密的主目錄</secondary></indexterm> 
+   <title>管理加密的主目錄</title>
    <para>
     若要保護主目錄中的資料不致遭到竊取或徹底移除，您可以為使用者建立加密的主目錄。這些主目錄使用 LUKS (Linux Unified Key Setup) 加密，會為使用者產生影像以及影像金鑰。複本金鑰受到使用者登入密碼保護。使用者登入系統時，就會裝載加密的主目錄，並且可以使用其中的內容。
    </para>
@@ -414,11 +398,7 @@
   </sect2>
 
   <sect2 xml:id="sec-y2-userman-adv-quota">
-   <title>管理配額</title><indexterm>
-   <primary>使用者</primary>
-   <secondary>定額</secondary></indexterm><indexterm>
-   <primary>定額</primary>
-   <secondary>使用者, 群組</secondary></indexterm>
+   <title>管理配額</title>
    <para>
     為避免出現事先未通知系統容量即用盡的情況，系統管理員可以為使用者或群組設定配額。配額可以針對一或多個檔案系統定義，並限制可以使用的磁碟空間容量以及可在其中建立的 inode (索引節點) 數量。Inode 是檔案系統上的資料結構，用於儲存關於一般檔案、目錄或其他檔案系統物件的基本資訊。它們會儲存檔案系統物件的所有屬性 (例如使用者和群組擁有權、讀取、寫入或執行許可權)，檔案名稱和內容除外。
    </para>
@@ -564,11 +544,7 @@
   </sect2>
  </sect1>
  <sect1 xml:id="sec-y2-userman-defaults">
-  <title>變更本地使用者的預設設定</title><indexterm>
-
-  <primary> 使用者</primary>
-
-  <secondary> 預設設定</secondary></indexterm> 
+  <title>變更本地使用者的預設設定</title>
 
   <para>
    建立新的本地使用者時，YaST 會使用幾個預設設定。舉例來說，預設設定包括使用者所屬的主要群組和次要群組，或使用者主目錄的存取許可權。您可以變更這些預設設定來符合自身需求。
@@ -616,10 +592,7 @@
   <title>將使用者指定給群組</title>
 
   <para>
-   <indexterm>
-   <primary>使用者</primary>
-   <secondary>群組指定</secondary>
-   </indexterm> 系統會根據您可從<guimenu>使用者及群組管理</guimenu>對話方塊的<guimenu>新使用者的預設值</guimenu>索引標籤中存取的預設設定，將本地使用者指定給幾個群組。下面說明了如何修改為個別使用者指定的群組。如果您需要變更新為使用者預設指定的群組，請參閱<xref linkend="sec-y2-userman-defaults"/>。
+    系統會根據您可從<guimenu>使用者及群組管理</guimenu>對話方塊的<guimenu>新使用者的預設值</guimenu>索引標籤中存取的預設設定，將本地使用者指定給幾個群組。下面說明了如何修改為個別使用者指定的群組。如果您需要變更新為使用者預設指定的群組，請參閱<xref linkend="sec-y2-userman-defaults"/>。
   </para>
 
   <procedure>
@@ -660,19 +633,7 @@
   </procedure>
  </sect1>
  <sect1 xml:id="sec-y2-userman-groups">
-  <title>管理群組</title><indexterm>
-
-  <primary>群組</primary>
-
-  <secondary>管理</secondary></indexterm><indexterm>
-
-  <primary>YaST</primary>
-
-  <secondary>群組管理</secondary></indexterm><indexterm>
-
-  <primary>設定</primary>
-
-  <secondary>群組</secondary></indexterm>
+  <title>管理群組</title>
 
   <para>
    使用 YaST 還可以輕鬆地新增、修改或刪除群組。
@@ -744,11 +705,7 @@
   </para>
  </sect1>
  <sect1 xml:id="cha-y2-userman-authent">
-  <title>變更使用者驗證方式</title><indexterm>
-
-  <primary> 使用者</primary>
-
-  <secondary> 驗證</secondary></indexterm> 
+  <title>變更使用者驗證方式</title>
 
   <para>
    機器連接到網路時，您可以變更驗證方式。下列選項可供使用︰

--- a/l10n/sles/zh-tw/xml/yast2_you.xml
+++ b/l10n/sles/zh-tw/xml/yast2_you.xml
@@ -6,11 +6,7 @@
    <dm:bugtracker/>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
- </info><indexterm>
- <primary>更新</primary>
- <secondary>線上</secondary></indexterm><indexterm>
- <primary>YaST</primary>
- <secondary>線上更新</secondary></indexterm>
+ </info>
  <para>
   SUSE 為您的產品提供持續的軟體安全性更新。依預設，更新 Applet 可以讓您的系統保持最新狀態。如需有關更新 Applet 的詳細資訊，請參閱<xref linkend="sec-updater"/>。本章介紹了用於更新軟體套件的替代工具︰YaST 線上更新。
  </para>


### PR DESCRIPTION
### PR creator: Description

The tag `<indexterm>` causes problems when used inline, see https://bugzilla.suse.com/show_bug.cgi?id=1205252

This change removes all `<indexterm>`s from the localized SLE 12 SP5 docs. The English have already been dealt with in cdd322699.

### PR creator: Are there any relevant issues/feature requests?

* https://bugzilla.suse.com/show_bug.cgi?id=1205252

The change was generated with the following script:

```
#! /bin/bash
FILES=$(grep -r indexterm l10n/ | awk -F : '{print $1}' | sort -u)
for file in $FILES
    do 
    xmlstarlet ed --inplace -P -N d=http://docbook.org/ns/docbook -d //d:indexterm "$file"
    sed -i 's|</info> |</info>|' "$file"
    sed -i 's|</title> |</title>|' "$file"
    sed -i 's|</para> |</para>|' "$file"
    sed -i 's|</systemitem> |</systemitem>|' "$file"
done
```

For some reason xmlstarlet sometimes inserts whitespaces when deleting the the tags. I'm sanitizing this with sed. However there are still some whitespace changes, e.g. at the end of the `<para>`s, but I can live with that. This change is only for the localized files, which already have poor formatting and are likely not going to be touched anway.

If you consider this output okay, I'll do the same for SLE 12 SP4.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4