### PR TITLE
AutoYaST: improve RAID documentation and fix wrong examples

### DIFF
--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -1626,11 +1626,11 @@
    </listitem>
   </itemizedlist>
   <para>
-   The following example shows a RAID1 configuration that uses a partition from
+   The following example shows a RAID10 configuration that uses a partition from
    the first disk and another one from the second disk as RAID members:
   </para>
   <example>
-   <title>RAID1 configuration</title>
+   <title>RAID10 configuration</title>
 <screen>&lt;partitioning config:type="list"&gt;
   &lt;drive&gt;
     &lt;device&gt;/dev/sda&lt;/device&gt;
@@ -1670,8 +1670,8 @@
     &lt;/partitions&gt;
     &lt;raid_options&gt;
       &lt;chunk_size&gt;4&lt;/chunk_size&gt;
-      &lt;parity_algorithm&gt;left_asymmetric&lt;/parity_algorithm&gt;
-      &lt;raid_type&gt;raid1&lt;/raid_type&gt;
+      &lt;parity_algorithm&gt;near_2&lt;/parity_algorithm&gt;
+      &lt;raid_type&gt;raid10&lt;/raid_type&gt;
     &lt;/raid_options&gt;
     &lt;use&gt;all&lt;/use&gt;
   &lt;/drive&gt;
@@ -1684,7 +1684,7 @@
    section is shown for simplicity's sake:
   </para>
   <example>
-   <title>RAID1 without partitions</title>
+   <title>RAID10 without partitions</title>
 <screen>&lt;drive&gt;
   &lt;device&gt;/dev/md/0&lt;/device&gt;
   &lt;disklabel&gt;none&lt;/disklabel&gt;
@@ -1696,8 +1696,8 @@
   &lt;/partitions&gt;
   &lt;raid_options&gt;
     &lt;chunk_size&gt;4&lt;/chunk_size&gt;
-    &lt;parity_algorithm&gt;left_asymmetric&lt;/parity_algorithm&gt;
-    &lt;raid_type&gt;raid1&lt;/raid_type&gt;
+    &lt;parity_algorithm&gt;near_2&lt;/parity_algorithm&gt;
+    &lt;raid_type&gt;raid10&lt;/raid_type&gt;
   &lt;/raid_options&gt;
   &lt;use&gt;all&lt;/use&gt;
 &lt;/drive&gt;</screen>
@@ -1742,7 +1742,7 @@
     </listitem>
    </itemizedlist>
    <example>
-    <title>Old style RAID1 configuration</title>
+    <title>Old style RAID10 configuration</title>
 <screen>&lt;partitioning config:type="list"&gt;
   &lt;drive&gt;
     &lt;device&gt;/dev/sda&lt;/device&gt;
@@ -1784,7 +1784,8 @@
         &lt;partition_nr config:type="integer"&gt;0&lt;/partition_nr&gt;
         &lt;raid_options&gt;
           &lt;chunk_size&gt;4&lt;/chunk_size&gt;
-          &lt;parity_algorithm&gt;left_asymmetric&lt;/parity_algorithm&gt;
+          &lt;parity_algorithm&gt;near_2&lt;/parity_algorithm&gt;
+          &lt;raid_type&gt;raid10&lt;/raid_type&gt;
         &lt;/raid_options&gt;
       &lt;/partition&gt;
     &lt;/partitions&gt;
@@ -1806,6 +1807,12 @@
    <variablelist>
     <varlistentry>
      <term>chunk_size</term>
+      <para>
+       Can be expressed as a size with the corresponding units (eg. "32M") or just as a
+       number. In the later case, the unit is assumed to be kilobytes. Since setting a
+       chunk size makes no sense in the case of RAID1, the option should not be specified
+       for such devices (bear in mind <literal>raid1</literal> is the default type).
+      </para>
      <listitem>
 <screen>&lt;chunk_size&gt;4&lt;/chunk_size&gt;</screen>
      </listitem>
@@ -1818,20 +1825,29 @@
       </para>
       <para>
        <literal>left_asymmetric</literal>, <literal>left_symmetric</literal>,
-       <literal>right_asymmetric</literal>, or
-       <literal>right_symmetric</literal>.
-      </para>
-      <para>
-       For RAID6 and RAID10, the following values can be used:
-      </para>
-      <para>
-       <literal>parity_first</literal>, <literal>parity_last</literal>,
+       <literal>right_asymmetric</literal>, <literal>right_symmetric</literal>,
+       <literal>first</literal>, <literal>last</literal>, <literal>first_6</literal>,
        <literal>left_asymmetric_6</literal>,
        <literal>left_symmetric_6</literal>,
        <literal>right_asymmetric_6</literal>,
-       <literal>right_symmetric_6</literal>, <literal>parity_first_6</literal>,
+       <literal>right_symmetric_6</literal>,
+       <literal>near_2</literal>, <literal>offset_2</literal>, <literal>far_2</literal>,
+       <literal>near_3</literal>, <literal>offset_3</literal>, or <literal>far_3</literal>.
+      </para>
+      <para>
+       For backwards compatibility with previous versions of AutoYaST, the following aliases
+       are also recognized:
+      </para>
+      <para>
+       <literal>parity_first</literal>, <literal>parity_last</literal>,
+       <literal>parity_first_6</literal>,
        <literal>n2</literal>, <literal>o2</literal>, <literal>f2</literal>,
