### PR TITLE
SELinux: Bugfix for bsc#1205596

### DIFF
--- a/xml/book_admin_slemicro.xml
+++ b/xml/book_admin_slemicro.xml
@@ -52,4 +52,8 @@
   <xi:include href="slemicro_toolbox.xml"/>
   <xi:include href="slemicro_pcp.xml"/>
  </part>
+ <part xml:id="part-slemicro-troubleshooting">
+  <title>Troubleshooting</title>
+  <xi:include href="slemicro_supportconfig.xml"/>
+ </part>
 </book>

--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -284,41 +284,9 @@ system_u:object_r:var_t var</screen>
  <sect1 xml:id="sec-selinux-install">
   <title>Installing &selnx; packages</title>
   <para>
-    If you are installing &selnx; with Zypper, search for all of the relevant
-    packages with the <command>--search-descriptions</command> option. You
-    will see a list like the following example:
-  </para>
-  <screen>&prompt.user;<command>zypper se --search-descriptions selinux</command>
-libselinux-devel
-libselinux1
-libselinux1-32bit
-libsemanage-devel
-libsemanage1
-libsepol-devel
-libsepol1
-mcstrans
-policycoreutils
-python3-policycoreutils
-python3-selinux
-python3-semanage
-python3-setools
-restorecond
-selinux-tools
-setools-console
-setools-devel
-setools-java
-setools-libs
-setools-tcl
-  </screen>
-  <para>
-    It is not necessary to install all of them. Install the following packages:
+   From the command-line, install the following packages:
   </para>
   <screen>&prompt.sudo;<command>zypper in restorecond policycoreutils setools-console</command></screen>
-  <para>
-    If you prefer to use &yast;, search for "selinux" in the Software
-    Management module, and install <package>restorecond</package>, <package>policycoreutils</package>, and <package>setools-console</package>.
-  </para>
-
   <para>
     This does not install a  policy. See
     <xref linkend="sec-selinux-getpolicy"/> for information on
@@ -330,46 +298,32 @@ setools-tcl
   <title>Installing an &selnx; policy</title>
   <para>
    The policy is an essential component of &selnx;. &productname; &productnumber;
-   does not include a default policy, and you must build a
+   does <emphasis>not</emphasis> include a default policy, and you must build a
    policy that is customized for your installation. &selnx; policies
    should be customized for your particular needs; consult your &suse;
    support engineer for assistance.
   </para>
   <para>
-    One way to get a policy to install and test is to download
-    it from
-    <link xlink:href="https://download.opensuse.org/repositories/security:/SELinux/"/>. This provides repositories for &slea; and &opensuse;. Copy
-    the repository link that matches your &slea; version, and add it with
-    Zypper:
+    For <emphasis>testing</emphasis> purposes you can obtain policies from
+    <link xlink:href="https://download.opensuse.org/repositories/security:/SELinux/"/>. This provides
+    repositories for &slea; and &opensuse; with a number of additional packages, including policies.
   </para>
-  <screen>&prompt.sudo;<command>zypper ar -f https://download.opensuse.org/repositories/security:/SELinux/&productnumber-leaprepo;/ Security-SELinux</command>
-      </screen>
+  <procedure>
+   <step>
+    <para>
+    Copy the repository link that matches your &slea; version, and add it with Zypper:
+    </para>
+    <screen>&prompt.sudo;<command>zypper ar -f \
+     https://download.opensuse.org/repositories/security:/SELinux/&productnumber-leaprepo;/ SELinux</command></screen>
+   </step>
+   <step>
+    <para>
+     Install the following packages:
+    </para>
+    <screen>&prompt.sudo;<command>zypper in selinux-policy-targeted selinux-policy-devel selinux-autorelabel</command></screen>
+   </step>
+  </procedure>
   <para>
-    If you prefer &yast;, use the Software Repositories module.
-  </para>
-  <para>
-    This repository provides a number of additional packages, including
-    policies, such as:
-  </para>
-  <screen>
-selinux-autorelabel
-selinux-policy
-selinux-policy-devel
-selinux-policy-doc
-selinux-policy-minimum
-selinux-policy-mls
-selinux-policy-sandbox
-selinux-policy-targeted
-setools-gui
-setroubleshoot
-setroubleshoot-plugins
-setroubleshoot-server
-</screen>
-  <para>
-   Install the following packages:
- </para>
- <screen>&prompt.sudo;<command>zypper in selinux-policy-targeted selinux-policy-devel selinux-autorelabel</command></screen>
- <para>
    The next step is to modify the &grub; bootloader, to permanently enable
    SELinux and set the SELinux mode.
    (<xref linkend="sec-selinux-grub"/>).

--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -305,8 +305,8 @@ system_u:object_r:var_t var</screen>
   </para>
   <para>
     For <emphasis>testing</emphasis> purposes you can obtain policies from
-    <link xlink:href="https://download.opensuse.org/repositories/security:/SELinux/"/>. This provides
-    repositories for &slea; and &opensuse; with a number of additional packages, including policies.
+    <link xlink:href="https://download.opensuse.org/repositories/security:/SELinux_legacy/"/>. This provides
+    repositories for &slea;<!-- and &opensuse;--> with a number of additional packages, including policies.
   </para>
   <procedure>
    <step>
@@ -314,7 +314,7 @@ system_u:object_r:var_t var</screen>
     Copy the repository link that matches your &slea; version, and add it with Zypper:
     </para>
     <screen>&prompt.sudo;<command>zypper ar -f \
-     https://download.opensuse.org/repositories/security:/SELinux/&productnumber-leaprepo;/ SELinux</command></screen>
+     https://download.opensuse.org/repositories/security:/SELinux_legacy/&productnumber-leaprepo;/ SELinux-Legacy</command></screen>
    </step>
    <step>
     <para>

--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -323,24 +323,21 @@ system_u:object_r:var_t var</screen>
     <screen>&prompt.sudo;<command>zypper in selinux-policy-targeted selinux-policy-devel</command></screen>
    </step>
   </procedure>
-  <para>
-   The next step is to modify the &grub; bootloader, to permanently enable
-   SELinux and set the SELinux mode.
-   (<xref linkend="sec-selinux-grub"/>).
-  </para>
-</sect1>
+ </sect1>
 
- <sect1 xml:id="sec-selinux-grub">
-   <title>Modifying the &grub; bootloader</title>
+ <sect1 xml:id="sec-selinux-mode-permissive">
+   <title>Putting &selnx; into permissive mode</title>
   <para>
    After installing the &selnx; packages, modify the &grub; boot
-   loader, either by editing <filename>/etc/default/grub</filename>,
+   loader as follows, either by editing <filename>/etc/default/grub</filename>,
    or with &yast;.
   </para>
-  <para>
-   In <filename>/etc/default/grub</filename>, add the following parameters
-   to the <literal>GRUB_CMDLINE_LINUX_DEFAULT=</literal> line:
-  </para>
+  <example xml:id="ex-sec-selinux-grubcfg">
+   <title>&grub; configuration file with &selnx;</title>
+   <para>
+    In <filename>/etc/default/grub</filename>, add the following parameters
+    to the <literal>GRUB_CMDLINE_LINUX_DEFAULT=</literal> line:
+   </para>
   <screen>security=selinux<co xml:id="co-security"/> selinux=1<co xml:id="co-selinux"/> enforcing=0<co xml:id="co-enforcing"/></screen>
   <calloutlist>
    <callout arearefs="co-security">
@@ -368,6 +365,7 @@ system_u:object_r:var_t var</screen>
     </para>
    </callout>
   </calloutlist>
+  </example>
   <para>
    After you have added the parameters in <filename>/etc/default/grub</filename>,
    run the <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>
@@ -418,26 +416,54 @@ Controlling terminal:           unconfined_u:object_r:user_tty_device_t:s0
   </example>
  </sect1>
 
- <sect1 xml:id="sec-selinux-configure">
-  <title>Configuring &selnx;</title>
+ <sect1 xml:id="sec-selinux-mode-enforcing">
+  <title>Putting &selnx; into enforcing mode</title>
   <para>
    At this point you have a completely functional &selnx; system and it is
    time to further configure it. In the current status, &selnx; is
    operational but not in enforcing mode. This means that it does not limit
    any activities, and it logs everything that it should be doing if it
    were in enforcing mode. Review the log files to learn what activities
-   are not allowed. As a first
-   test, put &selnx; in enforcing mode and find out if you can still use
-   your server after doing so: check that the option
-   <option>enforcing=1</option> is set in the &grub; configuration file,
-   while <option>SELINUX=enforcing</option> is set in
-   <filename>/etc/selinux/config</filename>. Reboot your server and see if
-   it still comes up the way you expect it to. If it does, leave it like
-   that and start modifying the server in a way that everything works as
-   expected. However, you may not even be able to boot the server properly.
-   In that case, switch back to the mode where &selnx; is not enforcing and
-   start tuning your server.
+   are not allowed.
   </para>
+  <para>After running &selnx; in permissive mode first, you can try to
+   put &selnx; in enforcing mode and find out if you can still use
+   your server after doing so.
+  </para>
+  <warning>
+   <title>Reset security context</title>
+   <para>
+    When systems run &selnx; in permissive mode, users and processes
+    might label various file-system objects incorrectly. This can cause
+    problems when switching to enforcing mode because &selnx; relies on
+    correct labels of file-system objects.
+   </para>
+   <para>
+    Before switching into enforcing mode, make sure to first reset the
+    security context (extended attributes). Do so by executing
+    <command>restorecon -R /</command> and then reboot the system.
+    System startup will take some time, as the entire file system
+    will be relabeled.
+   </para>
+  </warning>
+  <para>
+   To put &selnx; into enforcing mode, set the following parameter
+   in the &grub; configuration file: <parameter>enforcing=1</parameter>. For context,
+   see <xref linkend="ex-sec-selinux-grubcfg"/>.
+   Then edit <filename>/etc/selinux/config</filename> and make sure
+   <option>SELINUX=enforcing</option> is set.
+  </para>
+  <para>Now reboot your server and see if it still comes up the way you expect
+   it to and if you can still log in. If yes, leave it like
+   that and start <xref linkend="sec-selinux-configure"
+    xrefstyle="select:title"/>.
+  </para>
+  <para>In case you should not able to boot the server properly with &selnx;
+   in enforcing mode, switch back to permissive mode and start tuning your server.
+   </para>
+ </sect1>
+ <sect1 xml:id="sec-selinux-configure">
+  <title>Configuring &selnx;</title>
   <para>
     Before you start tuning your server, verify the &selnx; installation.
     You have already used the command <command>sestatus -v</command> to view

--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -320,7 +320,7 @@ system_u:object_r:var_t var</screen>
     <para>
      Install the following packages:
     </para>
-    <screen>&prompt.sudo;<command>zypper in selinux-policy-targeted selinux-policy-devel selinux-autorelabel</command></screen>
+    <screen>&prompt.sudo;<command>zypper in selinux-policy-targeted selinux-policy-devel</command></screen>
    </step>
   </procedure>
   <para>

--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -332,70 +332,56 @@ system_u:object_r:var_t var</screen>
 
  <sect1 xml:id="sec-selinux-grub">
    <title>Modifying the &grub; bootloader</title>
-<para>
+  <para>
    After installing the &selnx; packages, modify the &grub; boot
    loader, either by editing <filename>/etc/default/grub</filename>,
    or with &yast;.
   </para>
   <para>
-    In <filename>/etc/default/grub</filename>, add the following
-    line to the <literal>GRUB_CMDLINE_LINUX_DEFAULT=</literal> line:
+   In <filename>/etc/default/grub</filename>, add the following parameters
+   to the <literal>GRUB_CMDLINE_LINUX_DEFAULT=</literal> line:
   </para>
-  <screen>security=selinux selinux=1 enforcing=0</screen>
+  <screen>security=selinux<co xml:id="co-security"/> selinux=1<co xml:id="co-selinux"/> enforcing=0<co xml:id="co-enforcing"/></screen>
+  <calloutlist>
+   <callout arearefs="co-security">
+    <para>
+     This parameter tells the kernel to use &selnx; and not &aa;.
+    </para>
+   </callout>
+   <callout arearefs="co-selinux">
+    <para>
+     This parameter enables &selnx;.
+    </para>
+   </callout>
+   <callout arearefs="co-enforcing">
+    <para>
+     This parameter defines the mode in which to run &selnx;. Setting it
+     to <literal>0</literal> puts &selnx; in permissive mode. In this mode,
+     &selnx; is fully functional, but does not enforce any of the security settings in
+     the policy. In permissive mode, &selnx; does not protect your system but it still logs
+     everything that happens. Use this mode for testing and configuring your system.
+    </para>
+    <para>
+     After you have completed the &selnx; configuration, you can set the
+     parameter to <literal>1</literal> to run &selnx; in enforcing mode. In this mode,
+     it enforces the &selnx; policy and denies access based on policy rules.
+    </para>
+   </callout>
+  </calloutlist>
   <para>
-    Then run the <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>
-    command to rebuild your &grub; configuration.
+   After you have added the parameters in <filename>/etc/default/grub</filename>,
+   run the <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>
+   command to rebuild your &grub; configuration.
   </para>
   <para>
-    In &yast;, open <menuchoice> <guimenu>System</guimenu> <guimenu>Boot Loader</guimenu> <guimenu>Kernel Parameters</guimenu></menuchoice>.
-    Add <literal>security=selinux selinux=1 enforcing=0</literal> to
-    <guimenu>Optional Kernel Command Line Parameters</guimenu>.
-  </para>
-  <para>
-   These options are used for the following purposes:
+   Alternatively, to modify the bootloader via &yast;, open <menuchoice><guimenu>System</guimenu>
+   <guimenu>Boot Loader</guimenu><guimenu>Kernel Parameters</guimenu></menuchoice>.
+   Add the following line to the <guimenu>Optional Kernel Command Line Parameters</guimenu>:
+   <literal>security=selinux selinux=1 enforcing=0</literal>
   </para>
 
-  <variablelist>
-   <varlistentry>
-    <term><literal>security=selinux</literal>
-    </term>
-    <listitem>
-     <para>
-      This option tells the kernel to use &selnx; and not &aa;
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><literal>selinux=1</literal>
-    </term>
-    <listitem>
-     <para>
-      This option switches on &selnx;
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><literal>enforcing=0</literal>
-    </term>
-    <listitem>
-     <para>
-      This option puts &selnx; in permissive mode. In this mode, &selnx; is
-      fully functional, but does not enforce any of the security settings in
-      the policy. Use this mode for testing and configuring your system. To
-      switch on
-      &selnx; protection, when the system is fully operational, change the
-      option to <literal>enforcing=1</literal> and add
-      <literal>SELINUX=enforcing</literal> in
-      <filename>/etc/selinux/config</filename>.
-     </para>
-    </listitem>
-   </varlistentry>
-  </variablelist>
-
   <para>
