### PR TITLE
Fix typo

### DIFF
--- a/xml/tuning_kprobes.xml
+++ b/xml/tuning_kprobes.xml
@@ -339,7 +339,7 @@ c03dedc5  r  tcp_v4_rcv+0x0</screen>
     <para>
      Thorough but more technically oriented information about kernel probes
      is in <filename>/usr/src/linux/Documentation/kprobes.txt</filename>
-     (package <systemitem>kenrel-source</systemitem>).
+     (package <systemitem>kernel-source</systemitem>).
     </para>
    </listitem>
    <listitem>
@@ -347,7 +347,7 @@ c03dedc5  r  tcp_v4_rcv+0x0</screen>
      Examples of all three types of probes (together with related
      <filename>Makefile</filename>) are in the
      <filename>/usr/src/linux/samples/kprobes/</filename> directory (package
-     <systemitem>kenrel-source</systemitem>).
+     <systemitem>kernel-source</systemitem>).
     </para>
    </listitem>
    <listitem>


### PR DESCRIPTION
### Which product versions do the changes apply to?

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

> The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
