### PR TITLE
Improve ULP documentation

### DIFF
--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -220,8 +220,7 @@
 <screen>&prompt.user;ulp trigger -p <replaceable>PID</replaceable> --revert-all=<replaceable>LIBRARY</replaceable></screen>
         <para>
           In the example, <replaceable>LIBRARY</replaceable> refers to the
-          actual library, such as
-          <systemitem>libcrypto.so.1.1</systemitem>.
+          actual library, such as <systemitem>libcrypto.so.1.1</systemitem>.
         </para>
         <para>
           The latter approach can be useful when the source code of the

--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -45,7 +45,11 @@
     <para>
       User space live patching (&ulpa;) refers to the process of applying
       patches to the libraries used by a running process, without interrupting
-      it. Live patching operations are performed using the
+      it. This means that once a security fix is available as a livepatch,
+      then customer services will be secured without restart through a livepatch apply.
+    </para>
+    <para>
+      Live patching operations are performed using the
       <systemitem>ulp</systemitem> tool that is part of the
       <systemitem>libpulp</systemitem>.
     </para>
@@ -80,66 +84,37 @@
         </listitem>
         <listitem>
           <para>
-            To be live-patchable, a library must be compiled with the
-            <option>-fpatchable-function-entry</option> GCC flag. No changes to
-            the library source code are required.
-          </para>
-        </listitem>
-        <listitem>
-          <para>
-            Processes must preload the <systemitem>libpulp.so</systemitem>
-            library.
+            Applications with desired livepatch support must be
+            launched preloading <systemitem>libpulp.so.0</systemitem>. See <xref linkend="sec-ulp-libpulp"/> for more details.
           </para>
         </listitem>
       </itemizedlist>
+    </sect2>
+    <sect2 xml:id="sec-ulp-supported-libs">
+      <title> Supported Libraries</title>
+      <para>
+        Currently, only glibc and openssl (openssl1_1) are supported. To receive glibc
+        and openssl live patches, install both <systemitem>glibc-livepatches</systemitem> and <systemitem>openssl-livepatches</systemitem> packages:
+        <screen>> zypper install glibc-livepatches openssl-livepatches</screen>
+        And more packages will be available as components are prepared for livepatching.
+      </para>
     </sect2>
 
     <sect2 xml:id="sec-ulp-libpulp">
       <title>Using libpulp</title>
       <para>
         To use <systemitem>libpulp</systemitem> with an application, you must
-        perform the following steps:
+        preload <systemitem>libpulp.so.0</systemitem>:
+        <screen>> LD_PRELOAD=/usr/lib64/libpulp.so.0 <replaceable>APPLICATION</replaceable></screen>
+        This is enough to enable livepatching support on it.
       </para>
-      <orderedlist>
-        <listitem>
-          <para>
-            Make a library live-patchable.
-          </para>
-        </listitem>
-        <listitem>
-          <para>
-            When launching the application, preload
-            <systemitem>libpulp</systemitem> with the
-            <command>LD_PRELOAD=/usr/lib64/libpulp.so
-            ./<replaceable>APPLICATION</replaceable></command> command.
-          </para>
-        </listitem>
-      </orderedlist>
-      <sect3 xml:id="sec-ulp-prep-lib">
-        <title>Preparing a library to be live-patchable</title>
-        <para>
-          For a library to be live-patchable, it must contain a
-          <literal>NOP</literal> prologue in all function calls. GCC version 8
-          and higher, as well as the GCC version that ships with &sls;,
-          provides the <option>-fpatchable-function-entry</option> specifically
-          for that purpose. Thus, on the &x86-64; architecture, compiling a
-          library written in C with
-          <option>-fpatchable-function-entry=16,14</option> flag is sufficient
-          to make it live-patchable.
-        </para>
-        <para>
-          The libraries provided by the system packages glibc and openssl
-          (libopenssl_1_1) are already live-patchable on &productnameshort;
-          &productnumber;.
-        </para>
-      </sect3>
       <sect3 xml:id="sec-ulp-livepatch-check">
         <title>Checking if a library is live-patchable</title>
         <para>
           To check whether a library is live-patchable, use the following
           command:
         </para>
-<screen>ulp livepatchable <replaceable>LIBRARY</replaceable></screen>
+<screen>> ulp livepatchable <replaceable>LIBRARY</replaceable></screen>
       </sect3>
       <sect3 xml:id="sec-ulp-livepatch-container-check">
         <title>Checking if a <filename>.so</filename> file is a live patch container</title>
@@ -161,25 +136,30 @@
           Live patches are applied using the <systemitem>ulp
           trigger</systemitem> command, for example:
         </para>
-<screen>ulp trigger -p <replaceable>PID</replaceable> <replaceable>LIVEPATCH</replaceable>.ulp</screen>
+<screen>> ulp trigger -p <replaceable>PID</replaceable> <replaceable>LIVEPATCH</replaceable>.so</screen>
         <para>
           In this example, <literal>PID</literal> is the PID of the running
           process that uses the library to be patched and
-          <literal>LIVEPATCH.ulp</literal> is the actual live patch file.
+          <literal>LIVEPATCH.so</literal> is the actual live patch file.
         </para>
         <para>
