### PR TITLE
Taroth/selinux bugfix 1205596

### DIFF
--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -284,41 +284,9 @@ system_u:object_r:var_t var</screen>
  <sect1 xml:id="sec-selinux-install">
   <title>Installing &selnx; packages</title>
   <para>
-    If you are installing &selnx; with Zypper, search for all of the relevant
-    packages with the <command>--search-descriptions</command> option. You
-    will see a list like the following example:
-  </para>
-  <screen>&prompt.user;<command>zypper se --search-descriptions selinux</command>
-libselinux-devel
-libselinux1
-libselinux1-32bit
-libsemanage-devel
-libsemanage1
-libsepol-devel
-libsepol1
-mcstrans
-policycoreutils
-python3-policycoreutils
-python3-selinux
-python3-semanage
-python3-setools
-restorecond
-selinux-tools
-setools-console
-setools-devel
-setools-java
-setools-libs
-setools-tcl
-  </screen>
-  <para>
-    It is not necessary to install all of them. Install the following packages:
+   From the command-line, install the following packages:
   </para>
   <screen>&prompt.sudo;<command>zypper in restorecond policycoreutils setools-console</command></screen>
-  <para>
-    If you prefer to use &yast;, search for "selinux" in the Software
-    Management module, and install <package>restorecond</package>, <package>policycoreutils</package>, and <package>setools-console</package>.
-  </para>
-
   <para>
     This does not install a  policy. See
     <xref linkend="sec-selinux-getpolicy"/> for information on
@@ -330,46 +298,32 @@ setools-tcl
   <title>Installing an &selnx; policy</title>
   <para>
    The policy is an essential component of &selnx;. &productname; &productnumber;
-   does not include a default policy, and you must build a
+   does <emphasis>not</emphasis> include a default policy, and you must build a
    policy that is customized for your installation. &selnx; policies
    should be customized for your particular needs; consult your &suse;
    support engineer for assistance.
   </para>
   <para>
-    One way to get a policy to install and test is to download
-    it from
-    <link xlink:href="https://download.opensuse.org/repositories/security:/SELinux/"/>. This provides repositories for &slea; and &opensuse;. Copy
-    the repository link that matches your &slea; version, and add it with
-    Zypper:
+    For <emphasis>testing</emphasis> purposes you can obtain policies from
+    <link xlink:href="https://download.opensuse.org/repositories/security:/SELinux/"/>. This provides
+    repositories for &slea; and &opensuse; with a number of additional packages, including policies.
   </para>
-  <screen>&prompt.sudo;<command>zypper ar -f https://download.opensuse.org/repositories/security:/SELinux/&productnumber-leaprepo;/ Security-SELinux</command>
-      </screen>
+  <procedure>
+   <step>
+    <para>
+    Copy the repository link that matches your &slea; version, and add it with Zypper:
+    </para>
+    <screen>&prompt.sudo;<command>zypper ar -f \
+     https://download.opensuse.org/repositories/security:/SELinux/&productnumber-leaprepo;/ SELinux</command></screen>
+   </step>
+   <step>
+    <para>
+     Install the following packages:
+    </para>
+    <screen>&prompt.sudo;<command>zypper in selinux-policy-targeted selinux-policy-devel selinux-autorelabel</command></screen>
+   </step>
+  </procedure>
   <para>
-    If you prefer &yast;, use the Software Repositories module.
-  </para>
-  <para>
-    This repository provides a number of additional packages, including
-    policies, such as:
-  </para>
-  <screen>
-selinux-autorelabel
-selinux-policy
-selinux-policy-devel
-selinux-policy-doc
-selinux-policy-minimum
-selinux-policy-mls
-selinux-policy-sandbox
-selinux-policy-targeted
-setools-gui
-setroubleshoot
-setroubleshoot-plugins
-setroubleshoot-server
-</screen>
-  <para>
-   Install the following packages:
- </para>
- <screen>&prompt.sudo;<command>zypper in selinux-policy-targeted selinux-policy-devel selinux-autorelabel</command></screen>
- <para>
    The next step is to modify the &grub; bootloader, to permanently enable
    SELinux and set the SELinux mode.
    (<xref linkend="sec-selinux-grub"/>).

--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -284,7 +284,7 @@ system_u:object_r:var_t var</screen>
  <sect1 xml:id="sec-selinux-install">
   <title>Installing &selnx; packages</title>
   <para>
