### PR TITLE
Fix snapper command

### DIFF
--- a/xml/snapper.xml
+++ b/xml/snapper.xml
@@ -2679,7 +2679,7 @@ TIMELINE_MIN_AGE="1800"</screen>
       the used disk space for each snapshot in the
     <literal>Used Space</literal> column:
 </para>
-<screen>&prompt.root;snapper--iso list
+<screen>&prompt.root;snapper --iso list
   # | Type   | Pre # | Date                | User | Used Space | Cleanup | Description           | Userdata     
 ----+--------+-------+---------------------+------+------------+---------+-----------------------+--------------
  0  | single |       |                     | root |            |         | current               |              


### PR DESCRIPTION
### PR creator: Description

Fix `snapper--iso list` to `snapper --iso list`


### PR creator: Which product versions do the changes apply to?

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

Not sure if this should be backported.

- [ ] all necessary backports are done