-          The <literal>live patching succeeded</literal> message indicates that
-          the live-patching operation was successful.
+          The <literal>SUCCESS</literal> status message indicates that
+          the live-patching operation was successful. The <literal>SKIPPED</literal>
+          message indicates that the patch was skipped because it was not designed
+          for any library that is loaded in the process. The <literal>ERROR</literal>
+          message indicates an error, and more information can be retrieved by
+          inspectioning the libpulp internal message buffer. See <xref linkend="sec-ulp-internal-messages"/> for more information.
         </para>
         <para>
           It is also possible to apply multiple live patches by using
           wildcards. For example:
         </para>
-<screen>&prompt.user;ulp trigger -p <replaceable>PID</replaceable> '*.so'</screen>
+<screen>&prompt.user;ulp trigger '*.so'</screen>
         <para>
           This command will try to apply every patch in the current folder to
-          the process holding <literal>PID</literal>. In the end, the tool will
-          show how many patches it successfully applied.
+          every process that have libpulp loaded. If the patch is not suitable for
+          the process, it will be automatically skipped. In the end, the tool will
+          show how many patches it successfully applied to how many processes.
         </para>
       </sect3>
       <sect3 xml:id="sec-ulp-revert-livepatch">
@@ -195,7 +175,7 @@
           Alternatively, it is possible to remove all patches associated with a
           particular library. For example:
         </para>
-<screen>ulp trigger -p <replaceable>PID</replaceable> --revert-all=<replaceable>LIBRARY</replaceable></screen>
+<screen>> ulp trigger -p <replaceable>PID</replaceable> --revert-all=<replaceable>LIBRARY</replaceable></screen>
         <para>
           In the example above, <replaceable>LIBRARY</replaceable> refers to
           the actual library, for example:
@@ -208,6 +188,42 @@
           application running potentially unsecured code. For example:
         </para>
 <screen>&prompt.user;ulp trigger -p <replaceable>PID</replaceable>  --revert-all=libcrypto.so.1.1 new_livepatch2.so</screen>
+      </sect3>
+      <sect3 xml:id="sec-ulp-verify-patches">
+        <title>View applied patches</title>
+        <para>
+          It is possible to verify which applications has livepatches applied by running:
+        </para>
+        <screen>> sudo ulp patches</screen>
+        <para>
+          sudo is only necessary to see patches of other users processes.
+          The output will show which libraries are livepatchable and
+          patches loaded in programs, as well which bugs the patch
+          addresses:
+        </para>
+        <screen>
+PID: 10636, name: test
+  Livepatchable libraries:
+    in /lib64/libc.so.6:
+      livepatch: libc_livepatch1.so
+        bug labels: jsc#SLE-0000
+    in /usr/lib64/libpulp.so.0:
+        </screen>
+        <para>
+          It is also possible to see which functions are patched by the livepatch:
+        </para>
+        <screen>> ulp dump <replaceable>LIVEPATCH.so</replaceable>
+        </screen>
+      </sect3>
+
+      <sect3 xml:id="sec-ulp-internal-messages">
+        <title>View internal message queue</title>
+        <para>
+          Log messages from libpulp.so are stored in a buffer inside the library
+          and are not displayed unless requested by the user. To show these messages,
+          run:
+        </para>
+        <screen>> ulp messages -p <replaceable>PID</replaceable></screen>
       </sect3>
     </sect2>
   </sect1>

--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -113,6 +113,9 @@
       </para>
 <screen os="sled;sles">&prompt.user;zypper install glibc-livepatches openssl-livepatches</screen>
 <screen os="slemicro">&prompt.user;transactional-update pkg in glibc-livepatches openssl-livepatches</screen>
+          <para os="slemicro">
+            After successful installation, reboot your system.
+          </para>
     </sect2>
 
     <sect2 xml:id="sec-ulp-libpulp">

--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -113,9 +113,9 @@
       </para>
 <screen os="sled;sles">&prompt.user;zypper install glibc-livepatches openssl-livepatches</screen>
 <screen os="slemicro">&prompt.user;transactional-update pkg in glibc-livepatches openssl-livepatches</screen>
-          <para os="slemicro">
-            After successful installation, reboot your system.
-          </para>
+      <para os="slemicro">
+        After successful installation, reboot your system.
+      </para>
     </sect2>
 
     <sect2 xml:id="sec-ulp-libpulp">

--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -197,11 +197,11 @@
         </para>
 <screen>&prompt.user;ulp trigger '*.so'</screen>
         <para>
-          The command will try to apply every patch in the current folder to
-          every process that has the <systemitem>libpulp</systemitem> library
-          loaded. If the patch is not suitable for the process, it will be
-          automatically skipped. In the end, the tool will show how many
-          patches it successfully applied to how many processes.
+          The command tries to apply every patch in the current folder to every
+          process that have the <systemitem>libpulp</systemitem> library
+          loaded. If the patch is not suitable for the process, it is
+          automatically skipped. In the end, the tool shows how many patches it
+          successfully applied to how many processes.
         </para>
       </sect3>
       <sect3 xml:id="sec-ulp-revert-livepatch">
@@ -239,8 +239,8 @@
         </para>
 <screen>&prompt.user;ulp patches</screen>
         <para>