-   From the command-line, install the following packages:
+   From the command line, install the following packages:
   </para>
   <screen>&prompt.sudo;<command>zypper in restorecond policycoreutils setools-console</command></screen>
   <para>
@@ -419,10 +419,10 @@ Controlling terminal:           unconfined_u:object_r:user_tty_device_t:s0
  <sect1 xml:id="sec-selinux-mode-enforcing">
   <title>Putting &selnx; into enforcing mode</title>
   <para>
-   At this point you have a completely functional &selnx; system and it is
+   At this point you have a completely functional &selnx; system, and it is
    time to further configure it. In the current status, &selnx; is
    operational but not in enforcing mode. This means that it does not limit
-   any activities, and it logs everything that it should be doing if it
+   any activities and logs everything that it should be doing if it
    were in enforcing mode. Review the log files to learn what activities
    are not allowed.
   </para>
@@ -434,9 +434,9 @@ Controlling terminal:           unconfined_u:object_r:user_tty_device_t:s0
    <title>Reset security context</title>
    <para>
     When systems run &selnx; in permissive mode, users and processes
-    might label various file-system objects incorrectly. This can cause
+    might label various file system objects incorrectly. This can cause
     problems when switching to enforcing mode because &selnx; relies on
-    correct labels of file-system objects.
+    correct labels of file system objects.
    </para>
    <para>
     Before switching into enforcing mode, make sure to first reset the
@@ -456,7 +456,7 @@ Controlling terminal:           unconfined_u:object_r:user_tty_device_t:s0
    that and start <xref linkend="sec-selinux-configure"
     xrefstyle="select:title"/>.
   </para>
-  <para>In case you should not able to boot the server properly with &selnx;
+  <para>If you are not able to boot the server properly with &selnx;
    in enforcing mode, switch back to permissive mode. Check the log files with
    <command>less /var/log/audit/audit.log</command>. For more details, see
    <xref linkend="sec-selinux-troubleshoot"/>.

--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -442,9 +442,7 @@ Controlling terminal:           unconfined_u:object_r:user_tty_device_t:s0
     Before switching into enforcing mode, make sure to first reset the
     security context (extended attributes). Do so by executing
     <command>restorecon -R /</command> and then reboot the system.
-    System startup will take some time, as the entire file system
-    will be relabeled.
-   </para>
+    </para>
   </warning>
   <para>
    To put &selnx; into enforcing mode, set the following parameter
@@ -459,8 +457,10 @@ Controlling terminal:           unconfined_u:object_r:user_tty_device_t:s0
     xrefstyle="select:title"/>.
   </para>
   <para>In case you should not able to boot the server properly with &selnx;
-   in enforcing mode, switch back to permissive mode and start tuning your server.
-   </para>
+   in enforcing mode, switch back to permissive mode. Check the log files with
+   <command>less /var/log/audit/audit.log</command>. For more details, see
+   <xref linkend="sec-selinux-troubleshoot"/>.
+  </para>
  </sect1>
  <sect1 xml:id="sec-selinux-configure">
   <title>Configuring &selnx;</title>

--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -305,8 +305,8 @@ system_u:object_r:var_t var</screen>
   </para>
   <para>
     For <emphasis>testing</emphasis> purposes you can obtain policies from
-    <link xlink:href="https://download.opensuse.org/repositories/security:/SELinux/"/>. This provides
-    repositories for &slea; and &opensuse; with a number of additional packages, including policies.
+    <link xlink:href="https://download.opensuse.org/repositories/security:/SELinux_legacy/"/>. This provides
+    repositories for &slea;<!-- and &opensuse;--> with a number of additional packages, including policies.
   </para>
   <procedure>
    <step>
@@ -314,7 +314,7 @@ system_u:object_r:var_t var</screen>
     Copy the repository link that matches your &slea; version, and add it with Zypper:
     </para>
     <screen>&prompt.sudo;<command>zypper ar -f \
-     https://download.opensuse.org/repositories/security:/SELinux/&productnumber-leaprepo;/ SELinux</command></screen>
+     https://download.opensuse.org/repositories/security:/SELinux_legacy/&productnumber-leaprepo;/ SELinux-Legacy</command></screen>
    </step>
    <step>
     <para>

