### PR TITLE
AMD-SEV: integrate proofing corrections

### DIFF
--- a/xml/art_amd-sev.xml
+++ b/xml/art_amd-sev.xml
@@ -489,7 +489,7 @@
       the <literal>sevctl</literal> package. The following example illustrates
       the use of the <command>sevctl session</command> command to create all
       the prelaunch SEV-related artifacts. The <replaceable>NAME</replaceable>
-      parameter is optional and allows specifying a prefix for the artifact
+      parameter is optional and allows a prefix to be specified for the artifact
       file names. Using the VM name as a prefix is convenient for matching
       artifacts with VMs later. The path to the platform Diffie-Hellman (DH)
       certificate and the desired SEV policy are required parameters.
@@ -499,7 +499,7 @@
 
     <para>
       The <command>sevctl session</command> command produces four files:
-      tik.bin, tek.bin, godh.b64, and session.b64. If the optional
+      tik.bin, tek.bin, godh.b64 and session.b64. If the optional
       <replaceable>NAME</replaceable> parameter was used, the files are
       prefixed with the specified value. The transport integrity key (tik.bin)
       and transport encryption key (tek.bin) are used in the verification stage


### PR DESCRIPTION
### PR creator: Description

Integrate proofing corrections for the AMD-SEV Guide from proofing drop 3.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4