### PR TITLE
Increased KVM_MAX_VCPUS to 1024 (jsc#PED-2682)

### DIFF
--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -170,7 +170,7 @@
        </entry>
        <entry>
         <para>
-         288
+         1024
         </para>
        </entry>
       </row>


### PR DESCRIPTION
### PR creator: Description

This update will encourage customers to use large systems as a single VM.


### PR creator: Are there any relevant issues/feature requests?

fixes jsc#PED-2682


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
