### PR TITLE
PED1897-Add Rage encryption

### DIFF
--- a/xml/security_cryptofs.xml
+++ b/xml/security_cryptofs.xml
@@ -281,142 +281,80 @@
  <sect1 xml:id="sec-security-cryptofs-rage">
   <title>Encrypting files with Rage</title>
   <para>
-   Rage is a secure file encryption software to encrypt files. It has keys that
-   are easy to exchange with other people, and has secure defaults to prevent
-   accidental misuse or leaks of sensitive data. We recommend Rage to encrypt
-   files.
+   Rage is a secure file encryption software to encrypt files. It has
+   keys that are easy to exchange with other people, and has secure defaults
+   to prevent accidental misuse or leaks of sensitive data.
+   We recommend Rage to encrypt files.
   </para>
-  <para>
-   The recipient must first generate a key pair to encrypt a file with Rage:
-  </para>
-  <screen>&prompt.user;rage-keygen -o ~/rage.key 2 ~/rage.pub</screen>
-  <para>
-   Two files are created; <filename>rage.pub</filename> and <filename>rage.key</filename>.
-  </para>
-  <example>
-   <title><filename>rage.pub</filename> example</title>
-   <screen>&prompt.user;cat rage.pub
-Public key: age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e</screen>
-  </example>
-  <example>
-   <title><filename>rage.key</filename> example</title>
-   <screen>&prompt.user;cat file.key
-# created: 2023-05-30T16:29:20+05:30
-# public key: age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e</screen>
-  </example>
-  <important>
-   <title>Never share rage.key</title>
-   <para>
-    <emphasis>rage.key</emphasis> is a private key and should be kept confidential.
+  <para> The recipient must first generate a key pair to encrypt a file with Rage:
    </para>
-  </important>
-  <para>
-   <emphasis role="bold">Encrypt</emphasis>
-  </para>
-  <para>
-   To encrypt a file, you need the generated public key:
-  </para>
-  <screen>&prompt.user;rage -e -r <replaceable>PUBLIC_KEY</replaceable> -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
-  <para>
-   For example:
-  </para>
-  <screen>&prompt.user;rage -e -r age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e -o test.txt.age test.txte</screen>
-  <para>
-   <emphasis role="bold">Decrypt</emphasis>
-  </para>
-  <para>
-   The encrypted file can be only decrypted by the recipient who has the corresponding private key.
-   To share an encrypted file with another person, you have to use their public key to encrypt the
-   file.
-  </para>
-  <screen>&prompt.user;rage -d -i ~/rage.key -o <replaceable>DECRYPTED_FILE</replaceable> <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
-  <para>
-   For example:
-  </para>
-  <screen>&prompt.user;rage -d -i ~/rage.key -o test.txt.decrypted test.txt.age</screen>
-  <para>
-   <emphasis role="bold">Passphrases</emphasis>
-  </para>
-  <para>
-   You can encrypt files with passphrases with the <option>-p</option> or
-   <option>--passphrase</option> arguments.
-   By default, Rage automatically generates a secure passphrase, but you also have the option to
-   enter a passphrase.
-  </para>
-  <screen>&prompt.user;rage -e -p -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
-  <para>
-   For example:
-  </para>
-  <screen>&prompt.user;rage -e -p -o test.txt.age test.txt</screen>
-  <para>
-   <emphasis role="bold">SSH</emphasis>
-  </para>
-  <para>
-   You can encrypt files with SSH (Secure Socket Shell) keys. Rage supports <emphasis>ssh-rsa</emphasis> and <emphasis>ssh-ed25519</emphasis>
-   public keys,and decrypting with the respective private key file. <command>ssh-agent</command> is not supported.
-  </para>
-  <para>
-   You can use the SSH keys in place of the Rage keys.
-  </para>
-  <para>
-   For example:
-  </para>
-  <screen>&prompt.user; ssh-keygen -t ed25519</screen>
-  <para>
-   To encrypt:
-  </para>
-  <screen>&prompt.user; rage -e -a -R <replaceable>PUBLIC_KEY</replaceable> -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
-  <para>
-   For example:
-  </para>
-  <screen>&prompt.user; rage -e -a -R id_ed25519.pub -o test.txt.age test.txt</screen>
-  <para>
-   To decrypt:
-  </para>
-  <screen>&prompt.user; rage -d -i <replaceable>SSH_PRIVATE_KEY</replaceable> -o <replaceable>DECRYPTED_FILE</replaceable><replaceable>ENCRYPTED_FILE</replaceable></screen>
-  <para>
-   For example:
-  </para>
-  <screen>&prompt.user; rage -d -i id_ed25519 -o test.txt.decrypted test.txt.age</screen>
-  <important>
-   <title>Full path required</title>
-   <para>
-    You must enter the full path of the SSH key and the files.
+   <screen>&prompt.user;rage-keygen -o ~/rage.key 2 ~/rage.pub</screen>
+   <para>Two files are created; <emphasis>rage.pub</emphasis> and <emphasis>rage.key</emphasis>.
    </para>
