### PR TITLE
Dont rename the root account (PED-3897)

### DIFF
--- a/xml/ay_users_groups.xml
+++ b/xml/ay_users_groups.xml
@@ -116,10 +116,9 @@
        support renaming the &rootuser; account.
      </para>
      <para>
-       Usually the idea behind renaming the &rootuser; account is to hide or make it unpredictable.
+       Usually, the idea behind renaming the &rootuser; account is to hide it or make it unpredictable.
        However, <filename>/etc/passwd</filename> requires <literal>644</literal> permissions for
-       regular users, so any user of the given system is able to retrieve the login name for the
-       user ID 0.
+       regular users, so any user of the system can retrieve the login name for the user ID 0.
        <phrase os="sles;sled;osuse">For better ways to secure the &rootuser; account, refer to
          <xref linkend="sec-sec-prot-restrict-root"/> and
          <xref linkend="sec-sec-prot-restrict-root-ssh"/>.</phrase>

--- a/xml/ay_users_groups.xml
+++ b/xml/ay_users_groups.xml
@@ -119,8 +119,10 @@
        Usually the idea behind renaming the &rootuser; account is to hide or make it unpredictable.
        However, <filename>/etc/passwd</filename> requires <literal>644</literal> permissions for
        regular users, so any user of the given system is able to retrieve the login name for the
-       user ID 0. For better ways to secure the &rootuser; account, refer to <xref
-        linkend="sec-sec-prot-restrict-root"/> and <xref linkend="sec-sec-prot-restrict-root-ssh"/>.
+       user ID 0.
+       <phrase os="sles;sled;osuse">For better ways to secure the &rootuser; account, refer to
+         <xref linkend="sec-sec-prot-restrict-root"/> and
+         <xref linkend="sec-sec-prot-restrict-root-ssh"/>.</phrase>
      </para>
    </warning>
   <note xml:id="ann-Configuration-Security-users-uid">

--- a/xml/ay_users_groups.xml
+++ b/xml/ay_users_groups.xml
@@ -104,11 +104,11 @@
      <para>
        While it is technically possible to create an account with the user ID
        (<literal>uid</literal>) <literal>0</literal> and a name other than &rootuser;, certain
-       applications, scripts or 3rd party products may rely on the existence of a user called
+       applications, scripts or third-party products may rely on the existence of a user called
        &rootuser;. While such a configuration always targets individual environments, necessary
-       adjustments could be overwritten by vendor updates, so this becomes an ongoing task and is no
-       one time setting. Especially in very complex setups involving 3rd party applications it needs
-       to be verified with every involved vendor whether a rename of the &rootuser; account
+       adjustments could be overwritten by vendor updates, so this becomes an ongoing task, not
+       a one-time setting. This is especially true in very complex setups involving third-party applications, 
+       where it needs to be verified with every involved vendor whether a rename of the &rootuser; account
        is supported.
      </para>
      <para>

--- a/xml/ay_users_groups.xml
+++ b/xml/ay_users_groups.xml
@@ -95,6 +95,34 @@
     precedence over <command>linuxrc</command> passwords.
    </para>
   </note>
