### PR TITLE
Virtualization Guide: integrate proofing corrections

### DIFF
--- a/xml/libvirt_configuration_gui.xml
+++ b/xml/libvirt_configuration_gui.xml
@@ -291,7 +291,7 @@
           specify the virtual CPU address size when using
           <literal>host-model</literal> or <literal>custom</literal> CPU modes.
           The default virtual CPU address size for these modes may not be
-          sufficient for memory configurations of 4TB or more. The address size
+          sufficient for memory configurations of 4&nbsp;TB or more. The address size
           can only be specified by editing the &vmguest;s XML configuration.
           See <xref linkend="sec-libvirt-config-memory-virsh"/> for more
           information on specifying virtual CPU address size.

--- a/xml/libvirt_configuration_virsh.xml
+++ b/xml/libvirt_configuration_virsh.xml
@@ -305,7 +305,7 @@ current      live           4
         <title>Exceeding 255 CPUs</title>
         <para>
           With &kvm;, it is possible to define a &vmguest; with more than 255
-          CPUs, however, additional configuration is necessary to start and run
+          CPUs. However, additional configuration is necessary to start and run
           the &vmguest;. The <literal>ioapic</literal> feature needs to be
           tuned and an IOMMU device needs to be added to the &vmguest;. Below
           is an example configuration for 288 CPUs.

--- a/xml/libvirt_overview.xml
+++ b/xml/libvirt_overview.xml
@@ -21,7 +21,7 @@
     daemon deployment options: monolithic or modular daemons. &libvirt; has
     always provided the single monolithic daemon &libvirtd;. It includes the
     primary hypervisor drivers and all supporting secondary drivers needed for
-    storage, for example, networking, node device and management. The
+    storage, such as networking, node device and management. The
     monolithic &libvirtd; also provides secure remote access for external
     clients. With modular daemons, each driver runs in its own daemon, allowing
     users to customize their &libvirt; deployment. By default, the monolithic
@@ -271,7 +271,7 @@
           <emphasis>virtinterfaced</emphasis> - The host NIC management daemon
           which provides &libvirt;'s host network interface management APIs.
           For example, virtinterfaced can be used to create a bonded network
-          device on the host. &suse; discourages use of &libvirt;'s interface
+          device on the host. &suse; discourages the use of &libvirt;'s interface
           management APIs in favor of default networking tools like wicked or
           &nm;. It is recommended to disable virtinterfaced.
         </para>

--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -1280,7 +1280,7 @@
         <title>Intel flexMigration</title>
         <para>
           For machines that support Intel FlexMigration, CPU-ID masking and
-          faulting allow more flexibility in cross-CPU migration.
+          faulting allow for more flexibility in cross-CPU migration.
         </para>
       </note>
       <tip>


### PR DESCRIPTION
### PR creator: Description

Integrate proofing corrections for the Virtualization Guide from proofing drop 3.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4