### PR TITLE
ay_kernel_dumps: remove KDUMP_COPY_KERNEL

### DIFF
--- a/xml/ay_kernel_dumps.xml
+++ b/xml/ay_kernel_dumps.xml
@@ -68,7 +68,6 @@
 
     &lt;!-- dump target settings --&gt;
     &lt;KDUMP_SAVEDIR&gt;ftp://stravinsky.suse.de/incoming/dumps&lt;/KDUMP_SAVEDIR&gt;
-    &lt;KDUMP_COPY_KERNEL&gt;true&lt;/KDUMP_COPY_KERNEL&gt;
     &lt;KDUMP_FREE_DISK_SIZE&gt;64&lt;/KDUMP_FREE_DISK_SIZE&gt;
     &lt;KDUMP_KEEP_OLD_DUMPS&gt;5&lt;/KDUMP_KEEP_OLD_DUMPS&gt;
 
@@ -261,13 +260,6 @@
     the target partition would end up with less free disk space than specified
     in <literal>KDUMP_FREE_DISK_SIZE</literal>, the dump is not saved.
    </para>
-   <para>
-    To save the whole kernel and the debug information (if installed) to the
-    same directory, set <literal>KDUMP_COPY_KERNEL</literal> to
-    <literal>true</literal>. You will have everything you need to analyze the
-    dump in one directory (except kernel modules and their debugging
-    information).
-   </para>
   </sect3>
   <sect3 xml:id="CreateProfile-kdump-saving-compression">
    <title>Filtering and compression</title>
@@ -303,20 +295,6 @@
 <screen>&lt;KDUMP_SAVEDIR&gt;file:///var/crash/&lt;/KDUMP_SAVEDIR&gt;</screen>
       <para>
        required
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><literal>KDUMP_COPY_KERNEL</literal></term>
-     <listitem>
-      <para>
-       Set to <literal>true</literal>, if not only the dump should be saved to
-       <literal>KDUMP_SAVEDIR</literal> but also the kernel and its debugging
-       information (if installed).
-      </para>
-<screen>&lt;KDUMP_COPY_KERNEL&gt;false&lt;/KDUMP_COPY_KERNEL&gt;</screen>
-      <para>
-       optional
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
this config option has been removed since kdump version 1.9.0 and yast-kdump version 4.6.1

### PR creator: Description

Describe the overall goals of this pull request.


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#...


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
