### PR TITLE
Deployment: fix examples for uefi httpboot

### DIFF
--- a/xml/uefi-httpboot-server.xml
+++ b/xml/uefi-httpboot-server.xml
@@ -192,7 +192,7 @@ subnet6 2001:db8:f00f:cafe::/64 {
 	        option dhcp6.bootfile-url "tftp://[2001:db8:f00f:cafe::1]/bootloader.efi";
 	}
 
-	class "HTTPClient"; {
+	class "HTTPClient" {
 	        match substring (option dhcp6.vendor-class, 6, 10);
 	}
 
@@ -210,7 +210,7 @@ subnet6 2001:db8:f00f:cafe::/64 {
         match substring (option dhcp6.vendor-class, 6, 21);
 	}
 
-subclass "HTTPClient" "HTTPClient":Arch:00016 {
+subclass "HTTPClient" "HTTPClient:Arch:00016" {
         option dhcp6.bootfile-url "http://www.httpboot.local/sle/EFI/BOOT/bootx64.efi";
 	option dhcp6.name-servers 2001:db8:f00f:cafe::1;
 	option dhcp6.vendor-class 0 10 "HTTPClient";


### PR DESCRIPTION
### PR creator: Description

Fix typos in two examples for setting up the DHCPv6 server for both PXE and HTTP boot,  https://documentation.suse.com/sled/15-SP4/html/SLED-all/cha-deployment-prep-uefi-httpboot.html#httpboot-dhcpv6-pxe-server


### PR creator: Are there any relevant issues/feature requests?

* bsc#1207494
* jsc#DOCTEAM-839


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
