### PR TITLE
added the correct service name

### DIFF
--- a/xml/adm_wbem.xml
+++ b/xml/adm_wbem.xml
@@ -241,7 +241,7 @@
        </entry>
        <entry colname="2">
         <para>
-         Enter <command>systemctl start sfcb</command> as &rootuser; in the
+         Enter <command>systemctl start sblim-sfcb</command> as &rootuser; in the
          command line.
         </para>
        </entry>
@@ -254,7 +254,7 @@
        </entry>
        <entry colname="2">
         <para>
-         Enter <command>systemctl stop sfcb</command> as &rootuser; in the
+         Enter <command>systemctl stop sblim-sfcb</command> as &rootuser; in the
          command line.
         </para>
        </entry>
@@ -267,7 +267,7 @@
        </entry>
        <entry colname="2">
         <para>
-         Enter <command>systemctl status sfcb</command>as &rootuser; in the
+         Enter <command>systemctl status sblim-sfcb</command>as &rootuser; in the
          command line.
         </para>
        </entry>

--- a/xml/adm_wbem.xml
+++ b/xml/adm_wbem.xml
@@ -267,7 +267,7 @@
        </entry>
        <entry colname="2">
         <para>
-         Enter <command>systemctl status sblim-sfcb.service</command>as &rootuser; in the
+         Enter <command>systemctl status sblim-sfcb.service</command> as &rootuser; in the
          command line.
         </para>
        </entry>

--- a/xml/adm_wbem.xml
+++ b/xml/adm_wbem.xml
@@ -241,7 +241,7 @@
        </entry>
        <entry colname="2">
         <para>
-         Enter <command>systemctl start sblim-sfcb</command> as &rootuser; in the
+         Enter <command>systemctl start sblim-sfcb.service</command> as &rootuser; in the
          command line.
         </para>
        </entry>
@@ -254,7 +254,7 @@
        </entry>
        <entry colname="2">
         <para>
-         Enter <command>systemctl stop sblim-sfcb</command> as &rootuser; in the
+         Enter <command>systemctl stop sblim-sfcb.service</command> as &rootuser; in the
          command line.
         </para>
        </entry>
@@ -267,7 +267,7 @@
        </entry>
        <entry colname="2">
         <para>
-         Enter <command>systemctl status sblim-sfcb</command>as &rootuser; in the
+         Enter <command>systemctl status sblim-sfcb.service</command>as &rootuser; in the
          command line.
         </para>
        </entry>


### PR DESCRIPTION
### PR creator: Description

The current command syntax for the sfcbd daemon , is not correct and needs a prefix of 
`sblim`

### PR creator: Are there any relevant issues/feature requests?

[https://jira.suse.com/browse/DOCTEAM-699](DOCTEAM-699)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ x] SLE 15 SP4/openSUSE Leap 15.4
  - [ x] SLE 15 SP3/openSUSE Leap 15.3
  - [x ] SLE 15 SP2/openSUSE Leap 15.2
  - [ x] SLE 15 SP1
- SLE 12
  - [ x] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