-          The output will show the live patchable libraries and patches
-          loaded in programs as well as the bugs that the patch addresses:
+          The output shows which libraries are live patchable and patches
+          loaded in programs, as well which bugs the patch addresses:
         </para>
 <screen>PID: 10636, name: test
   Livepatchable libraries:

--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -63,7 +63,7 @@
     <tip>
       <para>
         You can run the <command>ulp</command> command either as a normal user
-        or a privileged used via the &sudo; mechanism. The difference is that
+        or a privileged user via the &sudo; mechanism. The difference is that
         running <command>ulp</command> via &sudo; lets you view information of
         processes or patch processes that are running by &rootuser;.
       </para>
@@ -183,7 +183,7 @@
             <term>ERROR</term>
             <listitem>
               <para>
-                An error occurred and you can retrieve more information by
+                An error occurred, and you can retrieve more information by
                 inspecting the <systemitem>libpulp</systemitem> internal
                 message buffer. See <xref linkend="sec-ulp-internal-messages"/>
                 for more information.
@@ -198,7 +198,7 @@
 <screen>&prompt.user;ulp trigger '*.so'</screen>
         <para>
           The command will try to apply every patch in the current folder to
-          every process that have the <systemitem>libpulp</systemitem> library
+          every process that has the <systemitem>libpulp</systemitem> library
           loaded. If the patch is not suitable for the process, it will be
           automatically skipped. In the end, the tool will show how many
           patches it successfully applied to how many processes.
@@ -220,12 +220,12 @@
 <screen>&prompt.user;ulp trigger -p <replaceable>PID</replaceable> --revert-all=<replaceable>LIBRARY</replaceable></screen>
         <para>
           In the example, <replaceable>LIBRARY</replaceable> refers to the
-          actual library, for example
+          actual library, such as
           <systemitem>libcrypto.so.1.1</systemitem>.
         </para>
         <para>
           The latter approach can be useful when the source code of the
-          original live patch is not available. Or, you want to remove a
+          original live patch is not available. Or you want to remove a
           specific old patch and apply a new one while the target application
           is still running a secure code, for example:
         </para>
@@ -234,13 +234,13 @@
       <sect3 xml:id="sec-ulp-verify-patches">
         <title>View applied patches</title>
         <para>
-          It is possible to verify which applications has live patches applied
+          It is possible to verify which applications have live patches applied
           by running:
         </para>
 <screen>&prompt.user;ulp patches</screen>
         <para>
-          The output will show which libraries are live patchable and patches
-          loaded in programs, as well which bugs the patch addresses:
+          The output will show the live patchable libraries and patches
+          loaded in programs as well as the bugs that the patch addresses:
         </para>
 <screen>PID: 10636, name: test
   Livepatchable libraries:

--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -16,15 +16,16 @@
     </dm:docmanager>
     <abstract>
       <para>
-        This chapter describes the basic principles and usage of &ulp;.
+        This chapter describes the basic principles and usage of user space
+        live patching.
       </para>
     </abstract>
   </info>
   <sect1 xml:id="sec-ulp">
-    <title>About &ulp;</title>
+    <title>About user space live patching</title>
 
     <important os="slemicro">
-      <title>&ulp; technical preview</title>
+      <title>Technical preview</title>
       <para>
         On &slema;, &ulpa; is a technical preview only.
       </para>
@@ -44,22 +45,29 @@
 
     <para>
       User space live patching (&ulpa;) refers to the process of applying
-      patches to the libraries used by a running process, without interrupting
-      it. This means that once a security fix is available as a livepatch,
-      then customer services will be secured without restart through a livepatch apply.
-    </para>
-    <para>
-      Live patching operations are performed using the
-      <systemitem>ulp</systemitem> tool that is part of the
-      <systemitem>libpulp</systemitem>.
+      patches to the libraries used by a running process without interrupting
+      them. Every time a security fix is available as a live patch, customer
+      services will be secured after applying the live patch without restarting
+      the processes.
     </para>
 
     <para>
-      <systemitem>libpulp</systemitem> is a framework that enables &ulp;. It
-      consists of the <systemitem>libpulp.so</systemitem> library and tools for
-      making libraries live-patchable and applying live patches (the
-      <systemitem>ulp</systemitem> binary).
+      Live patching operations are performed using the
+      <systemitem>ulp</systemitem> tool that is part of
+      <systemitem>libpulp</systemitem>. <systemitem>libpulp</systemitem> is a
+      framework that consists of the <systemitem>libpulp.so</systemitem>
+      library and the <command>ulp</command> binary that makes libraries live
+      patchable and applies live patches.
     </para>
+
+    <tip>
+      <para>
+        You can run the <command>ulp</command> command either as a normal user
+        or a privileged used via the &sudo; mechanism. The difference is that
+        running <command>ulp</command> via &sudo; lets you view information of
+        processes or patch processes that are running by &rootuser;.
+      </para>
+    </tip>
 
     <sect2 xml:id="sec-ulp-prereqs">
       <title>Prerequisites</title>
@@ -71,7 +79,7 @@
           <para>
             Install the &ulpa; on your system by running:
           </para>
