### PR TITLE
proofing corrections GNOME

### DIFF
--- a/xml/apps_firefox.xml
+++ b/xml/apps_firefox.xml
@@ -83,13 +83,13 @@
 <title>The menu bar</title>
 <para>
     While most functions of <productname>Firefox</productname> are available
-    through the menu button (&hamburger-icon;), some are only available
+    through the menu button, some are only available
     from the menu bar.
    </para>
    <sect3>
    <title>Using the menu bar</title>
 <para>
-    The menu bar of <productname>Firefox</productname> is hidden by default.
+    The <productname>Firefox</productname> menu bar is hidden by default.
     </para>
     <variablelist>
     <varlistentry>
@@ -245,7 +245,7 @@
     <procedure>
      <step>
       <para>
-       Click the menu button (&hamburger-icon;) to the right of the search bar.
+       Click the menu button to the right of the search bar.
       </para>
      </step>
      <step>
@@ -312,7 +312,7 @@
     </para>
     <para>
      To assign a shortcut for a search engine from the search bar, click the
-     menu button (&hamburger-icon;) to the right of the search bar and
+     menu button to the right of the search bar and
      select <menuchoice>
      <guimenu>Settings</guimenu><guimenu>Search</guimenu></menuchoice>. 
      In the <guimenu>Search Shortcuts</guimenu> section, select a search engine,

--- a/xml/apps_libreoffice.xml
+++ b/xml/apps_libreoffice.xml
@@ -662,8 +662,8 @@
    </step>
    <step>
     <para>
-     Go to the certificates preferences by opening the menu
-     (&hamburger-icon;), then select
+     Go to the certificates preferences by clicking on the menu button,
+     then select
      <menuchoice><guimenu>Settings</guimenu>
       <guimenu>Privacy &amp; Security</guimenu></menuchoice>.
     </para>


### PR DESCRIPTION
Corrections from proofing drop implemented

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
