### PR TITLE
Relocate note on isostat in multipath setups

### DIFF
--- a/xml/storage_nvmeof.xml
+++ b/xml/storage_nvmeof.xml
@@ -232,17 +232,6 @@
           </listitem>
         </varlistentry>
       </variablelist>
-      <note>
-        <title>Using <command>iostat</command> in multipath setups</title>
-        <para>
-          The <command>iostat</command> command might not show all controllers
-          that are listed by <command>nvme list-subsys</command>. By default,
-          <command>iostat</command> filters out all block devices with no I/O.
-          To make <command>iostat</command> show <emphasis>all</emphasis>
-          devices, use:
-        </para>
-<screen>iostat -p ALL</screen>
-      </note>
     </sect2>
   </sect1>
   <sect1 xml:id="sec-nvmeof-target-configuration">
@@ -386,7 +375,7 @@ Parameter traddr is now '10.0.0.3'.</screen>
             Link the subsystem to the port:
           </para>
 <screen>&prompt.nvmetcli;<command>cd /ports/1/subsystems</command>
-&prompt.nvmetcli;<command>create nqn.2014-08.org.nvmexpress:NVMf:uuid:c36f2c23-354d-416c-95de-f2b8ec353a82</command>      
+&prompt.nvmetcli;<command>create nqn.2014-08.org.nvmexpress:NVMf:uuid:c36f2c23-354d-416c-95de-f2b8ec353a82</command>
       </screen>
           <para>
             Now you can verify that the port is enabled using

--- a/xml/utilities.xml
+++ b/xml/utilities.xml
@@ -348,16 +348,16 @@ procs -----------memory----------- ---swap-- -----io---- -system-- -----cpu-----
    <note>
     <title>sysstat package</title>
     <para>
-     The <command>sar</command> command is a part of the 
-     <package>sysstat</package> package. Install it with &yast;, or with 
-     the <command>zypper in sysstat</command> command. <systemitem 
-     class="daemon">sysstat.service</systemitem> does not start by default, 
+     The <command>sar</command> command is a part of the
+     <package>sysstat</package> package. Install it with &yast;, or with
+     the <command>zypper in sysstat</command> command. <systemitem
+     class="daemon">sysstat.service</systemitem> does not start by default,
      and must be enabled and started with the following command:
     </para>
     <screen>&prompt.sudo;<command>systemctl enable --now sysstat</command>
     </screen>
    </note>
-   
+
    <sect3 xml:id="sec-util-multi-sar-report">
     <title>Generating reports with <command>sar</command></title>
     <para>
@@ -663,6 +663,17 @@ sdc               0.02         0.14         0.00      13641         37</screen>
      </para>
     </listitem>
    </itemizedlist>
+   <note>
+    <title>Using <command>iostat</command> in multipath setups</title>
+    <para>
+      The <command>iostat</command> command might not show all controllers
+      that are listed by <command>nvme list-subsys</command>. By default,
+      <command>iostat</command> filters out all block devices with no I/O.
+      To make <command>iostat</command> show <emphasis>all</emphasis>
+      devices, use the following command:
+    </para>
+<screen>&prompt.user; iostat -p ALL</screen>
+  </note>
   </sect2>
 
   <sect2 xml:id="sec-util-system-mpstat-monitoring">


### PR DESCRIPTION
### PR creator: Description

This PR relocates a note about `iostat` in multipath scenarios to the `utilities.xml` file of the Tuning guide. The change has been made based on [this Bugzilla comment](https://bugzilla.suse.com/show_bug.cgi?id=1194343#c8).


### PR creator: Are there any relevant issues/feature requests?

* JIRA: [DOCTEAM-665](https://jira.suse.com/browse/DOCTEAM-); there is a [duplicate](https://jira.suse.com/browse/DOCTEAM-1025) which will be closed along with merging this PR.
* [BSC#1194343](https://bugzilla.suse.com/show_bug.cgi?id=1194343)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