-<screen>&prompt.root;transactional-update pkg in libpulp0 libpulp-tools</screen>
+<screen>&prompt.user;transactional-update pkg in libpulp0 libpulp-tools</screen>
           <para>
             After successful installation, reboot your system.
           </para>
@@ -84,43 +92,50 @@
         </listitem>
         <listitem>
           <para>
-            Applications with desired livepatch support must be
-            launched preloading <systemitem>libpulp.so.0</systemitem>. See <xref linkend="sec-ulp-libpulp"/> for more details.
+            Applications with desired live patch support must be launched
+            preloading the <systemitem>libpulp.so.0</systemitem> library. See
+            <xref linkend="sec-ulp-libpulp"/> for more details.
           </para>
         </listitem>
       </itemizedlist>
     </sect2>
+
     <sect2 xml:id="sec-ulp-supported-libs">
-      <title> Supported Libraries</title>
+      <title>Supported Libraries</title>
       <para>
-        Currently, only glibc and openssl (openssl1_1) are supported. To receive glibc
-        and openssl live patches, install both <systemitem>glibc-livepatches</systemitem> and <systemitem>openssl-livepatches</systemitem> packages:
-        <screen>> zypper install glibc-livepatches openssl-livepatches</screen>
-        And more packages will be available as components are prepared for livepatching.
+        Currently, only <systemitem>glibc</systemitem> and
+        <systemitem>openssl</systemitem> (<systemitem>openssl1_1</systemitem>)
+        are supported. Additional packages will be available after they are
+        prepared for live patching. To receive <systemitem>glibc</systemitem>
+        and <systemitem>openssl</systemitem> live patches, install both
+        <package>glibc-livepatches</package> and
+        <package>openssl-livepatches</package> packages:
       </para>
+<screen os="sled;sles">&prompt.user;zypper install glibc-livepatches openssl-livepatches</screen>
+<screen os="slemicro">&prompt.user;transactional-update pkg in glibc-livepatches openssl-livepatches</screen>
     </sect2>
 
     <sect2 xml:id="sec-ulp-libpulp">
-      <title>Using libpulp</title>
+      <title>Using <systemitem>libpulp</systemitem></title>
       <para>
-        To use <systemitem>libpulp</systemitem> with an application, you must
-        preload <systemitem>libpulp.so.0</systemitem>:
-        <screen>> LD_PRELOAD=/usr/lib64/libpulp.so.0 <replaceable>APPLICATION</replaceable></screen>
-        This is enough to enable livepatching support on it.
+        To enable live patching on an application, you need to preload the
+        <systemitem>libpulp.so.0</systemitem> library when starting the
+        application:
       </para>
+<screen>&prompt.user;LD_PRELOAD=/usr/lib64/libpulp.so.0 <replaceable>APPLICATION_CMD</replaceable></screen>
       <sect3 xml:id="sec-ulp-livepatch-check">
-        <title>Checking if a library is live-patchable</title>
+        <title>Checking if a library is live patchable</title>
         <para>
-          To check whether a library is live-patchable, use the following
+          To check whether a library is live patchable, use the following
           command:
         </para>
-<screen>> ulp livepatchable <replaceable>LIBRARY</replaceable></screen>
+<screen>&prompt.user;ulp livepatchable <replaceable>PATH_TO_LIBRARY</replaceable></screen>
       </sect3>
       <sect3 xml:id="sec-ulp-livepatch-container-check">
         <title>Checking if a <filename>.so</filename> file is a live patch container</title>
         <para>
           A shared object (<filename>.so</filename>) is a live patch container
-          if it contains the ULP patch description embedded into it. You can
+          if it contains the &ulpa; patch description embedded into it. You can
           verify it with the following command:
         </para>
 <screen>&prompt.user;readelf -S <replaceable>SHARED_OBJECT</replaceable> | grep .ulp</screen>
@@ -133,97 +148,117 @@
       <sect3 xml:id="sec-ulp-apply-livepatch">
         <title>Applying live patches</title>
         <para>
-          Live patches are applied using the <systemitem>ulp
-          trigger</systemitem> command, for example:
+          Live patches are applied using the <command>ulp trigger</command>
+          command, for example:
         </para>
-<screen>> ulp trigger -p <replaceable>PID</replaceable> <replaceable>LIVEPATCH</replaceable>.so</screen>
+<screen>&prompt.user;ulp trigger -p <replaceable>PID</replaceable> <replaceable>LIVEPATCH</replaceable>.so</screen>
         <para>
-          In this example, <literal>PID</literal> is the PID of the running
+          Replace <literal>PID</literal> with the process ID of the running
           process that uses the library to be patched and
-          <literal>LIVEPATCH.so</literal> is the actual live patch file.
+          <literal>LIVEPATCH.so</literal> with the actual live patch file. The
+          command returns one of the following status messages:
         </para>