-  </important>
-  <para>
-   <emphasis role="bold">Multiple identities</emphasis>
-  </para>
-  <para>
-   Rage can encrypt multiple identities at the same time. All associated keys can be used to decrypt
-   a file.
-  </para>
-  <screen>rage -e -a -R <replaceable>FIRST_SSH_PUBLIC_KEY</replaceable>-r <replaceable>FIRST_RAGE_PUBLIC_KEY</replaceable>... -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
-  <para>
-   For example:
-  </para>
-  <screen>rage -e -a -R id_ed25519.pub -r age1h8equ4vs5pyp8ykw0z8m9n8m3psy6swme52ztth0v66frgu65ussm8gq0t -o -r age1y2lc7x59jcqvrpf3ppmnj3f93ytaegfkdnl5vrdyv83l8ekcae4sexgwkg test.txt.age test.txt</screen>
-  <tip>
-   <para>
-    You can use the <option>-h</option> or <option>--help</option> argument to list all the Rage
-    command arguments.
-   </para>
-  </tip>
+   <para><emphasis role="bold">rage.pub example</emphasis></para>
+   <screen>&prompt.user; cat file.pub
+    Public key: age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e </screen>
+    <para><emphasis role="bold">rage.key example</emphasis></para>
+   <screen>&prompt.user; cat file.key
+    # created: 2023-05-30T16:29:20+05:30
+    # public key: age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e </screen>
+    <important><para><emphasis>file.key</emphasis> is a private key and should be kept confidential.</para></important>
+   <para><emphasis role="bold">Encrypt</emphasis></para>
+   <para>To encrypt a file, you need the generated public key:</para>
+   <screen>&prompt.user;rage -e -r <replaceable>PUBLIC_KEY</replaceable> -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable> </screen>
+   <para>For example:</para>
+   <screen>>&prompt.user;rage -e -r age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e -o test.txt.age test.txte </screen>
+   <para><emphasis role="bold">Decrypt</emphasis></para>
+   <para>The encrypted file can be only decrypted by the recipient who has the corresponding private key.
+   To share an encrypted file with another person, you have to use that person's public key to encrypt the file.</para>
+   <screen>&prompt.user;rage -d -i ~/rage.key -o <replaceable>DECRYPTED_FILE</replaceable> <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable> </screen>
+   <para>For example:</para>
+   <screen>>&prompt.user;rage -d -i ~/rage.key -o test.txt.decrypted test.txt.age </screen>
+   <para><emphasis role="bold">Passphrases</emphasis></para>
+   <para>You can encrypt files with passphrases with the <envar>-p</envar> or <envar>--passphrase</envar> arguments.
+   By default, Rage automatically generates a secure passphrase, but you also have the option to enter a passphrase.</para>
+   <screen>&prompt.user;rage -e -p -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable> </screen>
+   <para>For example:</para>
+   <screen>>&prompt.user;rage -e -p -o test.txt.age test.txt </screen>
+   <para><emphasis role="bold">SSH</emphasis></para>
+   <para>You can encrypt files with SSH (Secure Socket Shell) keys. Rage supports <emphasis>ssh-rsa</emphasis> and <emphasis>ssh-ed25519</emphasis>
+   public keys,and decrypting with the respective private key file. <emphasis>ssh-agent</emphasis> is not supported.</para>
+   <para>You can use the SSH keys in place of the Rage keys.</para>
+   <para>For example:</para>
+   <screen>&prompt.user; ssh-keygen -t ed25519</screen>
+    <para>To encrypt:</para>
+   <screen>&prompt.user; rage -e -a -R <replaceable>PUBLIC_KEY</replaceable> -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
+    <para>For example:</para>
+    <screen>&prompt.user; rage -e -a -R id_ed25519.pub -o test.txt.age test.txt</screen>
+    <para>To decrypt:</para>
+    <screen>&prompt.user; rage -d -i <replaceable>SSH_PRIVATE_KEY</replaceable> -o <replaceable>DECRYPTED_FILE</replaceable><replaceable>ENCRYPTED_FILE</replaceable></screen>
+    <para>For example:</para>
+    <screen>&prompt.user; rage -d -i id_ed25519 -o test.txt.decrypted test.txt.age</screen>
+     <important><para>You must enter the full path of the key and the files.</para></important>
+     <para><emphasis role="bold">Multiple identities</emphasis></para>
+     <para>Rage can encrypt multiple identities at the same time. All the associated keys can be used to decrypt a file.</para>
+      <screen>rage -e -a -R <replaceable>FIRST_SSH_PUBLIC_KEY</replaceable>-r <replaceable>FIRST_RAGE_PUBLIC_KEY</replaceable>... -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
+      <para>For example:</para>
+      <screen>rage -e -a -R id_ed25519.pub -r age1h8equ4vs5pyp8ykw0z8m9n8m3psy6swme52ztth0v66frgu65ussm8gq0t -o -r age1y2lc7x59jcqvrpf3ppmnj3f93ytaegfkdnl5vrdyv83l8ekcae4sexgwkg test.txt.age test.txt</screen>
+       <tip>
+        <para>
+          You can use the <envar>-h</envar> or <envar>--help</envar> argument to list all the Rage command arguments.
+        </para>
+       </tip>
 
-  <sect2 xml:id="sec-security-cryptofs-rage-more-info">
-   <title>More information</title>
+       <sect2 xml:id="sec-security-cryptofs-rage-additional-resources">
+      <title>Additional Resources</title>
    <itemizedlist>
-    <listitem>
-     <para>
-      Rage Encryption GitHub repository: <link xlink:href="https://github.com/str4d/rage"/>
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      Age Encryption GitHub repository: <link xlink:href="https://github.com/C2SP/C2SP/blob/main/age.md"/>
-     </para>
-    </listitem>
-   </itemizedlist>
-  </sect2>
- </sect1>
+      <listitem>
+        <para>
+          <link xlink:href="https://github.com/str4d/rage"/> Rage Encryption GitHub repository
+        </para>
+        </listitem>
+        <listitem>
+        <para>
+          <link xlink:href="https://github.com/C2SP/C2SP/blob/main/age.md"/> Age Encryption GitHub repository
+        </para>
+        </listitem>
+    </itemizedlist> </sect2>
+      </sect1>
 </chapter>

--- a/xml/security_cryptofs.xml
+++ b/xml/security_cryptofs.xml
@@ -44,6 +44,15 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry>
+   <term>Encrypting single files with Rage</term>
+   <listitem>
+    <para>
+     You can use the Rage encryption tool to encrypt one or more files. See
+     <xref linkend="sec-security-cryptofs-rage"/> for more information.
+    </para>
+   </listitem>
+  </varlistentry>
  </variablelist>
  <warning>
   <title>Encryption offers limited protection</title>
@@ -194,10 +203,10 @@
 
 <!-- this feature was removed from YaST in sle15sp0
   https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15/#id5997
-  (cjs feb 5 2020)   
+  (cjs feb 5 2020)
   <sect2 xml:id="sec-security-cryptofs-y2-vdisk">
    <title>Creating an encrypted virtual disk</title> -->
-   
+
   <sect2 xml:id="sec-security-cryptofs-y2-removables">
    <title>Encrypting the content of removable media</title>
    <para>
@@ -232,14 +241,14 @@
    instructions. When generating the key pair, GPG creates a user ID (UID) to
    identify the key based on your real name, comments, and email address. You
    need this UID (or just a part of it like your first name or email address)
-   to specify the key you want to use to encrypt a file. To find the UID of 
-   an existing key, use the <command>gpg --list-keys</command> command. To 
+   to specify the key you want to use to encrypt a file. To find the UID of
+   an existing key, use the <command>gpg --list-keys</command> command. To
    encrypt a file use the following command:
   </para>
   <screen>&prompt.user;gpg -e -a --cipher-algo AES256 -r <replaceable>UID</replaceable> <replaceable>FILE</replaceable></screen>
   <para>
     Replace <replaceable>UID</replaceable> with part of the UID (for example,
-    your first name) and <replaceable>FILE</replaceable> with the file you 
+    your first name) and <replaceable>FILE</replaceable> with the file you
     want to encrypt. For example:
   </para>
   <screen>&prompt.user;gpg -e -a --cipher-algo AES256 -r Tux secret.txt</screen>
@@ -249,7 +258,7 @@
     this example, it is <filename>secret.txt.asc</filename>).
   </para>
   <para>
-    <command>-a</command> formats the file as ASCII text, if you want the 
+    <command>-a</command> formats the file as ASCII text, if you want the
     contents to be copy-able. Omit <command>-a</command> to create a binary
     file, which in the above example would be <filename>secret.txt.gpg</filename>.
   </para>
@@ -269,4 +278,15 @@
     the file.
   </para>
  </sect1>