+   <!-- cwickert 2023-07-04: This is based on https://www.suse.com/support/kb/doc/?id=000020537
+    If you change something here, please also update sec-yast-userman-users and
+    sec-yast-install-user-root.
+   -->
+   <warning>
+     <title>Do not create a superuser account with a name other than &rootuser;</title>
+     <para>
+       While it is technically possible to create an account with the user ID
+       (<literal>uid</literal>) <literal>0</literal> and a name other than &rootuser;, certain
+       applications, scripts or 3rd party products may rely on the existence of a user called
+       &rootuser;. While such a configuration always targets individual environments, necessary
+       adjustments could be overwritten by vendor updates, so this becomes an ongoing task and is no
+       one time setting. Especially in very complex setups involving 3rd party applications it needs
+       to be verified with every involved vendor whether a rename of the &rootuser; account
+       is supported.
+     </para>
+     <para>
+       As the implications for renaming the &rootuser; account cannot be foreseen, &suse; does not
+       support renaming the &rootuser; account.
+     </para>
+     <para>
+       Usually the idea behind renaming the &rootuser; account is to hide or make it unpredictable.
+       However, <filename>/etc/passwd</filename> requires <literal>644</literal> permissions for
+       regular users, so any user of the given system is able to retrieve the login name for the
+       user ID 0. For better ways to secure the &rootuser; account, refer to <xref
+        linkend="sec-sec-prot-restrict-root"/> and <xref linkend="sec-sec-prot-restrict-root-ssh"/>.
+     </para>
+   </warning>
   <note xml:id="ann-Configuration-Security-users-uid">
    <title>Specifying a user ID (<literal>uid</literal>)</title>
    <para>

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -2108,7 +2108,7 @@ sle-live-patching 8c541494</screen>
    If you have not chosen <guimenu>Use this Password for System
    Administrator</guimenu> in the previous step, you will be prompted to enter
    a password for the system administrator &rootuser; or provide a public SSH
-   key. Otherwise this configuration step is skipped.
+   key. Otherwise, this configuration step is skipped.
   </para>
   <figure>
    <title>Authentication for the system administrator &rootuser;</title>
@@ -2128,7 +2128,7 @@ sle-live-patching 8c541494</screen>
   </figure>
    <para>
      Enter the password for the system administrator &rootuser;. For verification purposes, the
-     password for &rootuser; must be entered twice. Do not forget the password, it cannot be
+     password for &rootuser; must be entered twice. Do not forget the password as it cannot be
      retrieved later.
    </para>
   <tip>
@@ -2155,9 +2155,9 @@ sle-live-patching 8c541494</screen>
          <term>Do not forget the &rootuser; password</term>
          <listitem>
            <para>
-             Only &rootuser; has the necessary privileges to change the system configuration,
-             install programs, manage users, and set up new hardware. To carry out such tasks, the
-             &rootuser; password is required. Do not forget the password, it cannot be retrieved
+             Only &rootuser; has the privileges to change the system configuration,
+             install programs, manage users and set up new hardware. To carry out such tasks, the
+             &rootuser; password is required. Do not forget the password as it cannot be retrieved
              later.
            </para>
          </listitem>
@@ -2168,8 +2168,8 @@ sle-live-patching 8c541494</screen>
            <para>
              Logging in as &rootuser; for daily work is rather risky: Commands from &rootuser; are
              usually executed without additional confirmation, so a single mistake can lead to
-             irretrievable loss of system files. Only use the &rootuser; account for system
-             administration, maintenance, and repair.
+             an irretrievable loss of system files. Only use the &rootuser; account for system
+             administration, maintenance and repair.
            </para>
          </listitem>
        </varlistentry>
@@ -2195,10 +2195,10 @@ sle-live-patching 8c541494</screen>
              not support renaming the &rootuser; account.
            </para>
            <para>
-             Usually the idea behind renaming the &rootuser; account is to hide or make it
+             Usually, the idea behind renaming the &rootuser; account is to hide it or make it
              unpredictable. However, <filename>/etc/passwd</filename> requires
-             <literal>644</literal> permissions for regular users, so any user of the given system
-             is able to retrieve the login name for the user ID 0.
+             <literal>644</literal> permissions for regular users, so any user of the system
+             can retrieve the login name for the user ID 0.
              <phrase os="sles;sled;osuse">For better ways to secure the &rootuser; account, refer to
                <xref linkend="sec-sec-prot-restrict-root"/> and
                <xref linkend="sec-sec-prot-restrict-root-ssh"/>.</phrase>

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -2147,7 +2147,7 @@ sle-live-patching 8c541494</screen>
    <important>
      <title>The &rootuser; user</title>
      <para>
-       &rootuser; is the name of the system administrator or superuser. Its user ID (uid) is 
+       &rootuser; is the name of the system administrator or superuser. Its user ID (uid) is
        <literal>0</literal>. Unlike regular users, &rootuser; account has unlimited privileges.
      </para>
      <variablelist>