--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -323,24 +323,21 @@ system_u:object_r:var_t var</screen>
     <screen>&prompt.sudo;<command>zypper in selinux-policy-targeted selinux-policy-devel</command></screen>
    </step>
   </procedure>
-  <para>
-   The next step is to modify the &grub; bootloader, to permanently enable
-   SELinux and set the SELinux mode.
-   (<xref linkend="sec-selinux-grub"/>).
-  </para>
-</sect1>
+ </sect1>
 
- <sect1 xml:id="sec-selinux-grub">
-   <title>Modifying the &grub; bootloader</title>
+ <sect1 xml:id="sec-selinux-mode-permissive">
+   <title>Putting &selnx; into permissive mode</title>
   <para>
    After installing the &selnx; packages, modify the &grub; boot
-   loader, either by editing <filename>/etc/default/grub</filename>,
+   loader as follows, either by editing <filename>/etc/default/grub</filename>,
    or with &yast;.
   </para>
-  <para>
-   In <filename>/etc/default/grub</filename>, add the following parameters
-   to the <literal>GRUB_CMDLINE_LINUX_DEFAULT=</literal> line:
-  </para>
+  <example xml:id="ex-sec-selinux-grubcfg">
+   <title>&grub; configuration file with &selnx;</title>
+   <para>
+    In <filename>/etc/default/grub</filename>, add the following parameters
+    to the <literal>GRUB_CMDLINE_LINUX_DEFAULT=</literal> line:
+   </para>
   <screen>security=selinux<co xml:id="co-security"/> selinux=1<co xml:id="co-selinux"/> enforcing=0<co xml:id="co-enforcing"/></screen>
   <calloutlist>
    <callout arearefs="co-security">
@@ -368,6 +365,7 @@ system_u:object_r:var_t var</screen>
     </para>
    </callout>
   </calloutlist>
+  </example>
   <para>
    After you have added the parameters in <filename>/etc/default/grub</filename>,
    run the <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>
@@ -418,26 +416,54 @@ Controlling terminal:           unconfined_u:object_r:user_tty_device_t:s0
   </example>
  </sect1>
 
- <sect1 xml:id="sec-selinux-configure">
-  <title>Configuring &selnx;</title>
+ <sect1 xml:id="sec-selinux-mode-enforcing">
+  <title>Putting &selnx; into enforcing mode</title>
   <para>
    At this point you have a completely functional &selnx; system and it is
    time to further configure it. In the current status, &selnx; is
    operational but not in enforcing mode. This means that it does not limit
    any activities, and it logs everything that it should be doing if it
    were in enforcing mode. Review the log files to learn what activities
-   are not allowed. As a first
-   test, put &selnx; in enforcing mode and find out if you can still use
-   your server after doing so: check that the option
-   <option>enforcing=1</option> is set in the &grub; configuration file,
-   while <option>SELINUX=enforcing</option> is set in
-   <filename>/etc/selinux/config</filename>. Reboot your server and see if
-   it still comes up the way you expect it to. If it does, leave it like
-   that and start modifying the server in a way that everything works as
-   expected. However, you may not even be able to boot the server properly.
-   In that case, switch back to the mode where &selnx; is not enforcing and
-   start tuning your server.
+   are not allowed.
   </para>
+  <para>After running &selnx; in permissive mode first, you can try to
+   put &selnx; in enforcing mode and find out if you can still use
+   your server after doing so.
+  </para>
+  <warning>
+   <title>Reset security context</title>
+   <para>
+    When systems run &selnx; in permissive mode, users and processes
+    might label various file-system objects incorrectly. This can cause
+    problems when switching to enforcing mode because &selnx; relies on
+    correct labels of file-system objects.
+   </para>
+   <para>
+    Before switching into enforcing mode, make sure to first reset the
+    security context (extended attributes). Do so by executing
+    <command>restorecon -R /</command> and then reboot the system.
+    System startup will take some time, as the entire file system
+    will be relabeled.
+   </para>
+  </warning>
+  <para>
+   To put &selnx; into enforcing mode, set the following parameter
+   in the &grub; configuration file: <parameter>enforcing=1</parameter>. For context,
+   see <xref linkend="ex-sec-selinux-grubcfg"/>.
+   Then edit <filename>/etc/selinux/config</filename> and make sure
+   <option>SELINUX=enforcing</option> is set.
+  </para>
+  <para>Now reboot your server and see if it still comes up the way you expect
+   it to and if you can still log in. If yes, leave it like
+   that and start <xref linkend="sec-selinux-configure"
+    xrefstyle="select:title"/>.
+  </para>
+  <para>In case you should not able to boot the server properly with &selnx;
+   in enforcing mode, switch back to permissive mode and start tuning your server.
+   </para>
+ </sect1>
+ <sect1 xml:id="sec-selinux-configure">
+  <title>Configuring &selnx;</title>
   <para>
     Before you start tuning your server, verify the &selnx; installation.
     You have already used the command <command>sestatus -v</command> to view