+ <sect1 xml:id="sec-security-cryptofs-rage">
+  <title>Encrypting files with Rage</title>
+  <para>
+   Rage is a secure file encryption software to encrypt files.
+   Rage has small explicit keys and does not have configuration options.
+  </para>
+  <para>You must first generate a key pair to encrypt a file with Rage:
+   </para>
+   <screen>&prompt.user;rage-keygen -o ~/rage.key 2> ~/<replaceable>FILE</replaceable></screen>
+   <para>Note that the public key is displayed in the file and a similar file with an <emphasis>age</emphasis> extension is created. </para>
+   </sect1>
 </chapter>

--- a/xml/security_cryptofs.xml
+++ b/xml/security_cryptofs.xml
@@ -281,80 +281,142 @@
  <sect1 xml:id="sec-security-cryptofs-rage">
   <title>Encrypting files with Rage</title>
   <para>
-   Rage is a secure file encryption software to encrypt files. It has
-   keys that are easy to exchange with other people, and has secure defaults
-   to prevent accidental misuse or leaks of sensitive data.
-   We recommend Rage to encrypt files.
+   Rage is a secure file encryption software to encrypt files. It has keys that
+   are easy to exchange with other people, and has secure defaults to prevent
+   accidental misuse or leaks of sensitive data. We recommend Rage to encrypt
+   files.
   </para>
-  <para> The recipient must first generate a key pair to encrypt a file with Rage:
+  <para>
+   The recipient must first generate a key pair to encrypt a file with Rage:
+  </para>
+  <screen>&prompt.user;rage-keygen -o ~/rage.key 2 ~/rage.pub</screen>
+  <para>
+   Two files are created; <filename>rage.pub</filename> and <filename>rage.key</filename>.
+  </para>
+  <example>
+   <title><filename>rage.pub</filename> example</title>
+   <screen>&prompt.user;cat rage.pub
+Public key: age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e</screen>
+  </example>
+  <example>
+   <title><filename>rage.key</filename> example</title>
+   <screen>&prompt.user;cat file.key
+# created: 2023-05-30T16:29:20+05:30
+# public key: age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e</screen>
+  </example>
+  <important>
+   <title>Never share rage.key</title>
+   <para>
+    <emphasis>rage.key</emphasis> is a private key and should be kept confidential.
    </para>
-   <screen>&prompt.user;rage-keygen -o ~/rage.key 2 ~/rage.pub</screen>
-   <para>Two files are created; <emphasis>rage.pub</emphasis> and <emphasis>rage.key</emphasis>.
+  </important>
+  <para>
+   <emphasis role="bold">Encrypt</emphasis>
+  </para>
+  <para>
+   To encrypt a file, you need the generated public key:
+  </para>
+  <screen>&prompt.user;rage -e -r <replaceable>PUBLIC_KEY</replaceable> -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
+  <para>
+   For example:
+  </para>
+  <screen>&prompt.user;rage -e -r age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e -o test.txt.age test.txte</screen>
+  <para>
+   <emphasis role="bold">Decrypt</emphasis>
+  </para>
+  <para>
+   The encrypted file can be only decrypted by the recipient who has the corresponding private key.
+   To share an encrypted file with another person, you have to use their public key to encrypt the
+   file.
+  </para>
+  <screen>&prompt.user;rage -d -i ~/rage.key -o <replaceable>DECRYPTED_FILE</replaceable> <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
+  <para>
+   For example:
+  </para>
+  <screen>&prompt.user;rage -d -i ~/rage.key -o test.txt.decrypted test.txt.age</screen>
+  <para>
+   <emphasis role="bold">Passphrases</emphasis>
+  </para>
+  <para>
+   You can encrypt files with passphrases with the <option>-p</option> or
+   <option>--passphrase</option> arguments.
+   By default, Rage automatically generates a secure passphrase, but you also have the option to
+   enter a passphrase.
+  </para>
+  <screen>&prompt.user;rage -e -p -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
+  <para>
+   For example:
+  </para>
+  <screen>&prompt.user;rage -e -p -o test.txt.age test.txt</screen>
+  <para>
+   <emphasis role="bold">SSH</emphasis>
+  </para>
+  <para>
+   You can encrypt files with SSH (Secure Socket Shell) keys. Rage supports <emphasis>ssh-rsa</emphasis> and <emphasis>ssh-ed25519</emphasis>
+   public keys,and decrypting with the respective private key file. <command>ssh-agent</command> is not supported.
+  </para>
+  <para>
+   You can use the SSH keys in place of the Rage keys.
+  </para>
+  <para>
+   For example:
+  </para>
+  <screen>&prompt.user; ssh-keygen -t ed25519</screen>
+  <para>
+   To encrypt:
+  </para>
+  <screen>&prompt.user; rage -e -a -R <replaceable>PUBLIC_KEY</replaceable> -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
+  <para>
+   For example:
+  </para>
+  <screen>&prompt.user; rage -e -a -R id_ed25519.pub -o test.txt.age test.txt</screen>
+  <para>
+   To decrypt:
+  </para>
+  <screen>&prompt.user; rage -d -i <replaceable>SSH_PRIVATE_KEY</replaceable> -o <replaceable>DECRYPTED_FILE</replaceable><replaceable>ENCRYPTED_FILE</replaceable></screen>
+  <para>
+   For example:
+  </para>
+  <screen>&prompt.user; rage -d -i id_ed25519 -o test.txt.decrypted test.txt.age</screen>
+  <important>
+   <title>Full path required</title>
+   <para>
+    You must enter the full path of the SSH key and the files.
    </para>
