### PR TITLE
Fix RMT/SMT comparison table

### DIFF
--- a/xml/rmt_migrate_from_smt.xml
+++ b/xml/rmt_migrate_from_smt.xml
@@ -505,7 +505,7 @@
       </entry>
       <entry>
        <para>
-        no
+        yes
        </para>
       </entry>
      </row>


### PR DESCRIPTION
### PR creator: Description

RMT does in fact support forwarding system registration data to SCC.
This PR fixes the RMT/SMT comparison table to fix that incorrect piece of information.

### PR creator: Are there any relevant issues/feature requests?

No.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
