### PR TITLE
Added command to find the current number of LUNs

### DIFF
--- a/xml/tuning_kexec.xml
+++ b/xml/tuning_kexec.xml
@@ -304,7 +304,7 @@ MaxHigh: 45824 </screen>
         system, run the following command:
        </para>
       </formalpara>
-      <screen>&prompt.user; cat /proc/scsi/scsi | grep Lun | wc -l</screen>
+<screen>&prompt.user; cat /proc/scsi/scsi | grep Lun | wc -l</screen>
      </listitem>
     </itemizedlist>
    </step>


### PR DESCRIPTION
### PR creator: Description

Minor addition - added command to find the current number of LUNs.


### PR creator: Are there any relevant issues/feature requests?

* [bsc#1194974](https://bugzilla.suse.com/show_bug.cgi?id=1194974)
* [jira#DOCTEAM-503](https://jira.suse.com/browse/DOCTEAM-503)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [x] all necessary backports are done
