### PR TITLE
[RMT] Fix install command with helm

### DIFF
--- a/xml/rmt_install.xml
+++ b/xml/rmt_install.xml
@@ -224,7 +224,7 @@
     all parameters are documented and their default values are defined. You can
     override these values by providing your own values file, for example:
    </para>
-   <screen>&prompt.user;cat &lt;&lt; EOF > myvalues.yaml
+   <screen>&prompt.user;cat &lt;&lt; EOF > rmt-config.yaml
 ---
 app:
   storage:
@@ -257,7 +257,7 @@ EOF
  <para>
   And to install RMT, run:
  </para>
-<screen>&prompt.user;helm install rmtsle oci://registry.suse.com/suse/rmt-helm -f myvalues-sle.yaml</screen> 
+<screen>&prompt.user;helm install rmtsle oci://registry.suse.com/suse/rmt-helm -f rmt-config.yaml</screen> 
    <sect3 xml:id="sec-rmt-helm-required-values">
     <title>Required values</title>
     <variablelist>

--- a/xml/rmt_install.xml
+++ b/xml/rmt_install.xml
@@ -257,7 +257,7 @@ EOF
  <para>
   And to install RMT, run:
  </para>
-<screen>&prompt.user;helm install rmtsle rmt/rmt-helm-0.1 -f myvalues-sle.yaml</screen> 
+<screen>&prompt.user;helm install rmtsle oci://registry.suse.com/suse/rmt-helm -f myvalues-sle.yaml</screen> 
    <sect3 xml:id="sec-rmt-helm-required-values">
     <title>Required values</title>
     <variablelist>


### PR DESCRIPTION
The original command would return an error, since Helm does not know where to get `rmt/rmt-helm-0.1` from.

### PR creator: Description

Fix small (but significant) issues in the RMT installation docs with kubernetes.


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
