### PR TITLE
Remove python-libteam package from docs

### DIFF
--- a/xml/net_teaming.xml
+++ b/xml/net_teaming.xml
@@ -184,11 +184,8 @@
   <title>General procedure</title>
   <step>
    <para>
-    Make sure you have all the necessary packages installed. Install the
-    packages
-    <package>libteam-tools</package>,
-    <package>libteamdctl0</package>, and
-    <package>python-libteam</package>.
+    Verify that the required packages <package>libteam-tools</package> and
+    <package>libteamdctl0</package> are installed.
    </para>
   </step>
   <step>


### PR DESCRIPTION
### PR creator: Description

The package is no longer in supported repos


### PR creator: Are there any relevant issues/feature requests?

* bsc#1212159


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