@@ -2181,7 +2181,7 @@ sle-live-patching 8c541494</screen>
          <term>Do not rename the &rootuser; user account</term>
          <listitem>
            <para>
-             &yast; will always name the system administrator &rootuser;. 
+             &yast; will always name the system administrator &rootuser;.
              While it is technically possible to rename the &rootuser; account, certain
              applications, scripts or 3rd party products may rely on the existence of a user called
              &rootuser;. While such a configuration always targets individual environments,

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -2107,7 +2107,7 @@ sle-live-patching 8c541494</screen>
   <para>
    If you have not chosen <guimenu>Use this Password for System
    Administrator</guimenu> in the previous step, you will be prompted to enter
-   a password for the System Administrator &rootuser; or provide a public SSH
+   a password for the system administrator &rootuser; or provide a public SSH
    key. Otherwise this configuration step is skipped.
   </para>
   <figure>
@@ -2126,21 +2126,11 @@ sle-live-patching 8c541494</screen>
     </imageobject>
    </mediaobject>
   </figure>
-  <para>
-   &rootuser; is the name of the superuser, or the administrator of the system.
-   Unlike regular users, &rootuser; has unlimited
-   rights to change the system configuration, install programs, and set up new
-   hardware. If users forget their passwords or have other problems with the
-   system, &rootuser; can help. The &rootuser; account should only be used for
-   system administration, maintenance, and repair. Logging in as &rootuser; for
-   daily work is rather risky: a single mistake could lead to irretrievable
-   loss of system files.
-  </para>
-  <para>
-   For verification purposes, the password for &rootuser; must be entered
-   twice. Do not forget the &rootuser; password. After having been entered,
-   this password cannot be retrieved.
-  </para>
+   <para>
+     Enter the password for the system administrator &rootuser;. For verification purposes, the
+     password for &rootuser; must be entered twice. Do not forget the password, it cannot be
+     retrieved later.
+   </para>
   <tip>
    <title>Passwords and keyboard layout</title>
    <para>
@@ -2150,19 +2140,72 @@ sle-live-patching 8c541494</screen>
    </para>
   </tip>
   <para>
-   The &rootuser; password can be changed any time later in the installed
-   system. To do so run &yast; and start <menuchoice> <guimenu>Security and
-   Users</guimenu> <guimenu>User and Group Management</guimenu> </menuchoice>.
+   To change the &rootuser; password later in the installed system, run &yast; and start
+   <menuchoice> <guimenu>Security and Users</guimenu> <guimenu>User and Group Management</guimenu>
+   </menuchoice>.
   </para>
