### PR TITLE
doc-kit - move to docbook5-book flavor (SLE15SP2)

### DIFF
--- a/DC-SLED-admin
+++ b/DC-SLED-admin
@@ -10,6 +10,7 @@ ROOTID=book-sle-admin
 ## Profiling
 PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLED-all
+++ b/DC-SLED-all
@@ -9,6 +9,7 @@ MAIN="MAIN.SLEDS.xml"
 ## Profiling
 PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLED-deployment
+++ b/DC-SLED-deployment
@@ -10,6 +10,7 @@ ROOTID=book-sle-deployment
 ## Profiling
 PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLED-gnomeuser
+++ b/DC-SLED-gnomeuser
@@ -10,6 +10,7 @@ ROOTID=book-gnomeuser
 ## Profiling
 PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLED-html
+++ b/DC-SLED-html
@@ -9,6 +9,7 @@ MAIN="MAIN.SLEDS.xml"
 ## Profiling
 PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLED-installquick
+++ b/DC-SLED-installquick
@@ -10,6 +10,7 @@ ROOTID=art-sle-installquick
 ## Profiling
 PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLED-modulesquick
+++ b/DC-SLED-modulesquick
@@ -10,6 +10,7 @@ ROOTID=art-modules
 ## Profiling
 PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLED-security
+++ b/DC-SLED-security
@@ -10,6 +10,7 @@ ROOTID=book-security
 ## Profiling
 PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLED-tuning
+++ b/DC-SLED-tuning
@@ -10,6 +10,7 @@ ROOTID=book-sle-tuning
 ## Profiling
 PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLED-upgrade
+++ b/DC-SLED-upgrade
@@ -10,6 +10,7 @@ ROOTID=book-sle-upgrade
 ## Profiling
 PROFOS="sled"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLES-admin
+++ b/DC-SLES-admin
@@ -10,6 +10,7 @@ ROOTID=book-sle-admin
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLES-all
+++ b/DC-SLES-all
@@ -9,6 +9,7 @@ MAIN="MAIN.SLEDS.xml"
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLES-amd-sev
+++ b/DC-SLES-amd-sev
@@ -10,6 +10,7 @@ ROOTID=art-amd-sev
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 
 ## stylesheet location

--- a/DC-SLES-autoyast
+++ b/DC-SLES-autoyast
@@ -10,6 +10,7 @@ ROOTID=book-autoyast
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLES-container
+++ b/DC-SLES-container
@@ -10,6 +10,7 @@ ROOTID=book-container
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLES-deployment
+++ b/DC-SLES-deployment
@@ -10,6 +10,7 @@ ROOTID=book-sle-deployment
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLES-gnomeuser
+++ b/DC-SLES-gnomeuser
@@ -10,6 +10,7 @@ ROOTID=book-gnomeuser
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLES-html
+++ b/DC-SLES-html
@@ -9,6 +9,7 @@ MAIN="MAIN.SLEDS.xml"
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLES-installquick
+++ b/DC-SLES-installquick
@@ -10,6 +10,7 @@ ROOTID=art-sle-installquick
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLES-jeos
+++ b/DC-SLES-jeos
@@ -10,6 +10,7 @@ ROOTID=art-jeos-quickstart
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLES-modulesquick
+++ b/DC-SLES-modulesquick
@@ -10,6 +10,7 @@ ROOTID=art-modules
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLES-rmt
+++ b/DC-SLES-rmt
@@ -10,6 +10,7 @@ ROOTID=book-rmt
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLES-rpi-quick
+++ b/DC-SLES-rpi-quick
@@ -10,6 +10,7 @@ ROOTID=art-rpiquick
 ## Profiling
 PROFOS="sles"
 PROFARCH="aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLES-security
