### PR TITLE
Tuning Guide: integrate proofing corrections

### DIFF
--- a/xml/common_intro_support.xml
+++ b/xml/common_intro_support.xml
@@ -36,7 +36,7 @@
   <title>Support statement for &productname;</title>
   <para>
    To receive support, you need an appropriate subscription with &suse;.
-   To view the specific support offerings available to you, go to
+   To view the specific support offers available to you, go to
    <link xlink:href="https://www.suse.com/support/"/> and select your product.
   </para>
   <para>
@@ -59,7 +59,7 @@
     <listitem>
      <para>
       Problem isolation, which means technical support designed to analyze
-      data, reproduce customer problems, isolate problem area and provide a
+      data, reproduce customer problems, isolate a problem area and provide a
       resolution for problems not resolved by Level&nbsp;1 or prepare for
       Level&nbsp;3.
      </para>

--- a/xml/common_intro_support.xml
+++ b/xml/common_intro_support.xml
@@ -36,7 +36,7 @@
   <title>Support statement for &productname;</title>
   <para>
    To receive support, you need an appropriate subscription with &suse;.
-   To view the specific support offers available to you, go to
+   To view the specific support offerings available to you, go to
    <link xlink:href="https://www.suse.com/support/"/> and select your product.
   </para>
   <para>

--- a/xml/common_intro_support.xml
+++ b/xml/common_intro_support.xml
@@ -59,7 +59,7 @@
     <listitem>
      <para>
       Problem isolation, which means technical support designed to analyze
-      data, reproduce customer problems, isolate a problem area and provide a
+      data, reproduce customer problems, isolate problem area and provide a
       resolution for problems not resolved by Level&nbsp;1 or prepare for
       Level&nbsp;3.
      </para>

--- a/xml/tuning_how.xml
+++ b/xml/tuning_how.xml
@@ -233,7 +233,7 @@
    impact. Each tuning activity should be measured over a sufficient time
    period to ensure you can do an analysis based on significant
    data. If you cannot measure a positive effect, do not make the change
-   permanent. Chances are, that it might have a negative effect in the
+   permanent. Chances are that it might have a negative effect in the
    future.
   </para>
  </sect1>

--- a/xml/tuning_sapconf.xml
+++ b/xml/tuning_sapconf.xml
@@ -247,7 +247,7 @@ Sapconf will not work properly!</screen>
     practice, as it can lead to &sapconf; not properly applying the profile.
    </para>
    <para>
-    To apply edited configuration, restart &sapconf;:
+    To apply the edited configuration, restart &sapconf;:
    </para>
    <screen>&prompt.root;<command>systemctl restart sapconf</command></screen>
    <para>

--- a/xml/tuning_taskscheduler.xml
+++ b/xml/tuning_taskscheduler.xml
@@ -478,7 +478,7 @@ pid 16244's current scheduling priority: 0
    </para>
 <screen>&prompt.root;<command>sysctl <replaceable>VARIABLE</replaceable>=<replaceable>VALUE</replaceable></command></screen>
    <para>
-    To get a list of all scheduler related variables, run the
+    To get a list of all scheduler-related variables, run the
     <command>sysctl</command> command, and use <command>grep</command>
     to filter the output:
    </para>

--- a/xml/utilities.xml
+++ b/xml/utilities.xml
@@ -1051,7 +1051,7 @@ systemd---accounts-daemon---{gdbus}
    <para>
     The command <command>top</command> (an abbreviation of <quote>table of
     processes</quote>) displays a list of processes that is refreshed every
-    two seconds. To terminate the program, press <keycap>q</keycap>. The
+    two seconds. To terminate the program, press <keycap>Q</keycap>. The
     parameter <option>-n 1</option> terminates the program after a single
     display of the process list. The following is an example output of the
     command <command>top -n 1</command>:


### PR DESCRIPTION
### PR creator: Description

Integrate proofing corrections for the Tuning Guide from proofing drop 3.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4