-   Now you can reboot. System startup will take some time, as &selnx;
-   will re-label the entire file system. After it is finished, run
-   the <command>sestatus -v</command> command to verify it is working.
+   Now you can reboot. After logging in, run the <command>sestatus -v</command> command.
    It should give you an output similar to
    <xref linkend="ex-selnx-sestatus" xrefstyle="select:label quotedtitle nopage"/>.
   </para>
@@ -404,31 +390,31 @@ system_u:object_r:var_t var</screen>
    <title>Verifying that &selnx; is functional</title>
 <screen>&prompt.sudo;<command>sestatus -v</command>
 SELinux status:                 enabled
-SELinuxfs mount:                /selinux
+SELinuxfs mount:                /sys/fs/selinux
+SELinux root directory:         /etc/selinux
+Loaded policy name:             targeted
 Current mode:                   permissive
 Mode from config file:          permissive
-Policy version:                 26
-Policy from config file:        minimum
+Policy MLS status:              enabled
+Policy deny_unknown status:     allowed
+Memory protection checking:     requested(insecure)
+Max kernel policy version:      33
 
 Process contexts:
-Current context:                root:staff_r:staff_t
-Init context:                   system_u:system_r:init_t
-/sbin/mingetty                  system_u:system_r:sysadm_t
-/usr/sbin/sshd                  system_u:system_r:sshd_t
+Current context:                unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
+Init context:                   system_u:system_r:init_t:s0
+/usr/sbin/sshd                  system_u:system_r:sshd_t:s0-s0:c0.c1023
 
 File contexts:
-Controlling term:               root:object_r:user_devpts_t
-/etc/passwd                     system_u:object_r:etc_t
-/etc/shadow                     system_u:object_r:shadow_t
-/bin/bash                       system_u:object_r:shell_exec_t
-/bin/login                      system_u:object_r:login_exec_t
-/bin/sh                         system_u:object_r:bin_t -&gt; system_u:object_r:shell_exec_t
-/sbin/agetty                    system_u:object_r:getty_exec_t
-/sbin/init                      system_u:object_r:init_exec_t
-/sbin/mingetty                  system_u:object_r:getty_exec_t
-/usr/sbin/sshd                  system_u:object_r:sshd_exec_t
-/lib/libc.so.6                  system_u:object_r:lib_t -&gt; system_u:object_r:lib_t
-/lib/ld-linux.so.2              system_u:object_r:lib_t -&gt; system_u:object_r:ld_so_t</screen>
+Controlling terminal:           unconfined_u:object_r:user_tty_device_t:s0
+/etc/passwd                     system_u:object_r:passwd_file_t:s0
+/etc/shadow                     system_u:object_r:shadow_t:s0
+/bin/bash                       system_u:object_r:shell_exec_t:s0 -> system_u:object_r:shell_exec_t:s0
+/bin/login                      system_u:object_r:login_exec_t:s0
+/bin/sh                         system_u:object_r:bin_t:s0 -> system_u:object_r:shell_exec_t:s0
+/sbin/agetty                    system_u:object_r:getty_exec_t:s0
+/sbin/init                      system_u:object_r:bin_t:s0 -> system_u:object_r:init_exec_t:s0
+/usr/sbin/sshd                  system_u:object_r:sshd_exec_t:s0</screen>
   </example>
  </sect1>
 

--- a/xml/slemicro_supportconfig.xml
+++ b/xml/slemicro_supportconfig.xml
@@ -340,8 +340,7 @@ Creating Tar Ball
    </variablelist>
    <para>
     <xref linkend="tab-admsupport-features-and-filenames"/> lists all available
-    features and their file names. Further service packs can extend the list,
-    as can plug-ins.
+    features and their file names. 
    </para>
    <table xml:id="tab-admsupport-features-and-filenames">
     <title>Comparison of features and file names in the TAR archive</title>
@@ -422,14 +421,6 @@ Creating Tar Ball
          <entry><filename>shell_history.txt</filename></entry>
       </row>
       <row>
-         <entry><parameter>IB</parameter></entry>
-         <entry><filename>ib.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>IMAN</parameter></entry>
-         <entry><filename>novell-iman.txt</filename></entry>
-      </row>
-      <row>
          <entry><parameter>ISCSI</parameter></entry>
          <entry><filename>fs-iscsi.txt</filename></entry>
       </row>
@@ -478,12 +469,12 @@ Creating Tar Ball
          <entry><filename>ocfs2.txt</filename></entry>
       </row>
       <row>
-         <entry><parameter>OFILES</parameter></entry>
-         <entry><filename>open-files.txt</filename></entry>
+         <entry><parameter>PAM</parameter></entry>
+         <entry><filename>pam.txt</filename></entry>
       </row>
       <row>
          <entry><parameter>PODMAN</parameter></entry>
-         <entry><filename>podman/</filename></entry>
+         <entry><filename>podman.txt</filename></entry>
       </row>
       <row>
          <entry><parameter>PRINT</parameter></entry>
@@ -561,11 +552,7 @@ Creating Tar Ball
          <entry><parameter>WEB</parameter></entry>
          <entry><filename>web.txt</filename></entry>
       </row>
-      <row>
-         <entry><parameter>X</parameter></entry>
-         <entry><filename>x.txt</filename></entry>
-      </row>
-     </tbody>
+      </tbody>
     </tgroup>
    </table>
    </section>
@@ -580,7 +567,7 @@ After you have created the archive using the <command>supportconfig</command> to
   <section xml:id="sec-slemicro-supportconfig-sr">
    <title>Creating a service request number</title>
    <para>
-    Before hand over the <command>supportconfig</command> data to Global Technical Support, you need
+    Before handing over the <command>supportconfig</command> data to Global Technical Support, you need
     to generate a service request number first. You will need it to upload the
     archive to support.
    </para>
@@ -624,12 +611,12 @@ After you have created the archive using the <command>supportconfig</command> to
      </step>
      <step>
       <para>
-       For the FTPS upload target <link xlink:href="ftps://support-ftp.us.suse.com"/>, use the following:
+       For the FTPS upload target <link xlink:href="ftps://support-ftp.us.suse.com"/>, use the following command:
       </para>
 <!--taroth 2014-04-04: bnc#871918-->
 <screen>&prompt.sudo;supportconfig -ar <replaceable>12345678901</replaceable></screen>
 <para>
-  To use a different upload target, for example for the EMEA area, use the <option>-U</option> followed by the particular URL, either <link xlink:href="https://support-ftp.emea.suse.com/incoming"/> or <link xlink:href="ftps://support-ftp.emea.suse.com/incoming/"/>
+  To use a different upload target, for example for the EMEA area, use the <option>-U</option> followed by the particular URL, either <link xlink:href="https://support-ftp.emea.suse.com/incoming/"/> or <link xlink:href="ftps://support-ftp.emea.suse.com/incoming/"/>
   </para>
   <screen>&prompt.sudo;supportconfig -r <replaceable>12345678901</replaceable> -U <replaceable>https://support-ftp.emea.suse.com/incoming</replaceable> </screen>
      </step>
@@ -650,7 +637,7 @@ After you have created the archive using the <command>supportconfig</command> to
       <para>
        Manually upload the
        <filename>/var/log/scc_<replaceable>SR12345678901</replaceable>*txz</filename>
-       archive to one of our FTP servers. Which one to use depends on your
+       archive to one of our servers. Which one to use depends on your
        location in the world: 
       </para>
       <itemizedlist mark="bullet" spacing="normal">
@@ -663,7 +650,7 @@ After you have created the archive using the <command>supportconfig</command> to
     <listitem>
      <para>
       EMEA, Europe, the Middle East, and Africa: FTP
-      <link xlink:href="https://support-ftp.emea.suse.com/incoming"/>, FTPS <link xlink:href="ftps://support-ftp.emea.suse.com/incoming"/>
+      <link xlink:href="https://support-ftp.emea.suse.com/incoming"/>, FTPS <link xlink:href="ftps://support-ftp.emea.suse.com/incoming/"/>
      </para>
     </listitem>
    </itemizedlist>
@@ -680,6 +667,168 @@ After you have created the archive using the <command>supportconfig</command> to
   </section>
 
 
+ </section>
+
+ <section xml:id="sec-gathering-yastlogs">
+  <title>Gathering information during the installation</title>
+  <para>
+   When performing the manual installation, <command>supportconfig</command> is not available.
+   However, you can collect log files from &yast; by using
+   <command>save_y2logs</command>. This command will create a
+   <filename>.tar.xz</filename> archive in the directory
+   <filename>/tmp</filename>.
+  </para>  
+</section>
+
+<section xml:id="sec-admsupport-kernel">
+  <title>Support of kernel modules</title>
+
+  <para>
+   An important requirement for every enterprise operating system is the level
+   of support you receive for your environment. Kernel modules are the most
+   relevant connector between hardware (<quote>controllers</quote>) and the
+   operating system. Every kernel module in &productnameshort; has a
+   <literal>supported</literal> flag that can take three possible values:
+  </para>
+
+  <itemizedlist mark="bullet" spacing="normal">
+   <listitem>
+    <para>
+     <quote>yes</quote>, thus <literal>supported</literal>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <quote>external</quote>, thus <literal>supported</literal>
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     <quote/> (empty, not set), thus <literal>unsupported</literal>
+    </para>
+   </listitem>
+  </itemizedlist>
+
+  <para>
+   The following rules apply:
+  </para>
+
+  <itemizedlist mark="bullet" spacing="normal">
+   <listitem>
+    <para>
+     All modules of a self-recompiled kernel are by default marked as
+     unsupported.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Kernel modules supported by &suse; partners and delivered using
+     <literal>&suse; SolidDriver Program</literal> are marked
+     <quote>external</quote>.
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     If the <literal>supported</literal> flag is not set, loading this module
+     will taint the kernel. Tainted kernels are not supported. 
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     Kernel modules not provided under a license compatible to the license of
+     the Linux kernel will also taint the kernel. For details, see
+     the state of <filename>/proc/sys/kernel/tainted</filename>.
+    </para>
+   </listitem>
+  </itemizedlist>
+
+  <section xml:id="sec-admsupport-kernel-background">
+   <title>Technical background</title>
+   <para/>
+   <itemizedlist mark="bullet" spacing="normal">
+    <listitem>
+     <para>
+      Linux kernel: The value of
+      <filename>/proc/sys/kernel/unsupported</filename> defaults to
+      <literal>2</literal> (<literal>do not warn in
+      syslog when loading unsupported modules</literal>). This default is used
+      in the installer and in the installed system. 
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <command>modprobe</command>: The <command>modprobe</command> utility for
+      checking module dependencies and loading modules appropriately checks for
+      the value of the <literal>supported</literal> flag. If the value is
+      <quote>yes</quote> or <quote>external</quote> the module will be loaded,
+      otherwise it will not. For information on how to override this behavior,
+      see <xref linkend="sec-admsupport-kernel-unsupported"/>.
+     </para>
+     <note>
+      <title>Support</title>
+      <para>
+       &suse; does not generally support the removal of storage modules via
+       <command>modprobe -r</command>.
+      </para>
+     </note>
+    </listitem>
+   </itemizedlist>
+  </section>
+
+  <section xml:id="sec-admsupport-kernel-unsupported">
+   <title>Working with unsupported modules</title>
+   <para>
+    While general supportability is important, situations can occur where
+    loading an unsupported module is required. For example, for testing or
+    debugging purposes, or if your hardware vendor provides a hotfix.
+   </para>
+   <itemizedlist mark="bullet" spacing="normal">
+    <listitem>
+     <para>
+      To override the default, copy
+      <filename>/lib/modprobe.d/10-unsupported-modules.conf</filename> to
+      <filename>/etc/modprobe.d/10-unsupported-modules.conf</filename> and
+      change the value of the variable
+      <varname>allow_unsupported_modules</varname> from <literal>0</literal> to
+      <literal>1</literal>. Do not edit
+      <filename>/lib/modprobe.d/10-unsupported-modules.conf</filename> directly;
+      any changes will be overwritten whenever the
+      <package>suse-module-tools</package> package is updated.
+     </para>
+     <para>
+      If an unsupported module is needed in the initrd, do not forget to run
+      <command>transactional-update initrd</command> to update the initrd.
+     </para>
+     <para>
+      If you only want to try loading a module once, you can use the
+      <option>--allow-unsupported-modules</option> option with
+      <command>modprobe</command>. For more information, see the comments in
+      <filename>/lib/modprobe.d/10-unsupported-modules.conf</filename> and the
+      <command>modprobe</command> help.
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      To enforce loading of unsupported
+      modules during boot and afterward, use the kernel command line option
+      <option>oem-modules</option>. While installing and initializing the
+      <systemitem class="resource">suse-module-tools</systemitem> package, the
+      kernel flag <literal>TAINT_NO_SUPPORT</literal>
+      (<filename>/proc/sys/kernel/tainted</filename>) will be evaluated. If the
+      kernel is already tainted, <literal>allow_unsupported_modules</literal>
+      will be enabled. This will prevent unsupported modules from failing in
+      the system being installed. If no unsupported modules are present during
+      installation and the other special kernel command line option
+      (<option>oem-modules=1</option>) is not used, the default still is to
+      disallow unsupported modules.
+     </para>
+    </listitem>
+   </itemizedlist>
+   <para>
+    Remember that loading and running unsupported modules will make the kernel
+    and the whole system unsupported by &suse;.
+   </para>
+  </section>
  </section>
 
  </chapter>

--- a/xml/slemicro_supportconfig.xml
+++ b/xml/slemicro_supportconfig.xml
@@ -34,32 +34,559 @@
  </info>
 
   <section xml:id="sec-collecting-information">
-  <title>Collecting system information with supportconfig</title>
+  <title>Collecting system information with <command>supportconfig</command></title>
   <para>
    To create a TAR archive with detailed system information that you can hand
    over to Global Technical Support, use the command <command>supportconfig</command>.
    The command line tool is provided by the
-   package <systemitem>supportutils</systemitem> which is installed by default.
-   
+   package <systemitem>supportutils</systemitem> which is installed by default.   
   </para>
   <para>
    Depending on which packages are installed on your system, some of these
-   packages integrate Supportconfig plug-ins.  When Supportconfig is executed,
+   packages integrate <command>supportconfig</command> plug-ins.  When <command>supportconfig</command> is executed,
    all plug-ins are executed as well and create one or more result files for
    the archive. That has the benefit that the only topics checked are those
-   that contain a specific plug-in for them.  Supportconfig plug-ins are stored
+   that contain a specific plug-in for them.  <command>supportconfig</command> plug-ins are stored
    in the directory <filename>/usr/lib/supportconfig/plugins/</filename>.
   </para>
