### PR TITLE
vt-doc: Describe setting vCPU address size for large VMs

### DIFF
--- a/xml/libvirt_configuration_gui.xml
+++ b/xml/libvirt_configuration_gui.xml
@@ -283,8 +283,14 @@
    <important>
     <title>Large memory &vmguest;s</title>
     <para>
-      &vmguest;s with memory requirements of 4TB or more currently need to
-      use the <literal>host-passthrough</literal> CPU model.
+     &vmguest;s with memory requirements of 4TB or more must either use the
+     <literal>host-passthrough</literal> CPU mode, or explicitly specify the
+     virtual CPU address size when using <literal>host-model</literal> or
+     <literal>custom</literal> CPU modes. The default virtual CPU address size
+     for these modes may not be sufficient for memory configurations of 4TB or
+     more. The address size can only be specified by editing the &vmguest;s
+     XML configuration. See <xref linkend="sec-libvirt-config-memory-virsh"/>
+     for more information on specifying virtual CPU address size.
     </para>
    </important>
   </sect2>

--- a/xml/libvirt_configuration_virsh.xml
+++ b/xml/libvirt_configuration_virsh.xml
@@ -595,8 +595,25 @@ Used memory:    8388608 KiB
   <important>
    <title>Large memory &vmguest;s</title>
    <para>
-    &vmguest;s with memory requirements of 4TB or more must currently
-    use the <literal>host-passthrough</literal> CPU model.
+    &vmguest;s with memory requirements of 4TB or more must either use the
+    <literal>host-passthrough</literal> CPU mode, or explicitly specify the
+    virtual CPU address size when using <literal>host-model</literal> or
+    <literal>custom</literal> CPU modes. The default virtual CPU address size
+    may not be sufficient for memory configurations of 4TB or more. The
+    following example shows how to use the &vmhost;'s physical CPU address
+    size when using the <literal>host-model</literal> CPU mode.
+   </para>
+<screen>
+[...]
+&lt;cpu mode='host-model check='partial''&gt;
+&lt;maxphysaddr mode='passthrough'&gt;
+&lt;/cpu&gt;
+[...]</screen>
+   <para>
+    For more information on specifying virtual CPU address size, see the
+    <literal>maxphysaddr</literal> option in the
+    <citetitle>CPU model and topology</citetitle> documentation at
+    <link xlink:href="https://libvirt.org/formatdomain.html#cpu-model-and-topology"/>.     
    </para>
   </important>
  </sect1>


### PR DESCRIPTION
The VT doc currently stipulates VMs with >4TB of memory require 'host-passthrough' CPU mode. With the resolution of bug#1199583, it is now possible to use 'host-model' and 'custom' CPU modes with large memory VMs by increasing the default CPU address size using the new 'maxphysaddr' setting. Mention this in the existing notices about large memory VMs.

### PR creator: Description

Add note about increasing vCPU address size with the new 'maxphysaddr' element.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1199583


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
