### PR TITLE
FIPS: add specific note for 15 SP5

### DIFF
--- a/xml/security_fips.xml
+++ b/xml/security_fips.xml
@@ -45,7 +45,7 @@
       systems, are vendor-affirmed, based on the
       <link xlink:href="https://csrc.nist.gov/csrc/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/Draft%20FIPS-140-3-CMVP%20Management%20Manual%20v1.2%20%5BDec%2023%202022%5D.pdf"><citetitle>FIPS 140-3 Module
       Validation Program Management Manual</citetitle></link>, see section
-      <citetitle>7.9.1 Vendor</citetitle>, subitem 1.a i.
+      <citetitle>7.9.1 Vendor</citetitle>, subitem 1.a, i.
     </para>
   </important>
   <sect1 xml:id="sec-fips-concept">

--- a/xml/security_fips.xml
+++ b/xml/security_fips.xml
@@ -29,15 +29,23 @@
       <dm:translation>yes</dm:translation>
     </dm:docmanager>
   </info>
+
   <important>
-    <title>&productname; &productnumber; and FIPS 140-3</title>
+    <title>&productname; &product-ga; SP5 and FIPS 140-3</title>
     <para>
-      &productname; &productnumber; is currently implementing the FIPS
-      140-3 standard. The relevant binaries are undergoing certification and
-      will be updated in the near future.
+      &productname; &product-ga; SP5 can run certified binaries of
+      &productname; &product-ga; SP4. This process is not automated. You need
+      to install the exact certified version of the packages and make sure
+      <emphasis>not</emphasis> to update them. The certified packages are
+      available in the regular repositories and/or in the
+      <literal>Certifications</literal> module.
     </para>
     <para>
-      For further details, contact your &suse; sales representative.
+      These cryptographic modules, if compatible between both operating
+      systems, are vendor-affirmed, based on the
+      <link xlink:href="https://csrc.nist.gov/csrc/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/Draft%20FIPS-140-3-CMVP%20Management%20Manual%20v1.2%20%5BDec%2023%202022%5D.pdf"><citetitle>FIPS 140-3 Module
+      Validation Program Management Manual</citetitle></link>, see section
+      <citetitle>7.9.1 Vendor</citetitle>, subitem 1.a i.
     </para>
   </important>
   <sect1 xml:id="sec-fips-concept">


### PR DESCRIPTION
### PR creator: Description

As discussed in a mail thread with the cert team.


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
