### PR TITLE
Bugfix/ldap modules

### DIFF
--- a/xml/security_ldap.xml
+++ b/xml/security_ldap.xml
@@ -47,8 +47,8 @@
   <xi:include href="security_ldap_firewall.xml"/>
   <xi:include href="security_ldap_backups.xml"/>
   <xi:include href="security_ldap_users.xml"/>
-  <xi:include href="security_ldap_sssd.xml"/>
   <xi:include href="security_ldap_modules.xml"/>
+  <xi:include href="security_ldap_sssd.xml"/>
   <!--migration is available only in SLE15 SP3 and up-->
   <xi:include href="security_ldap_migrate_test.xml"/>
   <!-- default installation uses self-signed cert -->

--- a/xml/security_ldap_modules.xml
+++ b/xml/security_ldap_modules.xml
@@ -21,7 +21,7 @@
   </dm:docmanager>
  </info>
   <para>
-    Use the following command to list all available pug-ins, enabled and
+    Use the following command to list all available plug-ins, enabled and
     disabled. Use your server's hostname rather than the instance name
     of your &ds389;, like the following example hostname of
     <replaceable>LDAPSERVER1</replaceable>:

--- a/xml/security_ldap_modules.xml
+++ b/xml/security_ldap_modules.xml
@@ -37,10 +37,10 @@ ACL Plugin
 ACL preoperation
 [...]</screen>
   <para>
-    The following command enables the MemberOf plug-in referenced in
-    <xref linkend="sec-security-ldap-server-sssd"/>. MemberOf simplifies
+    The following command enables the <literal>MemberOf</literal> plug-in referenced in
+    <xref linkend="sec-security-ldap-server-sssd"/>. <literal>MemberOf</literal> simplifies
     user searches, by returning the user and any groups the user
-    belongs to, with a single command. Without MemberOf, a client must
+    belongs to, with a single command. Without <literal>MemberOf</literal>, a client must
     run multiple lookups to find a user's group memberships.
   </para>
   <screen>
@@ -65,7 +65,7 @@ ACL preoperation
 </screen>
 
 <para>
- Next, configure the plug-in. The following example enables MemberOf to
+ Next, configure the plug-in. The following example enables <literal>MemberOf</literal> to
  search all entries. Use your instance name rather than the server's
  hostname:
 </para>
@@ -73,8 +73,8 @@ ACL preoperation
 Successfully changed the cn=MemberOf Plugin,cn=plugins,cn=config</screen>
 
 <para>
- After the MemberOf plug-in is enabled and configured, all new groups and
- users are automatically MemberOf targets. However, any
+ After the <literal>MemberOf</literal> plug-in is enabled and configured, all new groups and
+ users are automatically <literal>MemberOf</literal> targets. However, any
  users and groups that exist before it is enabled are not. They must be
  marked manually:
 </para>
@@ -95,8 +95,8 @@ memberOf: cn=SERVER_ADMINS,ou=groups,dc=ldap1,dc=com</screen>
 
 <para>
  Modifying a larger number of users is a lot of work. The following
- example shows how to make all legacy users MemberOf targets with one
- fixup command:
+ example shows how to make all legacy users <literal>MemberOf</literal> targets with one
+ <command>fixup</command> command:
 </para>
 <screen>&prompt.sudo;<command>dsconf LDAP1 plugin memberof fixup -f '(objectClass=*)' dc=LDAP1,dc=COM</command></screen>
 </sect1>

--- a/xml/security_ldap_modules.xml
+++ b/xml/security_ldap_modules.xml
@@ -15,13 +15,13 @@
  also scoping, https://directory.fedoraproject.org/docs/389ds/design/memberof-scoping.html
  cjs, March 12 2022-->
  <info>
-  <title>Managing modules</title>
+  <title>Managing plug-ins</title>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
  </info>
   <para>
-    Use the following command to list all available modules, enabled and
+    Use the following command to list all available pug-ins, enabled and
     disabled. Use your server's hostname rather than the instance name
     of your &ds389;, like the following example hostname of
     <replaceable>LDAPSERVER1</replaceable>:
@@ -37,7 +37,7 @@ ACL Plugin
 ACL preoperation
 [...]</screen>
   <para>
-    The following command enables the MemberOf plugin referenced in
+    The following command enables the MemberOf plug-in referenced in
     <xref linkend="sec-security-ldap-server-sssd"/>. MemberOf simplifies
     user searches, by returning the user and any groups the user
     belongs to, with a single command. Without MemberOf, a client must
@@ -47,9 +47,9 @@ ACL preoperation
 &prompt.sudo;<command>dsconf -D "cn=Directory Manager" ldap://<replaceable>LDAPSERVER1</replaceable> plugin memberof enable</command>
 </screen>
   <para>
-    Note that the plugin names used in commands are lowercase, so they
+    Note that the plug-in names used in commands are lowercase, so they
     are different from how
-    they appear when you list them. If you make a mistake with a plugin
+    they appear when you list them. If you make a mistake with a plug-in
     name, you will see a helpful error message:
   </para>
 <screen>dsconf instance plugin: error: invalid choice: 'MemberOf' (choose from
@@ -58,14 +58,14 @@ ACL preoperation
 'pass-through-auth', 'retro-changelog', 'posix-winsync', 'contentsync', 'list',
 'show', 'set')</screen>
     <para>
-    After enabling a plugin, it is necessary to restart the server:
+    After enabling a plug-in, it is necessary to restart the server:
     </para>
     <screen>
 &prompt.sudo;<command>systemctl restart dirsrv@<replaceable>LDAPSERVER1</replaceable>.service</command>
 </screen>
 
 <para>
- Next, configure the plugin. The following example enables MemberOf to
+ Next, configure the plug-in. The following example enables MemberOf to
  search all entries. Use your instance name rather than the server's
  hostname:
 </para>
@@ -73,7 +73,7 @@ ACL preoperation
 Successfully changed the cn=MemberOf Plugin,cn=plugins,cn=config</screen>
 
 <para>
- After the MemberOf plugin is enabled and configured, all new groups and
+ After the MemberOf plug-in is enabled and configured, all new groups and
  users are automatically MemberOf targets. However, any
  users and groups that exist before it is enabled are not. They must be
  marked manually:

--- a/xml/security_ldap_sssd.xml
+++ b/xml/security_ldap_sssd.xml
@@ -75,8 +75,15 @@
     <para>
       Review the output and make any necessary changes to suit your
       environment. The following <filename>/etc/sssd/sssd.conf</filename>
-      file demonstrates a working example:
+      file demonstrates a working example.
     </para>
+    <important>
+     <title>MemberOf</title>
+     <para>
+      The LDAP access filter relies on <literal>MemberOf</literal> being
+      configured. For details, see <xref linkend="sec-security-ldap-modules"/>.
+     </para>
+    </important>
     <screen>[sssd]
 services = nss, pam, ssh, sudo
 config_file_version = 2


### PR DESCRIPTION
### PR creator: Description

LDAP chapter: Fix the following issues:

1. First the topic is managing *plugins* not *modules* in 389-ds 
2. Second, this section needs to be before 6.6 (SSSD integration).
3. Third, SSSD section needs a warning in the example before the configuration in point 4 that the ldap access filter relies on memberOf being configured.

### PR creator: Are there any relevant issues/feature requests?

* bsc#1204350
* jsc#DOCTEAM-801


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
