### PR TITLE
vt-doc: Remove note about large memory VMs requiring host-passthrough

### DIFF
--- a/xml/libvirt_configuration_gui.xml
+++ b/xml/libvirt_configuration_gui.xml
@@ -202,11 +202,9 @@
     The <literal>host-passthrough</literal> model provides the &vmguest; with a CPU that is exactly
     the same as the &vmhost; CPU. This can be useful when the &vmguest; workload
     requires CPU features not available in &libvirt;'s simplified <literal>host-model</literal> CPU.
-    The host-passthrough model is also required in some cases, for example, when running
-    &vmguest;s with more than 4TB of memory. The <literal>host-passthrough</literal> model comes
-    with the disadvantage of reduced migration capability. A &vmguest; with
-    <literal>host-passthrough</literal> model CPU can only be migrated to a &vmhost; with identical
-    hardware.
+    The <literal>host-passthrough</literal> model comes with the disadvantage of reduced migration
+    capability. A &vmguest; with <literal>host-passthrough</literal> model CPU can only be migrated
+    to a &vmhost; with identical hardware.
    </para>
    <para>
     For more information on &libvirt;'s CPU model and topology options, see

--- a/xml/libvirt_configuration_virsh.xml
+++ b/xml/libvirt_configuration_virsh.xml
@@ -349,11 +349,10 @@ current      live           4
     When starting a &vmguest; with CPU mode <literal>host-passthrough</literal>, it is presented
     with a CPU that is exactly the same as the &vmhost; CPU. This can be
     useful when the &vmguest; workload requires CPU features not available in
-    &libvirt;'s simplified <literal>host-model</literal> CPU. The <literal>host-passthrough</literal> CPU mode is
-    also required in some cases, for example, when running &vmguest;s with more than
-    4TB of memory. The <literal>host-passthrough</literal> CPU mode comes with the disadvantage of
-    reduced migration flexibility. A &vmguest; with <literal>host-passthrough</literal> CPU mode
-    can only be migrated to a &vmhost; with identical hardware.
+    &libvirt;'s simplified <literal>host-model</literal> CPU. The <literal>host-passthrough</literal>
+    CPU mode comes with the disadvantage of reduced migration flexibility. A &vmguest; with
+    <literal>host-passthrough</literal> CPU mode can only be migrated to a &vmhost; with identical
+    hardware.
    </para>
    <para>
     When using the <literal>host-passthrough</literal> CPU mode, it is still possible to


### PR DESCRIPTION
SLE15 SP4 and newer do not require host-passthrough CPU type for VMs with greater than 4TB of memory. It's possible to use a custom CPU type and increase the CPU address bits if necessary with <maxphysaddr>.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