+
+  <para>
+    The following procedure shows how to create a Supportconfig archive, but
+    without submitting it to support directly. For uploading it, you need to
+    run the command with certain options as described in
+    <xref linkend="pro-admsupport-submit-cli"/>.
+   </para>
+   <procedure>
+    <step>
+     <para>
+      Open a shell and become <systemitem class="username">root</systemitem>.
+     </para>
+    </step>
+    <step>
+     <para>
+      Run <command>supportconfig</command>. Usually, it is enough to
+      run this tool without any options. Some options are very common and
+      are displayed in the following list:
+     </para>
+     <variablelist>
+      <varlistentry>
+       <term><option>-E <replaceable>MAIL</replaceable></option></term>
+       <term><option>-N <replaceable>NAME</replaceable></option></term>
+       <term><option>-O <replaceable>COMPANY</replaceable></option></term>
+       <term><option>-P <replaceable>PHONE</replaceable></option></term>
+       <listitem>
+        <para>
+         Sets your contact data: e-mail address (<option>-E</option>), company
+         name (<option>-O</option>), your name (<option>-N</option>), and
+         your phone number (<option>-P</option>).
+        </para>
+       </listitem>
+      </varlistentry>
+      <varlistentry>
+       <term><option>-i <replaceable>KEYWORDS</replaceable></option></term>
+       <term><option>-F</option></term>
+       <listitem>
+        <para>
+         Limits the features to check. The placeholder <replaceable>KEYWORDS</replaceable>
+         is a comma separated list of case-sensitive keywords. Get a list
+         of all keywords with <command>supportconfig -F</command>.
+        </para>
+       </listitem>
+      </varlistentry>
+      </variablelist>
+    </step>
+    <step>
+     <para>
+      Wait for the tool to complete the operation.
+     </para>
+    </step>
+    <step>
+     <para>
+      The default archive location is <filename>/var/log</filename>, with the
+      file name format being
+      <filename>scc_<replaceable>HOST</replaceable>_<replaceable>DATE</replaceable>_<replaceable>TIME</replaceable>.tbz</filename>
+     </para>
+    </step>
+   </procedure>
+
+   <section xml:id="sec-understanding-output-slemicro">
+    <title>Understanding the output of <command>supportconfig</command></title>
+    <para>
+    If you run <command>supportconfig</command>,
+    the script gives you a summary of what it did.
+   </para>
+    <screen>                     Support Utilities - Supportconfig
+                          Script Version: 3.1.11-46.2 <!--<co xml:id="co-admsupport-script-version"/>-->
+                          Library Version: 3.1.11-29.6
+                          Script Date: 2022 10 18<!-- <xref linkend="co-admsupport-script-version"/>-->
+[...]
+Gathering system information
+  Data Directory:    /var/log/scc_d251_180201_1525 <co xml:id="co-admsupport-script-datadir"/>
+
+  Basic Server Health Check...                 Done <co xml:id="co-admsupport-script-done"/>
+  RPM Database...                              Done <xref linkend="co-admsupport-script-done"/>
+  Basic Environment...                         Done <xref linkend="co-admsupport-script-done"/>
+  System Modules...                            Done <xref linkend="co-admsupport-script-done"/>
+[...]
+  File System List...                          Skipped <co xml:id="co-admsupport-script-skipped"/>
+[...]
+  Command History...                           Excluded <co xml:id="co-admsupport-script-excluded"/>
+[...]
+  Supportconfig Plugins:                       1 <co xml:id="co-admsupport-script-plugin"/>
+    Plugin: pstree...                          Done
+[...]
+Creating Tar Ball
+
+==[ DONE ]===================================================================
+  Log file tar ball: /var/log/scc_d251_180201_1525.txz <co xml:id="co-admsupport-script-archive"/>
+  Log file size:     732K
+  Log file md5sum:   bf23e0e15e9382c49f92cbce46000d8b
+=============================================================================</screen>
+   <calloutlist>
+    <!--<callout arearefs="co-admsupport-script-version">
+     <para>
+      The version and the date of the <command>supportconfig</command> command.
+      Higher versions can support more features.
+     </para>
+    </callout>-->
+    <callout arearefs="co-admsupport-script-datadir">
+     <para>
+      The temporary data directory to store the results. This directory is
+      archived as tar file, see <xref linkend="co-admsupport-script-archive"/>.
+     </para>
+    </callout>
+    <callout arearefs="co-admsupport-script-done">
+     <para>
+      The feature was enabled (either by default or selected manually) and
+      executed successfully. The result is stored in a file (see <xref
+       linkend="tab-admsupport-features-and-filenames"/>).
+     </para>
+    </callout>
+    <callout arearefs="co-admsupport-script-skipped">
+     <para>
+      The feature was skipped because some files of one or more RPM packages
+      were changed.
+     </para>
+    </callout>
+    <callout arearefs="co-admsupport-script-excluded">
+     <para>
+      The feature was excluded because it was deselected via the <option>-x</option>
+      option.
+     </para>
+    </callout>
+    <callout arearefs="co-admsupport-script-plugin">
+     <para>
+      The script found one plug-in and executes the plug-in
+      <command>pstree</command>. The plug-in was found in the directory
+      <filename class="directory">/usr/lib/supportconfig/plugins/</filename>.
+      See the man page for details.
+     </para>
+    </callout>
+    <callout arearefs="co-admsupport-script-archive">
+     <para>
+      The tar file name of the archive, by default compressed with <command>xz</command>.
+     </para>
+    </callout>
+   </calloutlist>
+   </section>
+
+   <section xml:id="sec-slemicro-options">
+    <title>Common supportconfig options</title>
+   <para>
+    The <command>supportconfig</command> utility is usually called without any
+    options. Display a list of all options with
+    <command>supportconfig</command> <option>-h</option>. The following list gives a brief overview of some common use cases:
+   </para>
+   <variablelist>
+    <varlistentry>
+     <term>Reducing the size of the information being gathered</term>
+     <listitem>
+      <para>
+       Use the minimal option (<option>-m</option>):
+      </para>
+<screen>&prompt.root;supportconfig -m</screen>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>Limiting the information to a specific topic</term>
+     <listitem>
+      <para>
+       If you have already localized a problem <!--with the default
+       <command>supportconfig</command> output and have found--> that relates
+       to a specific area or feature set only, you should limit the collected
+       information to the specific area for the next
+       <command>supportconfig</command> run. For example, if you detected
+       problems with LVM and want to test a recent change that you did to the
+       LVM configuration. In that case it makes sense to gather the minimum
+       Supportconfig information around LVM only:
+      </para>
+<screen>&prompt.root;supportconfig -i LVM</screen>
+      <para>
+       Additional keywords can be separated through commas. For example,
+       an additional disk test:
+      </para>
+      <screen>&prompt.root;supportconfig -i LVM,DISK</screen>
+      <para>
+       For a complete list of feature keywords that you can use for limiting
+       the collected information to a specific area, run:
+      </para>
+<screen>&prompt.root;supportconfig -F</screen>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>Including additional contact information in the output:</term>
+     <listitem>
+<screen>&prompt.root;supportconfig -E tux@example.org -N "Tux Penguin" -O<!--
+      --> "Penguin Inc." ...</screen>
+      <para>
+       (all in one line)
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>Collecting already rotated log files</term>
+     <listitem>
+<screen>&prompt.root;supportconfig -l</screen>
+      <para>
+       This is especially useful in high logging environments or after a kernel
+       crash when syslog rotates the log files after a reboot.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+   </section>
+
+   <section xml:id="sec-slemicro-archive-content">
+    <title>Overview of the archive content</title>
+   <para>
+    The TAR archive contains all the results from the features. Depending on
+    what you have selected (all or only a small set), the archive can contain
+    more or less files.
+    The set of features can be limited through the <option>-i</option>
+    option (see <xref linkend="sec-slemicro-options"/>).
+   </para>
+   <para>
+    To list the content of the archive, use the following <command>tar</command>
+    command:
+   </para>
+   <screen>&prompt.root;<command>tar</command> xf /var/log/scc_&exampleclient;_180131_1545.tbz</screen>
+   <para>
+    The following file names are always available inside the TAR archive:
+   </para>
+   <variablelist>
+    <title>Minimum files in archive</title>
+    <varlistentry>
+     <term><filename>basic-environment.txt</filename></term>
+     <listitem>
+      <para>Contains the date when this script was executed and system information
+       like version of the distribution, hypervisor information, and more.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><filename>basic-health-check.txt</filename></term>
+     <listitem>
+      <para>
+       Contains some basic health checks like uptime, virtual memory statistics,
+       free memory and hard disk, checks for zombie processes, and more.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><filename>hardware.txt</filename></term>
+     <listitem>
+      <para>
+       Contains basic hardware checks like information about the CPU architecture,
+       list of all connected hardware, interrupts, I/O ports, kernel boot messages,
+       and more.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><filename>messages.txt</filename></term>
+     <listitem>
+      <para>
+       Contains log messages from the system journal.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><filename>rpm.txt</filename></term>
+     <listitem>
+      <para>Contains a list of all installed RPM packages, the name,
+      where they are coming from, and their versions.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><filename>summary.xml</filename></term>
+     <listitem>
+      <para>Contains some information in XML format like distribution,
+      the version, and product specific fragments.</para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><filename>supportconfig.txt</filename></term>
+     <listitem>
+      <para>
+       Contains information about the <command>supportconfig</command> script
+       itself.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term><filename>y2log.txt</filename></term>
+     <listitem>
+      <para>
+       Contains &yast; specific information like specific packages, configuration
+       files, and log files.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+   <para>
+    <xref linkend="tab-admsupport-features-and-filenames"/> lists all available
+    features and their file names. Further service packs can extend the list,
+    as can plug-ins.
+   </para>
+   <table xml:id="tab-admsupport-features-and-filenames">
+    <title>Comparison of features and file names in the TAR archive</title>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>Feature</entry>
+       <entry>File name</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry><parameter>APPARMOR</parameter></entry>
+       <entry><filename>security-apparmor.txt</filename></entry>
+      </row>
+      <row>
+       <entry><parameter>AUDIT</parameter></entry>
+       <entry><filename>security-audit.txt</filename></entry>
+      </row>
+      <row>
+       <entry><parameter>AUTOFS</parameter></entry>
+       <entry><filename>fs-autofs.txt</filename></entry>
+      </row>
+      <row>
+       <entry><parameter>BOOT</parameter></entry>
+       <entry><filename>boot.txt</filename></entry>
+      </row>
+      <row>
+       <entry><parameter>BTRFS</parameter></entry>
+       <entry><filename>fs-btrfs.txt</filename></entry>
+      </row>
+      <row>
+       <entry><parameter>DAEMONS</parameter></entry>
+       <entry><filename>systemd.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>CIMOM</parameter></entry>
+         <entry><filename>cimom.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>CRASH</parameter></entry>
+         <entry><filename>crash.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>CRON</parameter></entry>
+         <entry><filename>cron.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>DHCP</parameter></entry>
+         <entry><filename>dhcp.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>DISK</parameter></entry>
+         <entry><filename>fs-diskio.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>DNS</parameter></entry>
+         <entry><filename>dns.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>DOCKER</parameter></entry>
+         <entry><filename>docker.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>DRBD</parameter></entry>
+         <entry><filename>drbd.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>ENV</parameter></entry>
+         <entry><filename>env.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>ETC</parameter></entry>
+         <entry><filename>etc.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>HISTORY</parameter></entry>
+         <entry><filename>shell_history.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>IB</parameter></entry>
+         <entry><filename>ib.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>IMAN</parameter></entry>
+         <entry><filename>novell-iman.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>ISCSI</parameter></entry>
+         <entry><filename>fs-iscsi.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>LDAP</parameter></entry>
+         <entry><filename>ldap.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>LIVEPATCH</parameter></entry>
+         <entry><filename>kernel-livepatch.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>LVM</parameter></entry>
+         <entry><filename>lvm.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>MEM</parameter></entry>
+         <entry><filename>memory.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>MOD</parameter></entry>
+         <entry><filename>modules.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>MPIO</parameter></entry>
+         <entry><filename>mpio.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>NET</parameter></entry>
+         <entry><filename>network-*.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>NFS</parameter></entry>
+         <entry><filename>nfs.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>NTP</parameter></entry>
+         <entry><filename>ntp.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>NVME</parameter></entry>
+         <entry><filename>nvme.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>OCFS2</parameter></entry>
+         <entry><filename>ocfs2.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>OFILES</parameter></entry>
+         <entry><filename>open-files.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>PODMAN</parameter></entry>
+         <entry><filename>podman/</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>PRINT</parameter></entry>
+         <entry><filename>print.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>PROC</parameter></entry>
+         <entry><filename>proc.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>SAR</parameter></entry>
+         <entry><filename>sar.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>SLERT</parameter></entry>
+         <entry><filename>slert.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>SLP</parameter></entry>
+         <entry><filename>slp.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>SMT</parameter></entry>
+         <entry><filename>smt.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>SMART</parameter></entry>
+         <entry><filename>fs-smartmon.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>SMB</parameter></entry>
+         <entry><filename>samba.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>SRAID</parameter></entry>
+         <entry><filename>fs-softraid.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>SSH</parameter></entry>
+         <entry><filename>ssh.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>SSSD</parameter></entry>
+         <entry><filename>sssd.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>SYSCONFIG</parameter></entry>
+         <entry><filename>sysconfig.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>SYSFS</parameter></entry>
+         <entry><filename>sysfs.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>TRANSACTIONAL</parameter></entry>
+         <entry><filename>transactional-update.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>TUNED</parameter></entry>
+         <entry><filename>tuned.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>UDEV</parameter></entry>
+         <entry><filename>udev.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>UFILES</parameter></entry>
+         <entry><filename>fs-files-additional.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>UP</parameter></entry>
+         <entry><filename>updates.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>WEB</parameter></entry>
+         <entry><filename>web.txt</filename></entry>
+      </row>
+      <row>
+         <entry><parameter>X</parameter></entry>
+         <entry><filename>x.txt</filename></entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </table>
+   </section>
  </section>
 
  <section xml:id="sec-submitting-information">
   <title>Submitting information to Global Technical Support</title>
+  <para>
+After you have created the archive using the <command>supportconfig</command> tool, you can submit the archive to &suse;.  
+  </para>
 
   <section xml:id="sec-slemicro-supportconfig-sr">
    <title>Creating a service request number</title>
    <para>
-    Supportconfig archives can be generated at any time. However, for
-    handing over the Supportconfig data to Global Technical Support, you need
+    <command>supportconfig</command> archives can be generated at any time. However, for
+    handing over the <command>supportconfig</command> data to Global Technical Support, you need
     to generate a service request number first. You will need it to upload the
     archive to support.
    </para>
@@ -82,7 +609,7 @@
     <title>Upload targets</title>
     <para>
     After having created a service request number, you can upload your
-    Supportconfig archives to Global Technical Support
+    Supportconfig archives to Global Technical Support. In the examples below, the <emphasis>12345678901</emphasis> serves as a placeholder for your service request number. Replace the placeholder with the service request number you created in <xref linkend="sec-slemicro-supportconfig-sr"/>.  
   </para>
   <procedure xml:id="pro-admsupport-submit-cli">
    <title>Submitting information to support from command line</title>

--- a/xml/slemicro_supportconfig.xml
+++ b/xml/slemicro_supportconfig.xml
@@ -13,13 +13,12 @@
     <abstract>
       <para>
         In case of problems, a detailed system report may be created with the
