### PR TITLE
Security Guide: add part about Compliance

### DIFF
--- a/xml/book_security.xml
+++ b/xml/book_security.xml
@@ -35,7 +35,6 @@
  </info>
  <xi:include href="security_intro.xml"/>
  <xi:include href="security_preface.xml"/>
- <xi:include href="common_criteria.xml"/>
 
  <part xml:id="part-auth">
   <title>Authentication</title>
@@ -77,8 +76,15 @@
   <xi:include href="security_vpnserver.xml"/>
   <xi:include href="security_xca.xml"/>
   <xi:include href="security_sysctl.xml"/>
+ </part>
+
+ <part xml:id="part-compliance">
+  <title>Regulations and Compliance</title>
+  <xi:include href="common_criteria.xml"/>
   <xi:include href="security_fips.xml"/>
-  </part>
+  <!-- Moved to SUSE/doc-unversioned  Feb 23 2022 cschroder-->
+  <xi:include os="sles" href="security_pcidss.xml"/>
+ </part>
 
  <part xml:id="part-apparmor">
   <title>Confining privileges with &aa;</title>
@@ -114,7 +120,6 @@
 <!-- ===================================================================== -->
 <!-- Appendixes                                                            -->
 <!-- ===================================================================== -->
- <!-- Moved to SUSE/doc-unversioned  Feb 23 2022 cschroder-->
- <xi:include os="sles" href="security_pcidss.xml"/>
+
  <xi:include href="common_legal.xml"/>
 </book>

--- a/xml/security_pcidss.xml
+++ b/xml/security_pcidss.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE appendix
+<!DOCTYPE chapter
 [
   <!ENTITY % entities SYSTEM "generic-entities.ent">
     %entities;
 ]>
 
-<appendix os="sles"
+<chapter os="sles"
        xmlns="http://docbook.org/ns/docbook"
        xmlns:xi="http://www.w3.org/2001/XInclude"
        xmlns:xlink="http://www.w3.org/1999/xlink"
        version="5.0"
-       xml:id="app-security-pci-dss">
+       xml:id="cha-security-pci-dss">
  <info>
   <title>Payment Card Industry Data Security Standard (PCI DSS)</title>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -26,4 +26,4 @@
   more information, see the &sle_pcidss_guide;
   (<link xlink:href="https://documentation.suse.com/compliance/all/html/SLES-pci-dss/article-security-pcidss.html"/>)
  </para>
-</appendix>
+</chapter>


### PR DESCRIPTION
### PR creator: Description

Based on feedback during SLE Doc Day and for better visibility of the Compliance-related topcis, it was agreed with the Cert team to add a new part about 'Compliance' to the Security Guide and move the relevant chapters there.   


### PR creator: Are there any relevant issues/feature requests?

* jsc-DOCTEAM-821


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
