### PR TITLE
Security Guide-adds consulting statement

### DIFF
--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -412,8 +412,7 @@ system_u:object_r:var_t var</screen>
    The policy is an essential component of &selnx;. &productname; &productnumber;
    includes the <emphasis>minimum</emphasis> &selnx; reference policy in the
    package <package>selinux-policy-minimum</package>. You must build a
-   policy that is customized for your installation. &selnx; policies
-   should be customized for your particular needs; consult &suse;
+   policy that is customized for your installation. Consult &suse;
    consulting services for assistance.
    The examples in this chapter refer to this policy if not stated otherwise.
   </para>

--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -412,7 +412,8 @@ system_u:object_r:var_t var</screen>
    The policy is an essential component of &selnx;. &productname; &productnumber;
    includes the <emphasis>minimum</emphasis> &selnx; reference policy in the
    package <package>selinux-policy-minimum</package>. You must build a
-   policy that is customized for your installation. Consult &suse;
+   policy that is customized for your installation. &selnx; policies
+   should be customized for your particular needs; consult &suse;
    consulting services for assistance.
    The examples in this chapter refer to this policy if not stated otherwise.
   </para>

--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -411,8 +411,11 @@ system_u:object_r:var_t var</screen>
   <para>
    The policy is an essential component of &selnx;. &productname; &productnumber;
    includes the <emphasis>minimum</emphasis> &selnx; reference policy in the
-   package <package>selinux-policy-minimum</package>. The examples in
-   this chapter refer to this policy if not stated otherwise.
+   package <package>selinux-policy-minimum</package>. You must build a
+   policy that is customized for your installation. &selnx; policies
+   should be customized for your particular needs; consult &suse;
+   consulting services for assistance.
+   The examples in this chapter refer to this policy if not stated otherwise.
   </para>
 <!-- fs 2018-09-27: Packages no longer exist
   <tip>

--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -413,11 +413,11 @@ system_u:object_r:var_t var</screen>
    includes the <emphasis>minimum</emphasis> &selnx; reference policy in the
    package <package>selinux-policy-minimum</package>. You must build a
    policy that is customized for your installation. &selnx; policies
-   should be customized for your particular needs; consult &suse;
+   should be customized for your particular needs. Contact &suse;
    consulting services for assistance.
    We recommend <literal>slemicro</literal> for customers and partners who are looking for a containerized or virtualized
-   host with full &selnx; support including a supported policy.
-   The examples in this chapter refer to this policy if not stated otherwise.
+   host with full &selnx; support, including a supported policy.
+   The examples in this chapter refer to this policy, if not stated otherwise.
   </para>
 <!-- fs 2018-09-27: Packages no longer exist
   <tip>

--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -415,6 +415,8 @@ system_u:object_r:var_t var</screen>
    policy that is customized for your installation. &selnx; policies
    should be customized for your particular needs; consult &suse;
    consulting services for assistance.
+   We recommend <literal>slemicro</literal> for customers and partners who are looking for a containerized or virtualized
+   host with full &selnx; support including a supported policy.
    The examples in this chapter refer to this policy if not stated otherwise.
   </para>
 <!-- fs 2018-09-27: Packages no longer exist


### PR DESCRIPTION
### PR creator: Description

Describe the overall goals of this pull request.

SLE 12 supported versions do not have the statement for SUSE consulting. 

### PR creator: Are there any relevant issues/feature requests?

[DOCTEAM-661](https://jira.suse.com/browse/DOCTEAM-661)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
