### PR TITLE
vt-doc: Remove outdated information about the use of UEFI

### DIFF
--- a/xml/gpu_passthru.xml
+++ b/xml/gpu_passthru.xml
@@ -252,51 +252,13 @@ kvm_intel
   </sect2>
 
   <sect2 xml:id="gpu-passthru-ovmf">
-   <title>Install and enable UEFI firmware</title>
+   <title>Install UEFI firmware</title>
    <para>
     For proper &gpuback; functionality, the host needs to boot using UEFI
-    firmware (that is, not using a legacy-style BIOS boot sequence).
+    firmware (that is, not using a legacy-style BIOS boot sequence). Install
+    the <package>qemu-ovmf</package> package if not already installed:
    </para>
-   <procedure>
-    <step>
-     <para>
-      Install the <package>qemu-ovmf</package> package which includes UEFI
-      firmware images:
-     </para>
 <screen>&prompt.sudo;zypper install qemu-ovmf</screen>
-    </step>
-    <step>
-     <para>
-      Get the list of OVMF <literal>bin</literal> and <literal>vars</literal>
-      files by filtering the results of the following command:
-     </para>
-<screen>&prompt.user;rpm -ql qemu-ovmf</screen>
-    </step>
-    <step>
-     <para>
-      Enable OVMF in the &libvirt; &qemu; configuration in the file
-      <filename>/etc/libvirt/qemu.conf</filename> by using the list obtained
-      from the previous step. It should look similar to the following:
-     </para>
-<screen>
-nvram = [
-"/usr/share/qemu/ovmf-x86_64-4m.bin:/usr/share/qemu/ovmf-x86_64-4m-vars.bin",
-"/usr/share/qemu/ovmf-x86_64-4m-code.bin:/usr/share/qemu/ovmf-x86_64-4m-vars.bin",
-"/usr/share/qemu/ovmf-x86_64-smm-ms-code.bin:/usr/share/qemu/ovmf-x86_64-smm-ms-vars.bin",
-"/usr/share/qemu/ovmf-x86_64-smm-opensuse-code.bin:/usr/share/qemu/ovmf-x86_64-smm-opensuse-vars.bin",
-"/usr/share/qemu/ovmf-x86_64-ms-4m-code.bin:/usr/share/qemu/ovmf-x86_64-ms-4m-vars.bin",
-"/usr/share/qemu/ovmf-x86_64-smm-suse-code.bin:/usr/share/qemu/ovmf-x86_64-smm-suse-vars.bin",
-"/usr/share/qemu/ovmf-x86_64-ms-code.bin:/usr/share/qemu/ovmf-x86_64-ms-vars.bin",
-"/usr/share/qemu/ovmf-x86_64-smm-code.bin:/usr/share/qemu/ovmf-x86_64-smm-vars.bin",
-"/usr/share/qemu/ovmf-x86_64-opensuse-4m-code.bin:/usr/share/qemu/ovmf-x86_64-opensuse-4m-vars.bin",
-"/usr/share/qemu/ovmf-x86_64-suse-4m-code.bin:/usr/share/qemu/ovmf-x86_64-suse-4m-vars.bin",
-"/usr/share/qemu/ovmf-x86_64-suse-code.bin:/usr/share/qemu/ovmf-x86_64-suse-vars.bin",
-"/usr/share/qemu/ovmf-x86_64-opensuse-code.bin:/usr/share/qemu/ovmf-x86_64-opensuse-vars.bin",
-"/usr/share/qemu/ovmf-x86_64-code.bin:/usr/share/qemu/ovmf-x86_64-vars.bin",
-]
-</screen>
-    </step>
-   </procedure>
   </sect2>
 
   <sect2 xml:id="gpu-passthru-reboot">


### PR DESCRIPTION
Specifying the various ovmf firmware with the 'nvram' setting in /etc/libvirt/qemu.conf is deprecated in favor of firmware autoselection, which is already documented in the section "Installing UEFI support". Remove the old, outdated information.

### PR creator: Description

Fix outdated section of the VT doc.


### PR creator: Are there any relevant issues/feature requests?

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