-   <para><emphasis role="bold">rage.pub example</emphasis></para>
-   <screen>&prompt.user; cat file.pub
-    Public key: age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e </screen>
-    <para><emphasis role="bold">rage.key example</emphasis></para>
-   <screen>&prompt.user; cat file.key
-    # created: 2023-05-30T16:29:20+05:30
-    # public key: age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e </screen>
-    <important><para><emphasis>file.key</emphasis> is a private key and should be kept confidential.</para></important>
-   <para><emphasis role="bold">Encrypt</emphasis></para>
-   <para>To encrypt a file, you need the generated public key:</para>
-   <screen>&prompt.user;rage -e -r <replaceable>PUBLIC_KEY</replaceable> -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable> </screen>
-   <para>For example:</para>
-   <screen>>&prompt.user;rage -e -r age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e -o test.txt.age test.txte </screen>
-   <para><emphasis role="bold">Decrypt</emphasis></para>
-   <para>The encrypted file can be only decrypted by the recipient who has the corresponding private key.
-   To share an encrypted file with another person, you have to use that person's public key to encrypt the file.</para>
-   <screen>&prompt.user;rage -d -i ~/rage.key -o <replaceable>DECRYPTED_FILE</replaceable> <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable> </screen>
-   <para>For example:</para>
-   <screen>>&prompt.user;rage -d -i ~/rage.key -o test.txt.decrypted test.txt.age </screen>
-   <para><emphasis role="bold">Passphrases</emphasis></para>
-   <para>You can encrypt files with passphrases with the <envar>-p</envar> or <envar>--passphrase</envar> arguments.
-   By default, Rage automatically generates a secure passphrase, but you also have the option to enter a passphrase.</para>
-   <screen>&prompt.user;rage -e -p -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable> </screen>
-   <para>For example:</para>
-   <screen>>&prompt.user;rage -e -p -o test.txt.age test.txt </screen>
-   <para><emphasis role="bold">SSH</emphasis></para>
-   <para>You can encrypt files with SSH (Secure Socket Shell) keys. Rage supports <emphasis>ssh-rsa</emphasis> and <emphasis>ssh-ed25519</emphasis>
-   public keys,and decrypting with the respective private key file. <emphasis>ssh-agent</emphasis> is not supported.</para>
-   <para>You can use the SSH keys in place of the Rage keys.</para>
-   <para>For example:</para>
-   <screen>&prompt.user; ssh-keygen -t ed25519</screen>
-    <para>To encrypt:</para>
-   <screen>&prompt.user; rage -e -a -R <replaceable>PUBLIC_KEY</replaceable> -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
-    <para>For example:</para>
-    <screen>&prompt.user; rage -e -a -R id_ed25519.pub -o test.txt.age test.txt</screen>
-    <para>To decrypt:</para>
-    <screen>&prompt.user; rage -d -i <replaceable>SSH_PRIVATE_KEY</replaceable> -o <replaceable>DECRYPTED_FILE</replaceable><replaceable>ENCRYPTED_FILE</replaceable></screen>
-    <para>For example:</para>
-    <screen>&prompt.user; rage -d -i id_ed25519 -o test.txt.decrypted test.txt.age</screen>
-     <important><para>You must enter the full path of the key and the files.</para></important>
-     <para><emphasis role="bold">Multiple identities</emphasis></para>
-     <para>Rage can encrypt multiple identities at the same time. All the associated keys can be used to decrypt a file.</para>
-      <screen>rage -e -a -R <replaceable>FIRST_SSH_PUBLIC_KEY</replaceable>-r <replaceable>FIRST_RAGE_PUBLIC_KEY</replaceable>... -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
-      <para>For example:</para>
-      <screen>rage -e -a -R id_ed25519.pub -r age1h8equ4vs5pyp8ykw0z8m9n8m3psy6swme52ztth0v66frgu65ussm8gq0t -o -r age1y2lc7x59jcqvrpf3ppmnj3f93ytaegfkdnl5vrdyv83l8ekcae4sexgwkg test.txt.age test.txt</screen>
-       <tip>
-        <para>
-          You can use the <envar>-h</envar> or <envar>--help</envar> argument to list all the Rage command arguments.
-        </para>
-       </tip>
+  </important>
+  <para>
+   <emphasis role="bold">Multiple identities</emphasis>
+  </para>
+  <para>
+   Rage can encrypt multiple identities at the same time. All associated keys can be used to decrypt
+   a file.
+  </para>
+  <screen>rage -e -a -R <replaceable>FIRST_SSH_PUBLIC_KEY</replaceable>-r <replaceable>FIRST_RAGE_PUBLIC_KEY</replaceable>... -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
+  <para>
+   For example:
+  </para>
+  <screen>rage -e -a -R id_ed25519.pub -r age1h8equ4vs5pyp8ykw0z8m9n8m3psy6swme52ztth0v66frgu65ussm8gq0t -o -r age1y2lc7x59jcqvrpf3ppmnj3f93ytaegfkdnl5vrdyv83l8ekcae4sexgwkg test.txt.age test.txt</screen>
+  <tip>
+   <para>
+    You can use the <option>-h</option> or <option>--help</option> argument to list all the Rage
+    command arguments.
+   </para>
+  </tip>
 
-       <sect2 xml:id="sec-security-cryptofs-rage-additional-resources">
-      <title>Additional Resources</title>
+  <sect2 xml:id="sec-security-cryptofs-rage-more-info">
+   <title>More information</title>
    <itemizedlist>
-      <listitem>
-        <para>
-          <link xlink:href="https://github.com/str4d/rage"/> Rage Encryption GitHub repository
-        </para>
-        </listitem>
-        <listitem>
-        <para>
-          <link xlink:href="https://github.com/C2SP/C2SP/blob/main/age.md"/> Age Encryption GitHub repository
-        </para>
-        </listitem>
-    </itemizedlist> </sect2>
-      </sect1>
+    <listitem>
+     <para>
+      Rage Encryption GitHub repository: <link xlink:href="https://github.com/str4d/rage"/>
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      Age Encryption GitHub repository: <link xlink:href="https://github.com/C2SP/C2SP/blob/main/age.md"/>
+     </para>
+    </listitem>
+   </itemizedlist>
+  </sect2>
+ </sect1>
 </chapter>

--- a/xml/security_cryptofs.xml
+++ b/xml/security_cryptofs.xml
@@ -336,9 +336,14 @@
       <screen>rage -e -a -R <replaceable>FIRST_SSH_PUBLIC_KEY</replaceable>-r <replaceable>FIRST_RAGE_PUBLIC_KEY</replaceable>... -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
       <para>For example:</para>
       <screen>rage -e -a -R id_ed25519.pub -r age1h8equ4vs5pyp8ykw0z8m9n8m3psy6swme52ztth0v66frgu65ussm8gq0t -o -r age1y2lc7x59jcqvrpf3ppmnj3f93ytaegfkdnl5vrdyv83l8ekcae4sexgwkg test.txt.age test.txt</screen>
-      </sect1
-    >       <sect1 xml:id="sec-security-cryptofs-rage-additional-resources">
-   <title>Additional Resources</title>
+       <tip>
+        <para>
+          You can use the <envar>-h</envar> or <envar>--help</envar> argument to list all the Rage command arguments.
+        </para>
+       </tip>
+
+       <sect2 xml:id="sec-security-cryptofs-rage-additional-resources">
+      <title>Additional Resources</title>
    <itemizedlist>
       <listitem>
         <para>
@@ -350,6 +355,6 @@
           <link xlink:href="https://github.com/C2SP/C2SP/blob/main/age.md"/> Age Encryption GitHub repository
         </para>
         </listitem>
-    </itemizedlist>
-   </sect1>
+    </itemizedlist> </sect2>
+      </sect1>
 </chapter>

--- a/xml/security_cryptofs.xml
+++ b/xml/security_cryptofs.xml
@@ -331,7 +331,7 @@
     <screen>&prompt.user; rage -d -i <replaceable>SSH_PRIVATE_KEY_FILE</replaceable> -o <replaceable>DECRYPTED_FILE</replaceable><replaceable>ENCRYPTED_FILE</replaceable></screen>
     <para>For example:</para>
     <screen>&prompt.user; rage -d -i id_ed25519 -o test.txt.decrypted test.txt.age</screen>