-  <important>
-   <title>The <systemitem class="username">root</systemitem> user</title>
-   <para>
-    The user &rootuser; has all the permissions needed to make changes to the
-    system. To carry out such tasks, the &rootuser; password is required. You
-    cannot carry out any administrative tasks without this password.
-   </para>
-  </important>
-
+   <important>
+     <title>The &rootuser; user</title>
+     <para>
+       &rootuser; is the name of the system administrator or superuser. Its user ID (uid) is 
+       <literal>0</literal>. Unlike regular users, &rootuser; account has unlimited privileges.
+     </para>
+     <variablelist>
+       <varlistentry>
+         <term>Do not forget the &rootuser; password</term>
+         <listitem>
+           <para>
+             Only &rootuser; has the necessary privileges to change the system configuration,
+             install programs, manage users, and set up new hardware. To carry out such tasks, the
+             &rootuser; password is required. Do not forget the password, it cannot be retrieved
+             later.
+           </para>
+         </listitem>
+       </varlistentry>
+       <varlistentry>
+         <term>Do not use the &rootuser; user for daily work</term>
+         <listitem>
+           <para>
+             Logging in as &rootuser; for daily work is rather risky: Commands from &rootuser; are
+             usually executed without additional confirmation, so a single mistake can lead to
+             irretrievable loss of system files. Only use the &rootuser; account for system
+             administration, maintenance, and repair.
+           </para>
+         </listitem>
+       </varlistentry>
+       <!-- cwickert 2023-07-04: This is based on https://www.suse.com/support/kb/doc/?id=000020537
+         If you change something here, please also update sec-yast-userman-users and
+         Configuration-Security-users.
+       -->
+       <varlistentry>
+         <term>Do not rename the &rootuser; user account</term>
+         <listitem>
+           <para>
+             &yast; will always name the system administrator &rootuser;. 
+             While it is technically possible to rename the &rootuser; account, certain
+             applications, scripts or 3rd party products may rely on the existence of a user called
+             &rootuser;. While such a configuration always targets individual environments,
+             necessary adjustments could be overwritten by vendor updates, so this becomes an
+             ongoing task and is no one time setting. Especially in very complex setups involving
+             3rd party applications it needs to be verified with every involved vendor whether a
+             rename of the &rootuser; account is supported.
+           </para>
+           <para>
+             As the implications for renaming the &rootuser; account cannot be foreseen, &suse; does
+             not support renaming the &rootuser; account.
+           </para>
+           <para>
+             Usually the idea behind renaming the &rootuser; account is to hide or make it
+             unpredictable. However, <filename>/etc/passwd</filename> requires
+             <literal>644</literal> permissions for regular users, so any user of the given system
+             is able to retrieve the login name for the user ID 0. For better ways to secure the
+             &rootuser; account, refer to <xref linkend="sec-sec-prot-restrict-root"/> and <xref
+               linkend="sec-sec-prot-restrict-root-ssh"/>.
+           </para>
+         </listitem>
+       </varlistentry>
+     </variablelist>
+   </important>
   <para>
    If you want to access the system remotely via SSH using a public key, import
    a key from a removable storage device or an existing partition.

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -2198,9 +2198,10 @@ sle-live-patching 8c541494</screen>
              Usually the idea behind renaming the &rootuser; account is to hide or make it
              unpredictable. However, <filename>/etc/passwd</filename> requires
              <literal>644</literal> permissions for regular users, so any user of the given system
-             is able to retrieve the login name for the user ID 0. For better ways to secure the
-             &rootuser; account, refer to <xref linkend="sec-sec-prot-restrict-root"/> and <xref
-               linkend="sec-sec-prot-restrict-root-ssh"/>.
+             is able to retrieve the login name for the user ID 0.
+             <phrase os="sles;sled;osuse">For better ways to secure the &rootuser; account, refer to
+               <xref linkend="sec-sec-prot-restrict-root"/> and
+               <xref linkend="sec-sec-prot-restrict-root-ssh"/>.</phrase>
            </para>
          </listitem>
        </varlistentry>

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -2183,11 +2183,11 @@ sle-live-patching 8c541494</screen>
            <para>
              &yast; will always name the system administrator &rootuser;.
              While it is technically possible to rename the &rootuser; account, certain
-             applications, scripts or 3rd party products may rely on the existence of a user called
+             applications, scripts or third-party products may rely on the existence of a user called
              &rootuser;. While such a configuration always targets individual environments,
              necessary adjustments could be overwritten by vendor updates, so this becomes an
-             ongoing task and is no one time setting. Especially in very complex setups involving
-             3rd party applications it needs to be verified with every involved vendor whether a
+             ongoing task, not a one-time setting. This is especially true in very complex setups involving
+             third-party applications, where it needs to be verified with every involved vendor whether a
              rename of the &rootuser; account is supported.
            </para>
            <para>

--- a/xml/yast2_userman.xml
+++ b/xml/yast2_userman.xml
@@ -252,6 +252,32 @@
    </step>
   </procedure>
 