-        <para>
-          The <literal>SUCCESS</literal> status message indicates that
-          the live-patching operation was successful. The <literal>SKIPPED</literal>
-          message indicates that the patch was skipped because it was not designed
-          for any library that is loaded in the process. The <literal>ERROR</literal>
-          message indicates an error, and more information can be retrieved by
-          inspectioning the libpulp internal message buffer. See <xref linkend="sec-ulp-internal-messages"/> for more information.
-        </para>
+        <variablelist>
+          <varlistentry>
+            <term>SUCCESS</term>
+            <listitem>
+              <para>
+                The live patching operation was successful.
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>SKIPPED</term>
+            <listitem>
+              <para>
+                The patch was skipped because it was not designed for any
+                library that is loaded in the process.
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>ERROR</term>
+            <listitem>
+              <para>
+                An error occurred and you can retrieve more information by
+                inspecting the <systemitem>libpulp</systemitem> internal
+                message buffer. See <xref linkend="sec-ulp-internal-messages"/>
+                for more information.
+              </para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
         <para>
           It is also possible to apply multiple live patches by using
-          wildcards. For example:
+          wildcards, for example:
         </para>
 <screen>&prompt.user;ulp trigger '*.so'</screen>
         <para>
-          This command will try to apply every patch in the current folder to
-          every process that have libpulp loaded. If the patch is not suitable for
-          the process, it will be automatically skipped. In the end, the tool will
-          show how many patches it successfully applied to how many processes.
+          The command will try to apply every patch in the current folder to
+          every process that have the <systemitem>libpulp</systemitem> library
+          loaded. If the patch is not suitable for the process, it will be
+          automatically skipped. In the end, the tool will show how many
+          patches it successfully applied to how many processes.
         </para>
       </sect3>
       <sect3 xml:id="sec-ulp-revert-livepatch">
         <title>Reverting live patches</title>
         <para>
-          <command>ulp trigger</command> can be used to revert live patches.
-          There are two ways to revert live patches. You can revert a live
-          patch by using the <option>--revert</option> switch and passing the
-          live patch container:
+          You can use the <command>ulp trigger</command> command to revert live
+          patches. There are two ways to revert live patches. You can revert a
+          live patch by using the <option>--revert</option> switch and passing
+          the live patch container:
         </para>
 <screen>&prompt.user;ulp trigger -p <replaceable>PID</replaceable> --revert <replaceable>LIVEPATCH</replaceable>.so</screen>
         <para>
           Alternatively, it is possible to remove all patches associated with a
-          particular library. For example:
+          particular library, for example:
         </para>
-<screen>> ulp trigger -p <replaceable>PID</replaceable> --revert-all=<replaceable>LIBRARY</replaceable></screen>
+<screen>&prompt.user;ulp trigger -p <replaceable>PID</replaceable> --revert-all=<replaceable>LIBRARY</replaceable></screen>
         <para>
-          In the example above, <replaceable>LIBRARY</replaceable> refers to
-          the actual library, for example:
+          In the example, <replaceable>LIBRARY</replaceable> refers to the
+          actual library, for example
           <systemitem>libcrypto.so.1.1</systemitem>.
         </para>
         <para>
           The latter approach can be useful when the source code of the
-          original live patch is not available, or you want to remove a
-          specific old patch and apply a new one, without the target
-          application running potentially unsecured code. For example:
+          original live patch is not available. Or, you want to remove a
+          specific old patch and apply a new one while the target application
+          is still running a secure code, for example:
         </para>
 <screen>&prompt.user;ulp trigger -p <replaceable>PID</replaceable>  --revert-all=libcrypto.so.1.1 new_livepatch2.so</screen>
       </sect3>
       <sect3 xml:id="sec-ulp-verify-patches">
         <title>View applied patches</title>
         <para>
-          It is possible to verify which applications has livepatches applied by running:
+          It is possible to verify which applications has live patches applied
+          by running:
         </para>
-        <screen>> sudo ulp patches</screen>
+<screen>&prompt.user;ulp patches</screen>
         <para>
-          sudo is only necessary to see patches of other users processes.
-          The output will show which libraries are livepatchable and
-          patches loaded in programs, as well which bugs the patch
-          addresses:
+          The output will show which libraries are live patchable and patches
+          loaded in programs, as well which bugs the patch addresses:
         </para>
-        <screen>
-PID: 10636, name: test
+<screen>PID: 10636, name: test
   Livepatchable libraries:
     in /lib64/libc.so.6:
       livepatch: libc_livepatch1.so
         bug labels: jsc#SLE-0000
-    in /usr/lib64/libpulp.so.0:
-        </screen>
+    in /usr/lib64/libpulp.so.0:</screen>
         <para>
-          It is also possible to see which functions are patched by the livepatch:
+          It is also possible to see which functions are patched by the live
+          patch:
         </para>
-        <screen>> ulp dump <replaceable>LIVEPATCH.so</replaceable>
-        </screen>
+<screen>&prompt.user;ulp dump <replaceable>LIVEPATCH.so</replaceable></screen>
       </sect3>
-
       <sect3 xml:id="sec-ulp-internal-messages">
         <title>View internal message queue</title>
         <para>
-          Log messages from libpulp.so are stored in a buffer inside the library
-          and are not displayed unless requested by the user. To show these messages,
-          run:
+          Log messages from <systemitem>libpulp.so</systemitem> are stored in a
+          buffer inside the library and are not displayed unless requested by
+          the user. To show these messages, run:
         </para>
-        <screen>> ulp messages -p <replaceable>PID</replaceable></screen>
+<screen>&prompt.user;ulp messages -p <replaceable>PID</replaceable></screen>
       </sect3>
     </sect2>
   </sect1>

