### PR TITLE
Security Guide: add pointer to STIG document

### DIFF
--- a/xml/book_security.xml
+++ b/xml/book_security.xml
@@ -84,6 +84,7 @@
   <xi:include href="security_fips.xml"/>
   <!-- Moved to SUSE/doc-unversioned  Feb 23 2022 cschroder-->
   <xi:include os="sles" href="security_pcidss.xml"/>
+  <xi:include os="sles" href="security_stig.xml"/>
  </part>
 
  <part xml:id="part-apparmor">

--- a/xml/security_stig.xml
+++ b/xml/security_stig.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE chapter
+[
+  <!ENTITY % entities SYSTEM "generic-entities.ent">
+    %entities;
+]>
+
+<chapter os="sles"
+       xmlns="http://docbook.org/ns/docbook"
+       xmlns:xi="http://www.w3.org/2001/XInclude"
+       xmlns:xlink="http://www.w3.org/1999/xlink"
+       version="5.0"
+       xml:id="cha-security-stig">
+ <info>
+  <title>Hardening &sle; with &stiga;</title>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:translation>yes</dm:translation>
+  </dm:docmanager>
+ </info>
+
+ <para>
+  &stiga; stands for <literal>&stig;</literal>.
+  The <orgname>&disa; (&disaa;)</orgname> organization, which is a parent
+  agency of the United States <orgname>Department of Defense (DoD)</orgname>,
+  approves and publishes <systemitem>&stig;s (&stiga;s)</systemitem> and
+  updates them every 90 days.
+ </para>
+
+ <para>
+  When a &stig; is implemented for a system, the system is hardened. The goals
+  are to minimize attacks and to prevent system access (both physically and
+  via a network) and to define processes for maintenance (applying software updates)
+  and vulnerability patching. &stig;s can also cover configuration settings,
+  for example for operating systems, routers, databases, firewalls, domain name
+  servers and switches.
+ </para>
+ <para>
+  For information on how to harden a &sle; system with &stiga;, see 
+  <link
+   xlink:href="https://documentation.suse.com/compliance/all/html/SLES-stig/article-stig.html"/>.
+ </para>
+</chapter>

--- a/xml/security_stig.xml
+++ b/xml/security_stig.xml
@@ -31,7 +31,7 @@
   are to minimize attacks and to prevent system access (both physically and
   via a network) and to define processes for maintenance (applying software updates)
   and vulnerability patching. &stig;s can also cover configuration settings,
-  for example for operating systems, routers, databases, firewalls, domain name
+  for example, for operating systems, routers, databases, firewalls, domain name
   servers and switches.
  </para>
  <para>


### PR DESCRIPTION
### PR creator: Description

See title, as proposed by Ivan from the Sec Cert team. Do not merge before we have published the STIG paper, otherwise the link will be broken.


### PR creator: Are there any relevant issues/feature requests?

Related to:
* jsc#DOCTEAM-616
* jsc#DOCTEAM-821


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