-        <command>supportconfig</command> command line tool. The tool will
-        collect information about the system such as: current kernel version,
-        hardware, installed packages, partition setup, and much more. The
-        result is a TAR archive of files. After opening a Service Request (SR),
-        you can upload the TAR archive to Global Technical Support. It will
-        help to locate the issue you reported and to assist you in solving the
-        problem.
+        <command>supportconfig</command> command-line tool. The tool
+        will collect information about the system, such as the current kernel
+        version, hardware, installed packages, partition setup, and much more.
+        The result is a TAR archive of files. After opening a Service Request
+        (SR), you can upload the TAR archive to Global Technical Support. It
+        will help you to locate the reported issue and solve the problem.
       </para>
 
       <para>
@@ -37,7 +36,7 @@
     <para>
       To create a TAR archive with detailed system information that you can
       hand over to Global Technical Support, use the command
-      <command>supportconfig</command>. The command line tool is provided by
+      <command>supportconfig</command>. The command-line tool is provided by
       the package <systemitem>supportutils</systemitem> which is installed by
       default.
     </para>
@@ -45,10 +44,11 @@
       Depending on which packages are installed on your system, some of these
       packages integrate <command>supportconfig</command> plug-ins. When
       <command>supportconfig</command> is executed, all plug-ins are executed
-      as well and create one or more result files for the archive. That has the
+      as well, creating one or more result files for the archive. This has the
       benefit that the only topics checked are those that contain a specific
-      plug-in for them. <command>supportconfig</command> plug-ins are stored in
-      the directory <filename>/usr/lib/supportconfig/plugins/</filename>.
+      plug-in for them. <command>supportconfig</command> plug-ins
+      are stored in the directory
+      <filename>/usr/lib/supportconfig/plugins/</filename>.
     </para>
     <para>
       The following procedure shows how to create a Supportconfig archive, but
@@ -84,7 +84,7 @@
             <listitem>
               <para>
                 Limits the features to check. The placeholder
-                <replaceable>KEYWORDS</replaceable> is a comma separated list
+                <replaceable>KEYWORDS</replaceable> is a comma-separated list
                 of case-sensitive keywords. Get a list of all keywords with
                 <command>supportconfig -F</command>.
               </para>
@@ -148,7 +148,7 @@ Creating Tar Ball
         <callout arearefs="co-admsupport-script-datadir">
           <para>
             The temporary data directory to store the results. This directory
-            is archived as tar file, see
+            is archived as a tar file, see
             <xref linkend="co-admsupport-script-archive"/>.
           </para>
         </callout>
@@ -182,8 +182,8 @@ Creating Tar Ball
         </callout>
         <callout arearefs="co-admsupport-script-archive">
           <para>
-            The tar file name of the archive, by default compressed with
-            <command>xz</command>.
+            The tar file name of the archive, compressed with
+            <command>xz</command> by default.
           </para>
         </callout>
       </calloutlist>
@@ -198,7 +198,7 @@ Creating Tar Ball
       </para>
       <variablelist>
         <varlistentry>
-          <term>Reducing the size of the information being gathered</term>
+          <term>Reducing the amount of the information being gathered</term>
           <listitem>
             <para>
               Use the minimal option (<option>-m</option>):
@@ -215,14 +215,15 @@ Creating Tar Ball
                 <command>supportconfig</command> output and have found-->
               that relates to a specific area or feature set only, you should
               limit the collected information to the specific area for the next
-              <command>supportconfig</command> run. For example, if you
+              <command>supportconfig</command> run. For example, you have
               detected problems with LVM and want to test a recent change that
-              you did to the LVM configuration. In that case it makes sense to
-              gather the minimum Supportconfig information around LVM only:
+              you introduced to the LVM configuration. In this case, it makes
+              sense to gather the minimum Supportconfig information around
+              LVM only:
             </para>
 <screen>&prompt.root;supportconfig -i LVM</screen>
             <para>
-              Additional keywords can be separated through commas. For example,
+              Additional keywords can be separated with commas. For example,
               an additional disk test:
             </para>
 <screen>&prompt.root;supportconfig -i LVM,DISK</screen>
@@ -248,7 +249,7 @@ Creating Tar Ball
           <listitem>
 <screen>&prompt.root;supportconfig -l</screen>
             <para>
-              This is especially useful in high logging environments or after a
+              This is especially useful in high-logging environments or after a
               kernel crash when syslog rotates the log files after a reboot.
             </para>
           </listitem>
@@ -260,12 +261,12 @@ Creating Tar Ball
       <para>
         The TAR archive contains all the results from the features. Depending
         on what you have selected (all or only a small set), the archive can
-        contain more or less files. The set of features can be limited through
+        contain more or fewer files. The set of features can be limited using
         the <option>-i</option> option (see
         <xref linkend="sec-slemicro-options"/>).
       </para>
       <para>
-        To list the content of the archive, use the following
+        To list the contents of the archive, use the following
         <command>tar</command> command:
       </para>
 <screen>&prompt.root;<command>tar</command> xf /var/log/scc_&exampleclient;_180131_1545.txz</screen>
@@ -316,8 +317,8 @@ Creating Tar Ball
           <term><filename>rpm.txt</filename></term>
           <listitem>
             <para>
-              Contains a list of all installed RPM packages, the name, where
-              they are coming from, and their versions.
+              Contains a list of all installed RPM packages, their names
+              and versions and where they come from.
             </para>
           </listitem>
         </varlistentry>
@@ -325,8 +326,8 @@ Creating Tar Ball
           <term><filename>summary.xml</filename></term>
           <listitem>
             <para>
-              Contains some information in XML format like distribution, the
-              version, and product specific fragments.
+              Contains information in XML format, such as distribution,
+              version and product-specific fragments.
             </para>
           </listitem>
         </varlistentry>
@@ -343,8 +344,8 @@ Creating Tar Ball
           <term><filename>y2log.txt</filename></term>
           <listitem>
             <para>
-              Contains &yast; specific information like specific packages,
-              configuration files, and log files.
+              Contains &yast;-specific information like specific packages,
+              configuration files and log files.
             </para>
           </listitem>
         </varlistentry>
@@ -711,7 +712,7 @@ Creating Tar Ball
         <title>Submitting information to support from command line</title>
         <para>
           The following procedure assumes that you have already created a
-          Supportconfig archive, but have not uploaded it yet.
+          Supportconfig archive but have not uploaded it yet.
         </para>
         <step>
           <para>
@@ -735,7 +736,7 @@ Creating Tar Ball
               <!--taroth 2014-04-04: bnc#871918-->
 <screen>&prompt.sudo;supportconfig -ar <replaceable>12345678901</replaceable></screen>
               <para>
-                To use a different upload target, for example for the EMEA
+                To use a different upload target, for example, for the EMEA
                 area, use the <option>-U</option> followed by the particular
                 URL, either
                 <link xlink:href="https://support-ftp.emea.suse.com/incoming/upload.php?file={tarball}"/>
@@ -748,7 +749,7 @@ Creating Tar Ball
         </step>
         <step>
           <para>
-            Servers <emphasis>without</emphasis> Internet connectivity
+            Servers <emphasis>without</emphasis> Internet connectivity:
           </para>
           <substeps performance="required">
             <step>
@@ -761,8 +762,8 @@ Creating Tar Ball
               <para>
                 Manually upload the
                 <filename>/var/log/scc_<replaceable>SR12345678901</replaceable>*txz</filename>
-                archive to one of our servers. Which one to use depends on your
-                location in the world:
+                archive to one of our servers. The selection of a server depends
+                on your location in the world:
               </para>
               <itemizedlist mark="bullet" spacing="normal">
                 <listitem>
@@ -822,12 +823,12 @@ Creating Tar Ball
       </listitem>
       <listitem>
         <para>
-          <quote>external</quote>, thus <literal>supported</literal>
+          <quote>external,</quote> thus <literal>supported</literal>
         </para>
       </listitem>
       <listitem>
         <para>
-          <quote/> (empty, not set), thus <literal>unsupported</literal>
+          (empty, not set), thus <literal>unsupported</literal>
         </para>
       </listitem>
     </itemizedlist>
@@ -845,7 +846,7 @@ Creating Tar Ball
         <para>
           Kernel modules supported by &suse; partners and delivered using
           <literal>&suse; SolidDriver Program</literal> are marked
-          <quote>external</quote>.
+          <quote>external.</quote>
         </para>
       </listitem>
       <listitem>
@@ -881,7 +882,7 @@ Creating Tar Ball
             utility for checking module dependencies and loading modules
             appropriately checks for the value of the
             <literal>supported</literal> flag. If the value is
-            <quote>yes</quote> or <quote>external</quote> the module will be
+            <quote>yes</quote> or <quote>external,</quote> the module will be
             loaded, otherwise it will not. For information on how to override
             this behavior, see
             <xref linkend="sec-admsupport-kernel-unsupported"/>.
@@ -931,8 +932,8 @@ Creating Tar Ball
         </listitem>
         <listitem>
           <para>
-            To enforce loading of unsupported modules during boot and
-            afterward, use the kernel command line option
+            To enforce the loading of unsupported modules during boot and
+            afterward, use the kernel command-line option
             <option>oem-modules</option>. While installing and initializing the
             <systemitem class="resource">suse-module-tools</systemitem>
             package, the kernel flag <literal>TAINT_NO_SUPPORT</literal>
@@ -941,9 +942,9 @@ Creating Tar Ball
             <literal>allow_unsupported_modules</literal> will be enabled. This
             will prevent unsupported modules from failing in the system being
             installed. If no unsupported modules are present during
-            installation and the other special kernel command line option
-            (<option>oem-modules=1</option>) is not used, the default still is
-            to disallow unsupported modules.
+            installation and the other special kernel command-line option
+            (<option>oem-modules=1</option>) is not used, the default is
+            still to disallow unsupported modules.
           </para>
         </listitem>
       </itemizedlist>

--- a/xml/slemicro_supportconfig.xml
+++ b/xml/slemicro_supportconfig.xml
@@ -4,113 +4,114 @@
   <!ENTITY % entities SYSTEM "generic-entities.ent">
     %entities;
 ]>
-
 <chapter version="5.0" xml:id="cha-adm-support-slemicro"
   xmlns="http://docbook.org/ns/docbook"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
-
- <title>Gathering system information for support</title>
- <info>
-  <abstract>
+  <title>Gathering system information for support</title>
+  <info>
+    <abstract>
       <para>
-    In case of problems, a detailed system report may be created with the <command>supportconfig</command> command line tool. The tool will collect information about the
-    system such as: current kernel version, hardware, installed packages,
-    partition setup, and much more. The result is a TAR archive of files. After
-    opening a Service Request (SR), you can upload the TAR archive to Global
-    Technical Support. It will help to locate the issue you reported and to
-    assist you in solving the problem.
-   </para>
+        In case of problems, a detailed system report may be created with the
+        <command>supportconfig</command> command line tool. The tool will
+        collect information about the system such as: current kernel version,
+        hardware, installed packages, partition setup, and much more. The
+        result is a TAR archive of files. After opening a Service Request (SR),
+        you can upload the TAR archive to Global Technical Support. It will
+        help to locate the issue you reported and to assist you in solving the
+        problem.
+      </para>
 
-   <para>
-    You can analyze the <command>supportconfig</command> output
-    for known issues to help resolve problems faster. 
-   </para>
-  </abstract>
-  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:bugtracker></dm:bugtracker>
-   <dm:translation>yes</dm:translation>
-  </dm:docmanager>
- </info>
-
+      <para>
+        You can analyze the <command>supportconfig</command> output for known
+        issues to help resolve problems faster.
+      </para>
+    </abstract>
+    <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+      <dm:bugtracker></dm:bugtracker>
+      <dm:translation>yes</dm:translation>
+    </dm:docmanager>
+  </info>
   <section xml:id="sec-collecting-information">
-  <title>Collecting system information with <command>supportconfig</command></title>
-  <para>
-   To create a TAR archive with detailed system information that you can hand
-   over to Global Technical Support, use the command <command>supportconfig</command>.
-   The command line tool is provided by the
-   package <systemitem>supportutils</systemitem> which is installed by default.   
-  </para>
-  <para>
-   Depending on which packages are installed on your system, some of these
-   packages integrate <command>supportconfig</command> plug-ins.  When <command>supportconfig</command> is executed,
-   all plug-ins are executed as well and create one or more result files for
-   the archive. That has the benefit that the only topics checked are those
-   that contain a specific plug-in for them.  <command>supportconfig</command> plug-ins are stored
-   in the directory <filename>/usr/lib/supportconfig/plugins/</filename>.
-  </para>
-
-  <para>
-    The following procedure shows how to create a Supportconfig archive, but
-    without submitting it to support directly. For uploading it, you need to
-    run the command with certain options as described in
-    <xref linkend="pro-admsupport-submit-cli"/>.
-   </para>
-   <procedure>
-    <step>
-     <para>
-      Run <command>supportconfig</command> as &rootuser;. Usually, it is enough to
-      run this tool without any options. Some options are very common and
-      are displayed in the following list:
-     </para>
-     <variablelist>
-      <varlistentry>
-       <term><option>-E <replaceable>MAIL</replaceable></option></term>
-       <term><option>-N <replaceable>NAME</replaceable></option></term>
-       <term><option>-O <replaceable>COMPANY</replaceable></option></term>
-       <term><option>-P <replaceable>PHONE</replaceable></option></term>
-       <listitem>
-        <para>
-         Sets your contact data: e-mail address (<option>-E</option>), company
-         name (<option>-O</option>), your name (<option>-N</option>), and
-         your phone number (<option>-P</option>).
-        </para>
-       </listitem>
-      </varlistentry>
-      <varlistentry>
-       <term><option>-i <replaceable>KEYWORDS</replaceable></option></term>
-       <term><option>-F</option></term>
-       <listitem>
-        <para>
-         Limits the features to check. The placeholder <replaceable>KEYWORDS</replaceable>
-         is a comma separated list of case-sensitive keywords. Get a list
-         of all keywords with <command>supportconfig -F</command>.
-        </para>
-       </listitem>
-      </varlistentry>
-      </variablelist>
-    </step>
-    <step>
-     <para>
-      Wait for the tool to complete the operation.
-     </para>
-    </step>
-    <step>
-     <para>
-      The default archive location is <filename>/var/log</filename>, with the
-      file name format being
-      <filename>scc_<replaceable>HOST</replaceable>_<replaceable>DATE</replaceable>_<replaceable>TIME</replaceable>.txz</filename>
-     </para>
-    </step>
-   </procedure>
-
-   <section xml:id="sec-understanding-output-slemicro">
-    <title>Understanding the output of <command>supportconfig</command></title>
+    <title>Collecting system information with <command>supportconfig</command></title>
     <para>