--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -8,203 +8,216 @@
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink"
  xml:id="cha-ulp" xml:lang="en">
- <title>User space live patching</title>
- <info>
-  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:bugtracker></dm:bugtracker>
-   <dm:translation>yes</dm:translation>
-  </dm:docmanager>
-  <abstract>
-   <para>
-    This chapter describes the basic principles and usage of &ulp;.
-   </para>
-  </abstract>
- </info>
- <sect1 xml:id="sec-ulp">
-  <title>About &ulp;</title>
+  <title>User space live patching</title>
+  <info>
+    <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+      <dm:bugtracker></dm:bugtracker>
+      <dm:translation>yes</dm:translation>
+    </dm:docmanager>
+    <abstract>
+      <para>
+        This chapter describes the basic principles and usage of &ulp;.
+      </para>
+    </abstract>
+  </info>
+  <sect1 xml:id="sec-ulp">
+    <title>About &ulp;</title>
 
-  <important os="slemicro">
-   <title>&ulp; technical preview</title>
-   <para>
-    On &slema;, &ulpa; is a technical preview only.
-   </para>
-  </important>
+    <important os="slemicro">
+      <title>&ulp; technical preview</title>
+      <para>
+        On &slema;, &ulpa; is a technical preview only.
+      </para>
+    </important>
 
-<note os="slemicro">
-    <title>Live patching on &slema;</title>
+    <note os="slemicro">
+      <title>Live patching on &slema;</title>
+      <para>
+        Only the currently running processes are affected by the live patches.
+        As the libraries are changed in the new snapshot and
+        <emphasis role="bold">not</emphasis> in the current one, new processes
+        started in the current snapshot still use the non-patched libraries
+        until you reboot. After the reboot, the system switches to the new
+        snapshot and all started processes will use the patched libraries.
+      </para>
+    </note>
+
     <para>
-        Only the currently running processes are affected by the live patches. As the libraries are changed in the new snapshot and <emphasis role="bold">not</emphasis> in the current one, new processes started in the current snapshot still use the non-patched libraries until you reboot. After the reboot, the system switches to the new snapshot and all started processes will use the patched libraries.
+      User space live patching (&ulpa;) refers to the process of applying
+      patches to the libraries used by a running process, without interrupting
+      it. Live patching operations are performed using the
+      <systemitem>ulp</systemitem> tool that is part of the
+      <systemitem>libpulp</systemitem>.
     </para>
-</note>
 
-  <para>
-   User space live patching (&ulpa;) refers to the process of applying patches
-   to the libraries used by a running process, without interrupting it. Live
-   patching operations are performed using the <systemitem>ulp</systemitem>
-   tool that is part of the <systemitem>libpulp</systemitem>.
-  </para>
+    <para>
+      <systemitem>libpulp</systemitem> is a framework that enables &ulp;. It
+      consists of the <systemitem>libpulp.so</systemitem> library and tools for
+      making libraries live-patchable and applying live patches (the
+      <systemitem>ulp</systemitem> binary).
+    </para>
 
-  <para>
-   <systemitem>libpulp</systemitem> is a framework that enables &ulp;. It
-   consists of the <systemitem>libpulp.so</systemitem> library and tools for
-   making libraries live-patchable and applying live patches (the
-   <systemitem>ulp</systemitem> binary).
-  </para>
-
-  <sect2 xml:id="sec-ulp-prereqs">
-   <title>Prerequisites</title>
-   <para>
-    For &ulpa; to work, two requirements must be met.
-   </para>
-   <itemizedlist>
-    <listitem os="slemicro">
-        <para>
+    <sect2 xml:id="sec-ulp-prereqs">
+      <title>Prerequisites</title>
+      <para>
+        For &ulpa; to work, two requirements must be met.
+      </para>
+      <itemizedlist>
+        <listitem os="slemicro">
+          <para>
             Install the &ulpa; on your system by running:
-        </para>
-        <screen>&prompt.root;transactional-update pkg in libpulp0 libpulp-tools</screen>
-        <para>
+          </para>
+<screen>&prompt.root;transactional-update pkg in libpulp0 libpulp-tools</screen>
+          <para>
             After successful installation, reboot your system.
-        </para>
-    </listitem>
-    <listitem os="sles;sled">
-        <para>
+          </para>
+        </listitem>
+        <listitem os="sles;sled">
+          <para>
             Install the &ulpa; on your system by running:
