### PR TITLE
AY Guide: Config Options - correct default value

### DIFF
--- a/xml/ay_general_options.xml
+++ b/xml/ay_general_options.xml
@@ -713,10 +713,10 @@
    is done by setting the &ay; parameter with the same name to
    <literal>true</literal>. Setting this value is optional and only applies to
    installations on &zseries; hardware. The default is
-   <literal>false</literal>.
+   <literal>true</literal>.
   </para>
 <screen><![CDATA[<general>
- <cio_ignore config:type="boolean">false</cio_ignore>
+ <cio_ignore config:type="boolean">true</cio_ignore>
  ...
 <general>]]></screen>
  </sect2>


### PR DESCRIPTION
### PR creator: Description

AutoYaST Guide: Correcting the default value for blacklisting unused devices on IBM Z.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1207426
* jsc#DOCTEAM-896


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
