### PR TITLE
AutoYaST -> OpenSCAP: Make sure ssg-apply gets found (BSC#1209400)

### DIFF
--- a/xml/ay_security_settings.xml
+++ b/xml/ay_security_settings.xml
@@ -185,10 +185,27 @@
   </itemizedlist>
 
   <important os="sles;sled">
-    <title>Availability in &sle; 15 SP4</title>
-    <para>
-     This feature is available for &sle; 15 SP4 GM via self-update or using the QU2 media.
-    </para>
+   <title>Availability in &sle; 15 SP4</title>
+   <para>
+    This feature is available for &sle; 15 SP4 GM via self-update or using the QU2 media. Make sure
+    to enable updates during installation with
+    <literal>&lt;install_updates t="boolean"&gt;true&lt;/install_updates&gt;</literal> in the
+    <literal>&lt;suse_register&gt;</literal> section (see <xref linkend="CreateProfile-Register"/>).
+   </para>
+   <para>
+    If you install without internet connection, add the the
+    <literal>Basesystem</literal> module from the QU2 medium to the
+    <literal>&lt;add_on_products&gt;</literal> section:
+   </para>
+<screen><![CDATA[
+<listentry t="map">
+  <media_url>relurl://</media_url>
+  <product>sle-module-basesystem</product>
+  <product_dir>/Module-Basesystem</product_dir>
+</listentry>]]></screen>
+   <para>
+    For more information, refer to <xref linkend="Software-Selections-additional"/>.
+   </para>
   </important>
 
   <para>


### PR DESCRIPTION
### PR creator: Description

SLE 15 SP4 OU2 supports system hardening with OpenSCAP. The required 'ssg-apply' utility however only gets found if you use the 'Basesystem' module from the media or enable online updates during installation. We did not take this into account in #1393.

### PR creator: Are there any relevant issues/feature requests?

* [bsc#...](https://bugzilla.suse.com/show_bug.cgi?id=1209400)
* [jsc#...](https://jira.suse.com/browse/DOCTEAM-937)

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
