### PR TITLE
Adding example for kexec

### DIFF
--- a/xml/tuning_kexec.xml
+++ b/xml/tuning_kexec.xml
@@ -113,7 +113,11 @@
  </sect1>
  <sect1 xml:id="cha-tuning-kexec-internals">
   <title>&kexec; internals</title>
-
+  <remark> ssarkar 07-25-2023:
+   We can reinforce the existing content with material from https://wiki.archlinux.org/title/kexec,
+   especially from the systemd-boot and troubleshooting sections. Perhaps it is better to take it up
+   when writing smart docs on these topics.
+  </remark>
   <para>
    The most important component of &kexec; is the
    <filename>/sbin/kexec</filename> command. You can load a kernel with &kexec;
@@ -188,6 +192,14 @@
    <option>--append</option><literal>=</literal><replaceable>"$(cat
    /proc/cmdline) more_options"</replaceable>.
   </para>
+
+  <para>
+   For example, to load the <filename>/boot/vmlinuz-5.14.21-150500.53-default</filename> kernel image
+   with the command line of the currently running production kernel and the
+   <filename>/boot/initrd</filename> file, run the following command:
+  </para>
+<screen>&prompt.root; kexec -l /boot/vmlinuz-5.14.21-150500.53-default \
+ --append="$(cat /proc/cmdline)" --initrd=/boot/initrd</screen>
 
   <para>
    You can always unload the previously loaded kernel. To unload a kernel that


### PR DESCRIPTION
### PR creator: Description

Adding a simple example for the `kexec` command to make it clear what and how the command can be executed. 


### PR creator: Are there any relevant issues/feature requests?

* [bsc#1194973](https://bugzilla.suse.com/show_bug.cgi?id=1194973)
* [jira#DOCTEAM-504](https://jira.suse.com/browse/DOCTEAM-504)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [x] all necessary backports are done
