### PR TITLE
Include Raspi Pi Quick in set

### DIFF
--- a/DC-SLES-raspberry-pi
+++ b/DC-SLES-raspberry-pi
@@ -4,12 +4,12 @@
 ## ----------------------------
 ##
 ## Basics
-MAIN="art_raspberry-pi.xml"
+MAIN="MAIN.SLEDS.xml"
 ROOTID=article-raspberry-pi
 
 ## Profiling
 PROFOS="sles"
-PROFARCH="aarch64"
+PROFARCH="x86_64;zseries;power;aarch64"
 PROFCONDITION="suse-product"
 
 ## stylesheet location

--- a/DEF-SLES-manuals
+++ b/DEF-SLES-manuals
@@ -7,6 +7,7 @@ pdfsub     SLES-gnome-user        common_copyright_gfdl.xml
 pdfsub     SLES-installation      common_copyright_gfdl.xml
 pdfsub     SLES-minimal-vm        common_copyright_gfdl.xml
 pdfsub     SLES-modules           common_copyright_gfdl.xml
+pdfsub     SLES-raspberry-pi      common_copyright_gfdl.xml
 pdfsub     SLES-rmt               common_copyright_gfdl.xml
 pdfsub     SLES-security          common_copyright_gfdl.xml
 pdfsub     SLES-storage           common_copyright_gfdl.xml

--- a/xml/MAIN.SLEDS.xml
+++ b/xml/MAIN.SLEDS.xml
@@ -122,6 +122,7 @@
   <xi:include os="sles" href="art_minimal-vm.xml"/>
   <xi:include os="sles" href="art_amd-sev.xml"/>
   <xi:include os="sles" href="art-nvidia-vgpu.xml"/>
+  <xi:include os="sles" href="art_raspberry-pi.xml"/>
   <xi:include href="common_legal.xml"/>
  </book>
 </set>

--- a/xml/art_raspberry-pi.xml
+++ b/xml/art_raspberry-pi.xml
@@ -25,13 +25,6 @@
   </author>
   <date><?dbtimestamp format="B d, Y"?></date>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:bugtracker>
-    <dm:url>https://bugzilla.suse.com/enter_bug.cgi</dm:url>
-    <dm:component>Documentation</dm:component>
-    <dm:product>PUBLIC SUSE Linux Enterprise Server 15 SP5</dm:product>
-    <dm:assignee>taroth@suse.com</dm:assignee>
-   </dm:bugtracker>
-   <dm:editurl>https://github.com/SUSE/doc-sle/edit/main/xml/</dm:editurl>
    <dm:translation>yes</dm:translation>
   </dm:docmanager>
   <abstract>


### PR DESCRIPTION
### PR creator: Description

We decided to move the Raspberry Pi Quick Start into the set. 

This has the following advantages:

- The Bugzilla information is inherited from the set and does not need to be updated individually for the Quick Start with each new SP.

- During localization hand-off, the Quick Start can be treated like any other deliverable (can be 'locdropped' with a DEF file).  

I also compared PDF and HTML builds before and after the changes: everything looks good. 

### PR creator: Are there any relevant issues/feature requests?

* see [internal locdrop howto](https://confluence.suse.com/display/documentation/Performing+a+loc+drop)



### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

