### PR TITLE
Change library names with the name of the packages.

### DIFF
--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -119,8 +119,9 @@
      make it live-patchable.
     </para>
     <para>
-     The glibc, libssl.so.1.1, and libcrypto.so.1.1 libraries are already
-     live-patchable on &sle; &product-ga; SP&product-sp;.
+     The libraries provided by the system pacakges glibc and openssl
+     (libopenssl_1_1) are already live-patchable on &sle; &product-ga;
+     SP&product-sp;.
     </para>
    </sect3>
    <sect3 xml:id="sec-ulp-livepatch-check">


### PR DESCRIPTION
### PR creator: Description
Previously, the ULP docs referenced the livepatchable libraries by a mix of the package name and the .so files. This is confusing, as people reported libgcrypt being livepatchable when in fact it was not because openssl provides libcrypt.so. Hence, update the name to always mention the package name.

Fixes bsc#120636.

### PR creator: Are there any relevant issues/feature requests?

* bsc#120636.

### PR creator: Which product versions do the changes apply to?

SLE-15-SP4

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ x] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

No. No backports are needed.

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
