### PR TITLE
Added extensive information for Python 3 module (from RN)

### DIFF
--- a/xml/art_modules.xml
+++ b/xml/art_modules.xml
@@ -674,33 +674,22 @@
   <sect2 xml:id="art-modules-python-3">
    <title>Python 3</title>
    <para>
-    &productname; 15 comes with a complete stack of Python 3.6 (interpreter,
-    setuptool, wheel, pip plus almost 550 additional modules). Python 3.6 is
-    fully supported by SUSE throught the complete lifecycle of SLE 15.
+    This module provides the Python 3.11 interpreter (including setuptools, wheel,
+    and pypi support) and many additional maintained python 3.11 modules. It has
+    a different lifecycle than &productname; itself. The Python 3.11 and the
+    contained python 3.11 modules are supported at least until end of December
+    2027. The Python 3.11 modules might be updated at the next service pack (if
+    compatible and when needed).
    </para>
    <para>
-    However, there are only very few pip installable modules that are still
-    compatible with 3.6 or older. Therefore, starting with SLE 15 SP4, &suse;
-    introduced the new Python 3 Module. It includes an additional modern Python
-    interpreter (plus setuptool, wheel, pip and pypi support, but no additional
-    modules). This new allows more flexibility in providing a fully supported
-    more recent Python interpreter in &productname;.
-   </para>
-   <para>
-    Packages from the Python 3 module do not collide with existing Python 3.6
-    packages and can be co-installed in a system without affecting any running
-    Python 3.6 workloads.
+    Packages within the Python 3 module can be installed alongside existing
+    Python packages and they can coexist within the same system without
+    impacting any ongoing Python 3.6 workloads.
    </para>
    <para>
     In &productname; &productnumber; the Python 3 Module ships with Python 3.11.
     Python 3.11 is compatible with versions 3.10 and 3.9. Code written in 3.9
     or 3.10 should run without or with only minimal changes in 3.11.
-   </para>
-   <para>
-    This module contains version 3.11 of selected Python 3 packages.
-    It has a different lifecycle than &productname; itself, version 3.11 will be
-    supported until December 2027. Packages in this module will be updated with
-    each service Pack (if applicable) and will be supported for 18 months.
    </para>
    <itemizedlist>
     <listitem>
@@ -716,7 +705,7 @@
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">Lifecycle:</emphasis> December 2027 (Python 3.11)
+      <emphasis role="bold">Lifecycle:</emphasis> December 31st 2027
      </para>
     </listitem>
     <listitem>

--- a/xml/art_modules.xml
+++ b/xml/art_modules.xml
@@ -674,9 +674,33 @@
   <sect2 xml:id="art-modules-python-3">
    <title>Python 3</title>
    <para>
-    This module contains the most recent version of selected Python 3 packages.
-    It has a different lifecycle than &sle; itself. Packages in this module are
-    frequently updated to new upstream versions.
+    &productname; 15 comes with a complete stack of Python 3.6 (interpreter,
+    setuptool, wheel, pip plus almost 550 additional modules). Python 3.6 is
+    fully supported by SUSE throught the complete lifecycle of SLE 15.
+   </para>
+   <para>
+    However, there are only very few pip installable modules that are still
+    compatible with 3.6 or older. Therefore, starting with SLE 15 SP4, &suse;
+    introduced the new Python 3 Module. It includes an additional modern Python
+    interpreter (plus setuptool, wheel, pip and pypi support, but no additional
+    modules). This new allows more flexibility in providing a fully supported
+    more recent Python interpreter in &productname;.
+   </para>
+   <para>
+    Packages from the Python 3 module do not collide with existing Python 3.6
+    packages and can be co-installed in a system without affecting any running
+    Python 3.6 workloads.
+   </para>
+   <para>
+    In &productname; &productnumber; the Python 3 Module ships with Python 3.11.
+    Python 3.11 is compatible with versions 3.10 and 3.9. Code written in 3.9
+    or 3.10 should run without or with only minimal changes in 3.11.
+   </para>
+   <para>
+    This module contains version 3.11 of selected Python 3 packages.
+    It has a different lifecycle than &productname; itself, version 3.11 will be
+    supported until December 2027. Packages in this module will be updated with
+    each service Pack (if applicable) and will be supported for 18 months.
    </para>
    <itemizedlist>
     <listitem>
@@ -692,7 +716,7 @@
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">Lifecycle:</emphasis> 10 years
+      <emphasis role="bold">Lifecycle:</emphasis> December 2027 (Python 3.11)
      </para>
     </listitem>
     <listitem>

--- a/xml/art_modules.xml
+++ b/xml/art_modules.xml
@@ -675,21 +675,21 @@
    <title>Python 3</title>
    <para>
     This module provides the Python 3.11 interpreter (including setuptools, wheel,
-    and pypi support) and many additional maintained python 3.11 modules. It has
+    and pypi support) and many additional maintained Python 3.11 modules. It has
     a different lifecycle than &productname; itself. The Python 3.11 and the
-    contained python 3.11 modules are supported at least until end of December
-    2027. The Python 3.11 modules might be updated at the next service pack (if
+    contained Python 3.11 modules are supported at least until the end of December
+    2027. The Python 3.11 modules might be updated with the next service pack (if
     compatible and when needed).
    </para>
    <para>
     Packages within the Python 3 module can be installed alongside existing
-    Python packages and they can coexist within the same system without
+    Python packages, and they can coexist in the same system without
     impacting any ongoing Python 3.6 workloads.
    </para>
    <para>
-    In &productname; &productnumber; the Python 3 Module ships with Python 3.11.
-    Python 3.11 is compatible with versions 3.10 and 3.9. Code written in 3.9
-    or 3.10 should run without or with only minimal changes in 3.11.
+    In &productname; &productnumber;, the Python 3 module ships with Python 3.11.
+    Python 3.11 is compatible with versions 3.10 and 3.9. The code written in 3.9
+    or 3.10 should run without changes or only with minimal changes in 3.11.
    </para>
    <itemizedlist>
     <listitem>
@@ -705,7 +705,7 @@
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">Lifecycle:</emphasis> December 31st 2027
+      <emphasis role="bold">Lifecycle:</emphasis> 31 Dec 2027
      </para>
     </listitem>
     <listitem>


### PR DESCRIPTION
fixes PED-4724

We need to update lifecycle information and module content on the Python 3 module description 

Backport required to
  - [ ] SLE 15 SP4/openSUSE Leap 15.5