-     <important><para>You must enter the full path of the key and the files.</para></important>
+     <important><para>You must enter the path to the key and files.</para></important>
      <para><emphasis role="bold">Multiple identities</emphasis></para>
      <para>Rage can encrypt to multiple identities at the same time. Any of the recipient's private keys can be used to decrypt the file.</para>
       <screen>rage -e -a -R <replaceable>FIRST_SSH_PUBLIC_KEY</replaceable>-r <replaceable>FIRST_RAGE_PUBLIC_KEY</replaceable>... -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>

--- a/xml/security_cryptofs.xml
+++ b/xml/security_cryptofs.xml
@@ -286,7 +286,30 @@
   </para>
   <para>You must first generate a key pair to encrypt a file with Rage:
    </para>
-   <screen>&prompt.user;rage-keygen -o ~/rage.key 2> ~/<replaceable>FILE</replaceable></screen>
-   <para>Note that the public key is displayed in the file and a similar file with an <emphasis>age</emphasis> extension is created. </para>
+   <screen>&prompt.user;rage-keygen -o ~/rage.key 2 ~/rage.pub</screen>
+   <para>Note that two files are created; <emphasis>rage.pub</emphasis> and <emphasis>rage.key</emphasis>. </para>
+   <para><emphasis role="bold">rage.pub example</emphasis></para>
+   <screen>&prompt.user; cat file.pub
+    Public key: age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e </screen>
+    <para><emphasis role="bold">rage.key example</emphasis></para>
+   <screen>&prompt.user; cat file.key
+    # created: 2023-05-30T16:29:20+05:30
+    # public key: age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e </screen>
+   <para><emphasis role="bold">Encrypt</emphasis></para>
+   <para>To encrypt a file, you need the generated public key:</para>
+   <screen>&prompt.user;rage -e -r <replaceable>PUBLIC_KEY</replaceable> -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable> </screen>
+   <para>An encrypted version of the specified file is recognizable by the <emphasis>.age</emphasis> file extension that is created.</para>
+   <para><emphasis role="bold">Decrypt</emphasis></para>
+   <para> </para>
+   </sect1>
+   <sect1 xml:id="sec-security-cryptofs-rage-additional-resources">
+   <title>Additional Resources</title>
+   <itemizedlist>
+      <listitem>
+        <para>
+          <link xlink:href="https://github.com/str4d/rage"/> Rage Encryption GitHub repository
+        </para>
+        </listitem>
+    </itemizedlist>
    </sect1>
 </chapter>

--- a/xml/security_cryptofs.xml
+++ b/xml/security_cryptofs.xml
@@ -284,6 +284,7 @@
    Rage is a secure file encryption software to encrypt files. It has
    keys that are easy to exchange with other people, and has secure defaults
    to prevent accidental misuse or leaks of sensitive data.
+   We recommend Rage to encrypt files.
   </para>
   <para> The recipient must first generate a key pair to encrypt a file with Rage:
    </para>

--- a/xml/security_cryptofs.xml
+++ b/xml/security_cryptofs.xml
@@ -292,36 +292,66 @@
    <screen>&prompt.user;rage-keygen -o ~/rage.key 2 ~/rage.pub</screen>
    <para>Two files are created; <emphasis>rage.pub</emphasis> and <emphasis>rage.key</emphasis>.
    </para>
-   <para><emphasis role="bold">rage.pub example</emphasis></para>
-   <screen>&prompt.user; cat file.pub
+   <variablelist>
+   <varlistentry>
+    <term><literal>rage.pub example</literal>
+    </term>
+    <listitem>
+    <screen>&prompt.user;cat file.pub
     Public key: age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e </screen>
-    <para><emphasis role="bold">rage.key example</emphasis></para>
-   <screen>&prompt.user; cat file.key
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term><literal>rage.key example</literal>
+    </term>
+    <listitem>
+     <screen>&prompt.user; cat file.key
     # created: 2023-05-30T16:29:20+05:30
     # public key: age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e </screen>
+    </listitem>
+   </varlistentry>
+     </variablelist>
     <important><para><emphasis>file.key</emphasis> is a private key and should be kept confidential.</para></important>
-   <para><emphasis role="bold">Encrypt</emphasis></para>
-   <para>To encrypt a file, you need the generated public key:</para>
+   <variablelist>
+  <varlistentry>
+   <term>Encrypt</term>
+   <listitem>
+    <para> To encrypt a file, you need the generated public key:</para>
    <screen>&prompt.user;rage -e -r <replaceable>PUBLIC_KEY</replaceable> -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable> </screen>
+  <para>For example:</para>
+   <screen>&prompt.user;rage -e -r age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e -o test.txt.age test.txt </screen>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term>Decrypt</term>
+   <listitem>
+    <para>
+     The encrypted file can be only decrypted by the recipient who has the corresponding private key.
+   To share an encrypted file with another person, you have to use that person's public key to encrypt the file.
+    </para>
+<screen>&prompt.user;rage -d -i ~/rage.key -o <replaceable>DECRYPTED_FILE</replaceable> <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable> </screen>
    <para>For example:</para>
-   <screen>>&prompt.user;rage -e -r age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e -o test.txt.age test.txte </screen>
-   <para><emphasis role="bold">Decrypt</emphasis></para>
-   <para>The encrypted file can be only decrypted by the recipient who has the corresponding private key.
-   To share an encrypted file with another person, you have to use that person's public key to encrypt the file.</para>
-   <screen>&prompt.user;rage -d -i ~/rage.key -o <replaceable>DECRYPTED_FILE</replaceable> <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable> </screen>
+   <screen>&prompt.user;rage -d -i ~/rage.key -o test.txt.decrypted test.txt.age </screen>
+   </listitem>
+  </varlistentry>
+  <varlistentry>
+   <term>Passphrases</term>
+   <listitem>
+    <para> You can encrypt files with passphrases with the <envar>-p</envar> or <envar>--passphrase</envar> arguments.
+   By default, Rage automatically generates a secure passphrase, but you also have the option to enter a passphrase.  </para>
+  <screen>&prompt.user;rage -e -p -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable> </screen>
    <para>For example:</para>
-   <screen>>&prompt.user;rage -d -i ~/rage.key -o test.txt.decrypted test.txt.age </screen>
-   <para><emphasis role="bold">Passphrases</emphasis></para>
-   <para>You can encrypt files with passphrases with the <envar>-p</envar> or <envar>--passphrase</envar> arguments.
-   By default, Rage automatically generates a secure passphrase, but you also have the option to enter a passphrase.</para>
-   <screen>&prompt.user;rage -e -p -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable> </screen>
+   <screen>&prompt.user;rage -e -p -o test.txt.age test.txt </screen>
+   </listitem>
+  </varlistentry>
+<varlistentry>
+   <term>SSH</term>
+   <listitem>
+    <para> You can encrypt files with SSH (Secure Socket Shell) keys instead of Rage keys. Rage supports <emphasis>ssh-rsa</emphasis> and <emphasis>ssh-ed25519</emphasis>  public keys,and decrypting with the respective private key file. <emphasis>ssh-agent</emphasis> and <emphasis>ssh-sk(FIDO)</emphasis> are not supported. </para>
+  <screen>&prompt.user;rage -e -p -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable> </screen>
    <para>For example:</para>
