### PR TITLE
Admin Guide: make systemd journal persistent

### DIFF
--- a/xml/journalctl.xml
+++ b/xml/journalctl.xml
@@ -43,38 +43,19 @@ systemd-journald.service - Journal Service
   <para>
    The journal stores log data in <filename>/run/log/journal/</filename> by
    default. Because the <filename>/run/</filename> directory is volatile by
-   nature, log data is lost at reboot. To make the log data persistent, the
-   directory <filename>/var/log/journal/</filename> must exist with correct
-   ownership and permissions so the systemd-journald service can store its
-   data. &systemd; will create the directory for you&mdash;and switch to
-   persistent logging&mdash;if you do the following:
+   nature, log data is lost at reboot. To make the log data persistent, create the
+   directory <filename>/var/log/journal/</filename> and make sure it
+   has the correct access modes and ownership, so the systemd-journald service can store its
+   data. To switch to persistent logging, execute the following commands:
   </para>
-
-  <procedure>
-   <step>
-    <para>
-     As &rootuser;, open <filename>/etc/systemd/journald.conf</filename> for
-     editing.
-    </para>
-<screen>&prompt.root;vi /etc/systemd/journald.conf</screen>
-   </step>
-   <step>
-    <para>
-     Uncomment the line containing <literal>Storage=</literal> and change it to
-    </para>
-<screen>[...]
-[Journal]
-Storage=persistent
-#Compress=yes
-[...]</screen>
-   </step>
-   <step>
-    <para>
-     Save the file and restart systemd-journald:
-    </para>
-<screen>&prompt.root;systemctl restart systemd-journald</screen>
-   </step>
-  </procedure>
+<screen>&prompt.sudo; mkdir /var/log/journal
+&prompt.sudo; systemd-tmpfiles --create --prefix=/var/log/journal
+&prompt.sudo; journalctl --flush
+</screen>
+  <para>
+   Any log data stored in <filename>/run/log/journal/</filename> will be flushed into
+   <filename>/var/log/journal/</filename>.
+  </para>
  </sect1>
  <sect1 xml:id="sec-journalctl-switches">
   <title><command>journalctl</command>: Useful switches</title>


### PR DESCRIPTION
### PR creator: Description

Adjust steps as requested in https://bugzilla.suse.com/show_bug.cgi?id=1196637#c28 after the software behavior has changed.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1196637
* jsc#DOCTEAM-895


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