+++ b/DC-SLES-security
@@ -10,6 +10,7 @@ ROOTID=book-security
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLES-storage
+++ b/DC-SLES-storage
@@ -10,6 +10,7 @@ ROOTID=book-storage
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLES-tuning
+++ b/DC-SLES-tuning
@@ -10,6 +10,7 @@ ROOTID=book-sle-tuning
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLES-upgrade
+++ b/DC-SLES-upgrade
@@ -10,6 +10,7 @@ ROOTID=book-sle-upgrade
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLES-virtualization
+++ b/DC-SLES-virtualization
@@ -10,6 +10,7 @@ ROOTID=book-virt
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLES-vt-best-practices
+++ b/DC-SLES-vt-best-practices
@@ -10,6 +10,7 @@ ROOTID=article-vt-best-practices
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-SLES-xen2kvmquick
+++ b/DC-SLES-xen2kvmquick
@@ -10,6 +10,7 @@ ROOTID=art-sles-xen2kvmquick
 ## Profiling
 PROFOS="sles"
 PROFARCH="x86_64;zseries;power;aarch64"
+PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"

--- a/DC-opensuse-all
+++ b/DC-opensuse-all
@@ -9,6 +9,7 @@ MAIN="MAIN.opensuse.xml"
 ## Profiling
 PROFOS="osuse"
 PROFARCH="x86_64"
+PROFCONDITION="community-project"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/opensuse2013-ns"

--- a/DC-opensuse-autoyast
+++ b/DC-opensuse-autoyast
@@ -10,6 +10,7 @@ ROOTID=book-autoyast
 ## Profiling
 PROFOS="osuse"
 PROFARCH="x86_64"
+PROFCONDITION="community-project"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/opensuse2013-ns"

--- a/DC-opensuse-gnomeuser
+++ b/DC-opensuse-gnomeuser
@@ -10,6 +10,7 @@ ROOTID=book-gnomeuser
 ## Profiling
 PROFOS="osuse"
 PROFARCH="x86_64"
+PROFCONDITION="community-project"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/opensuse2013-ns"

--- a/DC-opensuse-reference
+++ b/DC-opensuse-reference
@@ -10,6 +10,7 @@ ROOTID=book-opensuse-reference
 ## Profiling
 PROFOS="osuse"
 PROFARCH="x86_64"
+PROFCONDITION="community-project"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/opensuse2013-ns"

--- a/DC-opensuse-security
+++ b/DC-opensuse-security
@@ -10,6 +10,7 @@ ROOTID=book-security
 ## Profiling
 PROFOS="osuse"
 PROFARCH="x86_64"
+PROFCONDITION="community-project"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/opensuse2013-ns"

--- a/DC-opensuse-startup
+++ b/DC-opensuse-startup
@@ -10,6 +10,7 @@ ROOTID=book-opensuse-startup
 ## Profiling
 PROFOS="osuse"
 PROFARCH="x86_64"
+PROFCONDITION="community-project"
 
 ## Provo
 HTMLROOT="sles15"

--- a/DC-opensuse-tuning
+++ b/DC-opensuse-tuning
@@ -10,6 +10,7 @@ ROOTID=book-sle-tuning
 ## Profiling
 PROFOS="osuse"
 PROFARCH="x86_64"
+PROFCONDITION="community-project"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/opensuse2013-ns"

--- a/DC-opensuse-virtualization
+++ b/DC-opensuse-virtualization
@@ -10,6 +10,7 @@ ROOTID=book-virt
 ## Profiling
 PROFOS="osuse"
 PROFARCH="x86_64"
+PROFCONDITION="community-project"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/opensuse2013-ns"


### PR DESCRIPTION
### PR creator: Description

Move to another doc-kit flavor ( `docbook5-entities-only` -> `docbook5-book`) to also make it possible to update the common intro files (which are excluded with the current doc-kit flavor).

### PR creator: Are there any relevant issues/feature requests?

* jsc#DOCTEAM-77


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.
  - [x] SLE 15 SP4/openSUSE Leap 15.4