### PR TITLE
Fixed typo (bsc#1207682)

### DIFF
--- a/xml/tuning_memory.xml
+++ b/xml/tuning_memory.xml
@@ -47,7 +47,7 @@
       <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
         <dm:bugtracker>
         </dm:bugtracker>
-	<dm:translation>yes</dm:translation>
+        <dm:translation>yes</dm:translation>
       </dm:docmanager>
     </info>
     <para>
@@ -356,7 +356,7 @@
       the low watermark is reached then <command>kswapd</command> wakes to
       reclaim memory in the background. It stays awake until free memory
       reaches the high watermark. Applications will stall and reclaim
-      memory when the low watermark is reached.
+      memory when the min watermark is reached.
       </para>
       <para>
       The <literal>watermark_scale_factor</literal> defines the amount


### PR DESCRIPTION
- SLE 15/openSUSE Leap 15.x
  - [x ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ x] SLE 15 SP4/openSUSE Leap 15.4
  - [ x] SLE 15 SP3/openSUSE Leap 15.3
  - [ x] SLE 15 SP2/openSUSE Leap 15.2
  - [ x] SLE 15 SP1
- SLE 12
  - [ x] SLE 12 SP5
  - [ x] SLE 12 SP4

