### PR TITLE
Added closing / to XML elements (bsc#1206096)

### DIFF
--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -97,11 +97,11 @@
 <screen>&lt;general&gt;
    &lt;storage&gt;
      &lt;proposal&gt;
-       &lt;lvm config:type="boolean"&gt;true&lt;lvm/&gt;
-       &lt;windows_delete_mode config:type="symbol"&gt;all&lt;windows_delete_mode/&gt;
+       &lt;lvm config:type="boolean">true&lt;/lvm>
+       &lt;windows_delete_mode config:type="symbol">all&lt;/windows_delete_mode>
      &lt;/proposal&gt;
-   &lt;/storage&gt;
-&lt;/general&gt;</screen>
+   &lt;/storage>
+&lt;/general></screen>
   </example>
   <variablelist>
    <title></title>
@@ -111,7 +111,7 @@
      <para>
       Creates an LVM-based proposal. The default is <literal>false</literal>.
      </para>
-<screen>&lt;lvm config:type="boolean"&gt;true&lt;/lvm/&gt;</screen>
+<screen>&lt;lvm config:type="boolean">true&lt;/lvm></screen>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -121,7 +121,7 @@
       When set to <literal>true</literal>, &ay; resizes Windows partitions if
       needed to make room for the installation.
      </para>
-<screen>&lt;resize_windows config:type="boolean"&gt;false&lt;/resize_windows/&gt;</screen>
+<screen>&lt;resize_windows config:type="boolean">false&lt;/resize_windows></screen>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -144,7 +144,7 @@
        </para>
       </listitem>
      </itemizedlist>
-<screen>&lt;windows_delete_mode config:type="symbol"&gt;ondemand&lt;/windows_delete_mode/&gt;</screen>
+<screen>&lt;windows_delete_mode config:type="symbol">ondemand&lt;/windows_delete_mode></screen>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -167,7 +167,7 @@
        </para>
       </listitem>
      </itemizedlist>
-<screen>&lt;linux_delete_mode config:type="symbol"&gt;ondemand&lt;/linux_delete_mode/&gt;</screen>
+<screen>&lt;linux_delete_mode config:type="symbol">ondemand&lt;/linux_delete_mode></screen>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -190,7 +190,7 @@
        </para>
       </listitem>
      </itemizedlist>
-<screen>&lt;other_delete_mode config:type="symbol"&gt;ondemand&lt;/other_delete_mode/&gt;</screen>
+<screen>&lt;other_delete_mode config:type="symbol"&gt;ondemand&lt;/other_delete_mode></screen>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -200,7 +200,7 @@
       Enables encryption using the specified password. By default, encryption
       is disabled.
      </para>
-<screen>&lt;encryption_password&gt;some-secret&lt;/encryption_password/&gt;</screen>
+<screen>&lt;encryption_password&gt;some-secret&lt;/encryption_password></screen>
     </listitem>
    </varlistentry>
   </variablelist>

--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -97,11 +97,11 @@
 <screen>&lt;general&gt;
    &lt;storage&gt;
      &lt;proposal&gt;
-       &lt;lvm config:type="boolean"&gt;true&lt;lvm&gt;
-       &lt;windows_delete_mode config:type="symbol"&gt;all&lt;windows_delete_mode&gt;
+       &lt;lvm config:type="boolean"&gt;true&lt;lvm/&gt;
+       &lt;windows_delete_mode config:type="symbol"&gt;all&lt;windows_delete_mode/&gt;
      &lt;/proposal&gt;
-   &lt;storage&gt;
-&lt;general&gt;</screen>
+   &lt;/storage&gt;
+&lt;/general&gt;</screen>
   </example>
   <variablelist>
    <title></title>
@@ -111,7 +111,7 @@
      <para>
       Creates an LVM-based proposal. The default is <literal>false</literal>.
      </para>
-<screen>&lt;lvm config:type="boolean"&gt;true&lt;/lvm&gt;</screen>
+<screen>&lt;lvm config:type="boolean"&gt;true&lt;/lvm/&gt;</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -121,7 +121,7 @@
       When set to <literal>true</literal>, &ay; resizes Windows partitions if
       needed to make room for the installation.
      </para>
-<screen>&lt;resize_windows config:type="boolean"&gt;false&lt;/resize_windows&gt;</screen>
+<screen>&lt;resize_windows config:type="boolean"&gt;false&lt;/resize_windows/&gt;</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -144,7 +144,7 @@
        </para>
       </listitem>
      </itemizedlist>
-<screen>&lt;windows_delete_mode config:type="symbol"&gt;ondemand&lt;/windows_delete_mode&gt;</screen>
+<screen>&lt;windows_delete_mode config:type="symbol"&gt;ondemand&lt;/windows_delete_mode/&gt;</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -167,7 +167,7 @@
        </para>
       </listitem>
      </itemizedlist>
-<screen>&lt;linux_delete_mode config:type="symbol"&gt;ondemand&lt;/linux_delete_mode&gt;</screen>
+<screen>&lt;linux_delete_mode config:type="symbol"&gt;ondemand&lt;/linux_delete_mode/&gt;</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -190,7 +190,7 @@
        </para>
       </listitem>
      </itemizedlist>
-<screen>&lt;other_delete_mode config:type="symbol"&gt;ondemand&lt;/other_delete_mode&gt;</screen>
+<screen>&lt;other_delete_mode config:type="symbol"&gt;ondemand&lt;/other_delete_mode/&gt;</screen>
     </listitem>
    </varlistentry>
    <varlistentry>
@@ -200,7 +200,7 @@
       Enables encryption using the specified password. By default, encryption
       is disabled.
      </para>
-<screen>&lt;encryption_password&gt;some-secret&lt;/encryption_password&gt;</screen>
+<screen>&lt;encryption_password&gt;some-secret&lt;/encryption_password/&gt;</screen>
     </listitem>
    </varlistentry>
   </variablelist>


### PR DESCRIPTION
### PR creator: Description

XML configuration examples missed closing slash, this update fixes that


### PR creator: Are there any relevant issues/feature requests?

* bsc#1206069

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
  - [ ] SLE 15 SP0
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