-   <screen>>&prompt.user;rage -e -p -o test.txt.age test.txt </screen>
-   <para><emphasis role="bold">SSH</emphasis></para>
-   <para>You can encrypt files with SSH (Secure Socket Shell) keys. Rage supports <emphasis>ssh-rsa</emphasis> and <emphasis>ssh-ed25519</emphasis>
-   public keys,and decrypting with the respective private key file. <emphasis>ssh-agent</emphasis> and <emphasis>ssh-sk(FIDO)</emphasis> are not supported.</para>
-   <para>You can use the SSH keys in place of the Rage keys.</para>
-   <para>For example:</para>
+   <screen>&prompt.user;rage -e -p -o test.txt.age test.txt </screen>
+<para>For example:</para>
    <screen>&prompt.user; ssh-keygen -t ed25519</screen>
     <para>To encrypt:</para>
    <screen>&prompt.user; rage -e -a -R <replaceable>PUBLIC_KEY_FILE</replaceable> -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
@@ -332,16 +362,23 @@
     <para>For example:</para>
     <screen>&prompt.user; rage -d -i id_ed25519 -o test.txt.decrypted test.txt.age</screen>
      <important><para>You must enter the path to the key and files.</para></important>
-     <para><emphasis role="bold">Multiple identities</emphasis></para>
-     <para>Rage can encrypt to multiple identities at the same time. Any of the recipient's private keys can be used to decrypt the file.</para>
-      <screen>rage -e -a -R <replaceable>FIRST_SSH_PUBLIC_KEY</replaceable>-r <replaceable>FIRST_RAGE_PUBLIC_KEY</replaceable>... -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
-      <para>For example:</para>
-      <screen>rage -e -a -R id_ed25519.pub -r age1h8equ4vs5pyp8ykw0z8m9n8m3psy6swme52ztth0v66frgu65ussm8gq0t -o -r age1y2lc7x59jcqvrpf3ppmnj3f93ytaegfkdnl5vrdyv83l8ekcae4sexgwkg test.txt.age test.txt</screen>
-       <tip>
-        <para>
-          You can use the <envar>-h</envar> or <envar>--help</envar> argument to list all the Rage command arguments.
-        </para>
-       </tip>
+   </listitem>
+  </varlistentry>
+<varlistentry>
+   <term>Multiple identities</term>
+   <listitem>
+    <para> Rage can encrypt to multiple identities at the same time. Any of the recipient's private keys can be used to decrypt the file.</para>
+    <screen>rage -e -a -R <replaceable>FIRST_SSH_PUBLIC_KEY</replaceable>-r <replaceable>FIRST_RAGE_PUBLIC_KEY</replaceable>... -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
+    <para>For example:</para>
+    <screen>rage -e -a -R id_ed25519.pub -r age1h8equ4vs5pyp8ykw0z8m9n8m3psy6swme52ztth0v66frgu65ussm8gq0t -o -r age1y2lc7x59jcqvrpf3ppmnj3f93ytaegfkdnl5vrdyv83l8ekcae4sexgwkg test.txt.age test.txt</screen>
+    </listitem>
+  </varlistentry>
+   </variablelist>
+   <tip>
+   <para>
+   You can use the <envar>-h</envar> or <envar>--help</envar> argument to list all the Rage command arguments.
+   </para>
+    </tip>
 
        <sect2 xml:id="sec-security-cryptofs-rage-additional-resources">
       <title>Additional Resources</title>

--- a/xml/security_cryptofs.xml
+++ b/xml/security_cryptofs.xml
@@ -320,13 +320,34 @@
    <para>You can use the SSH keys in place of the Rage keys.</para>
    <para>For example:</para>
    <screen>&prompt.user; ssh-keygen -t ed25519</screen>
-    </sect1>
-   <sect1 xml:id="sec-security-cryptofs-rage-additional-resources">
+   <para>SSH keys has more complex cryptography, and embeds a public key tag in the encrypted file.
+   This makes it possible to track files that are encrypted to a specific public key</para>
+   <para>To encrypt:</para>
+   <screen>&prompt.user; rage -e -a -R <replaceable>PUBLIC_KEY</replaceable> -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
+    <para>For example:</para>
+    <screen>&prompt.user; rage -e -a -R id_ed25519.pub -o test.txt.age test.txt</screen>
+    <para>To decrypt:</para>
+    <screen>&prompt.user; rage -d -i <replaceable>SSH_PRIVATE_KEY</replaceable> -o <replaceable>DECRYPTED_FILE</replaceable><replaceable>ENCRYPTED_FILE</replaceable></screen>
+    <para>For example:</para>
+    <screen>&prompt.user; rage -d -i id_ed25519 -o test.txt.decrypted test.txt.age</screen>
+     <important><para>You must enter the full path of the key and the files.</para></important>
+     <para><emphasis role="bold">Multiple identities</emphasis></para>
+     <para>Rage can encrypt multiple identities at the same time. Note that all the associated keys can be used to decrypt a file.</para>
+      <screen>rage -e -a -R <replaceable>FIRST_SSH_PUBLIC_KEY</replaceable>-r <replaceable>FIRST_RAGE_PUBLIC_KEY</replaceable>... -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
+      <para>For example:</para>
+      <screen>rage -e -a -R id_ed25519.pub -r age1h8equ4vs5pyp8ykw0z8m9n8m3psy6swme52ztth0v66frgu65ussm8gq0t -o -r age1y2lc7x59jcqvrpf3ppmnj3f93ytaegfkdnl5vrdyv83l8ekcae4sexgwkg test.txt.age test.txt</screen>
+      </sect1
+    >       <sect1 xml:id="sec-security-cryptofs-rage-additional-resources">
    <title>Additional Resources</title>
    <itemizedlist>
       <listitem>
         <para>
           <link xlink:href="https://github.com/str4d/rage"/> Rage Encryption GitHub repository
+        </para>
+        </listitem>
+        <listitem>
+        <para>
+          <link xlink:href="https://github.com/C2SP/C2SP/blob/main/age.md"/> Age Encryption GitHub repository
         </para>
         </listitem>
     </itemizedlist>

--- a/xml/security_cryptofs.xml
+++ b/xml/security_cryptofs.xml
@@ -319,21 +319,21 @@
    <screen>>&prompt.user;rage -e -p -o test.txt.age test.txt </screen>
    <para><emphasis role="bold">SSH</emphasis></para>
    <para>You can encrypt files with SSH (Secure Socket Shell) keys. Rage supports <emphasis>ssh-rsa</emphasis> and <emphasis>ssh-ed25519</emphasis>
