### PR TITLE
Fix for bsc#1213642

### DIFF
--- a/xml/help_admin.xml
+++ b/xml/help_admin.xml
@@ -26,16 +26,16 @@
       xlink:href="https://documentation.suse.com/#sles"/><link os="sled"
       xlink:href="https://documentation.suse.com/#sled"/><link os="osuse"
       xlink:href="https://doc.opensuse.org"/>. Topics covered range from
-      deployment, upgrade, and system administration to virtualization, system
-      tuning, and security, among others.
+      deployment, upgrade and system administration to virtualization, system
+      tuning and security, among others.
     </para>
     <para os="sles">
-      At <link xlink:href="https://documentation.suse.com/sbp-supported.html"/>
-      you find &suse;'s best practice series of documents covering hands-on
+      At <link xlink:href="https://documentation.suse.com/sbp-supported.html"/>,
+      you can find &suse;'s best practice series of documents covering hands-on
       documentation on implementation scenarios. At <link
-      xlink:href="https://documentation.suse.com/trd-supported.html"/> our
+      xlink:href="https://documentation.suse.com/trd-supported.html"/>, our
       technical reference documentation series provides guides on deploying
-      solution components from SUSE and its partners.
+      solution components from &suse; and its partners.
     </para>
    </listitem>
   </varlistentry>
@@ -95,7 +95,7 @@
   </para>
 
   <note>
-   <title>Contents depends on installed packages</title>
+   <title>Contents depend on installed packages</title>
    <para>
     In the Linux world, manuals and other kinds of documentation are
     available in the form of packages, like software. How much and which
@@ -107,7 +107,7 @@
   </note>
 
   <sect2 xml:id="sec-help-onboard-docdir-releasenotes">
-   <title>Release Notes</title>
+   <title>Release notes</title>
    <para>
      We provide HTML, PDF, RTF and text versions of &productname; release
      notes. They are available on your installed system under

--- a/xml/help_admin.xml
+++ b/xml/help_admin.xml
@@ -14,18 +14,39 @@
   </dm:docmanager>
  </info>
  <para>
-  &productnamereg; comes with various sources of information and documentation,
-  many of which are already integrated into your installed system.
+  &productnamereg; comes with several sources of information and documentation,
+  available online or integrated into your installed system.
  </para>
  <variablelist>
+  <varlistentry>
+   <term>Product Documentation</term>
+   <listitem>
+    <para>
+      Extensive documentation for &productname; is available at <link os="sles"
+      xlink:href="https://documentation.suse.com/#sles"/> <link os="sles"
+      xlink:href="https://documentation.suse.com/#sled"/> <link os="osuse"
+      xlink:href="https://doc.opensuse.org"/>. Among others, topics covered range from
+      deployment, upgrade, and system administration to virtualization, system
+      tuning, and security.
+    </para>
+    <para os="sles">
+      At <link xlink:href="https://documentation.suse.com/sbp-supported.html"/>
+      you find &suse;'s best practice series of documents covering hands-on
+      documentation on implementation scenarios. At <link
+      xlink:href="https://documentation.suse.com/trd-supported.html"/> our
+      technical reference documentation series provides guides on deploying
+      solution components from SUSE and its partners.
+    </para>
+   </listitem>
+  </varlistentry>
   <varlistentry>
    <term>Documentation in <filename>/usr/share/doc</filename></term>
    <listitem>
     <para>