-    If you run <command>supportconfig</command>,
-    the script gives you a summary of what it did.
-   </para>
-    <screen>                     Support Utilities - Supportconfig
+      To create a TAR archive with detailed system information that you can
+      hand over to Global Technical Support, use the command
+      <command>supportconfig</command>. The command line tool is provided by
+      the package <systemitem>supportutils</systemitem> which is installed by
+      default.
+    </para>
+    <para>
+      Depending on which packages are installed on your system, some of these
+      packages integrate <command>supportconfig</command> plug-ins. When
+      <command>supportconfig</command> is executed, all plug-ins are executed
+      as well and create one or more result files for the archive. That has the
+      benefit that the only topics checked are those that contain a specific
+      plug-in for them. <command>supportconfig</command> plug-ins are stored in
+      the directory <filename>/usr/lib/supportconfig/plugins/</filename>.
+    </para>
+    <para>
+      The following procedure shows how to create a Supportconfig archive, but
+      without submitting it to support directly. For uploading it, you need to
+      run the command with certain options as described in
+      <xref linkend="pro-admsupport-submit-cli"/>.
+    </para>
+    <procedure>
+      <step>
+        <para>
+          Run <command>supportconfig</command> as &rootuser;. Usually, it is
+          enough to run this tool without any options. Some options are very
+          common and are displayed in the following list:
+        </para>
+        <variablelist>
+          <varlistentry>
+            <term><option>-E <replaceable>MAIL</replaceable></option></term>
+            <term><option>-N <replaceable>NAME</replaceable></option></term>
+            <term><option>-O <replaceable>COMPANY</replaceable></option></term>
+            <term><option>-P <replaceable>PHONE</replaceable></option></term>
+            <listitem>
+              <para>
+                Sets your contact data: e-mail address (<option>-E</option>),
+                company name (<option>-O</option>), your name
+                (<option>-N</option>), and your phone number
+                (<option>-P</option>).
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term><option>-i <replaceable>KEYWORDS</replaceable></option></term>
+            <term><option>-F</option></term>
+            <listitem>
+              <para>
+                Limits the features to check. The placeholder
+                <replaceable>KEYWORDS</replaceable> is a comma separated list
+                of case-sensitive keywords. Get a list of all keywords with
+                <command>supportconfig -F</command>.
+              </para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+      </step>
+      <step>
+        <para>
+          Wait for the tool to complete the operation.
+        </para>
+      </step>
+      <step>
+        <para>
+          The default archive location is <filename>/var/log</filename>, with
+          the file name format being
+          <filename>scc_<replaceable>HOST</replaceable>_<replaceable>DATE</replaceable>_<replaceable>TIME</replaceable>.txz</filename>
+        </para>
+      </step>
+    </procedure>
+    <section xml:id="sec-understanding-output-slemicro">
+      <title>Understanding the output of <command>supportconfig</command></title>
+      <para>
+        If you run <command>supportconfig</command>, the script gives you a
+        summary of what it did.
+      </para>
+<screen>                     Support Utilities - Supportconfig
                           Script Version: 3.1.11-46.2 <!--<co xml:id="co-admsupport-script-version"/>-->
                           Library Version: 3.1.11-29.6
                           Script Date: 2022 10 18<!-- <xref linkend="co-admsupport-script-version"/>-->
@@ -137,698 +138,819 @@ Creating Tar Ball
   Log file size:     732K
   Log file md5sum:   bf23e0e15e9382c49f92cbce46000d8b
 =============================================================================</screen>
