### PR TITLE
STIG Hardening: minor fixes

### DIFF
--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -2448,8 +2448,7 @@ sle-live-patching 8c541494</screen>
    <para>
     This category allows hardening your system with &openscap; security
     policies. The first policy that was implemented is the
-    <literal>&stig; (&stiga;)</literal> by the <orgname>&disa;</orgname>;
-    more policies will be added in future releases.
+   <literal>&stig; (&stiga;)</literal> by the <orgname>&disa;</orgname>.
    </para>
    <para>
     Click to <guimenu>enable</guimenu> the security policy. Incompliant

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -2448,7 +2448,8 @@ sle-live-patching 8c541494</screen>
    <para>
     This category allows hardening your system with &openscap; security
     policies. The first policy that was implemented is the
-   <literal>&stig; (&stiga;)</literal> by the <orgname>&disa;</orgname>.
+   <literal>&stig; (&stiga;)</literal> by the <orgname>&disa;</orgname>
+   (<orgname>&disaa;</orgname>).
    </para>
    <para>
     Click to <guimenu>enable</guimenu> the security policy. Incompliant

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -2432,12 +2432,12 @@ sle-live-patching 8c541494</screen>
     (<xref linkend="sec-yast-install-proposal-sofware"/>).
    </para>
   </sect2>
-  <sect2 xml:id="sec-yast-install-proposal-security-profile">
+  <sect2 os="sles;sled" xml:id="sec-yast-install-proposal-security-profile">
    <!--
     FIXME cwickert 2023-02-09: JSC#SLE-25039; additional profiles will be added
     later and the implementation will likely change.
    -->
-   <title os="sles;sled"><guimenu>Security Profiles</guimenu></title>
+   <title><guimenu>Security Profiles</guimenu></title>
    <important>
     <title>Availability in &sle; 15 SP4</title>
     <para>

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -2476,8 +2476,12 @@ sle-live-patching 8c541494</screen>
     the remaining rules, a full SCAP remediation is performed on first boot. You
     can also perform a <guimenu>scan only</guimenu> or <guimenu>do
      nothing</guimenu> and manually remediate the system later with &openscap;.
-    For more information, refer to the article
+    For more information, refer to the articles
     <link xlink:href="https://documentation.suse.com/compliance/all/html/SLES-stig/article-stig.html"><citetitle>Hardening &sle; with STIG</citetitle></link>
+    and
+    <link
+     xlink:href="https://documentation.suse.com/compliance/all/html/SLES-openscap/article-openscap.html"><citetitle>Hardening
+      &sle; with &openscap;</citetitle></link>.
    </para>
   </sect2>
   <sect2 xml:id="sec-yast-install-proposal-network">

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -2447,8 +2447,9 @@ sle-live-patching 8c541494</screen>
    </important>
    <para>
     This category allows hardening your system with &openscap; security
-    policies. The first policy that was implemented is the <literal>&disa;
-     &stiga;</literal>; more policies will be added in future releases.
+    policies. The first policy that was implemented is the
+    <literal>&stig; (&stiga;)</literal> by the <orgname>&disa;</orgname>;
+    more policies will be added in future releases.
    </para>
    <para>
     Click to <guimenu>enable</guimenu> the security policy. Incompliant
@@ -2465,7 +2466,7 @@ sle-live-patching 8c541494</screen>
      from the beginning of the installation process, boot the system with the
      boot parameter
      <literal>YAST_SECURITY_POLICY=<replaceable>POLICY</replaceable></literal>.
-     To check for compliance with the &disa; &stiga;, use 
+     To check for compliance with the &disaa; &stiga;, use 
      <literal>YAST_SECURITY_POLICY=stig</literal>. For more information about
      boot parameters, refer to <xref linkend="cha-boot-parameters"/>.
     </para>

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -2460,7 +2460,7 @@ sle-live-patching 8c541494</screen>
    <tip>
     <title>Checking policy compliance during installation</title>
     <para>
-     If you don not want to wait for the <guimenu>Installation
+     If you do not want to wait for the <guimenu>Installation
       Settings</guimenu> screen but want the installer to check the settings
      from the beginning of the installation process, boot the system with the
      boot parameter
@@ -2472,7 +2472,7 @@ sle-live-patching 8c541494</screen>
    </tip>
    <para>
     The installer does not check all rules of the profile but only those
-    necesary for the installation or that are hard to fix afterward. To apply
+    necessary for the installation or that are hard to fix afterward. To apply
     the remaining rules, a full SCAP remediation is performed on first boot. You
     can also perform a <guimenu>scan only</guimenu> or <guimenu>do
      nothing</guimenu> and manually remediate the system later with &openscap;.


### PR DESCRIPTION
### PR creator: Description

Fixes the validity issue for openSUSE  by profiling the complete section for SLES/SLED.
Also fixed some typos and tweaked some entities. As OpenSCAP was mentioned for fixing
any remaining issues manually, added a link to the OpenSCAP paper, too.  


### PR creator: Are there any relevant issues/feature requests?
* jsc#SLE-25039


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
