### PR TITLE
Storage Guide: integrate proofing corrections

### DIFF
--- a/xml/common_intro_available_doc.xml
+++ b/xml/common_intro_available_doc.xml
@@ -35,8 +35,8 @@
     <note>
      <title>Latest updates</title>
      <para>
-      The latest updates are usually available in the English
-      language version of this documentation.
+      The latest updates are usually available in the English-language 
+      version of this documentation.
      </para>
     </note>
    </listitem>

--- a/xml/storage_lvm.xml
+++ b/xml/storage_lvm.xml
@@ -1037,8 +1037,8 @@ root's password:
 
   <para>
    If there is an error on the LVM storage, the scanning of LVM volumes may
-   prevent entering the emergency/rescue shell. Thus, further problem diagnosis
-   is not possible. To disable this scanning in case of an LVM storage failure,
+   prevent the emergency/rescue shell from being entered. This makes further problem diagnosis
+   impossible. To disable this scanning in case of an LVM storage failure,
    you can pass the <option>nolvm</option> option on the kernel command line.
   </para>
  </sect1>

--- a/xml/storage_multipath.xml
+++ b/xml/storage_multipath.xml
@@ -104,7 +104,7 @@
       <para>
        An event sent by the kernel to user space and processed by the
        <command>udev</command> subsystem. Uevents are generated when devices
-       are added, removed, or change their properties.
+       are added or removed, or when they change their properties.
       </para>
      </listitem>
     </varlistentry>
@@ -555,10 +555,10 @@
   <para>
    The offline update of your system is similar to the fresh installation as
    described in <xref linkend="sec-multipath-installing"/>. There is no
-   <literal>blacklist</literal>, thus if the user selects to enable multipath,
+   <literal>blacklist</literal>, so if the user selects to enable multipath,
    the root device will appear as a multipath device, even if it is normally
-   not. When <command>dracut</command> builds the initramfs during the update
-   procedure, it sees a different storage stack as it would see on the booted
+   not one. When <command>dracut</command> builds the initramfs during the update
+   procedure, it sees a different storage stack than it would see on the booted
    system. See <xref linkend="sec-multipath-initrd-persistent"/> and
    <xref linkend="sec-multipath-referring"/>.
   </para>
@@ -1013,7 +1013,7 @@
      <term>multipath -T</term>
      <listitem>
       <para>
-       Has a similar function as the <command>multipath -t</command> command
+       Has a similar function to the <command>multipath -t</command> command
        but shows only hardware entries matching the hardware detected on the
        host.
       </para>
@@ -1194,7 +1194,7 @@
      We strongly recommend keeping <filename>multipathd.service</filename>
      always enabled and running on systems with multipath hardware. The service
      does support <command>systemd</command>'s socket activation mechanism, but
-     it is discouraged to rely on that. Multipath maps will not be set up
+     we do not recommend that you rely on that. Multipath maps will not be set up
      during boot if the service is disabled.
     </para>
    </warning>
@@ -1451,7 +1451,7 @@
    <title><filename>multipath.conf</filename> syntax</title>
    <para>
     The <filename>/etc/multipath.conf</filename> file uses a hierarchy of
-    sections, subsections, and option/value pairs.
+    sections, subsections and option/value pairs.
    </para>
    <itemizedlist>
     <listitem>