+          </para>
+<screen>&prompt.sudo;zypper in libpulp0 libpulp-tools</screen>
+        </listitem>
+        <listitem>
+          <para>
+            To be live-patchable, a library must be compiled with the
+            <option>-fpatchable-function-entry</option> GCC flag. No changes to
+            the library source code are required.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            Processes must preload the <systemitem>libpulp.so</systemitem>
+            library.
+          </para>
+        </listitem>
+      </itemizedlist>
+    </sect2>
+
+    <sect2 xml:id="sec-ulp-libpulp">
+      <title>Using libpulp</title>
+      <para>
+        To use <systemitem>libpulp</systemitem> with an application, you must
+        perform the following steps:
+      </para>
+      <orderedlist>
+        <listitem>
+          <para>
+            Make a library live-patchable.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            When launching the application, preload
+            <systemitem>libpulp</systemitem> with the
+            <command>LD_PRELOAD=/usr/lib64/libpulp.so
+            ./<replaceable>APPLICATION</replaceable></command> command.
+          </para>
+        </listitem>
+      </orderedlist>
+      <sect3 xml:id="sec-ulp-prep-lib">
+        <title>Preparing a library to be live-patchable</title>
+        <para>
+          For a library to be live-patchable, it must contain a
+          <literal>NOP</literal> prologue in all function calls. GCC version 8
+          and higher, as well as the GCC version that ships with &sls;,
+          provides the <option>-fpatchable-function-entry</option> specifically
+          for that purpose. Thus, on the &x86-64; architecture, compiling a
+          library written in C with
+          <option>-fpatchable-function-entry=16,14</option> flag is sufficient
+          to make it live-patchable.
         </para>
-        <screen>&prompt.sudo;zypper in libpulp0 libpulp-tools</screen>
-    </listitem>
-    <listitem>
-     <para>
-      To be live-patchable, a library must be compiled with the
-      <option>-fpatchable-function-entry</option> GCC flag. No changes to the
-      library source code are required.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      Processes must preload the <systemitem>libpulp.so</systemitem> library.
-     </para>
-    </listitem>
-   </itemizedlist>
-  </sect2>
-
-  <sect2 xml:id="sec-ulp-libpulp">
-   <title>Using libpulp</title>
-   <para>
-    To use <systemitem>libpulp</systemitem> with an application, you must
-    perform the following steps:
-   </para>
-   <orderedlist>
-    <listitem>
-     <para>
-      Make a library live-patchable.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      When launching the application, preload <systemitem>libpulp</systemitem>
-      with the <command>LD_PRELOAD=/usr/lib64/libpulp.so
-      ./<replaceable>APPLICATION</replaceable></command> command.
-     </para>
-    </listitem>
-   </orderedlist>
-   <sect3 xml:id="sec-ulp-prep-lib">
-    <title>Preparing a library to be live-patchable</title>
-    <para>
-     For a library to be live-patchable, it must contain a
-     <literal>NOP</literal> prologue in all function calls. GCC version 8 and
-     higher, as well as the GCC version that ships with &sls;, provides the
-     <option>-fpatchable-function-entry</option> specifically for that purpose.
-     Thus, on the &x86-64; architecture, compiling a library written in C with
-     <option>-fpatchable-function-entry=16,14</option> flag is sufficient to
-     make it live-patchable.
-    </para>
-    <para>
-     The libraries provided by the system packages glibc and openssl
-     (libopenssl_1_1) are already live-patchable on &productnameshort; &productnumber;.
-    </para>
-   </sect3>
-   <sect3 xml:id="sec-ulp-livepatch-check">
-    <title>Checking if a library is live-patchable</title>
-    <para>
-     To check whether a library is live-patchable, use the following command:
-    </para>
+        <para>
+          The libraries provided by the system packages glibc and openssl
+          (libopenssl_1_1) are already live-patchable on &productnameshort;
+          &productnumber;.
+        </para>
+      </sect3>
+      <sect3 xml:id="sec-ulp-livepatch-check">
+        <title>Checking if a library is live-patchable</title>
+        <para>
+          To check whether a library is live-patchable, use the following
+          command:
+        </para>
 <screen>ulp livepatchable <replaceable>LIBRARY</replaceable></screen>
-   </sect3>
-   <sect3 xml:id="sec-ulp-livepatch-container-check">
-    <title>Checking if a <filename>.so</filename> file is a live patch container</title>
-    <para>
-     A shared object (<filename>.so</filename>) is a live patch container if it
-     contains the ULP patch description embedded into it. You can verify it
-     with the following command:
-    </para>
+      </sect3>
+      <sect3 xml:id="sec-ulp-livepatch-container-check">
+        <title>Checking if a <filename>.so</filename> file is a live patch container</title>
+        <para>
+          A shared object (<filename>.so</filename>) is a live patch container
+          if it contains the ULP patch description embedded into it. You can
+          verify it with the following command:
+        </para>
 <screen>&prompt.user;readelf -S <replaceable>SHARED_OBJECT</replaceable> | grep .ulp</screen>
-    <para>
-     If the output shows that there are both <literal>.ulp</literal> and
-     <literal>.ulp.rev</literal> sections in the shared object, then it is a
-     live patch container.
-    </para>
-   </sect3>
-   <sect3 xml:id="sec-ulp-apply-livepatch">
-    <title>Applying live patches</title>
-    <para>
-     Live patches are applied using the <systemitem>ulp trigger</systemitem>
-     command, for example:
-    </para>
+        <para>
+          If the output shows that there are both <literal>.ulp</literal> and
+          <literal>.ulp.rev</literal> sections in the shared object, then it is
+          a live patch container.
+        </para>
+      </sect3>
+      <sect3 xml:id="sec-ulp-apply-livepatch">
+        <title>Applying live patches</title>
+        <para>
+          Live patches are applied using the <systemitem>ulp
+          trigger</systemitem> command, for example:
+        </para>
 <screen>ulp trigger -p <replaceable>PID</replaceable> <replaceable>LIVEPATCH</replaceable>.ulp</screen>
