### PR TITLE
Indicate that <partitioning/> section is ignored on an installed system

### DIFF
--- a/xml/ay_running_system.xml
+++ b/xml/ay_running_system.xml
@@ -19,7 +19,8 @@ xml:id="InstalledSystem">
  </info>
 
    <para>
-    In some cases it is useful to run &ay; in a running system.
+    In some cases it is useful to run &ay; in a running system. Bear in mind that the
+    <literal>partitioning</literal> section is ignored in this scenario.
    </para>
    <para>
     In the following example, an additional software package


### PR DESCRIPTION
### PR creator: Description

On an already installed system, AutoYaST ignores the `<partitioning>` section. Let's make this clear.

### PR creator: Are there any relevant issues/feature requests?

* [bsc#1211753](https://bugzilla.suse.com/show_bug.cgi?id=1211753)

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [X] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [X] SLE 15 SP4/openSUSE Leap 15.4
  - [X] SLE 15 SP3/openSUSE Leap 15.3
  - [X] SLE 15 SP2/openSUSE Leap 15.2
  - [X] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
