### PR TITLE
Add license blurb

### DIFF
--- a/xml/art_amd-sev.xml
+++ b/xml/art_amd-sev.xml
@@ -708,5 +708,6 @@ spec:
       </listitem>
     </itemizedlist>
   </sect1>
+  <xi:include href="common_copyright_quick.xml"/>
   <xi:include href="common_license_gfdl1.2.xml"/>
 </article>

--- a/xml/art_minimal-vm.xml
+++ b/xml/art_minimal-vm.xml
@@ -679,4 +679,6 @@ runcmd:
    </para>
   </tip>
  </sect1>
+ <xi:include href="common_copyright_quick.xml"/>
+ <xi:include href="common_license_gfdl1.2.xml"/>
 </article>

--- a/xml/art_virtualization-best-practices.xml
+++ b/xml/art_virtualization-best-practices.xml
@@ -4019,4 +4019,6 @@ LC_ALL=C PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
       </listitem>
     </itemizedlist>
   </sect1>
+  <xi:include href="common_copyright_quick.xml"/>
+  <xi:include href="common_license_gfdl1.2.xml"/>
 </article>


### PR DESCRIPTION
### PR creator: Description

Some articles were missing the license blurb as reported by Julia.

Adding them for
- Minimal VM Quick
- AMD-SEV
- Virt. Best Practices 


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