--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -320,7 +320,7 @@ system_u:object_r:var_t var</screen>
     <para>
      Install the following packages:
     </para>
-    <screen>&prompt.sudo;<command>zypper in selinux-policy-targeted selinux-policy-devel selinux-autorelabel</command></screen>
+    <screen>&prompt.sudo;<command>zypper in selinux-policy-targeted selinux-policy-devel</command></screen>
    </step>
   </procedure>
   <para>

--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -332,70 +332,56 @@ system_u:object_r:var_t var</screen>
 
  <sect1 xml:id="sec-selinux-grub">
    <title>Modifying the &grub; bootloader</title>
-<para>
+  <para>
    After installing the &selnx; packages, modify the &grub; boot
    loader, either by editing <filename>/etc/default/grub</filename>,
    or with &yast;.
   </para>
   <para>
-    In <filename>/etc/default/grub</filename>, add the following
-    line to the <literal>GRUB_CMDLINE_LINUX_DEFAULT=</literal> line:
+   In <filename>/etc/default/grub</filename>, add the following parameters
+   to the <literal>GRUB_CMDLINE_LINUX_DEFAULT=</literal> line:
   </para>
-  <screen>security=selinux selinux=1 enforcing=0</screen>
+  <screen>security=selinux<co xml:id="co-security"/> selinux=1<co xml:id="co-selinux"/> enforcing=0<co xml:id="co-enforcing"/></screen>
+  <calloutlist>
+   <callout arearefs="co-security">
+    <para>
+     This parameter tells the kernel to use &selnx; and not &aa;.
+    </para>
+   </callout>
+   <callout arearefs="co-selinux">
+    <para>
+     This parameter enables &selnx;.
+    </para>
+   </callout>
+   <callout arearefs="co-enforcing">
+    <para>
+     This parameter defines the mode in which to run &selnx;. Setting it
+     to <literal>0</literal> puts &selnx; in permissive mode. In this mode,
+     &selnx; is fully functional, but does not enforce any of the security settings in
+     the policy. In permissive mode, &selnx; does not protect your system but it still logs
+     everything that happens. Use this mode for testing and configuring your system.
+    </para>
+    <para>
+     After you have completed the &selnx; configuration, you can set the
+     parameter to <literal>1</literal> to run &selnx; in enforcing mode. In this mode,
+     it enforces the &selnx; policy and denies access based on policy rules.
+    </para>
+   </callout>
+  </calloutlist>
   <para>
-    Then run the <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>
-    command to rebuild your &grub; configuration.
+   After you have added the parameters in <filename>/etc/default/grub</filename>,
+   run the <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>
+   command to rebuild your &grub; configuration.
   </para>
   <para>
-    In &yast;, open <menuchoice> <guimenu>System</guimenu> <guimenu>Boot Loader</guimenu> <guimenu>Kernel Parameters</guimenu></menuchoice>.
-    Add <literal>security=selinux selinux=1 enforcing=0</literal> to
-    <guimenu>Optional Kernel Command Line Parameters</guimenu>.
-  </para>
-  <para>
-   These options are used for the following purposes:
+   Alternatively, to modify the bootloader via &yast;, open <menuchoice><guimenu>System</guimenu>
+   <guimenu>Boot Loader</guimenu><guimenu>Kernel Parameters</guimenu></menuchoice>.
+   Add the following line to the <guimenu>Optional Kernel Command Line Parameters</guimenu>:
+   <literal>security=selinux selinux=1 enforcing=0</literal>
   </para>
 