@@ -1525,7 +1525,7 @@ section {
      multiple times. If <emphasis>the same option in the same
      section</emphasis> is set in multiple files, or on multiple lines in the
      same file, the last value takes precedence. Separate precedence rules
-     apply between <filename>multipath.conf</filename> sections, see below.
+     apply between <filename>multipath.conf</filename> sections. See below.
     </para>
    </sect3>
   </sect2>
@@ -2371,7 +2371,7 @@ defaults {
    </informalexample>
    <para>
     By default, <systemitem>multipath-tools</systemitem> ignores all devices
-    except SCSI, DASD, or NVMe. Technically, the built-in devnode exclude list
+    except SCSI, DASD or NVMe. Technically, the built-in devnode exclude list
     is this negated regular expression:
    </para>
 <screen>    devnode !^(sd[a-z]|dasd[a-z]|nvme[0-9])</screen>
@@ -2380,7 +2380,7 @@ defaults {
   <sect2 xml:id="sec-multipath-blacklist-exceptions">
    <title>The <literal>blacklist exceptions</literal> section in <filename>multipath.conf</filename></title>
    <para>
-    Sometimes it is desired to configure only very specific devices for
+    Sometimes, it is desired to configure only very specific devices for
     multipathing. In this case, devices are excluded by default, and exceptions
     are defined for devices that should be part of a multipath map. The
     <literal>blacklist_exceptions</literal> section exists for this purpose. It
@@ -2475,7 +2475,7 @@ blacklist_exceptions {
           time for additional paths with the same WWID to appear. If this
           happens, the multipath map is set up as usual. Otherwise, when the
           timeout expires, the single device is released to the system as
-          non-multipath device. The timeout is configurable with the option
+          a non-multipath device. The timeout is configurable with the option
           <option>find_multipaths_timeout</option>.
          </para>
          <para>
@@ -2553,7 +2553,7 @@ blacklist_exceptions {
    <command>multipathd</command> and <command>multipath</command> internally
    use WWIDs to identify devices. WWIDs are also used as map names by default.
    For convenience, <systemitem>multipath-tools</systemitem> supports assigning
-   simpler, easier memorizable names to multipath devices.
+   simpler, more easily memorizable names to multipath devices.
   </para>
 
   <sect2 xml:id="sec-multipath-conf-file-wwid">
@@ -2563,8 +2563,8 @@ blacklist_exceptions {
     represent paths to the same storage volume.
     <systemitem>multipath-tools</systemitem> uses the device's World Wide
     Identification (WWID) for this purpose (sometimes also referred to as
-    Universally Unique ID (UUID) or Unique ID (UID — do not confuse with
-    &ldquo;User ID&rdquo;). The WWID of a map device is always the same as the
+    Universally Unique ID (UUID) or Unique ID (UID&mdash;do not confuse with
+    &ldquo;User ID&rdquo;)). The WWID of a map device is always the same as the
     WWID of its path devices.
    </para>
    <para>
@@ -3156,7 +3156,7 @@ size=64G features='3 queue_if_no_path pg_init_retries 50'<co xml:id="mp-co-top-f
      <callout arearefs="mp-co-top-pgst">
       <para>
        The status of the path group (<literal>active</literal>,
-       <literal>enabled</literal>, or <literal>disabled</literal>). The active
+       <literal>enabled</literal> or <literal>disabled</literal>). The active
        path group is the one that I/O is currently sent to.
       </para>
      </callout>
@@ -3445,7 +3445,7 @@ size=64G features='3 queue_if_no_path pg_init_retries 50'<co xml:id="mp-co-top-f
     otherwise). If a device is already mounted, an attempt by multipathd to
     make it part of a multipath map will fail with a &ldquo;Device or resource
     busy&rdquo; error. Vice-versa, the same error results if
-    <command>systemd</command> attempts to mount a device which has already
+    <command>systemd</command> attempts to mount a device that has already
     been made part of a multipath map.
    </para>
    <para>
@@ -3626,7 +3626,7 @@ Give root password for maintenance
      </para>
      <para>
       Watch out for the root switch ("<literal>Switching root.</literal>") and
-      for messages about SCSI devices, device mapper, multipath, and LVM2. Look
+      for messages about SCSI devices, device mapper, multipath and LVM2. Look
       for <command>systemd</command> messages about devices and file systems
       ("<literal>Found device</literal>…", "<literal>Mounting</literal>…",
       "<literal>Mounted</literal>…").

--- a/xml/storage_nfs.xml
+++ b/xml/storage_nfs.xml
@@ -256,7 +256,7 @@
             ignore the "Firewall not configurable" message and continue.
           </para>
           <para>
-            When configuring &firewalld; rules, add <literal>nfs</literal> or
+            When configuring &firewalld; rules, add the <literal>nfs</literal> or
             <literal>nfs</literal> service with the port value of 2049 for both
             TCP and UDP. Also add the <literal>mountd</literal> service with
             the port value of 20048 for both TCP and UDP.

--- a/xml/storage_nfs.xml
+++ b/xml/storage_nfs.xml
@@ -256,7 +256,7 @@
             ignore the "Firewall not configurable" message and continue.
           </para>
           <para>
-            When configuring &firewalld; rules, add the <literal>nfs</literal> or
+            When configuring &firewalld; rules, add the <literal>nfs3</literal> or
             <literal>nfs</literal> service with the port value of 2049 for both
             TCP and UDP. Also add the <literal>mountd</literal> service with
             the port value of 20048 for both TCP and UDP.


### PR DESCRIPTION
### PR creator: Description

Integrate proofing corrections for the Storage Guide from proofing drop 2

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
