### PR TITLE
RMT Guide: integrate proofing corrections

### DIFF
--- a/xml/rmt_rmt-cli.xml
+++ b/xml/rmt_rmt-cli.xml
@@ -338,7 +338,7 @@
     <term><command>rmt-cli systems purge</command></term>
     <listitem>
      <para>
-      This command lists and optionally deletes inactive systems.
+      This command lists and provides the option to delete inactive systems.
       It has the following options:
      </para>
      <itemizedlist>


### PR DESCRIPTION
### PR creator: Description

Integrate proofing corrections for the RMT Guide from proofing drop 3.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
