### PR TITLE
JSC#DOCTEAM-1020-adds sudo and format

### DIFF
--- a/xml/security_ldap_install.xml
+++ b/xml/security_ldap_install.xml
@@ -246,7 +246,7 @@ Instance "LDAP1" is running</screen>
 <screen>&prompt.sudo;<command>dsctl <replaceable>LDAP1</replaceable> remove</command>
 Not removing: if you are sure, add --do-it
 
-&prompt.sudo;dsctl <command><replaceable>LDAP1</replaceable> remove --do-it</command></screen>
+&prompt.sudo;<command>dsctl<replaceable>LDAP1</replaceable> remove --do-it</command></screen>
     <para>
      This command also removes partially installed or corrupted instances. You
      can reliably create and remove instances as often as you want.
@@ -257,7 +257,7 @@ Not removing: if you are sure, add --do-it
    If you forget the name of your instance, use <command>dsctl</command> to
    list all instances:
   </para>
-<screen>&prompt.user;<command>dsctl -l</command>
+<screen>&prompt.user;<command>sudo dsctl -l</command>
 slapd-<replaceable>LDAP1</replaceable></screen>
  </sect2>
 
@@ -275,13 +275,13 @@ slapd-<replaceable>LDAP1</replaceable></screen>
   <para>
    The following example prints the template to stdout:
   </para>
-<screen>&prompt.user;<command>dscreate create-template</command></screen>
+<screen>&prompt.user;<command>sudo dscreate create-template</command></screen>
   <para>
    This is good for a quick review of the template, but you must create a file
    to use in creating your new &ds389; instance. You can name this file
    anything you want:
   </para>
-<screen>&prompt.user;<command>dscreate create-template <replaceable>TEMPLATE.txt</replaceable></command></screen>
+<screen>&prompt.user;<command>sudo dscreate create-template <replaceable>TEMPLATE.txt</replaceable></command></screen>
   <para>
    This is a snippet from the new file:
   </para>


### PR DESCRIPTION
### PR creator: Description

Prefix of sudo is missing in some commands for 389 Directory Server . Also xml format error rectified.


### PR creator: Are there any relevant issues/feature requests?

[DOCTEAM-1020](https://jira.suse.com/browse/DOCTEAM-1020)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