-   public keys,and decrypting with the respective private key file. <emphasis>ssh-agent</emphasis> is not supported.</para>
+   public keys,and decrypting with the respective private key file. <emphasis>ssh-agent</emphasis> and <emphasis>ssh-sk(FIDO)</emphasis> are not supported.</para>
    <para>You can use the SSH keys in place of the Rage keys.</para>
    <para>For example:</para>
    <screen>&prompt.user; ssh-keygen -t ed25519</screen>
     <para>To encrypt:</para>
-   <screen>&prompt.user; rage -e -a -R <replaceable>PUBLIC_KEY</replaceable> -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
+   <screen>&prompt.user; rage -e -a -R <replaceable>PUBLIC_KEY_FILE</replaceable> -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
     <para>For example:</para>
     <screen>&prompt.user; rage -e -a -R id_ed25519.pub -o test.txt.age test.txt</screen>
     <para>To decrypt:</para>
-    <screen>&prompt.user; rage -d -i <replaceable>SSH_PRIVATE_KEY</replaceable> -o <replaceable>DECRYPTED_FILE</replaceable><replaceable>ENCRYPTED_FILE</replaceable></screen>
+    <screen>&prompt.user; rage -d -i <replaceable>SSH_PRIVATE_KEY_FILE</replaceable> -o <replaceable>DECRYPTED_FILE</replaceable><replaceable>ENCRYPTED_FILE</replaceable></screen>
     <para>For example:</para>
     <screen>&prompt.user; rage -d -i id_ed25519 -o test.txt.decrypted test.txt.age</screen>
      <important><para>You must enter the full path of the key and the files.</para></important>
      <para><emphasis role="bold">Multiple identities</emphasis></para>
-     <para>Rage can encrypt multiple identities at the same time. All the associated keys can be used to decrypt a file.</para>
+     <para>Rage can encrypt to multiple identities at the same time. Any of the recipient's private keys can be used to decrypt the file.</para>
       <screen>rage -e -a -R <replaceable>FIRST_SSH_PUBLIC_KEY</replaceable>-r <replaceable>FIRST_RAGE_PUBLIC_KEY</replaceable>... -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
       <para>For example:</para>
       <screen>rage -e -a -R id_ed25519.pub -r age1h8equ4vs5pyp8ykw0z8m9n8m3psy6swme52ztth0v66frgu65ussm8gq0t -o -r age1y2lc7x59jcqvrpf3ppmnj3f93ytaegfkdnl5vrdyv83l8ekcae4sexgwkg test.txt.age test.txt</screen>

--- a/xml/security_cryptofs.xml
+++ b/xml/security_cryptofs.xml
@@ -239,7 +239,7 @@
    To encrypt a file with GPG, you need to generate a key pair first. To do
    this, run the <command>gpg --gen-key</command> and follow the on-screen
    instructions. When generating the key pair, GPG creates a user ID (UID) to
-   identify the key based on your real name, comments, and email address. You
+   identify the key based on your real name, comments and email address. You
    need this UID (or just a part of it like your first name or email address)
    to specify the key you want to use to encrypt a file. To find the UID of
    an existing key, use the <command>gpg --list-keys</command> command. To
@@ -273,7 +273,7 @@
   </para>
   <para>
     Keep in mind that the encrypted file can be only decrypted using the same
-    key that was used for encryption. If you want to share an encrypted file
+    key that was used for encryption. To share an encrypted file
     with another person, you have to use that person's public key to encrypt
     the file.
   </para>
@@ -281,14 +281,15 @@
  <sect1 xml:id="sec-security-cryptofs-rage">
   <title>Encrypting files with Rage</title>
   <para>
-   Rage is a secure file encryption software to encrypt files.
-   Rage has small explicit keys and does not have configuration options.
+   Rage is a secure file encryption software to encrypt files. It has
+   keys that are easy to exchange with other people, and has secure defaults
+   to prevent accidental misuse or leaks of sensitive data.
   </para>
-  <para>You must first generate a key pair to encrypt a file with Rage:
+  <para> The recipient must first generate a key pair to encrypt a file with Rage:
    </para>
    <screen>&prompt.user;rage-keygen -o ~/rage.key 2 ~/rage.pub</screen>
-   <para>Note that two files are created; <emphasis>rage.pub</emphasis> and <emphasis>rage.key</emphasis>.
-   A recipient can be either an <emphasis>age</emphasis> or <emphasis>SSH</emphasis> public key.</para>
+   <para>Two files are created; <emphasis>rage.pub</emphasis> and <emphasis>rage.key</emphasis>.
+   </para>
    <para><emphasis role="bold">rage.pub example</emphasis></para>
    <screen>&prompt.user; cat file.pub
     Public key: age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e </screen>
@@ -296,33 +297,31 @@
    <screen>&prompt.user; cat file.key
     # created: 2023-05-30T16:29:20+05:30
     # public key: age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e </screen>
+    <important><para><emphasis>file.key</emphasis> is a private key and should be kept confidential.</para></important>
    <para><emphasis role="bold">Encrypt</emphasis></para>
    <para>To encrypt a file, you need the generated public key:</para>
    <screen>&prompt.user;rage -e -r <replaceable>PUBLIC_KEY</replaceable> -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable> </screen>
    <para>For example:</para>
    <screen>>&prompt.user;rage -e -r age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e -o test.txt.age test.txte </screen>
-   <para>An encrypted version of the specified file is recognizable by the <emphasis>.age</emphasis> file extension that is created.</para>
    <para><emphasis role="bold">Decrypt</emphasis></para>
-   <para>Note that the encrypted file can be only decrypted using the same key that was used for encryption.
-   If you want to share an encrypted file with another person, you have to use that person's public key to encrypt the file.</para>
+   <para>The encrypted file can be only decrypted by the recipient who has the corresponding private key.
+   To share an encrypted file with another person, you have to use that person's public key to encrypt the file.</para>
    <screen>&prompt.user;rage -d -i ~/rage.key -o <replaceable>DECRYPTED_FILE</replaceable> <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable> </screen>
    <para>For example:</para>
    <screen>>&prompt.user;rage -d -i ~/rage.key -o test.txt.decrypted test.txt.age </screen>
    <para><emphasis role="bold">Passphrases</emphasis></para>
    <para>You can encrypt files with passphrases with the <envar>-p</envar> or <envar>--passphrase</envar> arguments.
-   By default, Rage will automatically generate a secure passphrase, but you also have the option to enter a passphrase.</para>
+   By default, Rage automatically generates a secure passphrase, but you also have the option to enter a passphrase.</para>
    <screen>&prompt.user;rage -e -p -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable> </screen>
    <para>For example:</para>
    <screen>>&prompt.user;rage -e -p -o test.txt.age test.txt </screen>
    <para><emphasis role="bold">SSH</emphasis></para>