-       <literal>n3</literal>, <literal>o3</literal>, or <literal>f3</literal>.
+       <literal>n3</literal>, <literal>o3</literal>, <literal>f3</literal>.
+      </para>
+      <para>
+       The accepted values for each RAID depend on the level (eg. <literal>raid5</literal>)
+       and the number of devices in the RAID. Since parity makes no sense for RAID0 or RAID1,
+       the option should not be specified for such devices.
       </para>
 <screen>&lt;parity_algorithm&gt;left_asymmetric&lt;/parity_algorithm&gt;</screen>
      </listitem>

--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -1808,10 +1808,10 @@
     <varlistentry>
      <term>chunk_size</term>
       <para>
-       Can be expressed as a number with the corresponding units (eg. "32M") or just as a
-       number. If the unit is omitted, kilobytes are used as the default unit. 
-       Do not specify <literal>chunk_size</literal> for RAID1.
-       Bear in mind <literal>raid1</literal> is the default type.
+       Can be expressed as a number with the corresponding units (for example, 
+       <chunk_size>32M</chunk_size>) or just as a number. If the unit is omitted, kilobytes 
+       are used as the default unit. Do not specify <literal>chunk_size</literal> for 
+       RAID1. Bear in mind that <literal>raid1</literal> is the default type.
       </para>
      <listitem>
 <screen>&lt;chunk_size&gt;4&lt;/chunk_size&gt;</screen>
@@ -1846,8 +1846,8 @@
       </para>
       <para>
        The accepted values for each RAID depend on the RAID level (eg. <literal>raid5</literal>)
-       and the number of devices in the RAID. Since RAID0 or RAID1 do not provide any parity,
-       do not specify this option for such devices.
+       and the number of devices in the RAID. Given that RAID0 or RAID1 do not provide 
+       any parity, do not specify this option for such devices.
       </para>
 <screen>&lt;parity_algorithm&gt;left_asymmetric&lt;/parity_algorithm&gt;</screen>
      </listitem>

--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -1808,10 +1808,10 @@
     <varlistentry>
      <term>chunk_size</term>
       <para>
-       Can be expressed as a size with the corresponding units (eg. "32M") or just as a
-       number. In the later case, the unit is assumed to be kilobytes. Since setting a
-       chunk size makes no sense in the case of RAID1, the option should not be specified
-       for such devices (bear in mind <literal>raid1</literal> is the default type).
+       Can be expressed as a number with the corresponding units (eg. "32M") or just as a
+       number. If the unit is omitted, kilobytes are used as the default unit. 
+       Do not specify <literal>chunk_size</literal> for RAID1.
+       Bear in mind <literal>raid1</literal> is the default type.
       </para>
      <listitem>
 <screen>&lt;chunk_size&gt;4&lt;/chunk_size&gt;</screen>
@@ -1845,9 +1845,9 @@
        <literal>n3</literal>, <literal>o3</literal>, <literal>f3</literal>.
       </para>
       <para>
-       The accepted values for each RAID depend on the level (eg. <literal>raid5</literal>)
-       and the number of devices in the RAID. Since parity makes no sense for RAID0 or RAID1,
-       the option should not be specified for such devices.
+       The accepted values for each RAID depend on the RAID level (eg. <literal>raid5</literal>)
+       and the number of devices in the RAID. Since RAID0 or RAID1 do not provide any parity,
+       do not specify this option for such devices.
       </para>
 <screen>&lt;parity_algorithm&gt;left_asymmetric&lt;/parity_algorithm&gt;</screen>
      </listitem>


### PR DESCRIPTION
### Detected problems

There are several problems with the current documentation of `<raid_options>`.

First of all, the identifiers for the different MD parities changed at SLE-15. That was originally unintended, we just realized now. To fix the situation, we implemented backwards compatibility for importing (reading) the profile. But exporting (cloning) the system will keep using the identifiers that were introduced at SLE-15. Pull request implementing the mentioned backwards compatibility - https://github.com/yast/yast-storage-ng/pull/1331.

The documentation stating which parities were valid for each RAID level was not correct. On the one hand, it was not very precise (for example, parity makes no sense for RAID0 or RAID1, but the original text seems to suggest it's ok). On the other hand, the criteria is actually a bit more complex (it depends on both the RAID level and the number of devices). 

Something similar happens with the chunk size. It's also pointless for RAID1 devices (including it will even produce an error) but that was not mentioned. Unveiled during the investigations for [bsc#1205172](https://bugzilla.suse.com/show_bug.cgi?id=1205172)

And finally, all that wrong information was used in several examples which looked like this:

```xml
  <raid_options>
    <chunk_size>4</chunk_size>
    <parity_algorithm>left_asymmetric</parity_algorithm>
    <raid_type>raid1</raid_type>
  </raid_options>
```

Fun enough, those examples summarize many of the previous points. They specify a chunk size for RAID1 (which leads to a failure) and an invalid parity (which would also produce an error). 

### Proposed solution

Use the new `<parity_algorithm>` identifiers with a mention to the legacy ones.

Simplify the description about which parities are acceptable for each RAID.

Extended documentation for `<chunk_size>`.

Adapted the examples to define a RAID10 instead of a RAID1. That level of RAID supports both chunk size and parity. I also adapted the used parity because the original `left_asymmetric` is not acceptable for RAID10 (it was not acceptable for RAID1 either). So at least now the examples wouldn't immediately produce an error if used as-is.

### Relevant links (already mentioned above)

* https://github.com/yast/yast-storage-ng/pull/1331
* https://bugzilla.suse.com/show_bug.cgi?id=1205172

### Which product versions do the changes apply to?

Strictly speaking, the information affects all service packs of SLE-15. Except for the backwards compatibility for old parity identifiers - that is only being introduced at SLE-15-SP5.

But I guess it's fine if we just fix documentation for SLE-15-SP5.

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