+   <!-- cwickert 2023-07-04: This is based on https://www.suse.com/support/kb/doc/?id=000020537
+     If you change something here, please also update sec-yast-install-user-root and
+     Configuration-Security-users.
+   -->
+  <warning>
+    <title>Do not rename the &rootuser; account</title>
+    <para>
+      While it is technically possible to rename the &rootuser; account, certain applications,
+      scripts or 3rd party products may rely on the existence of a user called &rootuser;. While
+      such a configuration always targets individual environments, necessary adjustments could be
+      overwritten by vendor updates, so this becomes an ongoing task and is no one time setting.
+      Especially in very complex setups involving 3rd party applications it needs to be verified
+      with every involved vendor whether a rename of the &rootuser; account is supported.
+    </para>
+    <para>
+      As the implications for renaming the &rootuser; account cannot be foreseen, &suse; does not
+      support renaming the &rootuser; account.
+    </para>
+    <para>
+      Usually the idea behind renaming the &rootuser; account is to hide or make it unpredictable.
+      However, <filename>/etc/passwd</filename> requires <literal>644</literal> permissions for
+      regular users, so any user of the given system is able to retrieve the login name for the
+      user ID 0. For better ways to secure the &rootuser; account, refer to <xref
+        linkend="sec-sec-prot-restrict-root"/> and <xref linkend="sec-sec-prot-restrict-root-ssh"/>.
+    </para>
+  </warning>
   <tip>
    <title>Matching user IDs</title>
    <para>

--- a/xml/yast2_userman.xml
+++ b/xml/yast2_userman.xml
@@ -274,8 +274,10 @@
       Usually the idea behind renaming the &rootuser; account is to hide or make it unpredictable.
       However, <filename>/etc/passwd</filename> requires <literal>644</literal> permissions for
       regular users, so any user of the given system is able to retrieve the login name for the
-      user ID 0. For better ways to secure the &rootuser; account, refer to <xref
-        linkend="sec-sec-prot-restrict-root"/> and <xref linkend="sec-sec-prot-restrict-root-ssh"/>.
+      user ID 0.
+      <phrase os="sles;sled;osuse">For better ways to secure the &rootuser; account, refer to
+        <xref linkend="sec-sec-prot-restrict-root"/> and
+        <xref linkend="sec-sec-prot-restrict-root-ssh"/>.</phrase>
     </para>
   </warning>
   <tip>

--- a/xml/yast2_userman.xml
+++ b/xml/yast2_userman.xml
@@ -260,10 +260,10 @@
     <title>Do not rename the &rootuser; account</title>
     <para>
       While it is technically possible to rename the &rootuser; account, certain applications,
-      scripts or 3rd party products may rely on the existence of a user called &rootuser;. While
+      scripts or third-party products may rely on the existence of a user called &rootuser;. While
       such a configuration always targets individual environments, necessary adjustments could be
-      overwritten by vendor updates, so this becomes an ongoing task and is no one time setting.
-      Especially in very complex setups involving 3rd party applications it needs to be verified
+      overwritten by vendor updates, so this becomes an ongoing task, not a one-time setting.
+      This is especially true in very complex setups involving third-party applications, where it needs to be verified
       with every involved vendor whether a rename of the &rootuser; account is supported.
     </para>
     <para>

--- a/xml/yast2_userman.xml
+++ b/xml/yast2_userman.xml
@@ -271,9 +271,9 @@
       support renaming the &rootuser; account.
     </para>
     <para>
-      Usually the idea behind renaming the &rootuser; account is to hide or make it unpredictable.
+      Usually, the idea behind renaming the &rootuser; account is to hide it or make it unpredictable.
       However, <filename>/etc/passwd</filename> requires <literal>644</literal> permissions for
-      regular users, so any user of the given system is able to retrieve the login name for the
+      regular users, so any user of the system can retrieve the login name for the
       user ID 0.
       <phrase os="sles;sled;osuse">For better ways to secure the &rootuser; account, refer to
         <xref linkend="sec-sec-prot-restrict-root"/> and


### PR DESCRIPTION
### PR creator: Description

I was asked to clarify that renaming the account is not supported. I did that for the Deployment guide, but as the YaST installer always names the root account 'root', there is no real harm. But with AutoYaST and 'yast2 users' you can actually rename the account, so I fixed the other guides as well.

@lvicoun, please check b95ca63f43422bb282af5b8c6aed09735be248bc
@tbazant please check d951c0c590798f57afb9bec0c4c3d527f8174900
@dariavladykina please check everything for language and style.

### PR creator: Are there any relevant issues/feature requests?

* [PED-3897](https://jira.suse.com/browse/PED-3897)

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
