### PR TITLE
Correct SELinux Documentation for 15 SP5/SP4 (bsc#1208592) 

### DIFF
--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -403,7 +403,7 @@ SELinux-Legacy</command></screen>
     Before switching into enforcing mode, make sure to first reset the
     security context (extended attributes):
    </para>
-  <screen>&prompt.sudo;<command>restorecon -R /*</command></screen>
+  <screen>&prompt.sudo;<command>restorecon -R /</command></screen>
 
   <para>
    Now you can put &selnx; into enforcing mode by setting the following parameter

--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -329,61 +329,28 @@ SELinux-Legacy</command></screen>
  <sect1 xml:id="sec-selinux-mode-permissive">
    <title>Putting &selnx; into permissive mode</title>
   <para>
-   After installing the &selnx; packages, modify the &grub; boot
-   loader as follows, either by editing <filename>/etc/default/grub</filename>,
-   or with &yast;.
-  </para>
-  <example xml:id="ex-sec-selinux-grubcfg">
-   <title>&grub; configuration file with &selnx;</title>
-   <para>
-    In <filename>/etc/default/grub</filename>, add the following parameters
-    to the <literal>GRUB_CMDLINE_LINUX_DEFAULT=</literal> line:
-   </para>
-  <screen>security=selinux<co xml:id="co-security"/> selinux=1<co xml:id="co-selinux"/> enforcing=0<co xml:id="co-enforcing"/></screen>
-  <calloutlist>
-   <callout arearefs="co-security">
-    <para>
-     This parameter tells the kernel to use &selnx; and not &aa;.
-    </para>
-   </callout>
-   <callout arearefs="co-selinux">
-    <para>
-     This parameter enables &selnx;.
-    </para>
-   </callout>
-   <callout arearefs="co-enforcing">
-    <para>
-     This parameter defines the mode in which to run &selnx;. Setting it
-     to <literal>0</literal> puts &selnx; in permissive mode. In this mode,
-     &selnx; is fully functional, but does not enforce any of the security settings in
-     the policy. In permissive mode, &selnx; does not protect your system but it still logs
-     everything that happens. Use this mode for testing and configuring your system.
-    </para>
-    <para>
-     After you have completed the &selnx; configuration, you can set the
-     parameter to <literal>1</literal> to run &selnx; in enforcing mode. In this mode,
-     it enforces the &selnx; policy and denies access based on policy rules.
-    </para>
-   </callout>
-  </calloutlist>
-  </example>
-  <para>
-   After you have added the parameters in <filename>/etc/default/grub</filename>,
-   run the <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>
-   command to rebuild your &grub; configuration.
+   In permissive mode, &selnx; does not protect your system but it still logs
+   everything that happens. Use this mode for testing and configuring your system.
   </para>
   <para>
-   Alternatively, to modify the bootloader via &yast;, open <menuchoice><guimenu>System</guimenu>
-   <guimenu>Boot Loader</guimenu><guimenu>Kernel Parameters</guimenu></menuchoice>.
-   Add the following line to the <guimenu>Optional Kernel Command Line Parameters</guimenu>:
-   <literal>security=selinux selinux=1 enforcing=0</literal>
+   In <filename>/etc/selinux/config</filename>, &selnx; is set to permissive mode
+   by default.
   </para>
-
+  <para>
+   To enable the use of &selnx; for your system, modify the &grub; boot
+   loader. In <filename>/etc/default/grub</filename>, search for the line
+   <literal>GRUB_CMDLINE_LINUX_DEFAULT=</literal>. Add the following two parameters:
+  </para>
+  <screen>security=selinux selinux=1</screen>
+  <para>
+   The first parameter tells the kernel to use &selnx; and not &aa;. The second parameter enables &selnx;.
+   After adding the parameters, rebuild your &grub; configuration with the following command:
+  </para>
+  <screen>grub2-mkconfig -o /boot/grub2/grub.cfg</screen>
   <para>
    Now you can reboot.
     At this point you have a completely functional &selnx; system, and it is
-    time to further configure it. In the current status, &selnx; is
-    operational but not in enforcing mode. This means that it does not limit
+    time to further configure it. In the current status, &selnx; does not limit
     any activities and logs everything that it should be doing if it
     were in enforcing mode. Review the log files to learn what activities
     are not allowed.
@@ -406,11 +373,19 @@ SELinux-Legacy</command></screen>
   <screen>&prompt.sudo;<command>restorecon -R /</command></screen>
 
   <para>
-   Now you can put &selnx; into enforcing mode by setting the following parameter
-   in the &grub; configuration file: <parameter>enforcing=1</parameter>. For context,
-   see <xref linkend="ex-sec-selinux-grubcfg"/>.
-   Then edit <filename>/etc/selinux/config</filename> and make sure
-   <option>SELINUX=enforcing</option> is set.
+   Now you can put &selnx; into enforcing mode. For this, edit
+   <filename>/etc/selinux/config</filename> and set
+   <option>SELINUX=enforcing</option>.
+   As next step, edit <filename>/etc/default/grub</filename> and
+   add <literal>enforcing=1</literal> to <literal>GRUB_CMDLINE_LINUX_DEFAULT=</literal>.
+   The line should now contain the following parameters which are relevant for &selnx;:
+  </para>
+  <screen>security=selinux selinux=1 enforcing=1</screen>
+  <para>
+   Rebuild your &grub; configuration with
+   <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>.
+   At the next reboot, the &selnx; policy will be enforced
+   and access will be denied based on policy rules.
   </para>
   <para>Reboot your server and see if it still comes up the way you expect
    it to and if you can still log in.

--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -376,16 +376,6 @@ SELinux-Legacy</command></screen>
    Now you can put &selnx; into enforcing mode. For this, edit
    <filename>/etc/selinux/config</filename> and set
    <option>SELINUX=enforcing</option>.
-   As next step, edit <filename>/etc/default/grub</filename> and
-   add <literal>enforcing=1</literal> to <literal>GRUB_CMDLINE_LINUX_DEFAULT=</literal>.
-   The line should now contain the following parameters which are relevant for &selnx;:
-  </para>
-  <screen>security=selinux selinux=1 enforcing=1</screen>
-  <para>
-   Rebuild your &grub; configuration with
-   <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>.
-   At the next reboot, the &selnx; policy will be enforced
-   and access will be denied based on policy rules.
   </para>
   <para>Reboot your server and see if it still comes up the way you expect
    it to and if you can still log in.


### PR DESCRIPTION
### PR creator: Description

Add corrections suggested by @jsegitz: correct `restorecon`  command and remove (unneeded) `enforcing=0` boot parameter for permissive mode.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1208592
* jsc#DOCTEAM-906


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