-   <para>You can encrypt files with SSH (Secure Socket Shell). Rage supports <emphasis>ssh-rsa</emphasis> and <emphasis>ssh-ed25519</emphasis>
-   public keys,and decrypting with the respective private key file. Note that <emphasis>ssh-agent</emphasis> is not supported.</para>
+   <para>You can encrypt files with SSH (Secure Socket Shell) keys. Rage supports <emphasis>ssh-rsa</emphasis> and <emphasis>ssh-ed25519</emphasis>
+   public keys,and decrypting with the respective private key file. <emphasis>ssh-agent</emphasis> is not supported.</para>
    <para>You can use the SSH keys in place of the Rage keys.</para>
    <para>For example:</para>
    <screen>&prompt.user; ssh-keygen -t ed25519</screen>
-   <para>SSH keys has more complex cryptography, and embeds a public key tag in the encrypted file.
-   This makes it possible to track files that are encrypted to a specific public key</para>
-   <para>To encrypt:</para>
+    <para>To encrypt:</para>
    <screen>&prompt.user; rage -e -a -R <replaceable>PUBLIC_KEY</replaceable> -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
     <para>For example:</para>
     <screen>&prompt.user; rage -e -a -R id_ed25519.pub -o test.txt.age test.txt</screen>
@@ -332,7 +331,7 @@
     <screen>&prompt.user; rage -d -i id_ed25519 -o test.txt.decrypted test.txt.age</screen>
      <important><para>You must enter the full path of the key and the files.</para></important>
      <para><emphasis role="bold">Multiple identities</emphasis></para>
-     <para>Rage can encrypt multiple identities at the same time. Note that all the associated keys can be used to decrypt a file.</para>
+     <para>Rage can encrypt multiple identities at the same time. All the associated keys can be used to decrypt a file.</para>
       <screen>rage -e -a -R <replaceable>FIRST_SSH_PUBLIC_KEY</replaceable>-r <replaceable>FIRST_RAGE_PUBLIC_KEY</replaceable>... -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable></screen>
       <para>For example:</para>
       <screen>rage -e -a -R id_ed25519.pub -r age1h8equ4vs5pyp8ykw0z8m9n8m3psy6swme52ztth0v66frgu65ussm8gq0t -o -r age1y2lc7x59jcqvrpf3ppmnj3f93ytaegfkdnl5vrdyv83l8ekcae4sexgwkg test.txt.age test.txt</screen>

--- a/xml/security_cryptofs.xml
+++ b/xml/security_cryptofs.xml
@@ -283,9 +283,10 @@
   <para>
    Rage is a secure file encryption software to encrypt files. It has
    keys that are easy to exchange with other people, and has secure defaults
-   to prevent accidental misuse or leaks of sensitive data.
-   We recommend Rage to encrypt files.
+   to prevent accidental misuse or leaks of sensitive data. We recommend Rage to encrypt files.
   </para>
+  <para>You can install Rage with:</para>
+   <screen>&prompt.sudo;<command>zypper install rage-encryption</command></screen>
   <para> The recipient must first generate a key pair to encrypt a file with Rage:
    </para>
    <screen>&prompt.user;rage-keygen -o ~/rage.key 2 ~/rage.pub</screen>

--- a/xml/security_cryptofs.xml
+++ b/xml/security_cryptofs.xml
@@ -287,7 +287,8 @@
   <para>You must first generate a key pair to encrypt a file with Rage:
    </para>
    <screen>&prompt.user;rage-keygen -o ~/rage.key 2 ~/rage.pub</screen>
-   <para>Note that two files are created; <emphasis>rage.pub</emphasis> and <emphasis>rage.key</emphasis>. </para>
+   <para>Note that two files are created; <emphasis>rage.pub</emphasis> and <emphasis>rage.key</emphasis>.
+   A recipient can be either an <emphasis>age</emphasis> or <emphasis>SSH</emphasis> public key.</para>
    <para><emphasis role="bold">rage.pub example</emphasis></para>
    <screen>&prompt.user; cat file.pub
     Public key: age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e </screen>
@@ -298,10 +299,28 @@
    <para><emphasis role="bold">Encrypt</emphasis></para>
    <para>To encrypt a file, you need the generated public key:</para>
    <screen>&prompt.user;rage -e -r <replaceable>PUBLIC_KEY</replaceable> -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable> </screen>
+   <para>For example:</para>
+   <screen>>&prompt.user;rage -e -r age17e4g67cs07jk3lmylyq6gduv26uf7tz7nm9jrsaxn8xxx9uc9amsdg4a5e -o test.txt.age test.txte </screen>
    <para>An encrypted version of the specified file is recognizable by the <emphasis>.age</emphasis> file extension that is created.</para>
    <para><emphasis role="bold">Decrypt</emphasis></para>
-   <para> </para>
-   </sect1>
+   <para>Note that the encrypted file can be only decrypted using the same key that was used for encryption.
+   If you want to share an encrypted file with another person, you have to use that person's public key to encrypt the file.</para>
+   <screen>&prompt.user;rage -d -i ~/rage.key -o <replaceable>DECRYPTED_FILE</replaceable> <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable> </screen>
+   <para>For example:</para>
+   <screen>>&prompt.user;rage -d -i ~/rage.key -o test.txt.decrypted test.txt.age </screen>
+   <para><emphasis role="bold">Passphrases</emphasis></para>
+   <para>You can encrypt files with passphrases with the <envar>-p</envar> or <envar>--passphrase</envar> arguments.
+   By default, Rage will automatically generate a secure passphrase, but you also have the option to enter a passphrase.</para>
+   <screen>&prompt.user;rage -e -p -o <replaceable>ENCRYPTED_FILE</replaceable> <replaceable>FILE</replaceable> </screen>
+   <para>For example:</para>
+   <screen>>&prompt.user;rage -e -p -o test.txt.age test.txt </screen>
+   <para><emphasis role="bold">SSH</emphasis></para>
+   <para>You can encrypt files with SSH (Secure Socket Shell). Rage supports <emphasis>ssh-rsa</emphasis> and <emphasis>ssh-ed25519</emphasis>
+   public keys,and decrypting with the respective private key file. Note that <emphasis>ssh-agent</emphasis> is not supported.</para>
+   <para>You can use the SSH keys in place of the Rage keys.</para>
+   <para>For example:</para>
+   <screen>&prompt.user; ssh-keygen -t ed25519</screen>
+    </sect1>
    <sect1 xml:id="sec-security-cryptofs-rage-additional-resources">
    <title>Additional Resources</title>
    <itemizedlist>


### PR DESCRIPTION
### PR creator: Description

The scope of this PR is to add Rage encryption software and tell users that this is the preferred method over GPG.   

### PR creator: Are there any relevant issues/feature requests?

[PED-1897](https://jira.suse.com/browse/PED-1897)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [X] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