-    <para>
-     In this example, <literal>PID</literal> is the PID of the running process
-     that uses the library to be patched and <literal>LIVEPATCH.ulp</literal>
-     is the actual live patch file.
-    </para>
-    <para>
-     The <literal>live patching succeeded</literal> message indicates that the
-     live-patching operation was successful.
-    </para>
-    <para>
-     It is also possible to apply multiple live patches by using wildcards. For
-     example:
-    </para>
+        <para>
+          In this example, <literal>PID</literal> is the PID of the running
+          process that uses the library to be patched and
+          <literal>LIVEPATCH.ulp</literal> is the actual live patch file.
+        </para>
+        <para>
+          The <literal>live patching succeeded</literal> message indicates that
+          the live-patching operation was successful.
+        </para>
+        <para>
+          It is also possible to apply multiple live patches by using
+          wildcards. For example:
+        </para>
 <screen>&prompt.user;ulp trigger -p <replaceable>PID</replaceable> '*.so'</screen>
-    <para>
-     This command will try to apply every patch in the current folder to the
-     process holding <literal>PID</literal>. In the end, the tool will show how
-     many patches it successfully applied.
-    </para>
-   </sect3>
-   <sect3 xml:id="sec-ulp-revert-livepatch">
-    <title>Reverting live patches</title>
-    <para>
-     <command>ulp trigger</command> can be used to revert live patches. There
-     are two ways to revert live patches. You can revert a live patch by using
-     the <option>--revert</option> switch and passing the live patch container:
-    </para>
+        <para>
+          This command will try to apply every patch in the current folder to
+          the process holding <literal>PID</literal>. In the end, the tool will
+          show how many patches it successfully applied.
+        </para>
+      </sect3>
+      <sect3 xml:id="sec-ulp-revert-livepatch">
+        <title>Reverting live patches</title>
+        <para>
+          <command>ulp trigger</command> can be used to revert live patches.
+          There are two ways to revert live patches. You can revert a live
+          patch by using the <option>--revert</option> switch and passing the
+          live patch container:
+        </para>
 <screen>&prompt.user;ulp trigger -p <replaceable>PID</replaceable> --revert <replaceable>LIVEPATCH</replaceable>.so</screen>
-    <para>
-     Alternatively, it is possible to remove all patches associated with a
-     particular library. For example:
-    </para>
+        <para>
+          Alternatively, it is possible to remove all patches associated with a
+          particular library. For example:
+        </para>
 <screen>ulp trigger -p <replaceable>PID</replaceable> --revert-all=<replaceable>LIBRARY</replaceable></screen>
-    <para>
-     In the example above, <replaceable>LIBRARY</replaceable> refers to the
-     actual library, for example: <systemitem>libcrypto.so.1.1</systemitem>.
-    </para>
-    <para>
-     The latter approach can be useful when the source code of the original
-     live patch is not available, or you want to remove a specific old patch
-     and apply a new one, without the target application running potentially
-     unsecured code. For example:
-    </para>
+        <para>
+          In the example above, <replaceable>LIBRARY</replaceable> refers to
+          the actual library, for example:
+          <systemitem>libcrypto.so.1.1</systemitem>.
+        </para>
+        <para>
+          The latter approach can be useful when the source code of the
+          original live patch is not available, or you want to remove a
+          specific old patch and apply a new one, without the target
+          application running potentially unsecured code. For example:
+        </para>
 <screen>&prompt.user;ulp trigger -p <replaceable>PID</replaceable>  --revert-all=libcrypto.so.1.1 new_livepatch2.so</screen>
-   </sect3>
-  </sect2>
- </sect1>
- <sect1 xml:id="sec-ulp-info">
-  <title>More information</title>
+      </sect3>
+    </sect2>
+  </sect1>
+  <sect1 xml:id="sec-ulp-info">
+    <title>More information</title>
 
-  <para>
-   Further information about <systemitem>libpulp</systemitem> is available in
-   the project's <link xlink:href="https://github.com/SUSE/libpulp">Git
-   repository</link>.
-  </para>
- </sect1>
+    <para>
+      Further information about <systemitem>libpulp</systemitem> is available
+      in the project's <link xlink:href="https://github.com/SUSE/libpulp">Git
+      repository</link>.
+    </para>
+  </sect1>
 </chapter>


### PR DESCRIPTION
### PR creator: Description

The user space live patching documentation is rather technical and complicated for customers. This update tries to re-arrange information so that ULP is more acessible.

### PR assignee: Questions to be answered (referring to https://susedoc.github.io/doc-sle/main/html/SLES-administration/cha-ulp.html)

1. What id ULP good for? To keep system secure without application restart?
2. Are all SLE libraries compiled with the -fpatchable-function-entry GCC flag?
3. If yes, should a customer care about how to make library live-patchable?
4. libpulp is preloaded with `LD_PRELOAD=/usr/lib64/libpulp.so` followe by the application command?
5. Where do i get live patches from?
6. How to verify, for example, the patched syscall in glibc is installed ?
7. How to verify that EVERYTHING is using that new patched syscall since using the old version of the syscall would leave the security vulnerability open) ?

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