-  <variablelist>
-   <varlistentry>
-    <term><literal>security=selinux</literal>
-    </term>
-    <listitem>
-     <para>
-      This option tells the kernel to use &selnx; and not &aa;
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><literal>selinux=1</literal>
-    </term>
-    <listitem>
-     <para>
-      This option switches on &selnx;
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><literal>enforcing=0</literal>
-    </term>
-    <listitem>
-     <para>
-      This option puts &selnx; in permissive mode. In this mode, &selnx; is
-      fully functional, but does not enforce any of the security settings in
-      the policy. Use this mode for testing and configuring your system. To
-      switch on
-      &selnx; protection, when the system is fully operational, change the
-      option to <literal>enforcing=1</literal> and add
-      <literal>SELINUX=enforcing</literal> in
-      <filename>/etc/selinux/config</filename>.
-     </para>
-    </listitem>
-   </varlistentry>
-  </variablelist>
-
   <para>
-   Now you can reboot. System startup will take some time, as &selnx;
-   will re-label the entire file system. After it is finished, run
-   the <command>sestatus -v</command> command to verify it is working.
+   Now you can reboot. After logging in, run the <command>sestatus -v</command> command.
    It should give you an output similar to
    <xref linkend="ex-selnx-sestatus" xrefstyle="select:label quotedtitle nopage"/>.
   </para>
@@ -404,31 +390,31 @@ system_u:object_r:var_t var</screen>
    <title>Verifying that &selnx; is functional</title>
 <screen>&prompt.sudo;<command>sestatus -v</command>
 SELinux status:                 enabled
-SELinuxfs mount:                /selinux
+SELinuxfs mount:                /sys/fs/selinux
+SELinux root directory:         /etc/selinux
+Loaded policy name:             targeted
 Current mode:                   permissive
 Mode from config file:          permissive
-Policy version:                 26
-Policy from config file:        minimum
+Policy MLS status:              enabled
+Policy deny_unknown status:     allowed
+Memory protection checking:     requested(insecure)
+Max kernel policy version:      33
 
 Process contexts:
-Current context:                root:staff_r:staff_t
-Init context:                   system_u:system_r:init_t
-/sbin/mingetty                  system_u:system_r:sysadm_t
-/usr/sbin/sshd                  system_u:system_r:sshd_t
+Current context:                unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
+Init context:                   system_u:system_r:init_t:s0
+/usr/sbin/sshd                  system_u:system_r:sshd_t:s0-s0:c0.c1023
 
 File contexts:
-Controlling term:               root:object_r:user_devpts_t
-/etc/passwd                     system_u:object_r:etc_t
-/etc/shadow                     system_u:object_r:shadow_t
-/bin/bash                       system_u:object_r:shell_exec_t
-/bin/login                      system_u:object_r:login_exec_t
-/bin/sh                         system_u:object_r:bin_t -&gt; system_u:object_r:shell_exec_t
-/sbin/agetty                    system_u:object_r:getty_exec_t
-/sbin/init                      system_u:object_r:init_exec_t
-/sbin/mingetty                  system_u:object_r:getty_exec_t
-/usr/sbin/sshd                  system_u:object_r:sshd_exec_t
-/lib/libc.so.6                  system_u:object_r:lib_t -&gt; system_u:object_r:lib_t
-/lib/ld-linux.so.2              system_u:object_r:lib_t -&gt; system_u:object_r:ld_so_t</screen>
+Controlling terminal:           unconfined_u:object_r:user_tty_device_t:s0
+/etc/passwd                     system_u:object_r:passwd_file_t:s0
+/etc/shadow                     system_u:object_r:shadow_t:s0
+/bin/bash                       system_u:object_r:shell_exec_t:s0 -> system_u:object_r:shell_exec_t:s0
+/bin/login                      system_u:object_r:login_exec_t:s0
+/bin/sh                         system_u:object_r:bin_t:s0 -> system_u:object_r:shell_exec_t:s0
+/sbin/agetty                    system_u:object_r:getty_exec_t:s0
+/sbin/init                      system_u:object_r:bin_t:s0 -> system_u:object_r:init_exec_t:s0
+/usr/sbin/sshd                  system_u:object_r:sshd_exec_t:s0</screen>
   </example>
  </sect1>
 


### PR DESCRIPTION
### PR creator: Description

Update the SELinux chapter: documentation how to install the packages and a test policy was outdated (new repo, different packages). Also the procedure on how to enable SELinux in permissive and/or enforcing mode afterwards needed some modifications. 


### PR creator: Are there any relevant issues/feature requests?

* bsc#1205596
* jsc#DOCTEAM-856


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
  - [x] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