-   <calloutlist>
-    <!--<callout arearefs="co-admsupport-script-version">
-     <para>
-      The version and the date of the <command>supportconfig</command> command.
-      Higher versions can support more features.
-     </para>
-    </callout>-->
-    <callout arearefs="co-admsupport-script-datadir">
-     <para>
-      The temporary data directory to store the results. This directory is
-      archived as tar file, see <xref linkend="co-admsupport-script-archive"/>.
-     </para>
-    </callout>
-    <callout arearefs="co-admsupport-script-done">
-     <para>
-      The feature was enabled (either by default or selected manually) and
-      executed successfully. The result is stored in a file (see <xref
+      <calloutlist>
+        <!--<callout arearefs="co-admsupport-script-version">
+          <para>
+          The version and the date of the <command>supportconfig</command> command.
+          Higher versions can support more features.
+          </para>
+          </callout>-->
+        <callout arearefs="co-admsupport-script-datadir">
+          <para>
+            The temporary data directory to store the results. This directory
+            is archived as tar file, see
+            <xref linkend="co-admsupport-script-archive"/>.
+          </para>
+        </callout>
+        <callout arearefs="co-admsupport-script-done">
+          <para>
+            The feature was enabled (either by default or selected manually)
+            and executed successfully. The result is stored in a file (see
+            <xref
        linkend="tab-admsupport-features-and-filenames"/>).
-     </para>
-    </callout>
-    <callout arearefs="co-admsupport-script-skipped">
-     <para>
-      The feature was skipped because some files of one or more RPM packages
-      were changed.
-     </para>
-    </callout>
-    <callout arearefs="co-admsupport-script-excluded">
-     <para>
-      The feature was excluded because it was deselected via the <option>-x</option>
-      option.
-     </para>
-    </callout>
-    <callout arearefs="co-admsupport-script-plugin">
-     <para>
-      The script found one plug-in and executes the plug-in
-      <command>pstree</command>. The plug-in was found in the directory
-      <filename class="directory">/usr/lib/supportconfig/plugins/</filename>.
-      See the man page for details.
-     </para>
-    </callout>
-    <callout arearefs="co-admsupport-script-archive">
-     <para>
-      The tar file name of the archive, by default compressed with <command>xz</command>.
-     </para>
-    </callout>
-   </calloutlist>
-   </section>
-
-   <section xml:id="sec-slemicro-options">
-    <title>Common supportconfig options</title>
-   <para>
-    The <command>supportconfig</command> utility is usually called without any
-    options. Display a list of all options with
-    <command>supportconfig</command> <option>-h</option>. The following list gives a brief overview of some common use cases:
-   </para>
-   <variablelist>
-    <varlistentry>
-     <term>Reducing the size of the information being gathered</term>
-     <listitem>
+          </para>
+        </callout>
+        <callout arearefs="co-admsupport-script-skipped">
+          <para>
+            The feature was skipped because some files of one or more RPM
+            packages were changed.
+          </para>
+        </callout>
+        <callout arearefs="co-admsupport-script-excluded">
+          <para>
+            The feature was excluded because it was deselected via the
+            <option>-x</option> option.
+          </para>
+        </callout>
+        <callout arearefs="co-admsupport-script-plugin">
+          <para>
+            The script found one plug-in and executes the plug-in
+            <command>pstree</command>. The plug-in was found in the directory
+            <filename class="directory">/usr/lib/supportconfig/plugins/</filename>.
+            See the man page for details.
+          </para>
+        </callout>
+        <callout arearefs="co-admsupport-script-archive">
+          <para>
+            The tar file name of the archive, by default compressed with
+            <command>xz</command>.
+          </para>
+        </callout>
+      </calloutlist>
+    </section>
+    <section xml:id="sec-slemicro-options">
+      <title>Common supportconfig options</title>
       <para>
-       Use the minimal option (<option>-m</option>):
+        The <command>supportconfig</command> utility is usually called without
+        any options. Display a list of all options with
+        <command>supportconfig</command> <option>-h</option>. The following
+        list gives a brief overview of some common use cases:
       </para>
+      <variablelist>
+        <varlistentry>
+          <term>Reducing the size of the information being gathered</term>
+          <listitem>
+            <para>
+              Use the minimal option (<option>-m</option>):
+            </para>
 <screen>&prompt.root;supportconfig -m</screen>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>Limiting the information to a specific topic</term>
-     <listitem>
-      <para>
-       If you have already localized a problem <!--with the default
-       <command>supportconfig</command> output and have found--> that relates
-       to a specific area or feature set only, you should limit the collected
-       information to the specific area for the next
-       <command>supportconfig</command> run. For example, if you detected
-       problems with LVM and want to test a recent change that you did to the
-       LVM configuration. In that case it makes sense to gather the minimum
-       Supportconfig information around LVM only:
-      </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Limiting the information to a specific topic</term>
+          <listitem>
+            <para>
+              If you have already localized a problem
+              <!--with the default
+                <command>supportconfig</command> output and have found-->
+              that relates to a specific area or feature set only, you should
+              limit the collected information to the specific area for the next
+              <command>supportconfig</command> run. For example, if you
+              detected problems with LVM and want to test a recent change that
+              you did to the LVM configuration. In that case it makes sense to
+              gather the minimum Supportconfig information around LVM only:
+            </para>
 <screen>&prompt.root;supportconfig -i LVM</screen>
-      <para>
-       Additional keywords can be separated through commas. For example,
-       an additional disk test:
-      </para>
-      <screen>&prompt.root;supportconfig -i LVM,DISK</screen>
-      <para>
-       For a complete list of feature keywords that you can use for limiting
-       the collected information to a specific area, run:
-      </para>
+            <para>
+              Additional keywords can be separated through commas. For example,
+              an additional disk test:
+            </para>
+<screen>&prompt.root;supportconfig -i LVM,DISK</screen>
+            <para>
+              For a complete list of feature keywords that you can use for
+              limiting the collected information to a specific area, run:
+            </para>
 <screen>&prompt.root;supportconfig -F</screen>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>Including additional contact information in the output:</term>
-     <listitem>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Including additional contact information in the output:</term>
+          <listitem>
 <screen>&prompt.root;supportconfig -E tux@example.org -N "Tux Penguin" -O<!--
       --> "Penguin Inc." ...</screen>
-      <para>
-       (all in one line)
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>Collecting already rotated log files</term>
-     <listitem>
+            <para>
+              (all in one line)
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Collecting already rotated log files</term>
+          <listitem>
 <screen>&prompt.root;supportconfig -l</screen>
+            <para>
+              This is especially useful in high logging environments or after a
+              kernel crash when syslog rotates the log files after a reboot.
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </section>
+    <section xml:id="sec-slemicro-archive-content">
+      <title>Overview of the archive content</title>
       <para>
-       This is especially useful in high logging environments or after a kernel
-       crash when syslog rotates the log files after a reboot.
+        The TAR archive contains all the results from the features. Depending
+        on what you have selected (all or only a small set), the archive can
+        contain more or less files. The set of features can be limited through
+        the <option>-i</option> option (see
+        <xref linkend="sec-slemicro-options"/>).
       </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-   </section>
-
-   <section xml:id="sec-slemicro-archive-content">
-    <title>Overview of the archive content</title>
-   <para>
-    The TAR archive contains all the results from the features. Depending on
-    what you have selected (all or only a small set), the archive can contain
-    more or less files.
-    The set of features can be limited through the <option>-i</option>
-    option (see <xref linkend="sec-slemicro-options"/>).
-   </para>
-   <para>
-    To list the content of the archive, use the following <command>tar</command>
-    command:
-   </para>
-   <screen>&prompt.root;<command>tar</command> xf /var/log/scc_&exampleclient;_180131_1545.txz</screen>
-   <para>
-    The following file names are always available inside the TAR archive:
-   </para>
-   <variablelist>
-    <title>Minimum files in archive</title>
-    <varlistentry>
-     <term><filename>basic-environment.txt</filename></term>
-     <listitem>
-      <para>Contains the date when this script was executed and system information
-       like version of the distribution, hypervisor information, and more.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><filename>basic-health-check.txt</filename></term>
-     <listitem>
       <para>
-       Contains some basic health checks like uptime, virtual memory statistics,
-       free memory and hard disk, checks for zombie processes, and more.
+        To list the content of the archive, use the following
+        <command>tar</command> command:
       </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><filename>hardware.txt</filename></term>
-     <listitem>
+<screen>&prompt.root;<command>tar</command> xf /var/log/scc_&exampleclient;_180131_1545.txz</screen>
       <para>
-       Contains basic hardware checks like information about the CPU architecture,
-       list of all connected hardware, interrupts, I/O ports, kernel boot messages,
-       and more.
+        The following file names are always available inside the TAR archive:
       </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><filename>messages.txt</filename></term>
-     <listitem>
+      <variablelist>
+        <title>Minimum files in archive</title>
+        <varlistentry>
+          <term><filename>basic-environment.txt</filename></term>
+          <listitem>
+            <para>
+              Contains the date when this script was executed and system
+              information like version of the distribution, hypervisor
+              information, and more.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><filename>basic-health-check.txt</filename></term>
+          <listitem>
+            <para>
+              Contains some basic health checks like uptime, virtual memory
+              statistics, free memory and hard disk, checks for zombie
+              processes, and more.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><filename>hardware.txt</filename></term>
+          <listitem>
+            <para>
+              Contains basic hardware checks like information about the CPU
+              architecture, list of all connected hardware, interrupts, I/O
+              ports, kernel boot messages, and more.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><filename>messages.txt</filename></term>
+          <listitem>
+            <para>
+              Contains log messages from the system journal.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><filename>rpm.txt</filename></term>
+          <listitem>
+            <para>
+              Contains a list of all installed RPM packages, the name, where
+              they are coming from, and their versions.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><filename>summary.xml</filename></term>
+          <listitem>
+            <para>
+              Contains some information in XML format like distribution, the
+              version, and product specific fragments.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><filename>supportconfig.txt</filename></term>
+          <listitem>
+            <para>
+              Contains information about the <command>supportconfig</command>
+              script itself.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><filename>y2log.txt</filename></term>
+          <listitem>
+            <para>
+              Contains &yast; specific information like specific packages,
+              configuration files, and log files.
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
       <para>
-       Contains log messages from the system journal.
+        <xref linkend="tab-admsupport-features-and-filenames"/> lists all
+        available features and their file names.
       </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><filename>rpm.txt</filename></term>
-     <listitem>
-      <para>Contains a list of all installed RPM packages, the name,
-      where they are coming from, and their versions.</para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><filename>summary.xml</filename></term>
-     <listitem>
-      <para>Contains some information in XML format like distribution,
-      the version, and product specific fragments.</para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><filename>supportconfig.txt</filename></term>
-     <listitem>
-      <para>
-       Contains information about the <command>supportconfig</command> script
-       itself.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><filename>y2log.txt</filename></term>
-     <listitem>
-      <para>
-       Contains &yast; specific information like specific packages, configuration
-       files, and log files.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-   <para>
-    <xref linkend="tab-admsupport-features-and-filenames"/> lists all available
-    features and their file names. 
-   </para>
-   <table xml:id="tab-admsupport-features-and-filenames">
-    <title>Comparison of features and file names in the TAR archive</title>
-    <tgroup cols="2">
-     <thead>
-      <row>
-       <entry>Feature</entry>
-       <entry>File name</entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry><parameter>APPARMOR</parameter></entry>
-       <entry><filename>security-apparmor.txt</filename></entry>
-      </row>
-      <row>
-       <entry><parameter>AUDIT</parameter></entry>
-       <entry><filename>security-audit.txt</filename></entry>
-      </row>
-      <row>
-       <entry><parameter>AUTOFS</parameter></entry>
-       <entry><filename>fs-autofs.txt</filename></entry>
-      </row>
-      <row>
-       <entry><parameter>BOOT</parameter></entry>
-       <entry><filename>boot.txt</filename></entry>
-      </row>
-      <row>
-       <entry><parameter>BTRFS</parameter></entry>
-       <entry><filename>fs-btrfs.txt</filename></entry>
-      </row>
-      <row>
-       <entry><parameter>DAEMONS</parameter></entry>
-       <entry><filename>systemd.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>CIMOM</parameter></entry>
-         <entry><filename>cimom.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>CRASH</parameter></entry>
-         <entry><filename>crash.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>CRON</parameter></entry>
-         <entry><filename>cron.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>DHCP</parameter></entry>
-         <entry><filename>dhcp.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>DISK</parameter></entry>
-         <entry><filename>fs-diskio.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>DNS</parameter></entry>
-         <entry><filename>dns.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>DOCKER</parameter></entry>
-         <entry><filename>docker.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>DRBD</parameter></entry>
-         <entry><filename>drbd.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>ENV</parameter></entry>
-         <entry><filename>env.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>ETC</parameter></entry>
-         <entry><filename>etc.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>HISTORY</parameter></entry>
-         <entry><filename>shell_history.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>ISCSI</parameter></entry>
-         <entry><filename>fs-iscsi.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>LDAP</parameter></entry>
-         <entry><filename>ldap.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>LIVEPATCH</parameter></entry>
-         <entry><filename>kernel-livepatch.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>LVM</parameter></entry>
-         <entry><filename>lvm.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>MEM</parameter></entry>
-         <entry><filename>memory.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>MOD</parameter></entry>
-         <entry><filename>modules.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>MPIO</parameter></entry>
-         <entry><filename>mpio.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>NET</parameter></entry>
-         <entry><filename>network-*.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>NFS</parameter></entry>
-         <entry><filename>nfs.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>NTP</parameter></entry>
-         <entry><filename>ntp.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>NVME</parameter></entry>
-         <entry><filename>nvme.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>OCFS2</parameter></entry>
-         <entry><filename>ocfs2.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>PAM</parameter></entry>
-         <entry><filename>pam.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>PODMAN</parameter></entry>
-         <entry><filename>podman.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>PRINT</parameter></entry>
-         <entry><filename>print.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>PROC</parameter></entry>
-         <entry><filename>proc.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>SAR</parameter></entry>
-         <entry><filename>sar.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>SLERT</parameter></entry>
-         <entry><filename>slert.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>SLP</parameter></entry>
-         <entry><filename>slp.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>SMT</parameter></entry>
-         <entry><filename>smt.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>SMART</parameter></entry>
-         <entry><filename>fs-smartmon.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>SMB</parameter></entry>
-         <entry><filename>samba.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>SRAID</parameter></entry>
-         <entry><filename>fs-softraid.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>SSH</parameter></entry>
-         <entry><filename>ssh.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>SSSD</parameter></entry>
-         <entry><filename>sssd.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>SYSCONFIG</parameter></entry>
-         <entry><filename>sysconfig.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>SYSFS</parameter></entry>
-         <entry><filename>sysfs.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>TRANSACTIONAL</parameter></entry>
-         <entry><filename>transactional-update.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>TUNED</parameter></entry>
-         <entry><filename>tuned.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>UDEV</parameter></entry>
-         <entry><filename>udev.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>UFILES</parameter></entry>
-         <entry><filename>fs-files-additional.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>UP</parameter></entry>
-         <entry><filename>updates.txt</filename></entry>
-      </row>
-      <row>
-         <entry><parameter>WEB</parameter></entry>
-         <entry><filename>web.txt</filename></entry>
-      </row>
-      </tbody>
-    </tgroup>
-   </table>
-   </section>
- </section>
-
- <section xml:id="sec-submitting-information">
-  <title>Submitting information to Global Technical Support</title>
-  <para>
-After you have created the archive using the <command>supportconfig</command> tool, you can submit the archive to &suse;.  
-  </para>
-
-  <section xml:id="sec-slemicro-supportconfig-sr">
-   <title>Creating a service request number</title>
-   <para>
-    Before handing over the <command>supportconfig</command> data to Global Technical Support, you need
-    to generate a service request number first. You will need it to upload the
-    archive to support.
-   </para>
-   <para>
-    To create a service request, go to
-    <link xlink:href="https://scc.suse.com/support/requests"/> and follow the
-    instructions on the screen. Write down the service request number.
-   </para>
-   <note>
-    <title>Privacy statement</title>
-    <para>
-     &suse; treats system reports as confidential data. For
-     details about our privacy commitment, see <link
-     xlink:href="https://www.suse.com/company/policies/privacy/"/>.
-    </para>
-   </note>
+      <table xml:id="tab-admsupport-features-and-filenames">
+        <title>Comparison of features and file names in the TAR archive</title>
+        <tgroup cols="2">
+          <thead>
+            <row>
+              <entry>Feature</entry>
+              <entry>File name</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry><parameter>APPARMOR</parameter>
+              </entry>
+              <entry><filename>security-apparmor.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>AUDIT</parameter>
+              </entry>
+              <entry><filename>security-audit.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>AUTOFS</parameter>
+              </entry>
+              <entry><filename>fs-autofs.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>BOOT</parameter>
+              </entry>
+              <entry><filename>boot.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>BTRFS</parameter>
+              </entry>
+              <entry><filename>fs-btrfs.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>DAEMONS</parameter>
+              </entry>
+              <entry><filename>systemd.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>CIMOM</parameter>
+              </entry>
+              <entry><filename>cimom.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>CRASH</parameter>
+              </entry>
+              <entry><filename>crash.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>CRON</parameter>
+              </entry>
+              <entry><filename>cron.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>DHCP</parameter>
+              </entry>
+              <entry><filename>dhcp.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>DISK</parameter>
+              </entry>
+              <entry><filename>fs-diskio.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>DNS</parameter>
+              </entry>
+              <entry><filename>dns.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>DOCKER</parameter>
+              </entry>
+              <entry><filename>docker.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>DRBD</parameter>
+              </entry>
+              <entry><filename>drbd.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>ENV</parameter>
+              </entry>
+              <entry><filename>env.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>ETC</parameter>
+              </entry>
+              <entry><filename>etc.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>HISTORY</parameter>
+              </entry>
+              <entry><filename>shell_history.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>ISCSI</parameter>
+              </entry>
+              <entry><filename>fs-iscsi.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>LDAP</parameter>
+              </entry>
+              <entry><filename>ldap.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>LIVEPATCH</parameter>
+              </entry>
+              <entry><filename>kernel-livepatch.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>LVM</parameter>
+              </entry>
+              <entry><filename>lvm.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>MEM</parameter>
+              </entry>
+              <entry><filename>memory.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>MOD</parameter>
+              </entry>
+              <entry><filename>modules.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>MPIO</parameter>
+              </entry>
+              <entry><filename>mpio.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>NET</parameter>
+              </entry>
+              <entry><filename>network-*.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>NFS</parameter>
+              </entry>
+              <entry><filename>nfs.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>NTP</parameter>
+              </entry>
+              <entry><filename>ntp.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>NVME</parameter>
+              </entry>
+              <entry><filename>nvme.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>OCFS2</parameter>
+              </entry>
+              <entry><filename>ocfs2.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>PAM</parameter>
+              </entry>
+              <entry><filename>pam.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>PODMAN</parameter>
+              </entry>
+              <entry><filename>podman.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>PRINT</parameter>
+              </entry>
+              <entry><filename>print.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>PROC</parameter>
+              </entry>
+              <entry><filename>proc.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>SAR</parameter>
+              </entry>
+              <entry><filename>sar.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>SLERT</parameter>
+              </entry>
+              <entry><filename>slert.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>SLP</parameter>
+              </entry>
+              <entry><filename>slp.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>SMT</parameter>
+              </entry>
+              <entry><filename>smt.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>SMART</parameter>
+              </entry>
+              <entry><filename>fs-smartmon.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>SMB</parameter>
+              </entry>
+              <entry><filename>samba.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>SRAID</parameter>
+              </entry>
+              <entry><filename>fs-softraid.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>SSH</parameter>
+              </entry>
+              <entry><filename>ssh.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>SSSD</parameter>
+              </entry>
+              <entry><filename>sssd.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>SYSCONFIG</parameter>
+              </entry>
+              <entry><filename>sysconfig.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>SYSFS</parameter>
+              </entry>
+              <entry><filename>sysfs.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>TRANSACTIONAL</parameter>
+              </entry>
+              <entry><filename>transactional-update.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>TUNED</parameter>
+              </entry>
+              <entry><filename>tuned.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>UDEV</parameter>
+              </entry>
+              <entry><filename>udev.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>UFILES</parameter>
+              </entry>
+              <entry><filename>fs-files-additional.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>UP</parameter>
+              </entry>
+              <entry><filename>updates.txt</filename>
+              </entry>
+            </row>
+            <row>
+              <entry><parameter>WEB</parameter>
+              </entry>
+              <entry><filename>web.txt</filename>
+              </entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </section>
   </section>
-
-  <section xml:id="sec-slemicro-targets">
-    <title>Upload targets</title>
+  <section xml:id="sec-submitting-information">
+    <title>Submitting information to Global Technical Support</title>
     <para>
-    After having created a service request number, you can upload your
-    Supportconfig archives to Global Technical Support. In the examples below, the <emphasis>12345678901</emphasis> serves as a placeholder for your service request number. Replace the placeholder with the service request number you created in <xref linkend="sec-slemicro-supportconfig-sr"/>.  
-  </para>
-  <procedure xml:id="pro-admsupport-submit-cli">
-   <title>Submitting information to support from command line</title>
-   <para>
-    The following procedure assumes that you have already created a
-    Supportconfig archive, but have not uploaded it yet.
-   </para>
-   <step>
-    <para>
-     Servers with Internet connectivity:
+      After you have created the archive using the
+      <command>supportconfig</command> tool, you can submit the archive to
+      &suse;.
     </para>
-    <substeps performance="required">
-     <step>
+    <section xml:id="sec-slemicro-supportconfig-sr">
+      <title>Creating a service request number</title>
       <para>
-       To use the default upload target <link xlink:href="https://support-ftp.us.suse.com/incoming/"/>, run:
+        Before handing over the <command>supportconfig</command> data to Global
+        Technical Support, you need to generate a service request number first.
+        You will need it to upload the archive to support.
       </para>
+      <para>
+        To create a service request, go to
+        <link xlink:href="https://scc.suse.com/support/requests"/> and follow
+        the instructions on the screen. Write down the service request number.
+      </para>
+      <note>
+        <title>Privacy statement</title>
+        <para>
+          &suse; treats system reports as confidential data. For details about
+          our privacy commitment, see
+          <link
+     xlink:href="https://www.suse.com/company/policies/privacy/"/>.
+        </para>
+      </note>
+    </section>
+    <section xml:id="sec-slemicro-targets">
+      <title>Upload targets</title>
+      <para>
+        After having created a service request number, you can upload your
+        Supportconfig archives to Global Technical Support. In the examples
+        below, the <emphasis>12345678901</emphasis> serves as a placeholder for
+        your service request number. Replace the placeholder with the service
+        request number you created in
+        <xref linkend="sec-slemicro-supportconfig-sr"/>.
+      </para>
+      <procedure xml:id="pro-admsupport-submit-cli">
+        <title>Submitting information to support from command line</title>
+        <para>
+          The following procedure assumes that you have already created a
+          Supportconfig archive, but have not uploaded it yet.
+        </para>
+        <step>
+          <para>
+            Servers with Internet connectivity:
+          </para>
+          <substeps performance="required">
+            <step>
+              <para>
+                To use the default upload target
+                <link xlink:href="https://support-ftp.us.suse.com/incoming/"/>,
+                run:
+              </para>
 <screen>&prompt.sudo;supportconfig -ur <replaceable>12345678901</replaceable></screen>
-     </step>
-     <step>
-      <para>
-       For the FTPS upload target <link xlink:href="ftps://support-ftp.us.suse.com"/>, use the following command:
-      </para>
-<!--taroth 2014-04-04: bnc#871918-->
+            </step>
+            <step>
+              <para>
+                For the FTPS upload target
+                <link xlink:href="ftps://support-ftp.us.suse.com"/>, use the
+                following command:
+              </para>
+              <!--taroth 2014-04-04: bnc#871918-->
 <screen>&prompt.sudo;supportconfig -ar <replaceable>12345678901</replaceable></screen>
-<para>
-  To use a different upload target, for example for the EMEA area, use the <option>-U</option> followed by the particular URL, either <link xlink:href="https://support-ftp.emea.suse.com/incoming/"/> or <link xlink:href="ftps://support-ftp.emea.suse.com/incoming/"/>
-  </para>
-  <screen>&prompt.sudo;supportconfig -r <replaceable>12345678901</replaceable> -U <replaceable>https://support-ftp.emea.suse.com/incoming</replaceable> </screen>
-     </step>
-    </substeps>
-   </step>
-   <step>
-    <para>
-     Servers <emphasis>without</emphasis> Internet connectivity
-    </para>
-    <substeps performance="required">
-     <step>
-      <para>
-       Run the following:
-      </para>
+              <para>
+                To use a different upload target, for example for the EMEA
+                area, use the <option>-U</option> followed by the particular
+                URL, either
+                <link xlink:href="https://support-ftp.emea.suse.com/incoming/"/>
+                or
+                <link xlink:href="ftps://support-ftp.emea.suse.com/incoming/"/>
+              </para>
+<screen>&prompt.sudo;supportconfig -r <replaceable>12345678901</replaceable> -U <replaceable>https://support-ftp.emea.suse.com/incoming</replaceable> </screen>
+            </step>
+          </substeps>
+        </step>
+        <step>
+          <para>
+            Servers <emphasis>without</emphasis> Internet connectivity
+          </para>
+          <substeps performance="required">
+            <step>
+              <para>
+                Run the following:
+              </para>
 <screen>&prompt.sudo;supportconfig -r <replaceable>12345678901</replaceable></screen>
-     </step>
-     <step>
+            </step>
+            <step>
+              <para>
+                Manually upload the
+                <filename>/var/log/scc_<replaceable>SR12345678901</replaceable>*txz</filename>
+                archive to one of our servers. Which one to use depends on your
+                location in the world:
+              </para>
+              <itemizedlist mark="bullet" spacing="normal">
+                <listitem>
+                  <para>
+                    <!-- TODO: Fix outdated links -->
+                    North America: HTTPS
+                    <link xlink:href="https://support-ftp.us.suse.com/incoming/"/>,
+                    FTPS
+                    <link xlink:href="ftps://support-ftp.us.suse.com/incoming/"/>
+                  </para>
+                </listitem>
+                <listitem>
+                  <para>
+                    EMEA, Europe, the Middle East, and Africa: FTP
+                    <link xlink:href="https://support-ftp.emea.suse.com/incoming"/>,
+                    FTPS
+                    <link xlink:href="ftps://support-ftp.emea.suse.com/incoming/"/>
+                  </para>
+                </listitem>
+              </itemizedlist>
+            </step>
+          </substeps>
+        </step>
+        <step>
+          <para>
+            After the TAR archive arrives in the incoming directory of our FTP
+            server, it becomes automatically attached to your service request.
+          </para>
+        </step>
+      </procedure>
+    </section>
+  </section>
+  <section xml:id="sec-gathering-yastlogs">
+    <title>Gathering information during the installation</title>
+    <para>
+      When performing the manual installation, <command>supportconfig</command>
+      is not available. However, you can collect log files from &yast; by using
+      <command>save_y2logs</command>. This command will create a
+      <filename>.tar.xz</filename> archive in the directory
+      <filename>/tmp</filename>.
+    </para>
+  </section>
+  <section xml:id="sec-admsupport-kernel">
+    <title>Support of kernel modules</title>
+    <para>
+      An important requirement for every enterprise operating system is the
+      level of support you receive for your environment. Kernel modules are the
+      most relevant connector between hardware (<quote>controllers</quote>) and
+      the operating system. Every kernel module in &productnameshort; has a
+      <literal>supported</literal> flag that can take three possible values:
+    </para>
+    <itemizedlist mark="bullet" spacing="normal">
+      <listitem>
+        <para>
+          <quote>yes</quote>, thus <literal>supported</literal>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <quote>external</quote>, thus <literal>supported</literal>
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <quote/> (empty, not set), thus <literal>unsupported</literal>
+        </para>
+      </listitem>
+    </itemizedlist>
+    <para>
+      The following rules apply:
+    </para>
+    <itemizedlist mark="bullet" spacing="normal">
+      <listitem>
+        <para>
+          All modules of a self-recompiled kernel are by default marked as
+          unsupported.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Kernel modules supported by &suse; partners and delivered using
+          <literal>&suse; SolidDriver Program</literal> are marked
+          <quote>external</quote>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          If the <literal>supported</literal> flag is not set, loading this
+          module will taint the kernel. Tainted kernels are not supported.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Kernel modules not provided under a license compatible to the license
+          of the Linux kernel will also taint the kernel. For details, see the
+          state of <filename>/proc/sys/kernel/tainted</filename>.
+        </para>
+      </listitem>
+    </itemizedlist>
+    <section xml:id="sec-admsupport-kernel-background">
+      <title>Technical background</title>
+      <para/>
+      <itemizedlist mark="bullet" spacing="normal">
+        <listitem>
+          <para>
+            Linux kernel: The value of
+            <filename>/proc/sys/kernel/unsupported</filename> defaults to
+            <literal>2</literal> (<literal>do not warn in syslog when loading
+            unsupported modules</literal>). This default is used in the
+            installer and in the installed system.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            <command>modprobe</command>: The <command>modprobe</command>
+            utility for checking module dependencies and loading modules
+            appropriately checks for the value of the
+            <literal>supported</literal> flag. If the value is
+            <quote>yes</quote> or <quote>external</quote> the module will be
+            loaded, otherwise it will not. For information on how to override
+            this behavior, see
+            <xref linkend="sec-admsupport-kernel-unsupported"/>.
+          </para>
+          <note>
+            <title>Support</title>
+            <para>
+              &suse; does not generally support the removal of storage modules
+              via <command>modprobe -r</command>.
+            </para>
+          </note>
+        </listitem>
+      </itemizedlist>
+    </section>
+    <section xml:id="sec-admsupport-kernel-unsupported">
+      <title>Working with unsupported modules</title>
       <para>
-       Manually upload the
-       <filename>/var/log/scc_<replaceable>SR12345678901</replaceable>*txz</filename>
-       archive to one of our servers. Which one to use depends on your
-       location in the world: 
+        While general supportability is important, situations can occur where
+        loading an unsupported module is required. For example, for testing or
+        debugging purposes, or if your hardware vendor provides a hotfix.
       </para>
       <itemizedlist mark="bullet" spacing="normal">
-    <listitem>
-     <para>
-     <!-- TODO: Fix outdated links -->
-      North America: HTTPS <link xlink:href="https://support-ftp.us.suse.com/incoming/"/>, FTPS <link xlink:href="ftps://support-ftp.us.suse.com/incoming/"/>
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      EMEA, Europe, the Middle East, and Africa: FTP
-      <link xlink:href="https://support-ftp.emea.suse.com/incoming"/>, FTPS <link xlink:href="ftps://support-ftp.emea.suse.com/incoming/"/>
-     </para>
-    </listitem>
-   </itemizedlist>
-     </step>
-    </substeps>
-   </step>
-   <step>
-    <para>
-     After the TAR archive arrives in the incoming directory of our FTP server,
-     it becomes automatically attached to your service request.
-    </para>
-   </step>
-  </procedure>
-  </section>
-
-
- </section>
-
- <section xml:id="sec-gathering-yastlogs">
-  <title>Gathering information during the installation</title>
-  <para>
-   When performing the manual installation, <command>supportconfig</command> is not available.
-   However, you can collect log files from &yast; by using
-   <command>save_y2logs</command>. This command will create a
-   <filename>.tar.xz</filename> archive in the directory
-   <filename>/tmp</filename>.
-  </para>  
-</section>
-
-<section xml:id="sec-admsupport-kernel">
-  <title>Support of kernel modules</title>
-
-  <para>
-   An important requirement for every enterprise operating system is the level
-   of support you receive for your environment. Kernel modules are the most
-   relevant connector between hardware (<quote>controllers</quote>) and the
-   operating system. Every kernel module in &productnameshort; has a
-   <literal>supported</literal> flag that can take three possible values:
-  </para>
-
-  <itemizedlist mark="bullet" spacing="normal">
-   <listitem>
-    <para>
-     <quote>yes</quote>, thus <literal>supported</literal>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     <quote>external</quote>, thus <literal>supported</literal>
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     <quote/> (empty, not set), thus <literal>unsupported</literal>
-    </para>
-   </listitem>
-  </itemizedlist>
-
-  <para>
-   The following rules apply:
-  </para>
-
-  <itemizedlist mark="bullet" spacing="normal">
-   <listitem>
-    <para>
-     All modules of a self-recompiled kernel are by default marked as
-     unsupported.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     Kernel modules supported by &suse; partners and delivered using
-     <literal>&suse; SolidDriver Program</literal> are marked
-     <quote>external</quote>.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     If the <literal>supported</literal> flag is not set, loading this module
-     will taint the kernel. Tainted kernels are not supported. 
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     Kernel modules not provided under a license compatible to the license of
-     the Linux kernel will also taint the kernel. For details, see
-     the state of <filename>/proc/sys/kernel/tainted</filename>.
-    </para>
-   </listitem>
-  </itemizedlist>
-
-  <section xml:id="sec-admsupport-kernel-background">
-   <title>Technical background</title>
-   <para/>
-   <itemizedlist mark="bullet" spacing="normal">
-    <listitem>
-     <para>
-      Linux kernel: The value of
-      <filename>/proc/sys/kernel/unsupported</filename> defaults to
-      <literal>2</literal> (<literal>do not warn in
-      syslog when loading unsupported modules</literal>). This default is used
-      in the installer and in the installed system. 
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <command>modprobe</command>: The <command>modprobe</command> utility for
-      checking module dependencies and loading modules appropriately checks for
-      the value of the <literal>supported</literal> flag. If the value is
-      <quote>yes</quote> or <quote>external</quote> the module will be loaded,
-      otherwise it will not. For information on how to override this behavior,
-      see <xref linkend="sec-admsupport-kernel-unsupported"/>.
-     </para>
-     <note>
-      <title>Support</title>
+        <listitem>
+          <para>
+            To override the default, copy
+            <filename>/lib/modprobe.d/10-unsupported-modules.conf</filename> to
+            <filename>/etc/modprobe.d/10-unsupported-modules.conf</filename>
+            and change the value of the variable
+            <varname>allow_unsupported_modules</varname> from
+            <literal>0</literal> to <literal>1</literal>. Do not edit
+            <filename>/lib/modprobe.d/10-unsupported-modules.conf</filename>
+            directly; any changes will be overwritten whenever the
+            <package>suse-module-tools</package> package is updated.
+          </para>
+          <para>
+            If an unsupported module is needed in the initrd, do not forget to
+            run <command>transactional-update initrd</command> to update the
+            initrd.
+          </para>
+          <para>
+            If you only want to try loading a module once, you can use the
+            <option>--allow-unsupported-modules</option> option with
+            <command>modprobe</command>. For more information, see the comments
+            in <filename>/lib/modprobe.d/10-unsupported-modules.conf</filename>
+            and the <command>modprobe</command> help.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            To enforce loading of unsupported modules during boot and
+            afterward, use the kernel command line option
+            <option>oem-modules</option>. While installing and initializing the
+            <systemitem class="resource">suse-module-tools</systemitem>
+            package, the kernel flag <literal>TAINT_NO_SUPPORT</literal>
+            (<filename>/proc/sys/kernel/tainted</filename>) will be evaluated.
+            If the kernel is already tainted,
+            <literal>allow_unsupported_modules</literal> will be enabled. This
+            will prevent unsupported modules from failing in the system being
+            installed. If no unsupported modules are present during
+            installation and the other special kernel command line option
+            (<option>oem-modules=1</option>) is not used, the default still is
+            to disallow unsupported modules.
+          </para>
+        </listitem>
+      </itemizedlist>
       <para>
-       &suse; does not generally support the removal of storage modules via
-       <command>modprobe -r</command>.
+        Remember that loading and running unsupported modules will make the
+        kernel and the whole system unsupported by &suse;.
       </para>
-     </note>
-    </listitem>
-   </itemizedlist>
+    </section>
   </section>
-
-  <section xml:id="sec-admsupport-kernel-unsupported">
-   <title>Working with unsupported modules</title>
-   <para>
-    While general supportability is important, situations can occur where
-    loading an unsupported module is required. For example, for testing or
-    debugging purposes, or if your hardware vendor provides a hotfix.
-   </para>
-   <itemizedlist mark="bullet" spacing="normal">
-    <listitem>
-     <para>
-      To override the default, copy
-      <filename>/lib/modprobe.d/10-unsupported-modules.conf</filename> to
-      <filename>/etc/modprobe.d/10-unsupported-modules.conf</filename> and
-      change the value of the variable
-      <varname>allow_unsupported_modules</varname> from <literal>0</literal> to
-      <literal>1</literal>. Do not edit
-      <filename>/lib/modprobe.d/10-unsupported-modules.conf</filename> directly;
-      any changes will be overwritten whenever the
-      <package>suse-module-tools</package> package is updated.
-     </para>
-     <para>
-      If an unsupported module is needed in the initrd, do not forget to run
-      <command>transactional-update initrd</command> to update the initrd.
-     </para>
-     <para>
-      If you only want to try loading a module once, you can use the
-      <option>--allow-unsupported-modules</option> option with
-      <command>modprobe</command>. For more information, see the comments in
-      <filename>/lib/modprobe.d/10-unsupported-modules.conf</filename> and the
-      <command>modprobe</command> help.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      To enforce loading of unsupported
-      modules during boot and afterward, use the kernel command line option
-      <option>oem-modules</option>. While installing and initializing the
-      <systemitem class="resource">suse-module-tools</systemitem> package, the
-      kernel flag <literal>TAINT_NO_SUPPORT</literal>
-      (<filename>/proc/sys/kernel/tainted</filename>) will be evaluated. If the
-      kernel is already tainted, <literal>allow_unsupported_modules</literal>
-      will be enabled. This will prevent unsupported modules from failing in
-      the system being installed. If no unsupported modules are present during
-      installation and the other special kernel command line option
-      (<option>oem-modules=1</option>) is not used, the default still is to
-      disallow unsupported modules.
-     </para>
-    </listitem>
-   </itemizedlist>
-   <para>
-    Remember that loading and running unsupported modules will make the kernel
-    and the whole system unsupported by &suse;.
-   </para>
-  </section>
- </section>
-
- </chapter>
+</chapter>

--- a/xml/slemicro_supportconfig.xml
+++ b/xml/slemicro_supportconfig.xml
@@ -721,7 +721,7 @@ Creating Tar Ball
             <step>
               <para>
                 To use the default upload target
-                <link xlink:href="https://support-ftp.us.suse.com/incoming/"/>,
+                <link xlink:href="https://support-ftp.us.suse.com/incoming/upload.php?file={tarball}"/>,
                 run:
               </para>
 <screen>&prompt.sudo;supportconfig -ur <replaceable>12345678901</replaceable></screen>
@@ -738,7 +738,7 @@ Creating Tar Ball
                 To use a different upload target, for example for the EMEA
                 area, use the <option>-U</option> followed by the particular
                 URL, either
-                <link xlink:href="https://support-ftp.emea.suse.com/incoming/"/>
+                <link xlink:href="https://support-ftp.emea.suse.com/incoming/upload.php?file={tarball}"/>
                 or
                 <link xlink:href="ftps://support-ftp.emea.suse.com/incoming/"/>
               </para>
@@ -769,7 +769,7 @@ Creating Tar Ball
                   <para>
                     <!-- TODO: Fix outdated links -->
                     North America: HTTPS
-                    <link xlink:href="https://support-ftp.us.suse.com/incoming/"/>,
+                    <link xlink:href="https://support-ftp.us.suse.com/incoming/upload.php?file={tarball}"/>,
                     FTPS
                     <link xlink:href="ftps://support-ftp.us.suse.com/incoming/"/>
                   </para>
@@ -777,7 +777,7 @@ Creating Tar Ball
                 <listitem>
                   <para>
                     EMEA, Europe, the Middle East, and Africa: FTP
-                    <link xlink:href="https://support-ftp.emea.suse.com/incoming"/>,
+                    <link xlink:href="https://support-ftp.emea.suse.com/incoming/upload.php?file={tarball}"/>,
                     FTPS
                     <link xlink:href="ftps://support-ftp.emea.suse.com/incoming/"/>
                   </para>

--- a/xml/slemicro_supportconfig.xml
+++ b/xml/slemicro_supportconfig.xml
@@ -871,8 +871,8 @@ Creating Tar Ball
           <para>
             Linux kernel: The value of
             <filename>/proc/sys/kernel/unsupported</filename> defaults to
-            <literal>2</literal> (<literal>do not warn in syslog when loading
-            unsupported modules</literal>). This default is used in the
+            <literal>2</literal>, which means that no syslog warning is generated when unsupported modules are loaded.
+            This default is used in the
             installer and in the installed system.
           </para>
         </listitem>

--- a/xml/slemicro_supportconfig.xml
+++ b/xml/slemicro_supportconfig.xml
@@ -13,8 +13,8 @@
     <abstract>
       <para>
         In case of problems, a detailed system report may be created with the
-        <command>supportconfig</command> command-line tool. The tool
-        will collect information about the system, such as the current kernel
+        <command>supportconfig</command> command-line tool. The tool will
+        collect information about the system, such as the current kernel
         version, hardware, installed packages, partition setup, and much more.
         The result is a TAR archive of files. After opening a Service Request
         (SR), you can upload the TAR archive to Global Technical Support. It
@@ -46,9 +46,8 @@
       <command>supportconfig</command> is executed, all plug-ins are executed
       as well, creating one or more result files for the archive. This has the
       benefit that the only topics checked are those that contain a specific
-      plug-in for them. <command>supportconfig</command> plug-ins
-      are stored in the directory
-      <filename>/usr/lib/supportconfig/plugins/</filename>.
+      plug-in for them. <command>supportconfig</command> plug-ins are stored in
+      the directory <filename>/usr/lib/supportconfig/plugins/</filename>.
     </para>
     <para>
       The following procedure shows how to create a Supportconfig archive, but
@@ -218,13 +217,13 @@ Creating Tar Ball
               <command>supportconfig</command> run. For example, you have
               detected problems with LVM and want to test a recent change that
               you introduced to the LVM configuration. In this case, it makes
-              sense to gather the minimum Supportconfig information around
-              LVM only:
+              sense to gather the minimum Supportconfig information around LVM
+              only:
             </para>
 <screen>&prompt.root;supportconfig -i LVM</screen>
             <para>
-              Additional keywords can be separated with commas. For example,
-              an additional disk test:
+              Additional keywords can be separated with commas. For example, an
+              additional disk test:
             </para>
 <screen>&prompt.root;supportconfig -i LVM,DISK</screen>
             <para>
@@ -317,8 +316,8 @@ Creating Tar Ball
           <term><filename>rpm.txt</filename></term>
           <listitem>
             <para>
-              Contains a list of all installed RPM packages, their names
-              and versions and where they come from.
+              Contains a list of all installed RPM packages, their names and
+              versions and where they come from.
             </para>
           </listitem>
         </varlistentry>
@@ -326,8 +325,8 @@ Creating Tar Ball
           <term><filename>summary.xml</filename></term>
           <listitem>
             <para>
-              Contains information in XML format, such as distribution,
-              version and product-specific fragments.
+              Contains information in XML format, such as distribution, version
+              and product-specific fragments.
             </para>
           </listitem>
         </varlistentry>
@@ -762,8 +761,8 @@ Creating Tar Ball
               <para>
                 Manually upload the
                 <filename>/var/log/scc_<replaceable>SR12345678901</replaceable>*txz</filename>
-                archive to one of our servers. The selection of a server depends
-                on your location in the world:
+                archive to one of our servers. The selection of a server
+                depends on your location in the world:
               </para>
               <itemizedlist mark="bullet" spacing="normal">
                 <listitem>
@@ -871,9 +870,9 @@ Creating Tar Ball
           <para>
             Linux kernel: The value of
             <filename>/proc/sys/kernel/unsupported</filename> defaults to
-            <literal>2</literal>, which means that no syslog warning is generated when unsupported modules are loaded.
-            This default is used in the
-            installer and in the installed system.
+            <literal>2</literal>, which means that no syslog warning is
+            generated when unsupported modules are loaded. This default is used
+            in the installer and in the installed system.
           </para>
         </listitem>
         <listitem>
@@ -943,8 +942,8 @@ Creating Tar Ball
             will prevent unsupported modules from failing in the system being
             installed. If no unsupported modules are present during
             installation and the other special kernel command-line option
-            (<option>oem-modules=1</option>) is not used, the default is
-            still to disallow unsupported modules.
+            (<option>oem-modules=1</option>) is not used, the default is still
+            to disallow unsupported modules.
           </para>
         </listitem>
       </itemizedlist>

--- a/xml/slemicro_supportconfig.xml
+++ b/xml/slemicro_supportconfig.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE chapter
+[
+  <!ENTITY % entities SYSTEM "generic-entities.ent">
+    %entities;
+]>
+
+<chapter version="5.0" xml:id="cha-adm-support-slemicro"
+  xmlns="http://docbook.org/ns/docbook"
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+
+ <title>Gathering system information for support</title>
+ <info>
+  <abstract>
+      <para>
+    In case of problems, a detailed system report may be created with the <command>supportconfig</command> command line tool. The tool will collect information about the
+    system such as: current kernel version, hardware, installed packages,
+    partition setup, and much more. The result is a TAR archive of files. After
+    opening a Service Request (SR), you can upload the TAR archive to Global
+    Technical Support. It will help to locate the issue you reported and to
+    assist you in solving the problem.
+   </para>
+
+   <para>
+    You can analyze the <command>supportconfig</command> output
+    for known issues to help resolve problems faster. 
+   </para>
+  </abstract>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker></dm:bugtracker>
+   <dm:translation>yes</dm:translation>
+  </dm:docmanager>
+ </info>
+
+  <section xml:id="sec-collecting-information">
+  <title>Collecting system information with supportconfig</title>
+  <para>
+   To create a TAR archive with detailed system information that you can hand
+   over to Global Technical Support, use the command <command>supportconfig</command>.
+   The command line tool is provided by the
+   package <systemitem>supportutils</systemitem> which is installed by default.
+   
+  </para>
+  <para>
+   Depending on which packages are installed on your system, some of these
+   packages integrate Supportconfig plug-ins.  When Supportconfig is executed,
+   all plug-ins are executed as well and create one or more result files for
+   the archive. That has the benefit that the only topics checked are those
+   that contain a specific plug-in for them.  Supportconfig plug-ins are stored
+   in the directory <filename>/usr/lib/supportconfig/plugins/</filename>.
+  </para>
+ </section>
+
+ <section xml:id="sec-submitting-information">
+  <title>Submitting information to Global Technical Support</title>
+
+  <section xml:id="sec-slemicro-supportconfig-sr">
+   <title>Creating a service request number</title>
+   <para>
+    Supportconfig archives can be generated at any time. However, for
+    handing over the Supportconfig data to Global Technical Support, you need
+    to generate a service request number first. You will need it to upload the
+    archive to support.
+   </para>
+   <para>
+    To create a service request, go to
+    <link xlink:href="https://scc.suse.com/support/requests"/> and follow the
+    instructions on the screen. Write down the service request number.
+   </para>
+   <note>
+    <title>Privacy statement</title>
+    <para>
+     &suse; treats system reports as confidential data. For
+     details about our privacy commitment, see <link
+     xlink:href="https://www.suse.com/company/policies/privacy/"/>.
+    </para>
+   </note>
+  </section>
+
+  <section xml:id="sec-slemicro-targets">
+    <title>Upload targets</title>
+    <para>
+    After having created a service request number, you can upload your
+    Supportconfig archives to Global Technical Support
+  </para>
+  <procedure xml:id="pro-admsupport-submit-cli">
+   <title>Submitting information to support from command line</title>
+   <para>
+    The following procedure assumes that you have already created a
+    Supportconfig archive, but have not uploaded it yet.
+   </para>
+   <step>
+    <para>
+     Servers with Internet connectivity:
+    </para>
+    <substeps performance="required">
+     <step>
+      <para>
+       To use the default upload target, run:
+      </para>
+<screen>&prompt.sudo;supportconfig -ur <replaceable>12345678901</replaceable></screen>
+     </step>
+     <step>
+      <para>
+       For the secure upload target, use the following:
+      </para>
+<!--taroth 2014-04-04: bnc#871918-->
+<screen>&prompt.sudo;supportconfig -ar <replaceable>12345678901</replaceable></screen>
+     </step>
+    </substeps>
+   </step>
+   <step>
+    <para>
+     Servers <emphasis>without</emphasis> Internet connectivity
+    </para>
+    <substeps performance="required">
+     <step>
+      <para>
+       Run the following:
+      </para>
+<screen>&prompt.sudo;supportconfig -r <replaceable>12345678901</replaceable></screen>
+     </step>
+     <step>
+      <para>
+       Manually upload the
+       <filename>/var/log/scc_<replaceable>SR12345678901</replaceable>*tbz</filename>
+       archive to one of our FTP servers. Which one to use depends on your
+       location in the world: 
+      </para>
+      <itemizedlist mark="bullet" spacing="normal">
+    <listitem>
+     <para>
+     <!-- TODO: Fix outdated links -->
+      North America: FTP <link xlink:href="ftp://support-ftp.us.suse.com/incoming/"/>, FTPS <link xlink:href="ftps://support-ftp.us.suse.com/incoming/"/>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      EMEA, Europe, the Middle East, and Africa: FTP
+      <link xlink:href="ftp://support-ftp.emea.suse.com/incoming"/>, FTPS <link xlink:href="ftps://support-ftp.emea.suse.com/incoming"/>
+     </para>
+    </listitem>
+   </itemizedlist>
+     </step>
+    </substeps>
+   </step>
+   <step>
+    <para>
+     After the TAR archive arrives in the incoming directory of our FTP server,
+     it becomes automatically attached to your service request.
+    </para>
+   </step>
+  </procedure>
+  </section>
+
+
+ </section>
+
+ </chapter>

--- a/xml/slemicro_supportconfig.xml
+++ b/xml/slemicro_supportconfig.xml
@@ -59,12 +59,7 @@
    <procedure>
     <step>
      <para>
-      Open a shell and become <systemitem class="username">root</systemitem>.
-     </para>
-    </step>
-    <step>
-     <para>
-      Run <command>supportconfig</command>. Usually, it is enough to
+      Run <command>supportconfig</command> as &rootuser;. Usually, it is enough to
       run this tool without any options. Some options are very common and
       are displayed in the following list:
      </para>
@@ -104,7 +99,7 @@
      <para>
       The default archive location is <filename>/var/log</filename>, with the
       file name format being
-      <filename>scc_<replaceable>HOST</replaceable>_<replaceable>DATE</replaceable>_<replaceable>TIME</replaceable>.tbz</filename>
+      <filename>scc_<replaceable>HOST</replaceable>_<replaceable>DATE</replaceable>_<replaceable>TIME</replaceable>.txz</filename>
      </para>
     </step>
    </procedure>
@@ -269,7 +264,7 @@ Creating Tar Ball
     To list the content of the archive, use the following <command>tar</command>
     command:
    </para>
-   <screen>&prompt.root;<command>tar</command> xf /var/log/scc_&exampleclient;_180131_1545.tbz</screen>
+   <screen>&prompt.root;<command>tar</command> xf /var/log/scc_&exampleclient;_180131_1545.txz</screen>
    <para>
     The following file names are always available inside the TAR archive:
    </para>
@@ -585,8 +580,7 @@ After you have created the archive using the <command>supportconfig</command> to
   <section xml:id="sec-slemicro-supportconfig-sr">
    <title>Creating a service request number</title>
    <para>
-    <command>supportconfig</command> archives can be generated at any time. However, for
-    handing over the <command>supportconfig</command> data to Global Technical Support, you need
+    Before hand over the <command>supportconfig</command> data to Global Technical Support, you need
     to generate a service request number first. You will need it to upload the
     archive to support.
    </para>
@@ -624,16 +618,20 @@ After you have created the archive using the <command>supportconfig</command> to
     <substeps performance="required">
      <step>
       <para>
-       To use the default upload target, run:
+       To use the default upload target <link xlink:href="https://support-ftp.us.suse.com/incoming/"/>, run:
       </para>
 <screen>&prompt.sudo;supportconfig -ur <replaceable>12345678901</replaceable></screen>
      </step>
      <step>
       <para>
-       For the secure upload target, use the following:
+       For the FTPS upload target <link xlink:href="ftps://support-ftp.us.suse.com"/>, use the following:
       </para>
 <!--taroth 2014-04-04: bnc#871918-->
 <screen>&prompt.sudo;supportconfig -ar <replaceable>12345678901</replaceable></screen>
+<para>
+  To use a different upload target, for example for the EMEA area, use the <option>-U</option> followed by the particular URL, either <link xlink:href="https://support-ftp.emea.suse.com/incoming"/> or <link xlink:href="ftps://support-ftp.emea.suse.com/incoming/"/>
+  </para>
+  <screen>&prompt.sudo;supportconfig -r <replaceable>12345678901</replaceable> -U <replaceable>https://support-ftp.emea.suse.com/incoming</replaceable> </screen>
      </step>
     </substeps>
    </step>
@@ -651,7 +649,7 @@ After you have created the archive using the <command>supportconfig</command> to
      <step>
       <para>
        Manually upload the
-       <filename>/var/log/scc_<replaceable>SR12345678901</replaceable>*tbz</filename>
+       <filename>/var/log/scc_<replaceable>SR12345678901</replaceable>*txz</filename>
        archive to one of our FTP servers. Which one to use depends on your
        location in the world: 
       </para>
@@ -659,13 +657,13 @@ After you have created the archive using the <command>supportconfig</command> to
     <listitem>
      <para>
      <!-- TODO: Fix outdated links -->
-      North America: FTP <link xlink:href="ftp://support-ftp.us.suse.com/incoming/"/>, FTPS <link xlink:href="ftps://support-ftp.us.suse.com/incoming/"/>
+      North America: HTTPS <link xlink:href="https://support-ftp.us.suse.com/incoming/"/>, FTPS <link xlink:href="ftps://support-ftp.us.suse.com/incoming/"/>
      </para>
     </listitem>
     <listitem>
      <para>
       EMEA, Europe, the Middle East, and Africa: FTP
-      <link xlink:href="ftp://support-ftp.emea.suse.com/incoming"/>, FTPS <link xlink:href="ftps://support-ftp.emea.suse.com/incoming"/>
+      <link xlink:href="https://support-ftp.emea.suse.com/incoming"/>, FTPS <link xlink:href="ftps://support-ftp.emea.suse.com/incoming"/>
      </para>
     </listitem>
    </itemizedlist>

--- a/xml/slemicro_supportconfig.xml
+++ b/xml/slemicro_supportconfig.xml
@@ -818,7 +818,7 @@ Creating Tar Ball
     <itemizedlist mark="bullet" spacing="normal">
       <listitem>
         <para>
-          <quote>yes</quote>, thus <literal>supported</literal>
+          <quote>yes,</quote> thus <literal>supported</literal>
         </para>
       </listitem>
       <listitem>

--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -120,8 +120,7 @@
     </para>
     <para>
      The libraries provided by the system pacakges glibc and openssl
-     (libopenssl_1_1) are already live-patchable on &sle; &product-ga;
-     SP&product-sp;.
+     (libopenssl_1_1) are already live-patchable on &productnameshort; &productnumber;.
     </para>
    </sect3>
    <sect3 xml:id="sec-ulp-livepatch-check">

--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -119,8 +119,9 @@
      make it live-patchable.
     </para>
     <para>
-     The glibc, libssl.so.1.1, and libcrypto.so.1.1 libraries are already
-     live-patchable on &sle; &product-ga; SP&product-sp;.
+     The libraries provided by the system pacakges glibc and openssl
+     (libopenssl_1_1) are already live-patchable on &sle; &product-ga;
+     SP&product-sp;.
     </para>
    </sect3>
    <sect3 xml:id="sec-ulp-livepatch-check">


### PR DESCRIPTION
### PR creator: Description

Update the SELinux chapter: documentation how to install the packages and a test policy was outdated (new repo, different packages). Also the procedure on how to enable SELinux in permissive and/or enforcing mode afterwards needed some modifications. 


### PR creator: Are there any relevant issues/feature requests?

* bsc#1205596
* jsc#DOCTEAM-856


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