-     This traditional help directory holds documentation files and
-     release notes for your system. It contains also information of installed
-     packages in the subdirectory <filename>packages</filename>. Find more
-     detailed information in <xref linkend="sec-help-onboard-docdir"/>.
+     This directory holds release notes for your system (in the subdirectory
+     <filename>release-notes</filename>. It also contains information of
+     installed packages in the subdirectory <filename>packages</filename>. Find
+     more detailed information in <xref linkend="sec-help-onboard-docdir"/>.
     </para>
    </listitem>
   </varlistentry>
@@ -46,9 +67,7 @@
    <listitem>
     <para>
      The help center of the &gnome; desktop (&yelp;) provides central access to
-     the most important documentation resources on your system in searchable
-     form. These resources include online help for installed applications, man
-     pages, info pages, and the &suse; manuals delivered with your product.
+     the &gnome; desktop documentation.
     </para>
    </listitem>
   </varlistentry>
@@ -69,16 +88,16 @@
   <title>Documentation directory</title>
 
   <para>
-    The traditional directory to find documentation on your
-   installed Linux system is <filename>/usr/share/doc</filename>. The
-   directory contains information about the packages installed on your system,
-   plus release notes, manuals and more.
+    The traditional directory to find documentation on your installed Linux
+    system is <filename>/usr/share/doc</filename>. The directory contains the
+    release notes and information about the packages installed on your system,
+    plus manuals and more.
   </para>
 
   <note>
    <title>Contents depends on installed packages</title>
    <para>
-    In the Linux world, many manuals and other kinds of documentation are
+    In the Linux world, manuals and other kinds of documentation are
     available in the form of packages, like software. How much and which
     information you find in <filename>/usr/share/docs</filename> also depends
     on the (documentation) packages installed. If you cannot find the
@@ -87,31 +106,16 @@
    </para>
   </note>
 
-  <sect2 xml:id="sec-help-onboard-docdir-manual">
-   <title>&suse; manuals</title>
+  <sect2 xml:id="sec-help-onboard-docdir-releasenotes">
+   <title>Release Notes</title>
    <para>
-    We provide HTML and PDF versions of our books in different
-    languages. In the <filename>manual</filename> subdirectory, find HTML
-    versions of most of the &suse; manuals available for your product. For an
-    overview of all documentation available for your product refer to the
-    preface of the manuals.
+     We provide HTML, PDF, RTF and text versions of &productname; release
+     notes. They are available on your installed system under
+     <filename>/usr/share/doc/release-notes/</filename> or online at your
+     product-specific Web page at <link os="sles;sled"
+     xlink:href="https://www.suse.com/releasenotes//"/><link os="osuse"
+     xlink:href="https://doc.opensuse.org/release-notes/"/>.
    </para>
-   <para>
-    If more than one language is installed,
-    <filename>/usr/share/doc/manual</filename> may contain different language
-    versions of the manuals. The HTML versions of the &suse; manuals are also
-    available in the help center of both desktops. For information on where to
-    find the PDF and HTML versions of the books on your installation media,
-    refer to the &productname; Release Notes. They are available on your
-    installed system under <filename>/usr/share/doc/release-notes/</filename>
-    or online at your product-specific Web page at <link os="sles;sled"
-    xlink:href="https://www.suse.com/releasenotes//"/><link os="osuse"
-    xlink:href="https://doc.opensuse.org/release-notes/"/>.
-   </para>
-<!--The PDF files are available on the DVD in the directory
-     <filename>docu</filename>. For HTML, install the packages
-      <systemitem>opensuse-manual_LANG</systemitem> (replace
-     <replaceable>LANG</replaceable> with your preferred language.)-->
   </sect2>
 
   <sect2 xml:id="sec-help-onboard-docdir-pkg">
@@ -142,7 +146,7 @@
      </term>
      <listitem>
       <para>
-       Known bugs or malfunctions. Might also contain a link to a Bugzilla Web
+       Known bugs or malfunctions. May also contain a link to a Bugzilla Web
        page where you can search all bugs.
       </para>
      </listitem>
@@ -205,7 +209,7 @@
      </term>
      <listitem>
       <para>
-       Things that are not implemented yet, but might be in the future.
+       Features planned for the future.
       </para>
      </listitem>
     </varlistentry>
@@ -384,10 +388,10 @@
   </table>
 
   <para>
-   Each man page consists of several parts labeled <citetitle>NAME</citetitle>
-   , <citetitle>SYNOPSIS</citetitle> , <citetitle>DESCRIPTION</citetitle> ,
-   <citetitle>SEE ALSO</citetitle> , <citetitle>LICENSING</citetitle> , and
-   <citetitle>AUTHOR</citetitle> . There may be additional sections available
+   Each man page consists of several parts labeled <citetitle>NAME</citetitle>,
+   <citetitle>SYNOPSIS</citetitle>, <citetitle>DESCRIPTION</citetitle>,
+   <citetitle>SEE ALSO</citetitle>, <citetitle>LICENSING</citetitle>, and
+   <citetitle>AUTHOR</citetitle>. There may be additional sections available
    depending on the type of command.
   </para>
  </sect1>
@@ -473,7 +477,7 @@
      <para>
       The Linux Documentation Project (TLDP) is run by a team of volunteers who
       write Linux-related documentation (see
-      <link xlink:href="https://www.tldp.org"/>). It is probably the most
+      <link xlink:href="https://www.tldp.org"/>). It is the most
       comprehensive documentation resource for Linux. The set of documents
       contains tutorials for beginners, but is mainly focused on experienced
       users and professional system administrators. TLDP publishes HOWTOs,

--- a/xml/help_admin.xml
+++ b/xml/help_admin.xml
@@ -23,11 +23,11 @@
    <listitem>
     <para>
       Extensive documentation for &productname; is available at <link os="sles"
-      xlink:href="https://documentation.suse.com/#sles"/> <link os="sles"
-      xlink:href="https://documentation.suse.com/#sled"/> <link os="osuse"
-      xlink:href="https://doc.opensuse.org"/>. Among others, topics covered range from
+      xlink:href="https://documentation.suse.com/#sles"/><link os="sled"
+      xlink:href="https://documentation.suse.com/#sled"/><link os="osuse"
+      xlink:href="https://doc.opensuse.org"/>. Topics covered range from
       deployment, upgrade, and system administration to virtualization, system
-      tuning, and security.
+      tuning, and security, among others.
     </para>
     <para os="sles">
       At <link xlink:href="https://documentation.suse.com/sbp-supported.html"/>
@@ -44,7 +44,7 @@
    <listitem>
     <para>
      This directory holds release notes for your system (in the subdirectory
-     <filename>release-notes</filename>. It also contains information of
+     <filename>release-notes</filename>). It also contains information of
      installed packages in the subdirectory <filename>packages</filename>. Find
      more detailed information in <xref linkend="sec-help-onboard-docdir"/>.
     </para>
@@ -444,7 +444,7 @@
     </listitem>
    </varlistentry>
    <varlistentry>
-    <term>&productname; user community</term>
+    <term>User community</term>
     <listitem>
      <para>
       <link os="osuse" xlink:href="https://forums.opensuse.org/">&opensuse;
@@ -487,12 +487,5 @@
     </listitem>
    </varlistentry>
   </variablelist>
-
-  <para>
-   You can also try general-purpose search engines. For example, use the search
-   terms <literal>Linux CD-RW help</literal> or <literal>OpenOffice file
-   conversion problem</literal> if you have trouble with burning CDs or &libo;
-   file conversion.
-  </para>
  </sect1>
 </chapter>


### PR DESCRIPTION
* manuals are only available online
* added info on release notes
* fixed contents of GNOME help center



Backport needed to
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x ] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1


- [ ] all necessary backports are done
