### PR TITLE
Changes to the grub edit mode (bsc#1193363)

### DIFF
--- a/xml/grub2.xml
+++ b/xml/grub2.xml
@@ -4,753 +4,751 @@
   <!ENTITY % entities SYSTEM "generic-entities.ent">
     %entities;
 ]>
-
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-grub2">
- <title>The boot loader &grub;</title>
- <info>
-  <abstract>
-   <para>
-    This chapter describes how to configure &grub;, the boot loader used in
-    &productnamereg;. <phrase os="sled;sles">It is the successor to the
-    traditional GRUB boot loader&mdash;now called <quote>GRUB Legacy</quote>.
-    &grub; has been the default boot loader in &productnamereg; since
-    version 12.</phrase> A &yast; module is available for configuring the most
-    important settings. The boot procedure as a whole is outlined in <xref
-    linkend="cha-boot"/>. For details on Secure Boot support for UEFI machines,
-    see <xref linkend="cha-uefi"/>.
-   </para>
-  </abstract>
-  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:bugtracker></dm:bugtracker>
-   <dm:translation>yes</dm:translation>
-  </dm:docmanager>
- </info>
- <sect1 xml:id="sec-grub2-new-features">
-  <title>Main differences between GRUB legacy and &grub;</title>
+  <title>The boot loader &grub;</title>
+  <info>
+    <abstract>
+      <para>
+        This chapter describes how to configure &grub;, the boot loader used in
+        &productnamereg;. <phrase os="sled;sles">It is the successor to the
+        traditional GRUB boot loader&mdash;now called <quote>GRUB
+        Legacy</quote>. &grub; has been the default boot loader in
+        &productnamereg; since version 12.</phrase> A &yast; module is
+        available for configuring the most important settings. The boot
+        procedure as a whole is outlined in <xref
+    linkend="cha-boot"/>. For
+        details on Secure Boot support for UEFI machines, see
+        <xref linkend="cha-uefi"/>.
+      </para>
+    </abstract>
+    <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+      <dm:bugtracker></dm:bugtracker>
+      <dm:translation>yes</dm:translation>
+    </dm:docmanager>
+  </info>
+  <sect1 xml:id="sec-grub2-new-features">
+    <title>Main differences between GRUB legacy and &grub;</title>
 
-  <itemizedlist mark="bullet" spacing="normal">
-   <listitem>
-    <para>
-     The configuration is stored in different files.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     More file systems are supported (for example, Btrfs).
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     Can directly read files stored on LVM or RAID devices.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     The user interface can be translated and altered with themes.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     Includes a mechanism for loading modules to support additional features,
-     such as file systems, etc.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     Automatically searches for and generates boot entries for other kernels
-     and operating systems, such as Windows.
-    </para>
-   </listitem>
-   <listitem>
-    <para>
-     Includes a minimal Bash-like console.
-    </para>
-   </listitem>
-  </itemizedlist>
- </sect1>
- <sect1 xml:id="sec-grub2-file-structure">
-  <title>Configuration file structure</title>
+    <itemizedlist mark="bullet" spacing="normal">
+      <listitem>
+        <para>
+          The configuration is stored in different files.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          More file systems are supported (for example, Btrfs).
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Can directly read files stored on LVM or RAID devices.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The user interface can be translated and altered with themes.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Includes a mechanism for loading modules to support additional
+          features, such as file systems, etc.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Automatically searches for and generates boot entries for other
+          kernels and operating systems, such as Windows.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Includes a minimal Bash-like console.
+        </para>
+      </listitem>
+    </itemizedlist>
+  </sect1>
+  <sect1 xml:id="sec-grub2-file-structure">
+    <title>Configuration file structure</title>
 
-  <para>
-   The configuration of &grub; is based on the following files:
-  </para>
+    <para>
+      The configuration of &grub; is based on the following files:
+    </para>
 
-  <variablelist>
-   <varlistentry>
-    <term><filename>/boot/grub2/grub.cfg</filename>
-    </term>
-    <listitem>
-     <para>
-      This file contains the configuration of the &grub; menu items. It
-      replaces <filename>menu.lst</filename> used in GRUB Legacy.
-      <filename>grub.cfg</filename> should not be edited&mdash;it is automatically
-      generated by the command <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><filename>/boot/grub2/custom.cfg</filename>
-    </term>
-    <listitem>
-     <para>
-      This optional file is directly sourced by <filename>grub.cfg</filename>
-      at boot time and can be used to add custom items to the boot menu.
-      Starting with &productname; <phrase
-      os="sles;sled">12
-      SP2</phrase><phrase os="osuse">Leap 42.2</phrase> these entries will also
-      be parsed when using <command>grub-once</command>.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><filename>/etc/default/grub</filename>
-    </term>
-    <listitem>
-     <para>
-      This file controls the user settings of &grub; and normally includes
-      additional environmental settings such as backgrounds and themes.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term>Scripts under <filename>/etc/grub.d/</filename>
-    </term>
-    <listitem>
-     <para>
-      The scripts in this directory are read during execution of the command
-      <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>. Their instructions are
-      integrated into the main configuration file
-      <filename>/boot/grub/grub.cfg</filename>.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="vle-grub2-sysconfig">
-    <term><filename>/etc/sysconfig/bootloader</filename>
-    </term>
-    <listitem>
-     <para>
-      This configuration file holds certain basic settings like the boot loader
-      type and whether to enable UEFI Secure Boot support.
-     </para>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><filename arch="x86_64">/boot/grub2/x86_64-efi</filename>,
-     <filename arch="power">/boot/grub2/power-ieee1275</filename><phrase os="sles">,
-     <filename arch="zseries">/boot/grub2/s390x</filename></phrase>
-    </term>
-    <listitem>
-     <para>
-      These configuration files contain architecture-specific options.
-     </para>
-    </listitem>
-   </varlistentry>
-  </variablelist>
+    <variablelist>
+      <varlistentry>
+        <term><filename>/boot/grub2/grub.cfg</filename></term>
+        <listitem>
+          <para>
+            This file contains the configuration of the &grub; menu items. It
+            replaces <filename>menu.lst</filename> used in GRUB Legacy.
+            <filename>grub.cfg</filename> should not be edited&mdash;it is
+            automatically generated by the command <command>grub2-mkconfig -o
+            /boot/grub2/grub.cfg</command>.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><filename>/boot/grub2/custom.cfg</filename></term>
+        <listitem>
+          <para>
+            This optional file is directly sourced by
+            <filename>grub.cfg</filename> at boot time and can be used to add
+            custom items to the boot menu. Starting with &productname;
+            <phrase
+      os="sles;sled">12 SP2</phrase><phrase os="osuse">Leap
+            42.2</phrase> these entries will also be parsed when using
+            <command>grub-once</command>.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><filename>/etc/default/grub</filename></term>
+        <listitem>
+          <para>
+            This file controls the user settings of &grub; and normally
+            includes additional environmental settings such as backgrounds and
+            themes.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term>Scripts under <filename>/etc/grub.d/</filename></term>
+        <listitem>
+          <para>
+            The scripts in this directory are read during execution of the
+            command <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>.
+            Their instructions are integrated into the main configuration file
+            <filename>/boot/grub/grub.cfg</filename>.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry xml:id="vle-grub2-sysconfig">
+        <term><filename>/etc/sysconfig/bootloader</filename></term>
+        <listitem>
+          <para>
+            This configuration file holds certain basic settings like the boot
+            loader type and whether to enable UEFI Secure Boot support.
+          </para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><filename arch="x86_64">/boot/grub2/x86_64-efi</filename>, <filename arch="power">/boot/grub2/power-ieee1275</filename><phrase os="sles">, <filename arch="zseries">/boot/grub2/s390x</filename></phrase></term>
+        <listitem>
+          <para>
+            These configuration files contain architecture-specific options.
+          </para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
 
-  <para>
-   &grub; can be controlled in multiple ways. Boot entries from an existing
-   configuration can be selected from the graphical menu (splash screen). The
-   configuration is loaded from the file
-   <filename>/boot/grub2/grub.cfg</filename> which is compiled from other
-   configuration files (see below). All &grub; configuration files are
-   considered system files, and you need &rootuser; privileges to edit them.
-  </para>
+    <para>
+      &grub; can be controlled in multiple ways. Boot entries from an existing
+      configuration can be selected from the graphical menu (splash screen).
+      The configuration is loaded from the file
+      <filename>/boot/grub2/grub.cfg</filename> which is compiled from other
+      configuration files (see below). All &grub; configuration files are
+      considered system files, and you need &rootuser; privileges to edit them.
+    </para>
 
-  <note>
-   <title>Activating configuration changes</title>
-   <para>
-    After having manually edited &grub; configuration files, you need to run
-    <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command> to activate the changes. However, this
-    is not necessary when changing the configuration with &yast;, because &yast; will
-    automatically run this command.
-   </para>
-  </note>
+    <note>
+      <title>Activating configuration changes</title>
+      <para>
+        After having manually edited &grub; configuration files, you need to
+        run <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command> to
+        activate the changes. However, this is not necessary when changing the
+        configuration with &yast;, because &yast; will automatically run this
+        command.
+      </para>
+    </note>
 
-  <sect2 xml:id="sec-grub2-cfg">
-   <title>The file <filename>/boot/grub2/grub.cfg</filename></title>
-   <para>
-    The graphical splash screen with the boot menu is based on the &grub;
-    configuration file <filename>/boot/grub2/grub.cfg</filename>, which
-    contains information about all partitions or operating systems that can be
-    booted by the menu.
-   </para>
-   <para>
-    Every time the system is booted, &grub; loads the menu file directly from
-    the file system. For this reason, &grub; does not need to be re-installed
-    after changes to the configuration file. <filename>grub.cfg</filename> is
-    automatically rebuilt with kernel installations or removals.
-   </para>
-   <para>
-    <filename>grub.cfg</filename> is compiled from the file
-    <filename>/etc/default/grub</filename> and scripts found in the
-    <filename>/etc/grub.d/</filename> directory when running the command
-    <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>. Therefore you should never
-    edit the file manually. Instead, edit the related source files or use the
-    &yast; <guimenu>Boot Loader</guimenu> module to modify the configuration as
-    described in <xref linkend="sec-grub2-yast2-config"/>.
-   </para>
-  </sect2>
+    <sect2 xml:id="sec-grub2-cfg">
+      <title>The file <filename>/boot/grub2/grub.cfg</filename></title>
+      <para>
+        The graphical splash screen with the boot menu is based on the &grub;
+        configuration file <filename>/boot/grub2/grub.cfg</filename>, which
+        contains information about all partitions or operating systems that can
+        be booted by the menu.
+      </para>
+      <para>
+        Every time the system is booted, &grub; loads the menu file directly
+        from the file system. For this reason, &grub; does not need to be
+        re-installed after changes to the configuration file.
+        <filename>grub.cfg</filename> is automatically rebuilt with kernel
+        installations or removals.
+      </para>
+      <para>
+        <filename>grub.cfg</filename> is compiled from the file
+        <filename>/etc/default/grub</filename> and scripts found in the
+        <filename>/etc/grub.d/</filename> directory when running the command
+        <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>. Therefore
+        you should never edit the file manually. Instead, edit the related
+        source files or use the &yast; <guimenu>Boot Loader</guimenu> module to
+        modify the configuration as described in
+        <xref linkend="sec-grub2-yast2-config"/>.
+      </para>
+    </sect2>
 
-  <sect2 xml:id="sec-grub2-etc-default-grub">
-   <title>The file <filename>/etc/default/grub</filename></title>
-   <para>
-    More general options of &grub; belong here, such as the time the menu is
-    displayed, or the default OS to boot. To list all available options, see
-    the output of the following command:
-   </para>
+    <sect2 xml:id="sec-grub2-etc-default-grub">
+      <title>The file <filename>/etc/default/grub</filename></title>
+      <para>
+        More general options of &grub; belong here, such as the time the menu
+        is displayed, or the default OS to boot. To list all available options,
+        see the output of the following command:
+      </para>
 <screen>&prompt.user;grep "export GRUB_DEFAULT" -A50 /usr/sbin/grub2-mkconfig | grep GRUB_</screen>
-   <para>
-    In addition to already defined variables, the user may introduce their own
-    variables, and use them later in the scripts found in the
-    <filename>/etc/grub.d</filename> directory.
-   </para>
-   <para>
-    After having edited <filename>/etc/default/grub</filename>, update the main
-    configuration file with <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>.</para>
-   <note>
-    <title>Scope</title>
-    <remark>
+      <para>
+        In addition to already defined variables, the user may introduce their
+        own variables, and use them later in the scripts found in the
+        <filename>/etc/grub.d</filename> directory.
+      </para>
+      <para>
+        After having edited <filename>/etc/default/grub</filename>, update the
+        main configuration file with <command>grub2-mkconfig -o
+        /boot/grub2/grub.cfg</command>.
+      </para>
+      <note>
+        <title>Scope</title>
+        <remark>
      Do we really still have Xen-specific kernels? - sknorr, 2017-05-08
     </remark>
-    <para>
-     All options set in this file are general options that affect all boot
-     entries. Specific options for &xen; kernels or the &xen; hypervisor can be
-     set via the GRUB_*_XEN_* configuration options. See below for details.
-    </para>
-   </note>
-   <variablelist>
-    <varlistentry>
-     <term><literal>GRUB_DEFAULT</literal>
-     </term>
-     <listitem>
+        <para>
+          All options set in this file are general options that affect all boot
+          entries. Specific options for &xen; kernels or the &xen; hypervisor
+          can be set via the GRUB_*_XEN_* configuration options. See below for
+          details.
+        </para>
+      </note>
+      <variablelist>
+        <varlistentry>
+          <term><literal>GRUB_DEFAULT</literal></term>
+          <listitem>
+            <para>
+              Sets the boot menu entry that is booted by default. Its value can
+              be a numeric value, the complete name of a menu entry, or
+              <quote>saved</quote>.
+            </para>
+            <para>
+              <literal>GRUB_DEFAULT=2</literal> boots the third (counted from
+              zero) boot menu entry.
+            </para>
+            <para>
+              <literal>GRUB_DEFAULT="2&gt;0"</literal> boots the first submenu
+              entry of the third top-level menu entry.
+            </para>
+            <para>
+              <literal>GRUB_DEFAULT="Example boot menu entry"</literal> boots
+              the menu entry with the title <quote>Example boot menu
+              entry</quote>.
+            </para>
+            <para>
+              <literal>GRUB_DEFAULT=saved</literal> boots the entry specified
+              by the <command>grub2-once</command> or
+              <command>grub2-set-default</command> commands. While
+              <command>grub2-reboot</command> sets the default boot entry for
+              the next reboot only, <command>grub2-set-default</command> sets
+              the default boot entry until changed. <command>grub2-editenv
+              list</command> lists the next boot entry.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><literal>GRUB_HIDDEN_TIMEOUT</literal></term>
+          <listitem>
+            <para>
+              Waits the specified number of seconds for the user to press a
+              key. During the period no menu is shown unless the user presses a
+              key. If no key is pressed during the time specified, the control
+              is passed to <literal>GRUB_TIMEOUT</literal>.
+              <literal>GRUB_HIDDEN_TIMEOUT=0</literal> first checks whether
+              <keycap function="shift"/> is pressed and shows the boot menu if
+              yes, otherwise immediately boots the default menu entry. This is
+              the default when only one bootable OS is identified by &grub;.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><literal>GRUB_HIDDEN_TIMEOUT_QUIET</literal></term>
+          <listitem>
+            <para>
+              If <literal>false</literal> is specified, a countdown timer is
+              displayed on a blank screen when the
+              <literal>GRUB_HIDDEN_TIMEOUT</literal> feature is active.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><literal>GRUB_TIMEOUT</literal></term>
+          <listitem>
+            <para>
+              Time period in seconds the boot menu is displayed before
+              automatically booting the default boot entry. If you press a key,
+              the timeout is cancelled and &grub; waits for you to make the
+              selection manually. <literal>GRUB_TIMEOUT=-1</literal> will cause
+              the menu to be displayed until you select the boot entry
+              manually.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><literal>GRUB_CMDLINE_LINUX</literal></term>
+          <listitem>
+            <para>
+              Entries on this line are added at the end of the boot entries for
+              normal and recovery mode. Use it to add kernel parameters to the
+              boot entry.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><literal>GRUB_CMDLINE_LINUX_DEFAULT</literal></term>
+          <listitem>
+            <para>
+              Same as <literal>GRUB_CMDLINE_LINUX</literal> but the entries are
+              appended in the normal mode only.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><literal>GRUB_CMDLINE_LINUX_RECOVERY</literal></term>
+          <listitem>
+            <para>
+              Same as <literal>GRUB_CMDLINE_LINUX</literal> but the entries are
+              appended in the recovery mode only.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><literal>GRUB_CMDLINE_LINUX_XEN_REPLACE</literal></term>
+          <listitem>
+            <para>
+              This entry replaces the <literal>GRUB_CMDLINE_LINUX</literal>
+              parameters for all &xen; boot entries.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><literal>GRUB_CMDLINE_LINUX_XEN_REPLACE_DEFAULT</literal></term>
+          <listitem>
+            <para>
+              Same as <literal>GRUB_CMDLINE_LINUX_XEN_REPLACE</literal> but it
+              will only replace parameters
+              of<literal>GRUB_CMDLINE_LINUX_DEFAULT</literal>.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><literal>GRUB_CMDLINE_XEN</literal></term>
+          <listitem>
+            <para>
+              This entry specifies the kernel parameters for the &xen; guest
+              kernel only&mdash;the operation principle is the same as for
+              <literal>GRUB_CMDLINE_LINUX</literal>.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><literal>GRUB_CMDLINE_XEN_DEFAULT</literal></term>
+          <listitem>
+            <para>
+              Same as <literal>GRUB_CMDLINE_XEN</literal>&mdash;the operation
+              principle is the same as for
+              <literal>GRUB_CMDLINE_LINUX_DEFAULT</literal>.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><literal>GRUB_TERMINAL</literal></term>
+          <listitem>
+            <para>
+              Enables and specifies an input/output terminal device. Can be
+              <literal>console</literal> (PC BIOS and EFI consoles),
+              <literal>serial</literal> (serial terminal),
+              <literal>ofconsole</literal> (Open Firmware console), or the
+              default <literal>gfxterm</literal> (graphics-mode output). It is
+              also possible to enable more than one device by quoting the
+              required options, for example <literal>GRUB_TERMINAL="console
+              serial"</literal>.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><literal>GRUB_GFXMODE</literal></term>
+          <listitem>
+            <para>
+              The resolution used for the <literal>gfxterm</literal> graphical
+              terminal. You can only use modes supported by your graphics card
+              (VBE). The default is ‘auto’, which tries to select a preferred
+              resolution. You can display the screen resolutions available to
+              &grub; by typing <command>videoinfo</command> in the &grub;
+              command line. The command line is accessed by typing
+              <keycap>C</keycap> when the &grub; boot menu screen is displayed.
+            </para>
+            <para>
+              You can also specify a color depth by appending it to the
+              resolution setting, for example
+              <literal>GRUB_GFXMODE=1280x1024x24</literal>.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><literal>GRUB_BACKGROUND</literal></term>
+          <listitem>
+            <para>
+              Set a background image for the <literal>gfxterm</literal>
+              graphical terminal. The image must be a file readable by &grub;
+              at boot time, and it must end with the <literal>.png</literal>,
+              <literal>.tga</literal>, <literal>.jpg</literal>, or
+              <literal>.jpeg</literal> suffix. If necessary, the image will be
+              scaled to fit the screen.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><literal>GRUB_DISABLE_OS_PROBER</literal></term>
+          <listitem>
+            <para>
+              If this option is set to <literal>true</literal>, automatic
+              searching for other operating systems is disabled. Only the
+              kernel images in <filename>/boot/</filename> and the options from
+              your own scripts in <filename>/etc/grub.d/</filename> are
+              detected.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><literal>SUSE_BTRFS_SNAPSHOT_BOOTING</literal></term>
+          <listitem>
+            <para>
+              If this option is set to <literal>true</literal>, &grub; can boot
+              directly into Snapper snapshots. For more information, see
+              <xref linkend="sec-snapper-snapshot-boot"/>.
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
       <para>
-       Sets the boot menu entry that is booted by default. Its value can be a
-       numeric value, the complete name of a menu entry, or
-       <quote>saved</quote>.
+        For a complete list of options, see the
+        <link xlink:href="http://www.gnu.org/software/grub/manual/grub.html#Simple-configuration">
+        GNU GRUB manual</link>.
       </para>
-      <para>
-       <literal>GRUB_DEFAULT=2</literal> boots the third (counted from zero)
-       boot menu entry.
-      </para>
-      <para>
-       <literal>GRUB_DEFAULT="2&gt;0"</literal> boots the first submenu entry
-       of the third top-level menu entry.
-      </para>
-      <para>
-       <literal>GRUB_DEFAULT="Example boot menu entry"</literal> boots the menu
-       entry with the title <quote>Example boot menu entry</quote>.
-      </para>
-      <para>
-       <literal>GRUB_DEFAULT=saved</literal> boots the entry specified by the
-       <command>grub2-once</command> or <command>grub2-set-default</command>
-       commands. While <command>grub2-reboot</command> sets the
-       default boot entry for the next reboot only,
-       <command>grub2-set-default</command> sets the default boot entry until
-       changed. <command>grub2-editenv list</command> lists the next boot entry.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><literal>GRUB_HIDDEN_TIMEOUT</literal>
-     </term>
-     <listitem>
-      <para>
-       Waits the specified number of seconds for the user to press a key.
-       During the period no menu is shown unless the user presses a key. If no
-       key is pressed during the time specified, the control is passed to
-       <literal>GRUB_TIMEOUT</literal>.
-       <literal>GRUB_HIDDEN_TIMEOUT=0</literal> first checks whether
-       <keycap function="shift"/> is pressed and shows the boot menu if yes,
-       otherwise immediately boots the default menu entry. This is the default
-       when only one bootable OS is identified by &grub;.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><literal>GRUB_HIDDEN_TIMEOUT_QUIET</literal>
-     </term>
-     <listitem>
-      <para>
-       If <literal>false</literal> is specified, a countdown timer is displayed
-       on a blank screen when the <literal>GRUB_HIDDEN_TIMEOUT</literal>
-       feature is active.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><literal>GRUB_TIMEOUT</literal>
-     </term>
-     <listitem>
-      <para>
-       Time period in seconds the boot menu is displayed before automatically
-       booting the default boot entry. If you press a key, the timeout is
-       cancelled and &grub; waits for you to make the selection manually.
-       <literal>GRUB_TIMEOUT=-1</literal> will cause the menu to be displayed
-       until you select the boot entry manually.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><literal>GRUB_CMDLINE_LINUX</literal>
-     </term>
-     <listitem>
-      <para>
-       Entries on this line are added at the end of the boot entries for normal
-       and recovery mode. Use it to add kernel parameters to the boot entry.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><literal>GRUB_CMDLINE_LINUX_DEFAULT</literal>
-     </term>
-     <listitem>
-      <para>
-       Same as <literal>GRUB_CMDLINE_LINUX</literal> but the entries are
-       appended in the normal mode only.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><literal>GRUB_CMDLINE_LINUX_RECOVERY</literal>
-     </term>
-     <listitem>
-      <para>
-       Same as <literal>GRUB_CMDLINE_LINUX</literal> but the entries are
-       appended in the recovery mode only.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><literal>GRUB_CMDLINE_LINUX_XEN_REPLACE</literal>
-     </term>
-     <listitem>
-      <para>
-       This entry replaces the
-       <literal>GRUB_CMDLINE_LINUX</literal> parameters for all &xen; boot
-       entries.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><literal>GRUB_CMDLINE_LINUX_XEN_REPLACE_DEFAULT</literal>
-     </term>
-     <listitem>
-      <para>
-       Same as <literal>GRUB_CMDLINE_LINUX_XEN_REPLACE</literal> but it will
-       only replace parameters of<literal>GRUB_CMDLINE_LINUX_DEFAULT</literal>.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><literal>GRUB_CMDLINE_XEN</literal>
-     </term>
-     <listitem>
-      <para>
-       This entry specifies the kernel parameters for the &xen; guest kernel
-       only&mdash;the operation principle is the same as for
-       <literal>GRUB_CMDLINE_LINUX</literal>.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><literal>GRUB_CMDLINE_XEN_DEFAULT</literal>
-     </term>
-     <listitem>
-      <para>
-       Same as <literal>GRUB_CMDLINE_XEN</literal>&mdash;the operation
-       principle is the same as for
-       <literal>GRUB_CMDLINE_LINUX_DEFAULT</literal>.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><literal>GRUB_TERMINAL</literal>
-     </term>
-     <listitem>
-      <para>
-       Enables and specifies an input/output terminal device. Can be
-       <literal>console</literal> (PC BIOS and EFI consoles),
-       <literal>serial</literal> (serial terminal),
-       <literal>ofconsole</literal> (Open Firmware console), or the default
-       <literal>gfxterm</literal> (graphics-mode output). It is also possible
-       to enable more than one device by quoting the required options, for
-       example <literal>GRUB_TERMINAL="console serial"</literal>.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><literal>GRUB_GFXMODE</literal>
-     </term>
-     <listitem>
-      <para>
-       The resolution used for the <literal>gfxterm</literal> graphical
-       terminal. You can only use modes supported by your graphics
-       card (VBE). The default is ‘auto’, which tries to select a preferred
-       resolution. You can display the screen resolutions available to &grub;
-       by typing <command>videoinfo</command> in the &grub; command line. The
-       command line is accessed by typing <keycap>C</keycap> when the &grub;
-       boot menu screen is displayed.
-      </para>
-      <para>
-       You can also specify a color depth by appending it to the resolution
-       setting, for example <literal>GRUB_GFXMODE=1280x1024x24</literal>.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><literal>GRUB_BACKGROUND</literal>
-     </term>
-     <listitem>
-      <para>
-       Set a background image for the <literal>gfxterm</literal> graphical
-       terminal. The image must be a file readable by &grub; at boot time, and
-       it must end with the <literal>.png</literal>, <literal>.tga</literal>,
-       <literal>.jpg</literal>, or <literal>.jpeg</literal> suffix. If
-       necessary, the image will be scaled to fit the screen.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><literal>GRUB_DISABLE_OS_PROBER</literal>
-     </term>
-     <listitem>
-      <para>
-       If this option is set to <literal>true</literal>, automatic searching
-       for other operating systems is disabled. Only the kernel images in
-       <filename>/boot/</filename> and the options from your own scripts in
-       <filename>/etc/grub.d/</filename> are detected.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><literal>SUSE_BTRFS_SNAPSHOT_BOOTING</literal>
-     </term>
-     <listitem>
-      <para>
-       If this option is set to <literal>true</literal>, &grub; can boot
-       directly into Snapper snapshots. For more information, see
-       <xref linkend="sec-snapper-snapshot-boot"/>.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-   <para>
-    For a complete list of options, see the
-    <link xlink:href="http://www.gnu.org/software/grub/manual/grub.html#Simple-configuration">
-    GNU GRUB manual</link>.
-   </para>
-  </sect2>
+    </sect2>
 
-  <sect2 xml:id="sec-grub2-etc-grub-d">
-   <title>Scripts in <filename>/etc/grub.d</filename></title>
-   <para>
-    The scripts in this directory are read during execution of the
-    command <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>. Their instructions are
-    incorporated into <filename>/boot/grub2/grub.cfg</filename>. The order of
-    menu items in <filename>grub.cfg</filename> is determined by the order in
-    which the files in this directory are run. Files with a leading numeral are
-    executed first, beginning with the lowest number.
-    <filename>00_header</filename> is run before <filename>10_linux</filename>,
-    which would run before <filename>40_custom</filename>. If files with
-    alphabetic names are present, they are executed after the numerically named
-    files. Only executable files generate output to
-    <filename>grub.cfg</filename> during execution of
-    <command>grub2-mkconfig</command>. By default all files in the
-    <filename>/etc/grub.d</filename> directory are executable.
-   </para>
-   <tip>
-    <title>Persistent custom content in <filename>grub.cfg</filename></title>
-    <para>
-     Because <filename>/boot/grub2/grub.cfg</filename> is recompiled each time
-     <command>grub2-mkconfig</command> is run, any custom content is lost. To
-     insert your lines directly into
-     <filename>/boot/grub2/grub.cfg</filename> without losing them after
-     <command>grub2-mkconfig</command> is run, insert them between
-    </para>
-    <screen>### BEGIN /etc/grub.d/90_persistent ###</screen>
-    <para>
-     and
-    </para>
-    <screen>### END /etc/grub.d/90_persistent ###</screen>
-    <para>
-     The <filename>90_persistent</filename> script ensures that such
-     content will be preserved.
-    </para>
-    <para>
-     A list of the most important scripts follows:
-    </para>
-   </tip>
-   <variablelist>
-    <varlistentry>
-     <term><filename>00_header</filename>
-     </term>
-     <listitem>
+    <sect2 xml:id="sec-grub2-etc-grub-d">
+      <title>Scripts in <filename>/etc/grub.d</filename></title>
       <para>
-       Sets environmental variables such as system file locations, display
-       settings, themes, and previously saved entries. It also imports
-       preferences stored in the <filename>/etc/default/grub</filename>.
-       Normally you do not need to make changes to this file.
+        The scripts in this directory are read during execution of the command
+        <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command>. Their
+        instructions are incorporated into
+        <filename>/boot/grub2/grub.cfg</filename>. The order of menu items in
+        <filename>grub.cfg</filename> is determined by the order in which the
+        files in this directory are run. Files with a leading numeral are
+        executed first, beginning with the lowest number.
+        <filename>00_header</filename> is run before
+        <filename>10_linux</filename>, which would run before
+        <filename>40_custom</filename>. If files with alphabetic names are
+        present, they are executed after the numerically named files. Only
+        executable files generate output to <filename>grub.cfg</filename>
+        during execution of <command>grub2-mkconfig</command>. By default all
+        files in the <filename>/etc/grub.d</filename> directory are executable.
       </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><filename>10_linux</filename>
-     </term>
-     <listitem>
+      <tip>
+        <title>Persistent custom content in <filename>grub.cfg</filename></title>
+        <para>
+          Because <filename>/boot/grub2/grub.cfg</filename> is recompiled each
+          time <command>grub2-mkconfig</command> is run, any custom content is
+          lost. To insert your lines directly into
+          <filename>/boot/grub2/grub.cfg</filename> without losing them after
+          <command>grub2-mkconfig</command> is run, insert them between
+        </para>
+<screen>### BEGIN /etc/grub.d/90_persistent ###</screen>
+        <para>
+          and
+        </para>
+<screen>### END /etc/grub.d/90_persistent ###</screen>
+        <para>
+          The <filename>90_persistent</filename> script ensures that such
+          content will be preserved.
+        </para>
+        <para>
+          A list of the most important scripts follows:
+        </para>
+      </tip>
+      <variablelist>
+        <varlistentry>
+          <term><filename>00_header</filename></term>
+          <listitem>
+            <para>
+              Sets environmental variables such as system file locations,
+              display settings, themes, and previously saved entries. It also
+              imports preferences stored in the
+              <filename>/etc/default/grub</filename>. Normally you do not need
+              to make changes to this file.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><filename>10_linux</filename></term>
+          <listitem>
+            <para>
+              Identifies Linux kernels on the root device and creates relevant
+              menu entries. This includes the associated recovery mode option
+              if enabled. Only the latest kernel is displayed on the main menu
+              page, with additional kernels included in a submenu.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><filename>30_os-prober</filename></term>
+          <listitem>
+            <para>
+              This script uses <command>os-prober</command> to search for Linux
+              and other operating systems and places the results in the &grub;
+              menu. There are sections to identify specific other operating
+              systems, such as Windows or macOS.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><filename>40_custom</filename></term>
+          <listitem>
+            <para>
+              This file provides a simple way to include custom boot entries
+              into <filename>grub.cfg</filename>. Make sure that you do not
+              change the <literal>exec tail -n +3 $0</literal> part at the
+              beginning.
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
       <para>
-       Identifies Linux kernels on the root device and creates relevant menu
-       entries. This includes the associated recovery mode option if enabled.
-       Only the latest kernel is displayed on the main menu page, with
-       additional kernels included in a submenu.
+        The processing sequence is set by the preceding numbers with the lowest
+        number being executed first. If scripts are preceded by the same number
+        the alphabetical order of the complete name decides the order.
       </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><filename>30_os-prober</filename>
-     </term>
-     <listitem>
-      <para>
-       This script uses <command>os-prober</command> to search for Linux and
-       other operating systems and places the results in the &grub; menu. There
-       are sections to identify specific other operating systems, such as
-       Windows or macOS.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term><filename>40_custom</filename>
-     </term>
-     <listitem>
-      <para>
-       This file provides a simple way to include custom boot entries into
-       <filename>grub.cfg</filename>. Make sure that you do not change the
-       <literal>exec tail -n +3 $0</literal> part at the beginning.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-   <para>
-    The processing sequence is set by the preceding numbers with the lowest
-    number being executed first. If scripts are preceded by the same number the
-    alphabetical order of the complete name decides the order.
-   </para>
-   <tip>
-    <title><filename>/boot/grub2/custom.cfg</filename></title>
-    <para>
-     If you create <filename>/boot/grub2/custom.cfg</filename> and fill
-     it with content, it will be automatically included into
-     <filename>/boot/grub2/grub.cfg</filename> right after
-     <filename>40_custom</filename> at boot time.
-    </para>
-   </tip>
-  </sect2>
+      <tip>
+        <title><filename>/boot/grub2/custom.cfg</filename></title>
+        <para>
+          If you create <filename>/boot/grub2/custom.cfg</filename> and fill it
+          with content, it will be automatically included into
+          <filename>/boot/grub2/grub.cfg</filename> right after
+          <filename>40_custom</filename> at boot time.
+        </para>
+      </tip>
+    </sect2>
 
-  <sect2 xml:id="sec-grub2-map">
-   <title>Mapping between BIOS drives and Linux devices</title>
-   <para>
-    In GRUB Legacy, the <filename>device.map</filename> configuration file was
-    used to derive Linux device names from BIOS drive numbers. The mapping
-    between BIOS drives and Linux devices cannot always be guessed correctly.
-    For example, GRUB Legacy would get a wrong order if the boot sequence of
-    IDE and SCSI drives is exchanged in the BIOS configuration.
-   </para>
-   <para>
-    &grub; avoids this problem by using device ID strings (UUIDs) or file system
-    labels when generating <filename>grub.cfg</filename>. &grub; utilities
-    create a temporary device map on the fly, which is normally sufficient,
-    particularly for single-disk systems.
-   </para>
-   <para>
-    However, if you need to override the &grub;'s automatic device mapping
-    mechanism, create your custom mapping file
-    <filename>/boot/grub2/device.map</filename>. The following example changes
-    the mapping to make <literal>DISK 3</literal> the boot disk. Note that
-    &grub; partition numbers start with <literal>1</literal> and not with
-    <literal>0</literal> as in GRUB Legacy.
-   </para>
+    <sect2 xml:id="sec-grub2-map">
+      <title>Mapping between BIOS drives and Linux devices</title>
+      <para>
+        In GRUB Legacy, the <filename>device.map</filename> configuration file
+        was used to derive Linux device names from BIOS drive numbers. The
+        mapping between BIOS drives and Linux devices cannot always be guessed
+        correctly. For example, GRUB Legacy would get a wrong order if the boot
+        sequence of IDE and SCSI drives is exchanged in the BIOS configuration.
+      </para>
+      <para>
+        &grub; avoids this problem by using device ID strings (UUIDs) or file
+        system labels when generating <filename>grub.cfg</filename>. &grub;
+        utilities create a temporary device map on the fly, which is normally
+        sufficient, particularly for single-disk systems.
+      </para>
+      <para>
+        However, if you need to override the &grub;'s automatic device mapping
+        mechanism, create your custom mapping file
+        <filename>/boot/grub2/device.map</filename>. The following example
+        changes the mapping to make <literal>DISK 3</literal> the boot disk.
+        Note that &grub; partition numbers start with <literal>1</literal> and
+        not with <literal>0</literal> as in GRUB Legacy.
+      </para>
 <screen>(hd1)  /dev/disk-by-id/<replaceable>DISK3 ID</replaceable>
 (hd2)  /dev/disk-by-id/<replaceable>DISK1 ID</replaceable>
 (hd3)  /dev/disk-by-id/<replaceable>DISK2 ID</replaceable></screen>
-  </sect2>
+    </sect2>
 
-  <sect2 xml:id="sec-grub2-menu-change">
-   <title>Editing menu entries during the boot procedure</title>
-   <para>
-    Being able to directly edit menu entries is useful when the system does not
-    boot anymore because of a faulty configuration. It can also be used to test
-    new settings without altering the system configuration.
-   </para>
-   <procedure>
-    <step>
-     <para>
-      In the graphical boot menu, select the entry you want to edit with the
-      arrow keys.
-     </para>
-    </step>
-    <step>
-     <para>
-      Press <keycap>E</keycap> to open the text-based editor.
-     </para>
-    </step>
-    <step>
-     <para>
-      Use the arrow keys to move to the line you want to edit.
-     </para>
-     <figure xml:id="fig-grub2-boot-editor">
-      <title>&grub; boot editor</title>
-      <mediaobject>
-       <imageobject role="fo">
-        <imagedata fileref="grub2_edit_config.png" width="75%"/>
-       </imageobject>
-       <imageobject role="html">
-        <imagedata fileref="grub2_edit_config.png" width="75%"/>
-       </imageobject>
-      </mediaobject>
-     </figure>
-     <para>
-      Now you have two options:
-     </para>
-     <substeps performance="required">
-      <step>
-       <para>
-        Add space-separated parameters to the end of the line starting with
-        <literal>linux</literal> or <literal>linuxefi</literal> to edit the
-        kernel parameters. A complete list of parameters is available at
-        <link xlink:href="https://en.opensuse.org/Linuxrc"/>.
-       </para>
-      </step>
-      <step>
-       <para>
-        Or edit the general options to change for example the kernel version.
-        The <keycap function="tab"/> key suggests all possible completions.
-       </para>
-      </step>
-     </substeps>
-    </step>
-    <step>
-     <para>
-      Press <keycap>F10</keycap> to boot the system with the changes you made
-      or press <keycap function="escape"/> to discard your edits and return to
-      the &grub; menu.
-     </para>
-    </step>
-   </procedure>
-   <para>
-    Changes made this way only apply to the current boot process and are not
-    saved permanently.
-   </para>
-   <important>
-    <title>Keyboard layout during the boot procedure</title>
-    <para>
-     The US keyboard layout is the only one available when booting. See
-     <xref linkend="fig-trouble-install-keyboard-us"/>.
-    </para>
-   </important>
-   <note arch="x86_64">
-    <title>Boot loader on the installation media</title>
-    <para>
-     The Boot Loader of the installation media on systems with a traditional
-     BIOS is still GRUB Legacy. To add boot parameters, select an entry and start
-     typing. Additions you make to the installation boot entry will be
-     permanently saved in the installed system.
-    </para>
-   </note>
-   <note os="sles" arch="zseries">
-    <title>Editing &grub; menu entries on &zseries;</title>
-    <para>
-     Cursor movement and editing commands on &zseries; differ&mdash;see
-     <xref linkend="sec-grub2-zseries"/> for details.
-    </para>
-   </note>
-  </sect2>
+    <sect2 xml:id="sec-grub2-menu-change">
+      <title>Editing menu entries during the boot procedure</title>
+      <para>
+        Being able to directly edit menu entries is useful when the system does
+        not boot anymore because of a faulty configuration. It can also be used
+        to test new settings without altering the system configuration.
+      </para>
+      <procedure>
+        <step>
+          <para>
+            In the graphical boot menu, select the entry you want to edit with
+            the arrow keys.
+          </para>
+        </step>
+        <step>
+          <para>
+            Press <keycap>E</keycap> to open the text-based editor.
+          </para>
+        </step>
+        <step>
+          <para>
+            Use the arrow keys to move to the line you want to edit.
+          </para>
+          <figure xml:id="fig-grub2-boot-editor">
+            <title>&grub; boot editor</title>
+            <mediaobject>
+              <imageobject role="fo">
+                <imagedata fileref="grub2_edit_config.png" width="75%"/>
+              </imageobject>
+              <imageobject role="html">
+                <imagedata fileref="grub2_edit_config.png" width="75%"/>
+              </imageobject>
+            </mediaobject>
+          </figure>
+          <para>
+            Now you have two options:
+          </para>
+          <substeps performance="required">
+            <step>
+              <para>
+                Add space-separated parameters to the end of the line starting
+                with <literal>linux</literal> or <literal>linuxefi</literal> to
+                edit the kernel parameters. A complete list of parameters is
+                available at
+                <link xlink:href="https://en.opensuse.org/Linuxrc"/>.
+              </para>
+            </step>
+            <step>
+              <para>
+                Or edit the general options to change for example the kernel
+                version. The <keycap function="tab"/> key suggests all possible
+                completions.
+              </para>
+            </step>
+          </substeps>
+        </step>
+        <step>
+          <para>
+            Press <keycap>F10</keycap> to boot the system with the changes you
+            made or press <keycap function="escape"/> to discard your edits and
+            return to the &grub; menu.
+          </para>
+        </step>
+      </procedure>
+      <para>
+        Changes made this way only apply to the current boot process and are
+        not saved permanently.
+      </para>
+      <important>
+        <title>Keyboard layout during the boot procedure</title>
+        <para>
+          The US keyboard layout is the only one available when booting. See
+          <xref linkend="fig-trouble-install-keyboard-us"/>.
+        </para>
+      </important>
+      <note arch="x86_64">
+        <title>Boot loader on the installation media</title>
+        <para>
+          The Boot Loader of the installation media on systems with a
+          traditional BIOS is still GRUB Legacy. To add boot parameters, select
+          an entry and start typing. Additions you make to the installation
+          boot entry will be permanently saved in the installed system.
+        </para>
+      </note>
+      <note os="sles" arch="zseries">
+        <title>Editing &grub; menu entries on &zseries;</title>
+        <para>
+          Cursor movement and editing commands on &zseries; differ&mdash;see
+          <xref linkend="sec-grub2-zseries"/> for details.
+        </para>
+      </note>
+    </sect2>
 
-  <sect2 xml:id="sec-grub2-password">
-   <title>Setting a boot password</title>
-   <para>
-    Even before the operating system is booted, &grub; enables access to file
-    systems. Users without root permissions can access files in your Linux
-    system to which they have no access after the system is booted. To block
-    this kind of access or to prevent users from booting certain menu entries,
-    set a boot password.
-   </para>
-   <important>
-    <title>Booting requires a password</title>
-    <para>
-     If set, the boot password is required on every boot, which means the
-     system does not boot automatically.
-    </para>
-   </important>
-   <para>
-    Proceed as follows to set a boot password. Alternatively use &yast;
-    (<xref linkend="vle-grub2-yast2-boot-password"/>).
-   </para>
-   <procedure>
-    <step>
-     <para>
-      Encrypt the password using <command>grub2-mkpasswd-pbkdf2:</command>
-     </para>
+    <sect2 xml:id="sec-grub2-password">
+      <title>Setting a boot password</title>
+      <para>
+        Even before the operating system is booted, &grub; enables access to
+        file systems. Users without root permissions can access files in your
+        Linux system to which they have no access after the system is booted.
+        To block this kind of access or to prevent users from booting certain
+        menu entries, set a boot password.
+      </para>
+      <important>
+        <title>Booting requires a password</title>
+        <para>
+          If set, the boot password is required on every boot, which means the
+          system does not boot automatically.
+        </para>
+      </important>
+      <para>
+        Proceed as follows to set a boot password. Alternatively use &yast;
+        (<xref linkend="vle-grub2-yast2-boot-password"/>).
+      </para>
+      <procedure>
+        <step>
+          <para>
+            Encrypt the password using
+            <command>grub2-mkpasswd-pbkdf2:</command>
+          </para>
 <screen>&prompt.sudo;grub2-mkpasswd-pbkdf2
 Password: ****
 Reenter password: ****
 PBKDF2 hash of your password is grub.pbkdf2.sha512.10000.9CA4611006FE96BC77A...
 </screen>
-    </step>
-    <step>
-     <para>
-      Paste the resulting string into the file
-      <filename>/etc/grub.d/40_custom</filename> together with the <command>set
-      superusers</command> command.
-     </para>
+        </step>
+        <step>
+          <para>
+            Paste the resulting string into the file
+            <filename>/etc/grub.d/40_custom</filename> together with the
+            <command>set superusers</command> command.
+          </para>
 <screen>set superusers="root"
 password_pbkdf2 root grub.pbkdf2.sha512.10000.9CA4611006FE96BC77A...</screen>
-    </step>
-    <step>
-     <para>
-      To import the changes into the main configuration file, run:
-     </para>
-     <screen>&prompt.sudo;grub2-mkconfig -o /boot/grub2/grub.cfg</screen>
-    </step>
-   </procedure>
-   <para>
-    After you reboot, you will be prompted for a user name and a password when
-    trying to boot a menu entry. Enter <literal>root</literal> and the password
-    you typed during the <command>grub2-mkpasswd-pbkdf2</command> command. If
-    the credentials are correct, the system will boot the selected boot entry.
-   </para>
-   <para>
-    For more information, see
-    <link
+        </step>
+        <step>
+          <para>
+            To import the changes into the main configuration file, run:
+          </para>
+<screen>&prompt.sudo;grub2-mkconfig -o /boot/grub2/grub.cfg</screen>
+        </step>
+      </procedure>
+      <para>
+        After you reboot, you will be prompted for a user name and a password
+        when trying to boot a menu entry. Enter <literal>root</literal> and the
+        password you typed during the <command>grub2-mkpasswd-pbkdf2</command>
+        command. If the credentials are correct, the system will boot the
+        selected boot entry.
+      </para>
+      <para>
+        For more information, see
+        <link
     xlink:href="https://www.gnu.org/software/grub/manual/grub.html#Security"/>.
-   </para>
-  </sect2>
-  <sect2 xml:id="sec-grub2-authorization">
-   <title>Authorized access to boot menu entries</title>
-   <para>
-    You can configure &grub; to allow access to boot menu entries depending
-    on the level of authorization. You can configure multiple user accounts
-    protected with passwords and assign them access to different menu entries.
-    To configure authorization in &grub;, follow these steps:
-   </para>
-   <procedure>
-    <step>
-     <para>
-      Create and encrypt one password for each user account you want to use in
-      &grub;. Use the <command>grub2-mkpasswd-pbkdf2</command> command as
-      described in <xref linkend="sec-grub2-password"/>.
-     </para>
-    </step>
-    <step>
-     <para>
-      Delete the file <filename>/etc/grub.d/10_linux</filename>.
-      This prevents outputting the default &grub; menu entries.
-     </para>
-    </step>
-    <step>
-     <para>
-      Edit the <filename>/boot/grub2/custom.cfg</filename> file and add custom
-      menu entries manually. The following template is an example, adjust
-      it to better match your use case:
-     </para>
+      </para>
+    </sect2>
+
+    <sect2 xml:id="sec-grub2-authorization">
+      <title>Authorized access to boot menu entries</title>
+      <para>
+        You can configure &grub; to allow access to boot menu entries depending
+        on the level of authorization. You can configure multiple user accounts
+        protected with passwords and assign them access to different menu
+        entries. To configure authorization in &grub;, follow these steps:
+      </para>
+      <procedure>
+        <step>
+          <para>
+            Create and encrypt one password for each user account you want to
+            use in &grub;. Use the <command>grub2-mkpasswd-pbkdf2</command>
+            command as described in <xref linkend="sec-grub2-password"/>.
+          </para>
+        </step>
+        <step>
+          <para>
+            Delete the file <filename>/etc/grub.d/10_linux</filename>. This
+            prevents outputting the default &grub; menu entries.
+          </para>
+        </step>
+        <step>
+          <para>
+            Edit the <filename>/boot/grub2/custom.cfg</filename> file and add
+            custom menu entries manually. The following template is an example,
+            adjust it to better match your use case:
+          </para>
 <screen>
 set superusers=admin
 password admin <replaceable>ADMIN_PASSWORD</replaceable>
@@ -774,679 +772,738 @@ menuentry 'Maintenance mode' --users maintainer {
   initrd /boot/initrd
 }
 </screen>
-    </step>
-    <step>
-     <para>
-      Import the changes into the main configuration file:
-     </para>
-     <screen>&prompt.sudo;grub2-mkconfig -o /boot/grub2/grub.cfg</screen>
-    </step>
-   </procedure>
-   <para>
-    In the above example:
-   </para>
-   <itemizedlist>
-    <listitem>
-     <para>
-      The &grub; menu has two entries, <guimenu>Operational mode</guimenu>
-      and <guimenu>Maintenance mode</guimenu>.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      If no user is specified, both boot menu entries are accessible, but
-      no one can access &grub; command line or edit existing menu entries.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <literal>admin</literal> user can access &grub; command line and edit
-      existing menu entries.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      <literal>maintenance</literal> user can select the recovery menu item.
-     </para>
-    </listitem>
-   </itemizedlist>
-  </sect2>
- </sect1>
- <xi:include href="grub2_yast_i.xml"/>
- <sect1 os="sles" xml:id="sec-grub2-zseries">
-  <title>Differences in terminal usage on &zseries;</title>
-
-  <para>
-   On 3215 and 3270 terminals there are certain differences and limitations on
-   how to move the cursor and how to issue editing commands within &grub;.
-  </para>
-
-  <sect2 xml:id="sec-grub2-zseries-limitations">
-   <title>Limitations</title>
-   <variablelist>
-    <varlistentry>
-     <term>Interactivity</term>
-     <listitem>
+        </step>
+        <step>
+          <para>
+            Import the changes into the main configuration file:
+          </para>
+<screen>&prompt.sudo;grub2-mkconfig -o /boot/grub2/grub.cfg</screen>
+        </step>
+      </procedure>
       <para>
-       Interactivity is strongly limited. Typing often does not result in
-       visual feedback. To see where the cursor is, type an underscore
-       (<keycap>_</keycap>).
+        In the above example:
       </para>
-      <note>
-       <title>3270 compared to 3215</title>
-       <para>
-        The 3270 terminal is much better at displaying and refreshing screens
-        than the 3215 terminal.
-       </para>
-      </note>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>Cursor movement</term>
-     <listitem>
-      <para>
-       <quote>Traditional</quote> cursor movement is not possible.
-       <keycap function="alt"/>, <keycap function="meta"/>,
-       <keycap function="control"/> and the cursor keys do not work. To move
-       the cursor, use the key combinations listed in
-       <xref linkend="sec-grub2-zseries-keys"/>.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>Caret</term>
-     <listitem>
-      <para>
-       The caret (<keycap>^</keycap>) is used as a control character. To type a
-       literal <keycap>^</keycap> followed by a letter, type
-       <keycap>^</keycap>, <keycap>^</keycap>,
-       <replaceable>LETTER</replaceable>.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>Enter</term>
-     <listitem>
-      <para>
-       The <keycap function="enter"/> key does not work, use
-       <keycombo><keycap>^</keycap> <keycap>J</keycap></keycombo> instead.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </sect2>
+      <itemizedlist>
+        <listitem>
+          <para>
+            The &grub; menu has two entries, <guimenu>Operational
+            mode</guimenu> and <guimenu>Maintenance mode</guimenu>.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            If no user is specified, both boot menu entries are accessible, but
+            no one can access &grub; command line or edit existing menu
+            entries.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            <literal>admin</literal> user can access &grub; command line and
+            edit existing menu entries.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            <literal>maintenance</literal> user can select the recovery menu
+            item.
+          </para>
+        </listitem>
+      </itemizedlist>
+    </sect2>
+  </sect1>
+  <xi:include href="grub2_yast_i.xml"/>
+  <sect1 os="sles" xml:id="sec-grub2-zseries">
+    <title>Differences in terminal usage on &zseries;</title>
 
-  <sect2 xml:id="sec-grub2-zseries-keys">
-   <title>Key combinations</title>
-   <informaltable>
-    <tgroup cols="3">
-     <tbody>
-      <row>
-       <entry morerows="2" valign="top">
-        <para>
-         Common Substitutes:
-        </para>
-       </entry>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap> <keycap>J</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         engage (<quote>Enter</quote>)
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>L</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         abort, return to previous <quote>state</quote>
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>I</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         tab completion (in edit and shell mode)
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry morerows="8" valign="top">
-        <para>
-         Keys Available in Menu Mode:
-        </para>
-       </entry>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>A</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         first entry
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>E</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         last entry
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>P</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         previous entry
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>N</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         next entry
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>G</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         previous page
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>C</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         next page
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>F</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         boot selected entry or enter submenu (same as
-         <keycombo><keycap>^</keycap><keycap>J</keycap></keycombo>)
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>E</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         edit selected entry
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>C</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         enter GRUB-Shell
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry morerows="13" valign="top">
-        <para>
-         Keys Available in Edit Mode:
-        </para>
-       </entry>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>P</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         previous line
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>N</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         next line
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>B</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         backward char
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>F</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         forward char
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>A</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         beginning of line
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>E</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         end of line
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>H</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         backspace
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>D</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         delete
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>K</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         kill line
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>Y</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         yank
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>O</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         open line
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>L</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         refresh screen
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>X</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         boot entry
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>C</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         enter GRUB-Shell
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry morerows="10" valign="top">
-        <para>
-         Keys Available in Command Line Mode:
-        </para>
-       </entry>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>P</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         previous command
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>N</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         next command from history
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>A</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         beginning of line
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>E</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         end of line
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>B</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         backward char
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>F</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         forward char
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>H</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         backspace
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>D</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         delete
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>K</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         kill line
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>U</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         discard line
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         <keycombo><keycap>^</keycap><keycap>Y</keycap></keycombo>
-        </para>
-       </entry>
-       <entry>
-        <para>
-         yank
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </informaltable>
-  </sect2>
- </sect1>
- <sect1 xml:id="sec-grub2-commands">
-  <title>Helpful &grub; commands</title>
+    <para>
+      On 3215 and 3270 terminals there are certain differences and limitations
+      on how to move the cursor and how to issue editing commands within
+      &grub;.
+    </para>
 
-  <variablelist>
-   <varlistentry xml:id="vle-grub2-mkconfig">
-    <term><command>grub2-mkconfig</command>
-    </term>
-    <listitem>
-     <para>
-      Generates a new <filename>/boot/grub2/grub.cfg</filename> based on
-      <filename>/etc/default/grub</filename> and the scripts from
-      <filename>/etc/grub.d/</filename>.
-     </para>
-     <example>
-      <title>Usage of grub2-mkconfig</title>
+    <sect2 xml:id="sec-grub2-zseries-limitations">
+      <title>Limitations</title>
+      <variablelist>
+        <varlistentry>
+          <term>Interactivity</term>
+          <listitem>
+            <para>
+              Interactivity is strongly limited. Typing often does not result
+              in visual feedback. To see where the cursor is, type an
+              underscore (<keycap>_</keycap>).
+            </para>
+            <note>
+              <title>3270 compared to 3215</title>
+              <para>
+                The 3270 terminal is much better at displaying and refreshing
+                screens than the 3215 terminal.
+              </para>
+            </note>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Cursor movement</term>
+          <listitem>
+            <para>
+              <quote>Traditional</quote> cursor movement is not possible.
+              <keycap function="alt"/>, <keycap function="meta"/>,
+              <keycap function="control"/> and the cursor keys do not work. To
+              move the cursor, use the key combinations listed in
+              <xref linkend="sec-grub2-zseries-keys"/>.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Caret</term>
+          <listitem>
+            <para>
+              The caret (<keycap>^</keycap>) is used as a control character. To
+              type a literal <keycap>^</keycap> followed by a letter, type
+              <keycap>^</keycap>, <keycap>^</keycap>,
+              <replaceable>LETTER</replaceable>.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Enter</term>
+          <listitem>
+            <para>
+              The <keycap function="enter"/> key does not work, use
+              <keycombo><keycap>^</keycap> <keycap>J</keycap></keycombo>
+              instead.
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </sect2>
+
+    <sect2 xml:id="sec-grub2-zseries-keys">
+      <title>Key combinations</title>
+      <informaltable>
+        <tgroup cols="3">
+          <tbody>
+            <row>
+              <entry morerows="2" valign="top">
+                <para>
+                  Common Substitutes:
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap> <keycap>J</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  engage (<quote>Enter</quote>)
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>L</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  abort, return to previous <quote>state</quote>
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>I</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  tab completion (in edit and shell mode)
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry morerows="8" valign="top">
+                <para>
+                  Keys Available in Menu Mode:
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>A</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  first entry
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>E</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  last entry
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>P</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  previous entry
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>N</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  next entry
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>G</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  previous page
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>C</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  next page
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>F</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  boot selected entry or enter submenu (same as
+                  <keycombo><keycap>^</keycap><keycap>J</keycap></keycombo>)
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>E</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  edit selected entry
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>C</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  enter GRUB-Shell
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry morerows="13" valign="top">
+                <para>
+                  Keys Available in Edit Mode:
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>P</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  previous line
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>N</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  next line
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>B</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  backward char
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>F</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  forward char
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>A</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  beginning of line
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>E</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  end of line
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>H</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  backspace
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>D</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  delete
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>K</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  kill line
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>Y</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  yank
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>O</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  open line
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>L</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  refresh screen
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>X</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  boot entry
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>C</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  enter GRUB-Shell
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry morerows="10" valign="top">
+                <para>
+                  Keys Available in Command Line Mode:
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>P</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  previous command
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>N</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  next command from history
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>A</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  beginning of line
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>E</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  end of line
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>B</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  backward char
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>F</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  forward char
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>H</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  backspace
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>D</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  delete
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>K</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  kill line
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>U</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  discard line
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  <keycombo><keycap>^</keycap><keycap>Y</keycap></keycombo>
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  yank
+                </para>
+              </entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </informaltable>
+    </sect2>
+  </sect1>
+  <sect1 xml:id="sec-grub2-commands">
+    <title>Helpful &grub; commands</title>
+
+    <variablelist>
+      <varlistentry xml:id="vle-grub2-mkconfig">
+        <term><command>grub2-mkconfig</command></term>
+        <listitem>
+          <para>
+            Generates a new <filename>/boot/grub2/grub.cfg</filename> based on
+            <filename>/etc/default/grub</filename> and the scripts from
+            <filename>/etc/grub.d/</filename>.
+          </para>
+          <example>
+            <title>Usage of grub2-mkconfig</title>
 <screen>grub2-mkconfig -o /boot/grub2/grub.cfg</screen>
-     </example>
-     <tip>
-      <title>Syntax check</title>
-      <para>
-       Running <command>grub2-mkconfig</command> without any parameters prints
-       the configuration to STDOUT where it can be reviewed. Use
-       <xref linkend="vle-grub2-script-check"/> after
-       <filename>/boot/grub2/grub.cfg</filename> has been written to check its
-       syntax.
-      </para>
-     </tip>
-     <important>
-      <title><command>grub2-mkconfig</command> cannot repair UEFI Secure Boot tables</title>
-      <para>
-       If you are using UEFI Secure Boot and your system is not reaching &grub;
-       correctly anymore, you may need to additionally reinstall the Shim and
-       regenerate the UEFI boot table. To do so, use:
-      </para>
+          </example>
+          <tip>
+            <title>Syntax check</title>
+            <para>
+              Running <command>grub2-mkconfig</command> without any parameters
+              prints the configuration to STDOUT where it can be reviewed. Use
+              <xref linkend="vle-grub2-script-check"/> after
+              <filename>/boot/grub2/grub.cfg</filename> has been written to
+              check its syntax.
+            </para>
+          </tip>
+          <important>
+            <title><command>grub2-mkconfig</command> cannot repair UEFI Secure Boot tables</title>
+            <para>
+              If you are using UEFI Secure Boot and your system is not reaching
+              &grub; correctly anymore, you may need to additionally reinstall
+              the Shim and regenerate the UEFI boot table. To do so, use:
+            </para>
 <screen>&prompt.root;shim-install --config-file=/boot/grub2/grub.cfg</screen>
-     </important>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="vle-grub2-mkrescue">
-    <term><command>grub2-mkrescue</command></term>
-    <listitem>
-     <para>
-      Creates a bootable rescue image of your installed &grub; configuration.
-     </para>
-     <example>
-      <title>Usage of grub2-mkrescue</title>
+          </important>
+        </listitem>
+      </varlistentry>
+      <varlistentry xml:id="vle-grub2-mkrescue">
+        <term><command>grub2-mkrescue</command></term>
+        <listitem>
+          <para>
+            Creates a bootable rescue image of your installed &grub;
+            configuration.
+          </para>
+          <example>
+            <title>Usage of grub2-mkrescue</title>
 <screen>grub2-mkrescue -o save_path/name.iso iso</screen>
-     </example>
-    </listitem>
-   </varlistentry>
-   <varlistentry xml:id="vle-grub2-script-check">
-    <term><command>grub2-script-check</command>
-    </term>
-    <listitem>
-     <para>
-      Checks the given file for syntax errors.
-     </para>
-     <example>
-      <title>Usage of grub2-script-check</title>
+          </example>
+        </listitem>
+      </varlistentry>
+      <varlistentry xml:id="vle-grub2-script-check">
+        <term><command>grub2-script-check</command></term>
+        <listitem>
+          <para>
+            Checks the given file for syntax errors.
+          </para>
+          <example>
+            <title>Usage of grub2-script-check</title>
 <screen>grub2-script-check /boot/grub2/grub.cfg</screen>
-     </example>
-    </listitem>
-   </varlistentry>
-   <varlistentry>
-    <term><command>grub2-once</command>
-    </term>
-    <listitem>
-     <para>
-      Set the default boot entry for the next boot only. To get the list of
-      available boot entries use the <option>--list</option> option.
-     </para>
-     <example>
-      <title>Usage of grub2-once</title>
+          </example>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><command>grub2-once</command></term>
+        <listitem>
+          <para>
+            Set the default boot entry for the next boot only. To get the list
+            of available boot entries use the <option>--list</option> option.
+          </para>
+          <example>
+            <title>Usage of grub2-once</title>
 <screen>grub2-once number_of_the_boot_entry</screen>
-     </example>
-     <tip>
-      <title><command>grub2-once</command> help</title>
-      <para>
-       Call the program without any option to get a full list of all possible
-       options.
-      </para>
-     </tip>
-    </listitem>
-   </varlistentry>
-  </variablelist>
- </sect1>
- <sect1 xml:id="sec-grub2-info">
-  <title>More information</title>
+          </example>
+          <tip>
+            <title><command>grub2-once</command> help</title>
+            <para>
+              Call the program without any option to get a full list of all
+              possible options.
+            </para>
+          </tip>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </sect1>
+  <sect1 xml:id="grub-rescue-target">
+    <title>Entering rescue mode</title>
 
-  <para>
-   Extensive information about &grub; is available at <link
-   xlink:href="https://www.gnu.org/software/grub/"/>. Also refer to the
-   <command>grub</command> info page. <phrase os="sles;sled">You can also
-   search for the keyword <quote>&grub;</quote> in the Technical Information
-   Search at <link xlink:href="https://www.suse.com/support"/> to get
-   information about special issues.</phrase>
-  </para>
- </sect1>
+    <para>
+      <emphasis>Rescue mode</emphasis> is a specific &rootuser; user session
+      for troubleshooting and repairing systems where the booting process
+      fails. It offers a single-user environment with local file systems and
+      core system services active. Network interfaces are not activated. To
+      enter the rescue mode, follow these steps.
+    </para>
+
+    <procedure xml:id="proc-trouble-login-no">
+      <step>
+        <para>
+          Reboot the system. The boot screen appears, offering the &grub; boot
+          menu.
+        </para>
+      </step>
+      <step>
+        <para>
+          Select a menu entry from the &grub; boot menu that you want to start
+          and press <keycap>e</keycap> to edit the boot line.
+        </para>
+      </step>
+      <step>
+        <para>
+          Append the following parameter to the line containing the kernel
+          parameters:
+        </para>
+<screen>systemd.unit=rescue.target</screen>
+      </step>
+      <step>
+        <para>
+          Press <keycap function="control"/>+<keycap>X</keycap> to boot with
+          these settings.
+        </para>
+      </step>
+      <step>
+        <para>
+          Enter the user name and password for &rootuser;.
+        </para>
+      </step>
+      <step>
+        <para>
+          Make all the necessary changes.
+        </para>
+      </step>
+      <step>
+        <para>
+          Boot into the full multiuser and network mode by entering
+          <command>systemctl isolate graphical.target</command> at the command
+          line.
+        </para>
+      </step>
+    </procedure>
+  </sect1>
+  <sect1 xml:id="sec-grub2-info">
+    <title>More information</title>
+
+    <para>
+      Extensive information about &grub; is available at
+      <link
+   xlink:href="https://www.gnu.org/software/grub/"/>. Also refer to
+      the <command>grub</command> info page. <phrase os="sles;sled">You can
+      also search for the keyword <quote>&grub;</quote> in the Technical
+      Information Search at <link xlink:href="https://www.suse.com/support"/>
+      to get information about special issues.</phrase>
+    </para>
+  </sect1>
 </chapter>

--- a/xml/grub2.xml
+++ b/xml/grub2.xml
@@ -1498,7 +1498,7 @@ menuentry 'Maintenance mode' --users maintainer {
   <sect1 xml:id="sec-grub2-info">
     <title>More information</title>
 
-    <para>git rebase --abort
+    <para>
       Extensive information about &grub; is available at
       <link
    xlink:href="https://www.gnu.org/software/grub/"/>. Also refer to

--- a/xml/grub2.xml
+++ b/xml/grub2.xml
@@ -1449,7 +1449,7 @@ menuentry 'Maintenance mode' --users maintainer {
       enter the rescue mode, follow these steps.
     </para>
 
-    <procedure xml:id="proc-trouble-login-no">
+    <procedure xml:id="proc-rescue-mode">
      <title>Entering rescue mode</title>
       <step>
         <para>

--- a/xml/grub2.xml
+++ b/xml/grub2.xml
@@ -199,7 +199,7 @@
       </para>
 <screen>&prompt.user;grep "export GRUB_DEFAULT" -A50 /usr/sbin/grub2-mkconfig | grep GRUB_</screen>
       <para>
-        You can introduce custom variables, and use them later in the scripts
+        You can introduce custom variables and use them later in the scripts
         found in the
         <filename>/etc/grub.d</filename> directory.
       </para>
@@ -708,7 +708,7 @@ password_pbkdf2 root grub.pbkdf2.sha512.10000.9CA4611006FE96BC77A...</screen>
         </step>
       </procedure>
       <para>
-        After you reboot, &grub; prompts yoy for a user name and a password
+        After you reboot, &grub; prompts you for a user name and a password
         when trying to boot a menu entry. Enter <literal>root</literal> and the
         password you typed during the <command>grub2-mkpasswd-pbkdf2</command>
         command. If the credentials are correct, the system boots the
@@ -1460,7 +1460,6 @@ menuentry 'Maintenance mode' --users maintainer {
       <step>
         <para>
           Select the menu entry to boot
-          Select a menu entry from the &grub; boot menu that you want to start
           and press <keycap>e</keycap> to edit the boot line.
         </para>
       </step>

--- a/xml/grub2.xml
+++ b/xml/grub2.xml
@@ -98,7 +98,7 @@
             custom items to the boot menu. Starting with &productname;
             <phrase
       os="sles;sled">12 SP2</phrase><phrase os="osuse">Leap
-            42.2</phrase> these entries will also be parsed when using
+            42.2</phrase> these entries are also parsed when using
             <command>grub-once</command>.
           </para>
         </listitem>
@@ -158,7 +158,7 @@
         After having manually edited &grub; configuration files, you need to
         run <command>grub2-mkconfig -o /boot/grub2/grub.cfg</command> to
         activate the changes. However, this is not necessary when changing the
-        configuration with &yast;, because &yast; will automatically run this
+        configuration with &yast;, because &yast; automatically runs this
         command.
       </para>
     </note>
@@ -199,8 +199,8 @@
       </para>
 <screen>&prompt.user;grep "export GRUB_DEFAULT" -A50 /usr/sbin/grub2-mkconfig | grep GRUB_</screen>
       <para>
-        In addition to already defined variables, the user may introduce their
-        own variables, and use them later in the scripts found in the
+        You can introduce custom variables, and use them later in the scripts
+        found in the
         <filename>/etc/grub.d</filename> directory.
       </para>
       <para>
@@ -285,7 +285,7 @@
               Time period in seconds the boot menu is displayed before
               automatically booting the default boot entry. If you press a key,
               the timeout is cancelled and &grub; waits for you to make the
-              selection manually. <literal>GRUB_TIMEOUT=-1</literal> will cause
+              selection manually. <literal>GRUB_TIMEOUT=-1</literal> causes
               the menu to be displayed until you select the boot entry
               manually.
             </para>
@@ -333,7 +333,7 @@
           <listitem>
             <para>
               Same as <literal>GRUB_CMDLINE_LINUX_XEN_REPLACE</literal> but it
-              will only replace parameters
+              only replaces parameters
               of<literal>GRUB_CMDLINE_LINUX_DEFAULT</literal>.
             </para>
           </listitem>
@@ -368,7 +368,7 @@
               <literal>ofconsole</literal> (Open Firmware console), or the
               default <literal>gfxterm</literal> (graphics-mode output). It is
               also possible to enable more than one device by quoting the
-              required options, for example <literal>GRUB_TERMINAL="console
+              required options, for example, <literal>GRUB_TERMINAL="console
               serial"</literal>.
             </para>
           </listitem>
@@ -387,7 +387,7 @@
             </para>
             <para>
               You can also specify a color depth by appending it to the
-              resolution setting, for example
+              resolution setting, for example,
               <literal>GRUB_GFXMODE=1280x1024x24</literal>.
             </para>
           </listitem>
@@ -400,7 +400,7 @@
               graphical terminal. The image must be a file readable by &grub;
               at boot time, and it must end with the <literal>.png</literal>,
               <literal>.tga</literal>, <literal>.jpg</literal>, or
-              <literal>.jpeg</literal> suffix. If necessary, the image will be
+              <literal>.jpeg</literal> suffix. If necessary, the image is
               scaled to fit the screen.
             </para>
           </listitem>
@@ -469,7 +469,7 @@
 <screen>### END /etc/grub.d/90_persistent ###</screen>
         <para>
           The <filename>90_persistent</filename> script ensures that such
-          content will be preserved.
+          content is preserved.
         </para>
         <para>
           A list of the most important scripts follows:
@@ -481,7 +481,7 @@
           <listitem>
             <para>
               Sets environmental variables such as system file locations,
-              display settings, themes, and previously saved entries. It also
+              display settings, themes and previously saved entries. It also
               imports preferences stored in the
               <filename>/etc/default/grub</filename>. Normally you do not need
               to make changes to this file.
@@ -531,7 +531,7 @@
         <title><filename>/boot/grub2/custom.cfg</filename></title>
         <para>
           If you create <filename>/boot/grub2/custom.cfg</filename> and fill it
-          with content, it will be automatically included into
+          with content, it is automatically included into
           <filename>/boot/grub2/grub.cfg</filename> right after
           <filename>40_custom</filename> at boot time.
         </para>
@@ -558,8 +558,8 @@
         mechanism, create your custom mapping file
         <filename>/boot/grub2/device.map</filename>. The following example
         changes the mapping to make <literal>DISK 3</literal> the boot disk.
-        Note that &grub; partition numbers start with <literal>1</literal> and
-        not with <literal>0</literal> as in GRUB Legacy.
+        &grub; partition numbers start with <literal>1</literal> and
+        not with <literal>0</literal> as in &grub; Legacy.
       </para>
 <screen>(hd1)  /dev/disk-by-id/<replaceable>DISK3 ID</replaceable>
 (hd2)  /dev/disk-by-id/<replaceable>DISK1 ID</replaceable>
@@ -615,7 +615,7 @@
             </step>
             <step>
               <para>
-                Or edit the general options to change for example the kernel
+                Or edit the general options to change, for example, the kernel
                 version. The <keycap function="tab"/> key suggests all possible
                 completions.
               </para>
@@ -647,7 +647,7 @@
           The Boot Loader of the installation media on systems with a
           traditional BIOS is still GRUB Legacy. To add boot parameters, select
           an entry and start typing. Additions you make to the installation
-          boot entry will be permanently saved in the installed system.
+          boot entry are permanently saved in the installed system.
         </para>
       </note>
       <note os="sles" arch="zseries">
@@ -708,10 +708,10 @@ password_pbkdf2 root grub.pbkdf2.sha512.10000.9CA4611006FE96BC77A...</screen>
         </step>
       </procedure>
       <para>
-        After you reboot, you will be prompted for a user name and a password
+        After you reboot, &grub; prompts yoy for a user name and a password
         when trying to boot a menu entry. Enter <literal>root</literal> and the
         password you typed during the <command>grub2-mkpasswd-pbkdf2</command>
-        command. If the credentials are correct, the system will boot the
+        command. If the credentials are correct, the system boots the
         selected boot entry.
       </para>
       <para>
@@ -1439,7 +1439,7 @@ menuentry 'Maintenance mode' --users maintainer {
   </sect1>
 
   <sect1 xml:id="grub-rescue-target">
-    <title>Entering rescue mode</title>
+    <title>Rescue mode</title>
 
     <para>
       <emphasis>Rescue mode</emphasis> is a specific &rootuser; user session
@@ -1450,6 +1450,7 @@ menuentry 'Maintenance mode' --users maintainer {
     </para>
 
     <procedure xml:id="proc-trouble-login-no">
+     <title>Entering rescue mode</title>
       <step>
         <para>
           Reboot the system. The boot screen appears, offering the &grub; boot
@@ -1458,6 +1459,7 @@ menuentry 'Maintenance mode' --users maintainer {
       </step>
       <step>
         <para>
+          Select the menu entry to boot
           Select a menu entry from the &grub; boot menu that you want to start
           and press <keycap>e</keycap> to edit the boot line.
         </para>
@@ -1477,7 +1479,7 @@ menuentry 'Maintenance mode' --users maintainer {
       </step>
       <step>
         <para>
-          Enter the user name and password for &rootuser;.
+          Enter the password for &rootuser;.
         </para>
       </step>
       <step>
@@ -1487,7 +1489,8 @@ menuentry 'Maintenance mode' --users maintainer {
       </step>
       <step>
         <para>
-          Boot into the full multiuser and network mode by entering
+          Enter normal operating target again by entering
+          <command>systemctl isolate multi-user.target</command> or
           <command>systemctl isolate graphical.target</command> at the command
           line.
         </para>

--- a/xml/systemd.xml
+++ b/xml/systemd.xml
@@ -709,8 +709,9 @@
           <term><systemitem>emergency.target</systemitem></term>
           <listitem>
             <para>
-              Starts an emergency shell on the console. Only use it at the boot
-              prompt as <literal>systemd.unit=emergency.target</literal>.
+              Starts a minimal emergency &rootuser; shell on the console. Only
+              use it at the boot prompt as
+              <literal>systemd.unit=emergency.target</literal>.
             </para>
           </listitem>
         </varlistentry>
@@ -759,7 +760,11 @@
           <term><systemitem>rescue.target</systemitem></term>
           <listitem>
             <para>
-              Starts a single-user system without network.
+              Starts a single-user &rootuser; session without network. Basic
+              tools for system administration are available. The
+              <literal>rescue</literal> target is suitable for solving multiple
+              system problems, for example, failing logins or fixing issues with
+              a display driver.
             </para>
           </listitem>
         </varlistentry>

--- a/xml/troubleshooting.xml
+++ b/xml/troubleshooting.xml
@@ -726,10 +726,10 @@
         </listitem>
       </itemizedlist>
       <para>
-        In all cases that do not involve external network problems, the
-        solution is to reboot the system into the rescue target and repair the
-        configuration before booting again into operating mode and attempting
-        to log in again. To boot into the rescue targe, follow the procedure
+        In all cases that do not involve external network problems, the solution
+        is to reboot the system into the rescue mode and repair the
+        configuration before booting again into operating mode and attempting to
+        log in again. To boot into the rescue targe, follow the procedure
         outlined in <xref linkend="proc-trouble-login-no"/>.
       </para>
     </sect2>
@@ -782,7 +782,7 @@
         </step>
         <step>
           <para>
-            Log in as&rootuser; and check the system journal with
+            Log in as &rootuser; and check the system journal with
             <command>journalctl -e</command> for error messages of the login
             process and of PAM.
           </para>

--- a/xml/troubleshooting.xml
+++ b/xml/troubleshooting.xml
@@ -884,26 +884,6 @@
             authentication problems for this user. Try graphical login again.
           </para>
         </step>
-        <!--
-          <step>
-          <para>
-          If graphical login still fails, do a console login with <keycombo>
-          <keycap function="control"/>
-          <keycap function="alt"/> <keycap>F1</keycap> </keycombo>.
-          Try to start an X session on another display&mdash;the first one
-          (<literal>:0</literal>) is already in use:
-          </para>
-          <screen>startx -\- :1</screen>
-          <para>
-          This should bring up a graphical screen and your desktop. If it does
-          not, check the log files of the X Window System
-          (<filename>/var/log/Xorg.<replaceable>DISPLAYNUMBER</replaceable>.log</filename>)
-          or the log file for your desktop applications
-          (<filename>.xsession-errors</filename> in the user's home directory)
-          for any irregularities.
-          </para>
-          </step>
-          -->
         <step>
           <para>
             If the desktop could not start because of corrupt configuration

--- a/xml/troubleshooting.xml
+++ b/xml/troubleshooting.xml
@@ -958,7 +958,7 @@
         </step>
         <step>
           <para>
-            Become&rootuser;.
+            Become &rootuser;.
           </para>
         </step>
         <step>

--- a/xml/troubleshooting.xml
+++ b/xml/troubleshooting.xml
@@ -678,8 +678,8 @@
       <para>
         This often occurs when the system is configured to use network
         authentication or directory services and cannot retrieve results from
-        its configured servers. The &rootuser; user, as the only local user, is
-        the only user that can still log in to these machines. The following
+        its configured servers. The &rootuser; user is the only local user that
+        can still log in to these machines. The following
         are common reasons a machine appears functional but cannot process
         logins correctly:
       </para>
@@ -729,7 +729,7 @@
         In cases that do not involve external network problems, the solution is
         to log in as &rootuser; and repair the configuration. If you cannot log
         in to the running system, reboot it into the rescue mode as outlined in
-        outlined in <xref linkend="proc-rescue-mode"/>.
+        <xref linkend="proc-rescue-mode"/>.
        </para>
 
     </sect2>
@@ -895,8 +895,8 @@
           <para>
             See if another user can log in to the misbehaving machine. If
             another user can log in without difficulty or if &rootuser; can log
-            in, log in and examine the system journal with <command>journalctl
-            -e</command>&gt; file. Locate the time stamps that correspond to
+            in, log in and examine the system journal with the <command>journalctl
+            -e</command> &gt; file. Locate the time stamps that correspond to
             the login attempts and determine if PAM has produced any error
             messages.
           </para>
@@ -1318,7 +1318,7 @@ networks: files dns
             <para>
               If the name service and network hardware are properly configured
               and running, but certain external network connections still get
-              long time-outs or fail entirely, use
+              long timeouts or fail entirely, use
               <command>traceroute</command>
               <replaceable>FULLY_QUALIFIED_DOMAIN_NAME</replaceable> (executed
               as &rootuser;) to track the network route these requests are

--- a/xml/troubleshooting.xml
+++ b/xml/troubleshooting.xml
@@ -14,7 +14,7 @@
   </info>
   <para>
     This chapter describes a range of potential problems and their solutions.
-    Even if your situation is not precisely listed here, there may be one
+    Even if your situation is not precisely listed, there may be one
     similar enough to offer hints to the solution of your problem.
   </para>
   <sect1 xml:id="sec-trouble-info">
@@ -172,7 +172,7 @@
             </entry>
             <entry>
               <para>
-                Various start-up and runtime log files from the X Window
+                Start-up and runtime log files from the X Window
                 System. It is useful for debugging failed X start-ups.
               </para>
             </entry>
@@ -726,12 +726,11 @@
         </listitem>
       </itemizedlist>
       <para>
-        In all cases that do not involve external network problems, the solution
-        is to reboot the system into the rescue mode and repair the
-        configuration before booting again into operating mode and attempting to
-        log in again. To boot into the rescue targe, follow the procedure
-        outlined in <xref linkend="proc-trouble-login-no"/>.
-      </para>
+        In cases that do not involve external network problems, the solution is
+        to log in as &rootuser; and repair the configuration. If you cannot log
+        in to the running system, reboot it into the rescue mode as outlined in
+        <xref linkend="proc-trouble-login-no"/>.
+        outlined in <xref linkend="proc-rescue-mode"/>.
     </sect2>
 
     <sect2 xml:id="sec-trouble-login-pw">

--- a/xml/troubleshooting.xml
+++ b/xml/troubleshooting.xml
@@ -727,9 +727,8 @@
             DNS is not working at the moment (which prevents &gnome; from
             working and the system from making validated requests to secure
             servers). One indication that this is the case is that the machine
-            takes an extremely long time to respond to any action. Find more
-            information about this topic in
-            <xref linkend="sec-trouble-netconfig"/>.
+            takes a long time to respond to any action. Find more information
+            about this topic in <xref linkend="sec-trouble-netconfig"/>.
           </para>
         </listitem>
         <listitem>
@@ -762,51 +761,9 @@
         In all cases that do not involve external network problems, the
         solution is to reboot the system into the rescue target and repair the
         configuration before booting again into operating mode and attempting
-        to log in again. To boot into the rescue target:
+        to log in again. To boot into the rescue targe, follow the procedure
+        outlined in <xref linkend="proc-trouble-login-no"/>.
       </para>
-      <procedure xml:id="proc-trouble-login-no">
-        <step>
-          <para>
-            Reboot the system. The boot screen appears, offering the &grub;
-            boot menu.
-          </para>
-        </step>
-        <step>
-          <para>
-            Select a menu entry from the &grub; boot menu and press
-            <keycap>e</keycap> to edit the boot line.
-          </para>
-        </step>
-        <step>
-          <para>
-            Add the following parameter to the line containing the kernel
-            parameters:
-          </para>
-<screen>systemd.unit=rescue.target</screen>
-        </step>
-        <step>
-          <para>
-            Press <keycap>F10</keycap>.
-          </para>
-        </step>
-        <step>
-          <para>
-            Enter the user name and password for &rootuser;.
-          </para>
-        </step>
-        <step>
-          <para>
-            Make all the necessary changes.
-          </para>
-        </step>
-        <step>
-          <para>
-            Boot into the full multiuser and network mode by entering
-            <command>systemctl isolate graphical.target</command> at the
-            command line.
-          </para>
-        </step>
-      </procedure>
     </sect2>
 
     <sect2 xml:id="sec-trouble-login-pw">

--- a/xml/troubleshooting.xml
+++ b/xml/troubleshooting.xml
@@ -729,8 +729,9 @@
         In cases that do not involve external network problems, the solution is
         to log in as &rootuser; and repair the configuration. If you cannot log
         in to the running system, reboot it into the rescue mode as outlined in
-        <xref linkend="proc-trouble-login-no"/>.
         outlined in <xref linkend="proc-rescue-mode"/>.
+       </para>
+
     </sect2>
 
     <sect2 xml:id="sec-trouble-login-pw">

--- a/xml/troubleshooting.xml
+++ b/xml/troubleshooting.xml
@@ -4,1737 +4,1736 @@
   <!ENTITY % entities SYSTEM "generic-entities.ent">
     %entities;
 ]>
-
 <chapter xmlns="http://docbook.org/ns/docbook" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-trouble">
- <title>Common problems and their solutions</title>
- <info>
-  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:bugtracker></dm:bugtracker>
-   <dm:translation>yes</dm:translation>
-  </dm:docmanager>
- </info>
- <para>
-  This chapter describes a range of potential problems and their solutions.
-  Even if your situation is not precisely listed here, there may be one similar
-  enough to offer hints to the solution of your problem.
- </para>
- <sect1 xml:id="sec-trouble-info">
-  <title>Finding and gathering information</title>
-
+  <title>Common problems and their solutions</title>
+  <info>
+    <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+      <dm:bugtracker></dm:bugtracker>
+      <dm:translation>yes</dm:translation>
+    </dm:docmanager>
+  </info>
   <para>
-   Linux reports things in a detailed way. There are several places to
-   look when you encounter problems with your system. Most of them are
-   standard to Linux systems in general, and some are relevant to &productname;
-   systems. Most log files can be viewed with &yast; (<menuchoice>
-   <guimenu>Miscellaneous</guimenu> <guimenu>Start-Up Log</guimenu>
-   </menuchoice>).
+    This chapter describes a range of potential problems and their solutions.
+    Even if your situation is not precisely listed here, there may be one
+    similar enough to offer hints to the solution of your problem.
   </para>
+  <sect1 xml:id="sec-trouble-info">
+    <title>Finding and gathering information</title>
 
-<!-- fs 2010-05-21:
-    Weird location for this paragraph - completely out of context (support).
-    Move to a better location
-
-    Profiling, since the support query module is not available for openSUSE.
--->
-
-  <para>
-   &yast; offers the possibility to collect all system information
-   needed by the support team. Use <menuchoice>
-<!-- TODO check this vvvvvv -->
-   <guimenu>Other</guimenu> <guimenu>Support</guimenu> </menuchoice> and select
-   the problem category. When all information is gathered, attach it to your
-   support request.
-  </para>
-
-  <para>
-   A list of the most frequently checked log files follows with the description
-   of their typical purpose. Paths containing <filename>~</filename> refer to
-   the current user's home directory.
-  </para>
-
-  <table xml:id="tab-trouble-info">
-   <title>Log files</title>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>
-       <para>
-        Log File
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Description
-       </para>
-      </entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>
-       <para>
-        <filename>~/.xsession-errors</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Messages from the desktop applications currently running.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <filename>/var/log/apparmor/</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Log files from AppArmor, see <xref linkend="part-apparmor"/> for
-        detailed information.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <filename>/var/log/audit/audit.log</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Log file from Audit to track any access to files, directories, or
-        resources of your system, and trace system calls. See
-        <xref linkend="part-audit"/> for detailed information.
-       </para>
-      </entry>
-     </row>
-<!-- 2014-06-04 tbazant: now part of journald
-     <row>
-      <entry>
-       <para>
-        <filename>/var/log/boot.msg</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Messages from the kernel reported during the boot process.
-       </para>
-      </entry>
-     </row> -->
-     <row>
-      <entry>
-       <para>
-        <filename>/var/log/mail.*</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Messages from the mail system.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <filename>/var/log/NetworkManager</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Log file from &nm; to collect problems with network connectivity
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <filename>/var/log/samba/</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Directory containing Samba server and client log messages.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <filename>/var/log/warn</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        All messages from the kernel and system log daemon with the
-        <quote>warning</quote> level or higher.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <filename>/var/log/wtmp</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Binary file containing user login records for the current machine
-        session. View it with <command>last</command>.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <filename>/var/log/Xorg.*.log</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Various start-up and runtime log files from the X Window System. It is
-        useful for debugging failed X start-ups.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <filename>/var/log/YaST2/</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Directory containing &yast;'s actions and their results.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <filename>/var/log/zypper.log</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Log file of Zypper.
-       </para>
-      </entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </table>
-
-  <para>
-   Apart from log files, your machine also supplies you with information about
-   the running system. See
-   <xref linkend="tab-trouble-system" xrefstyle="select:label title nopage"/>
-  </para>
-
-  <table xml:id="tab-trouble-system">
-   <title>System information with the <filename>/proc</filename> file system</title>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>
-       <para>
-        File
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Description
-       </para>
-      </entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>
-       <para>
-        <filename>/proc/cpuinfo</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Contains processor information, including its type, make, model, and
-        performance.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <filename>/proc/dma</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Shows which DMA channels are currently being used.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <filename>/proc/interrupts</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Shows which interrupts are in use, and how many of each have been in
-        use.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <filename>/proc/iomem</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Displays the status of I/O (input/output) memory.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <filename>/proc/ioports</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Shows which I/O ports are in use at the moment.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <filename>/proc/meminfo</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Displays memory status.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <filename>/proc/modules</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Displays the individual modules.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <filename>/proc/mounts</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Displays devices currently mounted.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <filename>/proc/partitions</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Shows the partitioning of all hard disks.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <filename>/proc/version</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Displays the current version of Linux.
-       </para>
-      </entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </table>
-
-  <para>
-   Apart from the <filename>/proc</filename> file system, the Linux kernel
-   exports information with the <literal>sysfs</literal> module, an in-memory
-   file system. This module represents kernel objects, their attributes and
-   relationships. For more information about <literal>sysfs</literal>, see the
-   context of udev in <xref linkend="cha-udev"/>.
-   <xref linkend="tab-trouble-sysfs" xrefstyle="select:label nopage"/> contains
-   an overview of the most common directories under <filename>/sys</filename>.
-  </para>
-
-  <table xml:id="tab-trouble-sysfs">
-   <title>System information with the <filename>/sys</filename> file system</title>
-   <tgroup cols="2">
-    <thead>
-     <row>
-      <entry>
-       <para>
-        File
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Description
-       </para>
-      </entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>
-       <para>
-        <filename>/sys/block</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Contains subdirectories for each block device discovered in the system.
-        Generally, these are mostly disk type devices.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <filename>/sys/bus</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Contains subdirectories for each physical bus type.
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <filename>/sys/class</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Contains subdirectories grouped together as a functional types of
-        devices (like graphics, net, printer, etc.)
-       </para>
-      </entry>
-     </row>
-     <row>
-      <entry>
-       <para>
-        <filename>/sys/device</filename>
-       </para>
-      </entry>
-      <entry>
-       <para>
-        Contains the global device hierarchy.
-       </para>
-      </entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </table>
-
-  <para>
-   Linux comes with several tools for system analysis and monitoring. See
-   <xref linkend="cha-util"/> for a selection of the most important ones used
-   in system diagnostics.
-  </para>
-
-  <para>
-   Each of the following scenarios begins with a header describing the problem
-   followed by a paragraph or two offering suggested solutions, available
-   references for more detailed solutions, and cross-references to other
-   scenarios that are related.
-  </para>
- </sect1>
-
- <sect1 xml:id="sec-trouble-boot">
-  <title>Boot problems</title>
-
-  <para>
-   Boot problems are situations when your system does not boot properly (does
-   not boot to the expected target and login screen).
-  </para>
-
-  <sect2 xml:id="sec-trouble-boot-nogrub">
-   <title>The &grub; boot loader fails to load</title>
-   <para>
-    If the hardware is functioning properly, it is possible that the boot
-    loader is corrupted and Linux cannot start on the machine. In this case, it
-    is necessary to repair the boot loader. To do so, you need to start the
-    Rescue System as described in
-    <xref linkend="sec-trouble-data-recover-rescue"/> and follow the
-    instructions in <xref linkend="sec-trouble-data-recover-rescue-grub"/>.
-   </para>
-   <para>
-    Alternatively, you can use the Rescue System to fix the boot loader as
-    follows. Boot your machine from the installation media. In the boot screen,
-    choose <menuchoice><guimenu>More</guimenu> <guimenu>Boot Linux
-    System</guimenu></menuchoice>. Select the disk containing the installed
-    system and kernel with the default kernel options.
-   </para>
-
-   <figure xml:id="fig-rescue-selectdisk" os="osuse">
-    <title>Select disk</title>
-    <mediaobject>
-     <imageobject role="fo">
-      <imagedata fileref="rescue_select_disk.png" width="50%"/>
-     </imageobject>
-     <imageobject role="html">
-      <imagedata fileref="rescue_select_disk.png" width="50%"/>
-     </imageobject>
-    </mediaobject>
-   </figure>
-
-   <para>
-    When the system is booted, start &yast; and switch to
-    <menuchoice><guimenu>System</guimenu> <guimenu>Boot
-    Loader</guimenu></menuchoice>. Make sure that the <guimenu>Write generic
-    Boot Code to MBR</guimenu> option is enabled, and click
-    <guimenu>OK</guimenu>. This fixes the corrupted boot loader by overwriting
-    it, or installs the boot loader if it is missing.
-   </para>
-
-   <para>
-    Other reasons for the machine not booting may be BIOS-related:
-   </para>
-   <variablelist>
-    <varlistentry>
-     <term>BIOS settings</term>
-     <listitem>
-      <para>
-       Check your BIOS for references to your hard disk. &grub; may simply not
-       be started if the hard disk itself cannot be found with the current BIOS
-       settings.
-      </para>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>BIOS boot order</term>
-     <listitem>
-      <para>
-       Check whether your system's boot order includes the hard disk. If the
-       hard disk option was not enabled, your system may install properly, but
-       fails to boot when access to the hard disk is required.
-      </para>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </sect2>
-
-  <sect2 xml:id="sec-trouble-boot-hang" os="sled;osuse">
-   <title>No login or prompt appears</title>
-   <para>
-    This behavior typically occurs after a failed kernel upgrade and it is
-    known as a <emphasis>kernel panic</emphasis> because of the type of error
-    on the system console that sometimes can be seen at the final stage of the
-    process. If, in fact, the machine has just been rebooted following a
-    software update, the immediate goal is to reboot it using the old, proven
-    version of the Linux kernel and associated files. This can be done in the
-    &grub; boot loader screen during the boot process as follows:
-   </para>
-   <procedure>
-    <step>
-     <para>
-      Reboot the computer using the reset button, or switch it off and on
-      again.
-     </para>
-    </step>
-    <step>
-     <para>
-      When the &grub; boot screen becomes visible, select the <guimenu>Advanced
-      Options</guimenu> entry and choose the previous kernel from the menu. The
-      machine will boot using the prior version of the kernel and its
-      associated files.
-     </para>
-    </step>
-    <step xml:id="st-trouble-boot-hang-modify-grub">
-     <para>
-      After the boot process has completed, remove the newly installed kernel
-      and, if necessary, set the default boot entry to the old kernel using the
-      &yast; <guimenu>Boot Loader</guimenu> module. For more information refer
-      to <xref linkend="sec-grub2-yast2-config"/>. However, doing this is
-      probably not necessary because automated update tools normally modify it
-      for you during the rollback process.
-     </para>
-    </step>
-    <step>
-     <para>
-      Reboot.
-     </para>
-    </step>
-   </procedure>
-   <para>
-    If this does not fix the problem, boot the computer using the installation
-    media. After the machine has booted, continue with
-    <xref linkend="st-trouble-boot-hang-modify-grub" xrefstyle="StepOnPage"/>.
-   </para>
-  </sect2>
-
-  <sect2 xml:id="sec-trouble-boot-prompt">
-   <title>No graphical login</title>
-   <para>
-    If the machine starts, but does not boot into the graphical login
-    manager, anticipate problems either with the choice of the default systemd
-    target or the configuration of the X Window System. To check the current
-    systemd default target run the command <command>sudo systemctl
-    get-default</command>. If the value returned is <emphasis>not</emphasis>
-    <literal>graphical.target</literal>, run the command <command>sudo
-    systemctl isolate graphical.target</command>. If the graphical login screen
-    starts, log in and start <menuchoice> <guimenu>&yast;</guimenu>
-    <guimenu>System</guimenu> <guimenu>&ycc_runlevel;</guimenu></menuchoice>
-    and set the <guimenu>Default System Target</guimenu> to <guimenu>Graphical
-    Interface</guimenu>. From now on the system should boot into the graphical
-    login screen.
-   </para>
-   <para>
-    If the graphical login screen does not start even if having booted or
-    switched to the graphical target, your desktop or X Window software is
-    probably misconfigured or corrupted. Examine the log files at
-    <filename>/var/log/Xorg.*.log</filename> for detailed messages from the X
-    server as it attempted to start. If the desktop fails during start, it may
-    log error messages to the system journal that can be queried with the
-    command <command>journalctl</command> (see <xref linkend="cha-journalctl"/>
-    for more information). If these error messages hint at a configuration
-    problem in the X server, try to fix these issues. If the graphical system
-    still does not come up, consider reinstalling the graphical desktop.
-   </para>
-<!--
-   2014-08-20, tiwai
-   startx doesn't work for normal user any longer.  Only root can do.
-   <tip>
-    <title>Starting X window system manually</title>
     <para>
-     One quick test: the <command>startx</command> command should force the
-     X Window System to start with the configured defaults if the user is
-     currently logged in on the console. If that does not work, it should
-     log errors to the console.
+      Linux reports things in a detailed way. There are several places to look
+      when you encounter problems with your system. Most of them are standard
+      to Linux systems in general, and some are relevant to &productname;
+      systems. Most log files can be viewed with &yast; (<menuchoice>
+      <guimenu>Miscellaneous</guimenu> <guimenu>Start-Up Log</guimenu>
+      </menuchoice>).
     </para>
-   </tip>
-   -->
-  </sect2>
 
-  <sect2 xml:id="sec-trouble-boot-btrfs">
-   <title>Root Btrfs partition cannot be mounted</title>
-   <para>
-    If a <systemitem class="filesystem">btrfs</systemitem> root partition
-    becomes corrupted, try the following options:
-   </para>
-   <itemizedlist>
-    <listitem>
-     <para>
-      Mount the partition with the <option>-o recovery</option> option.
-     </para>
-    </listitem>
-    <listitem>
-     <remark>toms 2014-03-12: According to FATE#315126: "this one is open to
-      debate, it might do more harm than good.."</remark>
-     <para>
-      If that fails, run <command>btrfs-zero-log</command> on your root
-      partition.
-     </para>
-    </listitem>
-   </itemizedlist>
-  </sect2>
+    <!-- fs 2010-05-21:
+      Weird location for this paragraph - completely out of context (support).
+      Move to a better location
+      Profiling, since the support query module is not available for openSUSE.
+      -->
 
-  <sect2 xml:id="sec-trouble-boot-forcecheck">
-   <title>Force checking root partitions</title>
-   <remark>toms 2016-05-18: FATE#320126</remark>
-   <para>
-    If the root partition becomes corrupted, use the parameter
-    <parameter>forcefsck</parameter> on the boot prompt. This passes the option
-    <option>-f</option> (force) to the <command>fsck</command> command.
-   </para>
-  </sect2>
-  
-  <sect2 xml:id="sec-trouble-boot-disable-swap">
-      <title>Disable swap to enable booting</title>
+    <para>
+      &yast; offers the possibility to collect all system information needed by
+      the support team. Use <menuchoice>
+        <!-- TODO check this vvvvvv -->
+      <guimenu>Other</guimenu> <guimenu>Support</guimenu> </menuchoice> and
+      select the problem category. When all information is gathered, attach it
+      to your support request.
+    </para>
+
+    <para>
+      A list of the most frequently checked log files follows with the
+      description of their typical purpose. Paths containing
+      <filename>~</filename> refer to the current user's home directory.
+    </para>
+
+    <table xml:id="tab-trouble-info">
+      <title>Log files</title>
+      <tgroup cols="2">
+        <thead>
+          <row>
+            <entry>
+              <para>
+                Log File
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Description
+              </para>
+            </entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry>
+              <para>
+                <filename>~/.xsession-errors</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Messages from the desktop applications currently running.
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                <filename>/var/log/apparmor/</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Log files from AppArmor, see <xref linkend="part-apparmor"/>
+                for detailed information.
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                <filename>/var/log/audit/audit.log</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Log file from Audit to track any access to files, directories,
+                or resources of your system, and trace system calls. See
+                <xref linkend="part-audit"/> for detailed information.
+              </para>
+            </entry>
+          </row>
+          <!-- 2014-06-04 tbazant: now part of journald
+            <row>
+            <entry>
+            <para>
+            <filename>/var/log/boot.msg</filename>
+            </para>
+            </entry>
+            <entry>
+            <para>
+            Messages from the kernel reported during the boot process.
+            </para>
+            </entry>
+            </row> -->
+          <row>
+            <entry>
+              <para>
+                <filename>/var/log/mail.*</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Messages from the mail system.
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                <filename>/var/log/NetworkManager</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Log file from &nm; to collect problems with network
+                connectivity
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                <filename>/var/log/samba/</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Directory containing Samba server and client log messages.
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                <filename>/var/log/warn</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                All messages from the kernel and system log daemon with the
+                <quote>warning</quote> level or higher.
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                <filename>/var/log/wtmp</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Binary file containing user login records for the current
+                machine session. View it with <command>last</command>.
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                <filename>/var/log/Xorg.*.log</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Various start-up and runtime log files from the X Window
+                System. It is useful for debugging failed X start-ups.
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                <filename>/var/log/YaST2/</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Directory containing &yast;'s actions and their results.
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                <filename>/var/log/zypper.log</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Log file of Zypper.
+              </para>
+            </entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+
+    <para>
+      Apart from log files, your machine also supplies you with information
+      about the running system. See
+      <xref linkend="tab-trouble-system" xrefstyle="select:label title nopage"/>
+    </para>
+
+    <table xml:id="tab-trouble-system">
+      <title>System information with the <filename>/proc</filename> file system</title>
+      <tgroup cols="2">
+        <thead>
+          <row>
+            <entry>
+              <para>
+                File
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Description
+              </para>
+            </entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry>
+              <para>
+                <filename>/proc/cpuinfo</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Contains processor information, including its type, make,
+                model, and performance.
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                <filename>/proc/dma</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Shows which DMA channels are currently being used.
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                <filename>/proc/interrupts</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Shows which interrupts are in use, and how many of each have
+                been in use.
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                <filename>/proc/iomem</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Displays the status of I/O (input/output) memory.
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                <filename>/proc/ioports</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Shows which I/O ports are in use at the moment.
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                <filename>/proc/meminfo</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Displays memory status.
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                <filename>/proc/modules</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Displays the individual modules.
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                <filename>/proc/mounts</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Displays devices currently mounted.
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                <filename>/proc/partitions</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Shows the partitioning of all hard disks.
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                <filename>/proc/version</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Displays the current version of Linux.
+              </para>
+            </entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+
+    <para>
+      Apart from the <filename>/proc</filename> file system, the Linux kernel
+      exports information with the <literal>sysfs</literal> module, an
+      in-memory file system. This module represents kernel objects, their
+      attributes and relationships. For more information about
+      <literal>sysfs</literal>, see the context of udev in
+      <xref linkend="cha-udev"/>.
+      <xref linkend="tab-trouble-sysfs" xrefstyle="select:label nopage"/>
+      contains an overview of the most common directories under
+      <filename>/sys</filename>.
+    </para>
+
+    <table xml:id="tab-trouble-sysfs">
+      <title>System information with the <filename>/sys</filename> file system</title>
+      <tgroup cols="2">
+        <thead>
+          <row>
+            <entry>
+              <para>
+                File
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Description
+              </para>
+            </entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry>
+              <para>
+                <filename>/sys/block</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Contains subdirectories for each block device discovered in the
+                system. Generally, these are mostly disk type devices.
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                <filename>/sys/bus</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Contains subdirectories for each physical bus type.
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                <filename>/sys/class</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Contains subdirectories grouped together as a functional types
+                of devices (like graphics, net, printer, etc.)
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                <filename>/sys/device</filename>
+              </para>
+            </entry>
+            <entry>
+              <para>
+                Contains the global device hierarchy.
+              </para>
+            </entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </table>
+
+    <para>
+      Linux comes with several tools for system analysis and monitoring. See
+      <xref linkend="cha-util"/> for a selection of the most important ones
+      used in system diagnostics.
+    </para>
+
+    <para>
+      Each of the following scenarios begins with a header describing the
+      problem followed by a paragraph or two offering suggested solutions,
+      available references for more detailed solutions, and cross-references to
+      other scenarios that are related.
+    </para>
+  </sect1>
+  <sect1 xml:id="sec-trouble-boot">
+    <title>Boot problems</title>
+
+    <para>
+      Boot problems are situations when your system does not boot properly
+      (does not boot to the expected target and login screen).
+    </para>
+
+    <sect2 xml:id="sec-trouble-boot-nogrub">
+      <title>The &grub; boot loader fails to load</title>
       <para>
-          When a swap device is not available and the system cannot enable it
-          during boot, booting may fail. Try disabling all swap devices by
-          appending the following options to the kernel command line:
-      </para>
-      <screen>systemd.device_wants_unit=off systemd.mask=swap.target</screen>
-      <para>
-          You may also try disabling specific swap devices:
-      </para>
-      <screen>systemd.mask=dev-sda1.swap</screen>
-  </sect2>
-  
-  <sect2 xml:id="sec-trouble-boot-dual-boot">
-   <title>&grub; fails during reboot on a dual-boot
-    system</title>
-   <remark>jufa 2021-06-09: bsc#1185274</remark>
-   <para>
-    If &grub; fails during reboot, disable the
-    <option>Fast Boot</option> setting in the BIOS.
-     </para>
-   
-  </sect2>
- </sect1>
- 
- <sect1 xml:id="sec-trouble-login">
-  <title>Login problems</title>
-
-  <para>
-   Login problems occur when your machine does boot to the
-   expected welcome screen or login prompt, but refuses to accept the user name
-   and password, or accepts them but then does not behave properly (fails to
-   start the graphic desktop, produces errors, drops to a command line, etc.).
-  </para>
-
-  <sect2 xml:id="sec-trouble-login-no">
-   <title>Valid user name and password combinations fail</title>
-   <para>
-    This usually occurs when the system is configured to use network
-    authentication or directory services and, for some reason, cannot retrieve
-    results from its configured servers. The
-    <systemitem class="username">root</systemitem> user, as the only local
-    user, is the only user that can still log in to these machines. The
-    following are common reasons a machine appears functional but cannot
-    process logins correctly:
-   </para>
-   <itemizedlist>
-    <listitem>
-     <para>
-      The network is not working. For further directions on this, turn to
-      <xref linkend="sec-trouble-netconfig"/>.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      DNS is not working at the moment (which prevents &gnome; from working and
-      the system from making validated requests to secure servers). One
-      indication that this is the case is that the machine takes an extremely
-      long time to respond to any action. Find more information about this
-      topic in <xref linkend="sec-trouble-netconfig"/>.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      If the system is configured to use Kerberos, the system's local time may
-      have drifted past the accepted variance with the Kerberos server time
-      (this is typically 300 seconds). If NTP (network time protocol) is not
-      working properly or local NTP servers are not working, Kerberos
-      authentication ceases to function because it depends on common clock
-      synchronization across the network.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      The system's authentication configuration is misconfigured. Check the PAM
-      configuration files involved for any typographical errors or misordering
-      of directives. For additional background information about PAM and the
-      syntax of the configuration files involved, refer to
-      <xref linkend="cha-pam"/>.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      The home partition is encrypted. Find more information about this topic
-      in <xref linkend="sec-trouble-login-encrypted"/>.
-     </para>
-    </listitem>
-   </itemizedlist>
-   <para>
-    In all cases that do not involve external network problems, the solution is
-    to reboot the system into single-user mode and repair the configuration
-    before booting again into operating mode and attempting to log in again. To
-    boot into single-user mode:
-   </para>
-   <procedure xml:id="proc-trouble-login-no">
-    <step>
-     <para>
-      Reboot the system. The boot screen appears, offering a prompt.
-     </para>
-    </step>
-<!--taroth 2014-03-10: added the following 4 steps to replace the following
-     one (according to fs and grub2.xml  [id=grub2.menu.change],
-     this should work, but I did not try it....):
-     Enter <command>1</command> at the boot prompt to make the system
-     boot into single-user mode. -
-     -->
-    <step>
-     <para>
-      Press <keycap function="escape"/> to exit the splash screen and get to
-      the &grub; text-based menu.
-     </para>
-    </step>
-    <step>
-     <para>
-      Press <keycap>B</keycap> to enter the &grub; editor.
-     </para>
-    </step>
-    <step>
-     <para>
-      Add the following parameter to the line containing the kernel parameters:
-     </para>
-<screen>systemd.unit=rescue.target</screen>
-    </step>
-    <step>
-     <para>
-      Press <keycap>F10</keycap>.
-     </para>
-    </step>
-    <step>
-     <para>
-      Enter the user name and password for
-      <systemitem class="username">root</systemitem>.
-     </para>
-    </step>
-    <step>
-     <para>
-      Make all the necessary changes.
-     </para>
-    </step>
-    <step>
-     <para>
-      Boot into the full multiuser and network mode by entering
-      <command>systemctl isolate graphical.target</command> at the command
-      line.
-     </para>
-    </step>
-   </procedure>
-  </sect2>
-
-  <sect2 xml:id="sec-trouble-login-pw">
-   <title>Valid user name and password not accepted</title>
-   <para>
-    This is by far the most common problem users encounter, because there are
-    many reasons this can occur. Depending on whether you use local user
-    management and authentication or network authentication, login failures
-    occur for different reasons.
-   </para>
-   <para>
-    Local user management can fail for the following reasons:
-   </para>
-   <itemizedlist>
-    <listitem>
-     <para>
-      The user may have entered the wrong password.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      The user's home directory containing the desktop configuration files is
-      corrupted or write protected.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      There may be problems with the X Window System authenticating this
-      particular user, especially if the user's home directory has been used
-      with another Linux distribution before installing the current one.
-     </para>
-    </listitem>
-   </itemizedlist>
-   <para>
-    To locate the reason for a local login failure, proceed as follows:
-   </para>
-   <procedure>
-    <step>
-     <para>
-      Check whether the user remembered their password correctly before you start
-      debugging the whole authentication mechanism. If the user may have not have
-      remembered their password correctly, use the &yast; User Management module to
-      change the user's password. Pay attention to the <keycap>Caps
-      Lock</keycap> key and unlock it, if necessary.
-     </para>
-    </step>
-    <step>
-     <para>
-      Log in as <systemitem class="username">root</systemitem> and check the
-      system journal with <command>journalctl -e</command> for error messages
-      of the login process and of PAM.
-     </para>
-    </step>
-    <step>
-     <para>
-      Try to log in from a console (using <keycombo>
-      <keycap function="control"/> <keycap function="alt"/> <keycap>F1</keycap>
-      </keycombo>). If this is successful, the blame cannot be put on PAM,
-      because it is possible to authenticate this user on this machine. Try to
-      locate any problems with the X Window System or the &gnome; desktop. For
-      more information, refer to <xref linkend="sec-trouble-login-dk"/>.
-     </para>
-    </step>
-    <step>
-     <para>
-      If the user's home directory has been used with another Linux
-      distribution, remove the <filename>Xauthority</filename> file in the
-      user's home. Use a console login via <keycombo>
-      <keycap function="control"/> <keycap function="alt"/> <keycap>F1</keycap>
-      </keycombo> and run <command>rm .Xauthority</command> as this user. This
-      should eliminate X authentication problems for this user. Try graphical
-      login again.
-     </para>
-    </step>
-<!--
-    <step>
-     <para>
-      If graphical login still fails, do a console login with <keycombo>
-      <keycap function="control"/>
-      <keycap function="alt"/> <keycap>F1</keycap> </keycombo>.
-      Try to start an X session on another display&mdash;the first one
-      (<literal>:0</literal>) is already in use:
-     </para>
-<screen>startx -\- :1</screen>
-     <para>
-      This should bring up a graphical screen and your desktop. If it does
-      not, check the log files of the X Window System
-      (<filename>/var/log/Xorg.<replaceable>DISPLAYNUMBER</replaceable>.log</filename>)
-      or the log file for your desktop applications
-      (<filename>.xsession-errors</filename> in the user's home directory)
-      for any irregularities.
-     </para>
-    </step>
-    -->
-    <step>
-     <para>
-      If the desktop could not start because of corrupt configuration files,
-      proceed with <xref linkend="sec-trouble-login-dk"/>.
-     </para>
-    </step>
-   </procedure>
-   <para>
-    In the following, common reasons a network authentication for a particular
-    user may fail on a specific machine are listed:
-   </para>
-   <itemizedlist>
-    <listitem>
-     <para>
-      The user may have entered the wrong password.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      The user name exists in the machine's local authentication files and is
-      also provided by a network authentication system, causing conflicts.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      The home directory exists but is corrupt or unavailable. Perhaps it is
-      write protected or is on a server that is inaccessible at the moment.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      The user does not have permission to log in to that particular host in
-      the authentication system.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      The machine has changed host names, for whatever reason, and the user
-      does not have permission to log in to that host.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      The machine cannot reach the authentication server or directory server
-      that contains that user's information.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      There may be problems with the X Window System authenticating this
-      particular user, especially if the user's home has been used with another
-      Linux distribution before installing the current one.
-     </para>
-    </listitem>
-   </itemizedlist>
-   <para>
-    To locate the cause of the login failures with network authentication,
-    proceed as follows:
-   </para>
-   <procedure xml:id="proc-trouble-login-pw">
-    <step>
-     <para>
-      Check whether the user remembered their password correctly before you
-      start debugging the whole authentication mechanism.
-     </para>
-    </step>
-    <step>
-     <para>
-      Determine the directory server which the machine relies on for
-      authentication and make sure that it is up and running and properly
-      communicating with the other machines.
-     </para>
-    </step>
-    <step>
-     <para>
-      Determine that the user's user name and password work on other machines
-      to make sure that their authentication data exists and is properly
-      distributed.
-     </para>
-    </step>
-    <step>
-     <para>
-      See if another user can log in to the misbehaving machine. If another
-      user can log in without difficulty or if
-      <systemitem class="username">root</systemitem> can log in, log in and
-      examine the system journal with <command>journalctl -e</command>&gt;
-      file. Locate the time stamps that correspond to the login attempts and
-      determine if PAM has produced any error messages.
-     </para>
-    </step>
-    <step>
-     <para>
-      Try to log in from a console (using <keycombo>
-      <keycap function="control"/> <keycap function="alt"/> <keycap>F1</keycap>
-      </keycombo>). If this is successful, the problem is not with PAM or the
-      directory server on which the user's home is hosted, because it is
-      possible to authenticate this user on this machine. Try to locate any
-      problems with the X Window System or the &gnome; desktop. For more
-      information, refer to <xref linkend="sec-trouble-login-dk"/>.
-     </para>
-    </step>
-    <step>
-     <para>
-      If the user's home directory has been used with another Linux
-      distribution, remove the <filename>Xauthority</filename> file in the
-      user's home. Use a console login via <keycombo>
-      <keycap function="control"/> <keycap function="alt"/> <keycap>F1</keycap>
-      </keycombo> and run <command>rm .Xauthority</command> as this user. This
-      should eliminate X authentication problems for this user. Try graphical
-      login again.
-     </para>
-    </step>
-<!--
-    <step>
-     <para>
-      If graphical login still fails, do a console login with <keycombo>
-      <keycap function="control"/>
-      <keycap function="alt"/> <keycap>F1</keycap> </keycombo>.
-      Try to start an X session on another display&mdash;the first one
-      (<literal>:0</literal>) is already in use:
-     </para>
-<screen>startx -\- :1</screen>
-     <para>
-      This should bring up a graphical screen and your desktop. If it does
-      not, check the log files of the X Window System
-      (<filename>/var/log/Xorg.<replaceable>DISPLAYNUMBER</replaceable>.log</filename>)
-      or the log file for your desktop applications
-      (<filename>.xsession-errors</filename> in the user's home directory)
-      for any irregularities.
-     </para>
-    </step>
-    -->
-    <step>
-     <para>
-      If the desktop could not start because of corrupt configuration files,
-      proceed with <xref linkend="sec-trouble-login-dk"/>.
-     </para>
-    </step>
-   </procedure>
-  </sect2>
-
-  <sect2 xml:id="sec-trouble-login-encrypted">
-   <title>Login to encrypted home partition fails</title>
-   <para>
-    It is recommended to use an encrypted home partition for laptops. If you
-    cannot log in to your laptop, the reason might be that your partition
-    could not be unlocked.
-   </para>
-   <para>
-    During the boot time, you need to enter the passphrase to unlock your
-    encrypted partition. If you do not enter it, the boot process continues,
-    leaving the partition locked.
-   </para>
-   <para>
-    To unlock your encrypted partition, proceed as follows:
-   </para>
-   <procedure>
-    <step>
-     <para>
-      Switch to the text console with <keycombo> <keycap function="control"/>
-      <keycap function="alt"/> <keycap>F1</keycap> </keycombo>.
-     </para>
-    </step>
-    <step>
-     <para>
-      Become <systemitem class="username">root</systemitem>.
-     </para>
-    </step>
-    <step>
-     <para>
-      Restart the unlocking process again with:
-     </para>
-<screen>&prompt.root;systemctl restart home.mount</screen>
-    </step>
-    <step>
-     <para>
-      Enter your passphrase to unlock your encrypted partition.
-     </para>
-    </step>
-    <step>
-     <para>
-      Exit the text console and switch back to the login screen with <keycombo>
-      <keycap function="alt"/> <keycap>F7</keycap> </keycombo>.
-     </para>
-    </step>
-    <step>
-     <para>
-      Log in as usual.
-     </para>
-    </step>
-   </procedure>
-  </sect2>
-
-  <sect2 xml:id="sec-trouble-login-dk">
-   <title>&gnome; desktop has issues</title>
-   <para>
-     If you are experiencing issues with the &gnome; desktop, there
-     are several ways to troubleshoot the misbehaving graphical
-     desktop environment. The recommended procedure described below
-     offers the safest option to fix a broken &gnome; desktop.
-   </para>
-   <procedure>
-     <title>Troubleshooting &gnome;</title>
-     <step>
-       <para>
-	 Launch &yast; and switch to <guimenu>Security and Users</guimenu>.
-       </para>
-     </step>
-     <step>
-       <para>
-	 Open the <guimenu>User and Group Management</guimenu> dialog and click <guimenu>Add</guimenu>.
-       </para>
-     </step>
-     <step>
-       <para>
-	 Fill out the required fields and click <guimenu>OK</guimenu> to create a new user.
-       </para>
-     </step>
-     <step>
-       <para>
-	 Log out and log in as the new user. This gives you a fresh
-	  &gnome; environment.
-       </para>
-     </step>
-     <step>
-       <para>
-	 Copy individual subdirectories from the
-	 <filename>~/.local/</filename> and
-	 <filename>~/.config/</filename> directories of the old user
-	 account to the respective directories of the new user
-	 account.
-       </para>
-       <para>
-	 Log out and log in again as the new user after every
-	 copy operation to check whether &gnome; still works
-	 correctly.
-       </para>
-     </step>
-     <step>
-       <para>
-	 Repeat the previous step until you find the configuration file that
-	 breaks &gnome;.
-       </para>
-     </step>
-     <step>
-       <para>
-	 Log in as the old user, and move the offending configuration
-	 file to a different location. Log out and log in again as the
-	 old user.
-       </para>
-     </step>
-     <step>
-       <para>
-	 Delete the previously created user.
-       </para>
-     </step>
-   </procedure>
-  </sect2>
-
- </sect1>
- <sect1 xml:id="sec-trouble-netconfig">
-  <title>Network problems</title>
-
-  <para>
-   Many problems of your system may be network-related, even though they do not
-   seem to be at first. For example, the reason for a system not allowing users
-   to log in may be a network problem. This section introduces a
-   simple checklist you can apply to identify the cause of any network problem
-   encountered.
-  </para>
-
-  <procedure xml:id="proc-trouble-config-net">
-   <title>How to identify network problems</title>
-   <para>
-    When checking the network connection of your machine, proceed as follows:
-   </para>
-   <step>
-    <para>
-     If you use an Ethernet connection, check the hardware first. Make sure
-     that your network cable is properly plugged into your computer and router
-     (or hub, etc.). The control lights next to your Ethernet connector are
-     normally both be active.
-    </para>
-    <para>
-     If the connection fails, check whether your network cable works with
-     another machine. If it does, your network card causes the failure. If hubs
-     or switches are included in your network setup, they may be faulty, as
-     well.
-    </para>
-   </step>
-   <step>
-    <para>
-     If using a wireless connection, check whether the wireless link can be
-     established by other machines. If not, contact the wireless network's
-     administrator.
-    </para>
-   </step>
-   <step>
-    <para>
-     When you have checked your basic network connectivity, try to find out
-     which service is not responding. Gather the address information of all
-     network servers needed in your setup. Either look them up in the
-     appropriate &yast; module or ask your system administrator. The following
-     list gives typical network servers involved in a setup together with
-     the symptoms of an outage.
-    </para>
-    <variablelist>
-     <varlistentry>
-      <term>DNS (name service)</term>
-      <listitem>
-       <para>
-        A broken or malfunctioning name service affects the network's
-        functionality in many ways. If the local machine relies on any network
-        servers for authentication and these servers cannot be found because of
-        name resolution issues, users would not even be able to log in.
-        Machines in the network managed by a broken name server would not be
-        able to <quote>see</quote> each other and communicate.
-       </para>
-      </listitem>
-     </varlistentry>
-     <varlistentry>
-      <term>NTP (time service)</term>
-      <listitem>
-       <para>
-        A malfunctioning or broken NTP service could affect Kerberos
-        authentication and X server functionality.
-       </para>
-      </listitem>
-     </varlistentry>
-     <varlistentry>
-      <term>NFS (file service)</term>
-      <listitem>
-       <para>
-        If any application needs data stored in an NFS mounted directory, it
-        cannot start or function properly if this service was down or
-        misconfigured. In the worst case scenario, a user's personal desktop
-        configuration would not come up if their home directory containing the
-        <filename>.gconf</filename> subdirectory could not be found because of
-        a faulty NFS server.
-       </para>
-      </listitem>
-     </varlistentry>
-     <varlistentry>
-      <term>Samba (file service)</term>
-      <listitem>
-       <para>
-        If any application needs data stored in a directory on a faulty Samba
-        server, it cannot start or function properly.
-       </para>
-      </listitem>
-     </varlistentry>
-     <varlistentry>
-      <term>NIS (user management)</term>
-      <listitem>
-       <para>
-        If your &productname; system relies on a faulty NIS server to provide
-        the user data, users cannot log in to this machine.
-       </para>
-      </listitem>
-     </varlistentry>
-     <varlistentry>
-      <term>LDAP (user management)</term>
-      <listitem>
-       <para>
-        If your &productname; system relies on a faulty LDAP server to provide
-        the user data, users cannot log in to this machine.
-       </para>
-      </listitem>
-     </varlistentry>
-     <varlistentry>
-      <term>Kerberos (authentication)</term>
-      <listitem>
-       <para>
-        Authentication does not work and login to any machine fails.
-       </para>
-      </listitem>
-     </varlistentry>
-     <varlistentry>
-      <term>CUPS (network printing)</term>
-      <listitem>
-       <para>
-        Users cannot print.
-       </para>
-      </listitem>
-     </varlistentry>
-    </variablelist>
-   </step>
-   <step>
-    <para>
-     Check whether the network servers are running and whether your network
-     setup allows you to establish a connection:
-    </para>
-    <important>
-     <title>Limitations</title>
-     <para>
-      The debugging procedure described below only applies to a simple network
-      server/client setup that does not involve any internal routing. It
-      assumes both server and client are members of the same subnet without the
-      need for additional routing.
-     </para>
-    </important>
-    <substeps performance="required">
-     <step>
-      <para>
-       Use <command>ping</command>
-       <replaceable>IP_ADDRESS/HOSTNAME</replaceable>
-       (replace with the host name or IP address of the server) to check whether
-       each one of them is up and responding to the network. If this command is
-       successful, it tells you that the host you were looking for is up and
-       running and that the name service for your network is configured
-       correctly.
+        If the hardware is functioning properly, it is possible that the boot
+        loader is corrupted and Linux cannot start on the machine. In this
+        case, it is necessary to repair the boot loader. To do so, you need to
+        start the Rescue System as described in
+        <xref linkend="sec-trouble-data-recover-rescue"/> and follow the
+        instructions in <xref linkend="sec-trouble-data-recover-rescue-grub"/>.
       </para>
       <para>
-       If ping fails with <literal>destination host unreachable</literal>,
-       either your system or the desired server is not properly configured or
-       down. Check whether your system is reachable by running
-       <command>ping</command> <replaceable>IP address</replaceable> or
-       <replaceable>YOUR_HOSTNAME</replaceable> from another machine. If you
-       can reach your machine from another machine, it is the server that is
-       not running or not configured correctly.
+        Alternatively, you can use the Rescue System to fix the boot loader as
+        follows. Boot your machine from the installation media. In the boot
+        screen, choose <menuchoice><guimenu>More</guimenu> <guimenu>Boot Linux
+        System</guimenu></menuchoice>. Select the disk containing the installed
+        system and kernel with the default kernel options.
+      </para>
+      <figure xml:id="fig-rescue-selectdisk" os="osuse">
+        <title>Select disk</title>
+        <mediaobject>
+          <imageobject role="fo">
+            <imagedata fileref="rescue_select_disk.png" width="50%"/>
+          </imageobject>
+          <imageobject role="html">
+            <imagedata fileref="rescue_select_disk.png" width="50%"/>
+          </imageobject>
+        </mediaobject>
+      </figure>
+      <para>
+        When the system is booted, start &yast; and switch to
+        <menuchoice><guimenu>System</guimenu> <guimenu>Boot
+        Loader</guimenu></menuchoice>. Make sure that the <guimenu>Write
+        generic Boot Code to MBR</guimenu> option is enabled, and click
+        <guimenu>OK</guimenu>. This fixes the corrupted boot loader by
+        overwriting it, or installs the boot loader if it is missing.
       </para>
       <para>
-       If ping fails with <literal>unknown host</literal>, the name service is
-       not configured correctly or the host name used was incorrect. For
-       further checks on this matter, refer to
-       <xref linkend="st-trouble-config-net-host" xrefstyle="StepOnPage"/>. If
-       ping still fails, either your network card is not configured correctly
-       or your network hardware is faulty.
-      </para>
-     </step>
-     <step xml:id="st-trouble-config-net-host">
-      <para>
-       Use <command>host</command> <replaceable>HOSTNAME</replaceable> to
-       check whether the host name of the server you are trying to connect to
-       is properly translated into an IP address and vice versa. If this
-       command returns the IP address of this host, the name service is up and
-       running. If the <command>host</command> command fails, check all network
-       configuration files relating to name and address resolution on your
-       host:
+        Other reasons for the machine not booting may be BIOS-related:
       </para>
       <variablelist>
-       <varlistentry>
-        <term><filename>/var/run/netconfig/resolv.conf</filename>
-        </term>
+        <varlistentry>
+          <term>BIOS settings</term>
+          <listitem>
+            <para>
+              Check your BIOS for references to your hard disk. &grub; may
+              simply not be started if the hard disk itself cannot be found
+              with the current BIOS settings.
+            </para>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>BIOS boot order</term>
+          <listitem>
+            <para>
+              Check whether your system's boot order includes the hard disk. If
+              the hard disk option was not enabled, your system may install
+              properly, but fails to boot when access to the hard disk is
+              required.
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </sect2>
+
+    <sect2 xml:id="sec-trouble-boot-hang" os="sled;osuse">
+      <title>No login or prompt appears</title>
+      <para>
+        This behavior typically occurs after a failed kernel upgrade and it is
+        known as a <emphasis>kernel panic</emphasis> because of the type of
+        error on the system console that sometimes can be seen at the final
+        stage of the process. If, in fact, the machine has just been rebooted
+        following a software update, the immediate goal is to reboot it using
+        the old, proven version of the Linux kernel and associated files. This
+        can be done in the &grub; boot loader screen during the boot process as
+        follows:
+      </para>
+      <procedure>
+        <step>
+          <para>
+            Reboot the computer using the reset button, or switch it off and on
+            again.
+          </para>
+        </step>
+        <step>
+          <para>
+            When the &grub; boot screen becomes visible, select the
+            <guimenu>Advanced Options</guimenu> entry and choose the previous
+            kernel from the menu. The machine will boot using the prior version
+            of the kernel and its associated files.
+          </para>
+        </step>
+        <step xml:id="st-trouble-boot-hang-modify-grub">
+          <para>
+            After the boot process has completed, remove the newly installed
+            kernel and, if necessary, set the default boot entry to the old
+            kernel using the &yast; <guimenu>Boot Loader</guimenu> module. For
+            more information refer to <xref linkend="sec-grub2-yast2-config"/>.
+            However, doing this is probably not necessary because automated
+            update tools normally modify it for you during the rollback
+            process.
+          </para>
+        </step>
+        <step>
+          <para>
+            Reboot.
+          </para>
+        </step>
+      </procedure>
+      <para>
+        If this does not fix the problem, boot the computer using the
+        installation media. After the machine has booted, continue with
+        <xref linkend="st-trouble-boot-hang-modify-grub" xrefstyle="StepOnPage"/>.
+      </para>
+    </sect2>
+
+    <sect2 xml:id="sec-trouble-boot-prompt">
+      <title>No graphical login</title>
+      <para>
+        If the machine starts, but does not boot into the graphical login
+        manager, anticipate problems either with the choice of the default
+        systemd target or the configuration of the X Window System. To check
+        the current systemd default target run the command <command>sudo
+        systemctl get-default</command>. If the value returned is
+        <emphasis>not</emphasis> <literal>graphical.target</literal>, run the
+        command <command>sudo systemctl isolate graphical.target</command>. If
+        the graphical login screen starts, log in and start <menuchoice>
+        <guimenu>&yast;</guimenu> <guimenu>System</guimenu>
+        <guimenu>&ycc_runlevel;</guimenu></menuchoice> and set the
+        <guimenu>Default System Target</guimenu> to <guimenu>Graphical
+        Interface</guimenu>. From now on the system should boot into the
+        graphical login screen.
+      </para>
+      <para>
+        If the graphical login screen does not start even if having booted or
+        switched to the graphical target, your desktop or X Window software is
+        probably misconfigured or corrupted. Examine the log files at
+        <filename>/var/log/Xorg.*.log</filename> for detailed messages from the
+        X server as it attempted to start. If the desktop fails during start,
+        it may log error messages to the system journal that can be queried
+        with the command <command>journalctl</command> (see
+        <xref linkend="cha-journalctl"/> for more information). If these error
+        messages hint at a configuration problem in the X server, try to fix
+        these issues. If the graphical system still does not come up, consider
+        reinstalling the graphical desktop.
+      </para>
+      <!--
+        2014-08-20, tiwai
+        startx doesn't work for normal user any longer.  Only root can do.
+        <tip>
+        <title>Starting X window system manually</title>
+        <para>
+        One quick test: the <command>startx</command> command should force the
+        X Window System to start with the configured defaults if the user is
+        currently logged in on the console. If that does not work, it should
+        log errors to the console.
+        </para>
+        </tip>
+        -->
+    </sect2>
+
+    <sect2 xml:id="sec-trouble-boot-btrfs">
+      <title>Root Btrfs partition cannot be mounted</title>
+      <para>
+        If a <systemitem class="filesystem">btrfs</systemitem> root partition
+        becomes corrupted, try the following options:
+      </para>
+      <itemizedlist>
         <listitem>
-         <para>
-          This file is used to keep track of the name server and domain you are
-          currently using. It is a symbolic link to
-          <filename>/run/netconfig/resolv.conf</filename> and is usually
-          automatically adjusted by &yast; or DHCP.
-          Make sure that this file has the following structure and all
-          network addresses and domain names are correct:
-         </para>
+          <para>
+            Mount the partition with the <option>-o recovery</option> option.
+          </para>
+        </listitem>
+        <listitem>
+          <remark>toms 2014-03-12: According to FATE#315126: "this one is open to
+      debate, it might do more harm than good.."</remark>
+          <para>
+            If that fails, run <command>btrfs-zero-log</command> on your root
+            partition.
+          </para>
+        </listitem>
+      </itemizedlist>
+    </sect2>
+
+    <sect2 xml:id="sec-trouble-boot-forcecheck">
+      <title>Force checking root partitions</title>
+      <remark>toms 2016-05-18: FATE#320126</remark>
+      <para>
+        If the root partition becomes corrupted, use the parameter
+        <parameter>forcefsck</parameter> on the boot prompt. This passes the
+        option <option>-f</option> (force) to the <command>fsck</command>
+        command.
+      </para>
+    </sect2>
+
+    <sect2 xml:id="sec-trouble-boot-disable-swap">
+      <title>Disable swap to enable booting</title>
+      <para>
+        When a swap device is not available and the system cannot enable it
+        during boot, booting may fail. Try disabling all swap devices by
+        appending the following options to the kernel command line:
+      </para>
+<screen>systemd.device_wants_unit=off systemd.mask=swap.target</screen>
+      <para>
+        You may also try disabling specific swap devices:
+      </para>
+<screen>systemd.mask=dev-sda1.swap</screen>
+    </sect2>
+
+    <sect2 xml:id="sec-trouble-boot-dual-boot">
+      <title>&grub; fails during reboot on a dual-boot system</title>
+      <remark>jufa 2021-06-09: bsc#1185274</remark>
+      <para>
+        If &grub; fails during reboot, disable the <option>Fast Boot</option>
+        setting in the BIOS.
+      </para>
+    </sect2>
+  </sect1>
+  <sect1 xml:id="sec-trouble-login">
+    <title>Login problems</title>
+
+    <para>
+      Login problems occur when your system refuses to accept the user name and
+      password, or accepts them but then fails to start the graphic desktop,
+      produces errors, or drops to a command line, for example.
+    </para>
+
+    <sect2 xml:id="sec-trouble-login-no">
+      <title>Valid user name and password combinations fail</title>
+      <para>
+        This often occurs when the system is configured to use network
+        authentication or directory services and cannot retrieve results from
+        its configured servers. The &rootuser; user, as the only local user, is
+        the only user that can still log in to these machines. The following
+        are common reasons a machine appears functional but cannot process
+        logins correctly:
+      </para>
+      <itemizedlist>
+        <listitem>
+          <para>
+            The network is not working. For further directions on this, turn to
+            <xref linkend="sec-trouble-netconfig"/>.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            DNS is not working at the moment (which prevents &gnome; from
+            working and the system from making validated requests to secure
+            servers). One indication that this is the case is that the machine
+            takes an extremely long time to respond to any action. Find more
+            information about this topic in
+            <xref linkend="sec-trouble-netconfig"/>.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            If the system is configured to use Kerberos, the system's local
+            time may have drifted past the accepted variance with the Kerberos
+            server time (this is typically 300 seconds). If NTP (network time
+            protocol) is not working properly or local NTP servers are not
+            working, Kerberos authentication ceases to function because it
+            depends on common clock synchronization across the network.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            The system's authentication configuration is misconfigured. Check
+            the PAM configuration files involved for any typographical errors
+            or misordering of directives. For additional background information
+            about PAM and the syntax of the configuration files involved, refer
+            to <xref linkend="cha-pam"/>.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            The home partition is encrypted. Find more information about this
+            topic in <xref linkend="sec-trouble-login-encrypted"/>.
+          </para>
+        </listitem>
+      </itemizedlist>
+      <para>
+        In all cases that do not involve external network problems, the
+        solution is to reboot the system into the rescue target and repair the
+        configuration before booting again into operating mode and attempting
+        to log in again. To boot into the rescue target:
+      </para>
+      <procedure xml:id="proc-trouble-login-no">
+        <step>
+          <para>
+            Reboot the system. The boot screen appears, offering the &grub;
+            boot menu.
+          </para>
+        </step>
+        <step>
+          <para>
+            Select a menu entry from the &grub; boot menu and press
+            <keycap>e</keycap> to edit the boot line.
+          </para>
+        </step>
+        <step>
+          <para>
+            Add the following parameter to the line containing the kernel
+            parameters:
+          </para>
+<screen>systemd.unit=rescue.target</screen>
+        </step>
+        <step>
+          <para>
+            Press <keycap>F10</keycap>.
+          </para>
+        </step>
+        <step>
+          <para>
+            Enter the user name and password for &rootuser;.
+          </para>
+        </step>
+        <step>
+          <para>
+            Make all the necessary changes.
+          </para>
+        </step>
+        <step>
+          <para>
+            Boot into the full multiuser and network mode by entering
+            <command>systemctl isolate graphical.target</command> at the
+            command line.
+          </para>
+        </step>
+      </procedure>
+    </sect2>
+
+    <sect2 xml:id="sec-trouble-login-pw">
+      <title>Valid user name and password not accepted</title>
+      <para>
+        This is by far the most common problem users encounter, because there
+        are many reasons this can occur. Depending on whether you use local
+        user management and authentication or network authentication, login
+        failures occur for different reasons.
+      </para>
+      <para>
+        Local user management can fail for the following reasons:
+      </para>
+      <itemizedlist>
+        <listitem>
+          <para>
+            The user may have entered the wrong password.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            The user's home directory containing the desktop configuration
+            files is corrupted or write protected.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            There may be problems with the X Window System authenticating this
+            particular user, especially if the user's home directory has been
+            used with another Linux distribution before installing the current
+            one.
+          </para>
+        </listitem>
+      </itemizedlist>
+      <para>
+        To locate the reason for a local login failure, proceed as follows:
+      </para>
+      <procedure>
+        <step>
+          <para>
+            Check whether the user remembered their password correctly before
+            you start debugging the whole authentication mechanism. If the user
+            may have not have remembered their password correctly, use the
+            &yast; User Management module to change the user's password. Pay
+            attention to the <keycap>Caps Lock</keycap> key and unlock it, if
+            necessary.
+          </para>
+        </step>
+        <step>
+          <para>
+            Log in as&rootuser; and check the system journal with
+            <command>journalctl -e</command> for error messages of the login
+            process and of PAM.
+          </para>
+        </step>
+        <step>
+          <para>
+            Try to log in from a console (using <keycombo>
+            <keycap function="control"/> <keycap function="alt"/>
+            <keycap>F1</keycap> </keycombo>). If this is successful, the blame
+            cannot be put on PAM, because it is possible to authenticate this
+            user on this machine. Try to locate any problems with the X Window
+            System or the &gnome; desktop. For more information, refer to
+            <xref linkend="sec-trouble-login-dk"/>.
+          </para>
+        </step>
+        <step>
+          <para>
+            If the user's home directory has been used with another Linux
+            distribution, remove the <filename>Xauthority</filename> file in
+            the user's home. Use a console login via <keycombo>
+            <keycap function="control"/> <keycap function="alt"/>
+            <keycap>F1</keycap> </keycombo> and run <command>rm
+            .Xauthority</command> as this user. This should eliminate X
+            authentication problems for this user. Try graphical login again.
+          </para>
+        </step>
+        <!--
+          <step>
+          <para>
+          If graphical login still fails, do a console login with <keycombo>
+          <keycap function="control"/>
+          <keycap function="alt"/> <keycap>F1</keycap> </keycombo>.
+          Try to start an X session on another display&mdash;the first one
+          (<literal>:0</literal>) is already in use:
+          </para>
+          <screen>startx -\- :1</screen>
+          <para>
+          This should bring up a graphical screen and your desktop. If it does
+          not, check the log files of the X Window System
+          (<filename>/var/log/Xorg.<replaceable>DISPLAYNUMBER</replaceable>.log</filename>)
+          or the log file for your desktop applications
+          (<filename>.xsession-errors</filename> in the user's home directory)
+          for any irregularities.
+          </para>
+          </step>
+          -->
+        <step>
+          <para>
+            If the desktop could not start because of corrupt configuration
+            files, proceed with <xref linkend="sec-trouble-login-dk"/>.
+          </para>
+        </step>
+      </procedure>
+      <para>
+        In the following, common reasons a network authentication for a
+        particular user may fail on a specific machine are listed:
+      </para>
+      <itemizedlist>
+        <listitem>
+          <para>
+            The user may have entered the wrong password.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            The user name exists in the machine's local authentication files
+            and is also provided by a network authentication system, causing
+            conflicts.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            The home directory exists but is corrupt or unavailable. Perhaps it
+            is write protected or is on a server that is inaccessible at the
+            moment.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            The user does not have permission to log in to that particular host
+            in the authentication system.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            The machine has changed host names, for whatever reason, and the
+            user does not have permission to log in to that host.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            The machine cannot reach the authentication server or directory
+            server that contains that user's information.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            There may be problems with the X Window System authenticating this
+            particular user, especially if the user's home has been used with
+            another Linux distribution before installing the current one.
+          </para>
+        </listitem>
+      </itemizedlist>
+      <para>
+        To locate the cause of the login failures with network authentication,
+        proceed as follows:
+      </para>
+      <procedure xml:id="proc-trouble-login-pw">
+        <step>
+          <para>
+            Check whether the user remembered their password correctly before
+            you start debugging the whole authentication mechanism.
+          </para>
+        </step>
+        <step>
+          <para>
+            Determine the directory server which the machine relies on for
+            authentication and make sure that it is up and running and properly
+            communicating with the other machines.
+          </para>
+        </step>
+        <step>
+          <para>
+            Determine that the user's user name and password work on other
+            machines to make sure that their authentication data exists and is
+            properly distributed.
+          </para>
+        </step>
+        <step>
+          <para>
+            See if another user can log in to the misbehaving machine. If
+            another user can log in without difficulty or if &rootuser; can log
+            in, log in and examine the system journal with <command>journalctl
+            -e</command>&gt; file. Locate the time stamps that correspond to
+            the login attempts and determine if PAM has produced any error
+            messages.
+          </para>
+        </step>
+        <step>
+          <para>
+            Try to log in from a console (using <keycombo>
+            <keycap function="control"/> <keycap function="alt"/>
+            <keycap>F1</keycap> </keycombo>). If this is successful, the
+            problem is not with PAM or the directory server on which the user's
+            home is hosted, because it is possible to authenticate this user on
+            this machine. Try to locate any problems with the X Window System
+            or the &gnome; desktop. For more information, refer to
+            <xref linkend="sec-trouble-login-dk"/>.
+          </para>
+        </step>
+        <step>
+          <para>
+            If the user's home directory has been used with another Linux
+            distribution, remove the <filename>Xauthority</filename> file in
+            the user's home. Use a console login via <keycombo>
+            <keycap function="control"/> <keycap function="alt"/>
+            <keycap>F1</keycap> </keycombo> and run <command>rm
+            .Xauthority</command> as this user. This should eliminate X
+            authentication problems for this user. Try graphical login again.
+          </para>
+        </step>
+        <!--
+          <step>
+          <para>
+          If graphical login still fails, do a console login with <keycombo>
+          <keycap function="control"/>
+          <keycap function="alt"/> <keycap>F1</keycap> </keycombo>.
+          Try to start an X session on another display&mdash;the first one
+          (<literal>:0</literal>) is already in use:
+          </para>
+          <screen>startx -\- :1</screen>
+          <para>
+          This should bring up a graphical screen and your desktop. If it does
+          not, check the log files of the X Window System
+          (<filename>/var/log/Xorg.<replaceable>DISPLAYNUMBER</replaceable>.log</filename>)
+          or the log file for your desktop applications
+          (<filename>.xsession-errors</filename> in the user's home directory)
+          for any irregularities.
+          </para>
+          </step>
+          -->
+        <step>
+          <para>
+            If the desktop could not start because of corrupt configuration
+            files, proceed with <xref linkend="sec-trouble-login-dk"/>.
+          </para>
+        </step>
+      </procedure>
+    </sect2>
+
+    <sect2 xml:id="sec-trouble-login-encrypted">
+      <title>Login to encrypted home partition fails</title>
+      <para>
+        It is recommended to use an encrypted home partition for laptops. If
+        you cannot log in to your laptop, the reason might be that your
+        partition could not be unlocked.
+      </para>
+      <para>
+        During the boot time, you need to enter the passphrase to unlock your
+        encrypted partition. If you do not enter it, the boot process
+        continues, leaving the partition locked.
+      </para>
+      <para>
+        To unlock your encrypted partition, proceed as follows:
+      </para>
+      <procedure>
+        <step>
+          <para>
+            Switch to the text console with <keycombo>
+            <keycap function="control"/> <keycap function="alt"/>
+            <keycap>F1</keycap> </keycombo>.
+          </para>
+        </step>
+        <step>
+          <para>
+            Become&rootuser;.
+          </para>
+        </step>
+        <step>
+          <para>
+            Restart the unlocking process again with:
+          </para>
+<screen>&prompt.root;systemctl restart home.mount</screen>
+        </step>
+        <step>
+          <para>
+            Enter your passphrase to unlock your encrypted partition.
+          </para>
+        </step>
+        <step>
+          <para>
+            Exit the text console and switch back to the login screen with
+            <keycombo> <keycap function="alt"/> <keycap>F7</keycap>
+            </keycombo>.
+          </para>
+        </step>
+        <step>
+          <para>
+            Log in as usual.
+          </para>
+        </step>
+      </procedure>
+    </sect2>
+
+    <sect2 xml:id="sec-trouble-login-dk">
+      <title>&gnome; desktop has issues</title>
+      <para>
+        If you are experiencing issues with the &gnome; desktop, there are
+        several ways to troubleshoot the misbehaving graphical desktop
+        environment. The recommended procedure described below offers the
+        safest option to fix a broken &gnome; desktop.
+      </para>
+      <procedure>
+        <title>Troubleshooting &gnome;</title>
+        <step>
+          <para>
+            Launch &yast; and switch to <guimenu>Security and Users</guimenu>.
+          </para>
+        </step>
+        <step>
+          <para>
+            Open the <guimenu>User and Group Management</guimenu> dialog and
+            click <guimenu>Add</guimenu>.
+          </para>
+        </step>
+        <step>
+          <para>
+            Fill out the required fields and click <guimenu>OK</guimenu> to
+            create a new user.
+          </para>
+        </step>
+        <step>
+          <para>
+            Log out and log in as the new user. This gives you a fresh &gnome;
+            environment.
+          </para>
+        </step>
+        <step>
+          <para>
+            Copy individual subdirectories from the
+            <filename>~/.local/</filename> and <filename>~/.config/</filename>
+            directories of the old user account to the respective directories
+            of the new user account.
+          </para>
+          <para>
+            Log out and log in again as the new user after every copy operation
+            to check whether &gnome; still works correctly.
+          </para>
+        </step>
+        <step>
+          <para>
+            Repeat the previous step until you find the configuration file that
+            breaks &gnome;.
+          </para>
+        </step>
+        <step>
+          <para>
+            Log in as the old user, and move the offending configuration file
+            to a different location. Log out and log in again as the old user.
+          </para>
+        </step>
+        <step>
+          <para>
+            Delete the previously created user.
+          </para>
+        </step>
+      </procedure>
+    </sect2>
+  </sect1>
+  <sect1 xml:id="sec-trouble-netconfig">
+    <title>Network problems</title>
+
+    <para>
+      Many problems of your system may be network-related, even though they do
+      not seem to be at first. For example, the reason for a system not
+      allowing users to log in may be a network problem. This section
+      introduces a simple checklist you can apply to identify the cause of any
+      network problem encountered.
+    </para>
+
+    <procedure xml:id="proc-trouble-config-net">
+      <title>How to identify network problems</title>
+      <para>
+        When checking the network connection of your machine, proceed as
+        follows:
+      </para>
+      <step>
+        <para>
+          If you use an Ethernet connection, check the hardware first. Make
+          sure that your network cable is properly plugged into your computer
+          and router (or hub, etc.). The control lights next to your Ethernet
+          connector are normally both be active.
+        </para>
+        <para>
+          If the connection fails, check whether your network cable works with
+          another machine. If it does, your network card causes the failure. If
+          hubs or switches are included in your network setup, they may be
+          faulty, as well.
+        </para>
+      </step>
+      <step>
+        <para>
+          If using a wireless connection, check whether the wireless link can
+          be established by other machines. If not, contact the wireless
+          network's administrator.
+        </para>
+      </step>
+      <step>
+        <para>
+          When you have checked your basic network connectivity, try to find
+          out which service is not responding. Gather the address information
+          of all network servers needed in your setup. Either look them up in
+          the appropriate &yast; module or ask your system administrator. The
+          following list gives typical network servers involved in a setup
+          together with the symptoms of an outage.
+        </para>
+        <variablelist>
+          <varlistentry>
+            <term>DNS (name service)</term>
+            <listitem>
+              <para>
+                A broken or malfunctioning name service affects the network's
+                functionality in many ways. If the local machine relies on any
+                network servers for authentication and these servers cannot be
+                found because of name resolution issues, users would not even
+                be able to log in. Machines in the network managed by a broken
+                name server would not be able to <quote>see</quote> each other
+                and communicate.
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>NTP (time service)</term>
+            <listitem>
+              <para>
+                A malfunctioning or broken NTP service could affect Kerberos
+                authentication and X server functionality.
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>NFS (file service)</term>
+            <listitem>
+              <para>
+                If any application needs data stored in an NFS mounted
+                directory, it cannot start or function properly if this service
+                was down or misconfigured. In the worst case scenario, a user's
+                personal desktop configuration would not come up if their home
+                directory containing the <filename>.gconf</filename>
+                subdirectory could not be found because of a faulty NFS server.
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>Samba (file service)</term>
+            <listitem>
+              <para>
+                If any application needs data stored in a directory on a faulty
+                Samba server, it cannot start or function properly.
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>NIS (user management)</term>
+            <listitem>
+              <para>
+                If your &productname; system relies on a faulty NIS server to
+                provide the user data, users cannot log in to this machine.
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>LDAP (user management)</term>
+            <listitem>
+              <para>
+                If your &productname; system relies on a faulty LDAP server to
+                provide the user data, users cannot log in to this machine.
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>Kerberos (authentication)</term>
+            <listitem>
+              <para>
+                Authentication does not work and login to any machine fails.
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term>CUPS (network printing)</term>
+            <listitem>
+              <para>
+                Users cannot print.
+              </para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+      </step>
+      <step>
+        <para>
+          Check whether the network servers are running and whether your
+          network setup allows you to establish a connection:
+        </para>
+        <important>
+          <title>Limitations</title>
+          <para>
+            The debugging procedure described below only applies to a simple
+            network server/client setup that does not involve any internal
+            routing. It assumes both server and client are members of the same
+            subnet without the need for additional routing.
+          </para>
+        </important>
+        <substeps performance="required">
+          <step>
+            <para>
+              Use <command>ping</command>
+              <replaceable>IP_ADDRESS/HOSTNAME</replaceable> (replace with the
+              host name or IP address of the server) to check whether each one
+              of them is up and responding to the network. If this command is
+              successful, it tells you that the host you were looking for is up
+              and running and that the name service for your network is
+              configured correctly.
+            </para>
+            <para>
+              If ping fails with <literal>destination host
+              unreachable</literal>, either your system or the desired server
+              is not properly configured or down. Check whether your system is
+              reachable by running <command>ping</command> <replaceable>IP
+              address</replaceable> or <replaceable>YOUR_HOSTNAME</replaceable>
+              from another machine. If you can reach your machine from another
+              machine, it is the server that is not running or not configured
+              correctly.
+            </para>
+            <para>
+              If ping fails with <literal>unknown host</literal>, the name
+              service is not configured correctly or the host name used was
+              incorrect. For further checks on this matter, refer to
+              <xref linkend="st-trouble-config-net-host" xrefstyle="StepOnPage"/>.
+              If ping still fails, either your network card is not configured
+              correctly or your network hardware is faulty.
+            </para>
+          </step>
+          <step xml:id="st-trouble-config-net-host">
+            <para>
+              Use <command>host</command> <replaceable>HOSTNAME</replaceable>
+              to check whether the host name of the server you are trying to
+              connect to is properly translated into an IP address and vice
+              versa. If this command returns the IP address of this host, the
+              name service is up and running. If the <command>host</command>
+              command fails, check all network configuration files relating to
+              name and address resolution on your host:
+            </para>
+            <variablelist>
+              <varlistentry>
+                <term><filename>/var/run/netconfig/resolv.conf</filename></term>
+                <listitem>
+                  <para>
+                    This file is used to keep track of the name server and
+                    domain you are currently using. It is a symbolic link to
+                    <filename>/run/netconfig/resolv.conf</filename> and is
+                    usually automatically adjusted by &yast; or DHCP. Make sure
+                    that this file has the following structure and all network
+                    addresses and domain names are correct:
+                  </para>
 <screen>search <replaceable>FULLY_QUALIFIED_DOMAIN_NAME</replaceable>
 nameserver <replaceable>IPADDRESS_OF_NAMESERVER</replaceable></screen>
-         <para>
-          This file can contain more than one name server address, but at least
-          one of them must be correct to provide name resolution to your host.
-          If needed, adjust this file using the &yast; Network Settings module
-          (Hostname/DNS tab).
-         </para>
-         <para>
-          If your network connection is handled via DHCP, enable DHCP to change
-          host name and name service information by selecting <guimenu>Set
-          Hostname via DHCP</guimenu> (can be set globally for any interface or
-          per interface) and <guimenu>Update Name Servers and Search List via DHCP</guimenu>
-          in the &yast; Network Settings module (Hostname/DNS tab).
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term><filename>/etc/nsswitch.conf</filename>
-        </term>
-        <listitem>
-         <para>
-          This file tells Linux where to look for name service information. It
-          should look like this:
-         </para>
+                  <para>
+                    This file can contain more than one name server address,
+                    but at least one of them must be correct to provide name
+                    resolution to your host. If needed, adjust this file using
+                    the &yast; Network Settings module (Hostname/DNS tab).
+                  </para>
+                  <para>
+                    If your network connection is handled via DHCP, enable DHCP
+                    to change host name and name service information by
+                    selecting <guimenu>Set Hostname via DHCP</guimenu> (can be
+                    set globally for any interface or per interface) and
+                    <guimenu>Update Name Servers and Search List via
+                    DHCP</guimenu> in the &yast; Network Settings module
+                    (Hostname/DNS tab).
+                  </para>
+                </listitem>
+              </varlistentry>
+              <varlistentry>
+                <term><filename>/etc/nsswitch.conf</filename></term>
+                <listitem>
+                  <para>
+                    This file tells Linux where to look for name service
+                    information. It should look like this:
+                  </para>
 <screen> ...
 hosts: files dns
 networks: files dns
 ...</screen>
-         <para>
-          The <option>dns</option> entry is vital. It tells Linux to use an
-          external name server. Normally, these entries are automatically
-          managed by &yast;, but it would be prudent to check.
-         </para>
-         <para>
-          If all the relevant entries on the host are correct, let your system
-          administrator check the DNS server configuration for the correct zone
-          information. <phrase os="sles;osuse">For detailed information about
-          DNS, refer to <xref linkend="cha-dns"/>.</phrase> If you have made
-          sure that the DNS configuration of your host and the DNS server are
-          correct, proceed with checking the configuration of your network and
-          network device.
-         </para>
-        </listitem>
-       </varlistentry>
-      </variablelist>
-     </step>
-     <step>
-      <para>
-       If your system cannot establish a connection to a network server and you
-       have excluded name service problems from the list of possible culprits,
-       check the configuration of your network card.
-      </para>
-      <para>
-       Use the command <command>ip addr show</command>
-       <replaceable>NETWORK_DEVICE</replaceable> to check whether this device
-       was properly configured. Make sure that the <option>inet
-       address</option> with the netmask
-       (<literal>/<replaceable>MASK</replaceable></literal>) is configured
-       correctly. An error in the IP address or a missing bit in your network
-       mask would render your network configuration unusable. If necessary,
-       perform this check on the server as well.
-      </para>
-     </step>
-     <step>
-      <para>
-       If the name service and network hardware are properly configured and
-       running, but certain external network connections still get long time-outs
-       or fail entirely, use <command>traceroute</command>
-       <replaceable>FULLY_QUALIFIED_DOMAIN_NAME</replaceable> (executed as
-       <systemitem class="username">root</systemitem>) to track the network
-       route these requests are taking. This command lists any gateway (hop)
-       that a request from your machine passes on its way to its destination.
-       It lists the response time of each hop and whether this hop is
-       reachable. Use a combination of traceroute and ping to track down the
-       culprit and let the administrators know.
-      </para>
-     </step>
-    </substeps>
-   </step>
-  </procedure>
+                  <para>
+                    The <option>dns</option> entry is vital. It tells Linux to
+                    use an external name server. Normally, these entries are
+                    automatically managed by &yast;, but it would be prudent to
+                    check.
+                  </para>
+                  <para>
+                    If all the relevant entries on the host are correct, let
+                    your system administrator check the DNS server
+                    configuration for the correct zone information.
+                    <phrase os="sles;osuse">For detailed information about DNS,
+                    refer to <xref linkend="cha-dns"/>.</phrase> If you have
+                    made sure that the DNS configuration of your host and the
+                    DNS server are correct, proceed with checking the
+                    configuration of your network and network device.
+                  </para>
+                </listitem>
+              </varlistentry>
+            </variablelist>
+          </step>
+          <step>
+            <para>
+              If your system cannot establish a connection to a network server
+              and you have excluded name service problems from the list of
+              possible culprits, check the configuration of your network card.
+            </para>
+            <para>
+              Use the command <command>ip addr show</command>
+              <replaceable>NETWORK_DEVICE</replaceable> to check whether this
+              device was properly configured. Make sure that the <option>inet
+              address</option> with the netmask
+              (<literal>/<replaceable>MASK</replaceable></literal>) is
+              configured correctly. An error in the IP address or a missing bit
+              in your network mask would render your network configuration
+              unusable. If necessary, perform this check on the server as well.
+            </para>
+          </step>
+          <step>
+            <para>
+              If the name service and network hardware are properly configured
+              and running, but certain external network connections still get
+              long time-outs or fail entirely, use
+              <command>traceroute</command>
+              <replaceable>FULLY_QUALIFIED_DOMAIN_NAME</replaceable> (executed
+              as &rootuser;) to track the network route these requests are
+              taking. This command lists any gateway (hop) that a request from
+              your machine passes on its way to its destination. It lists the
+              response time of each hop and whether this hop is reachable. Use
+              a combination of traceroute and ping to track down the culprit
+              and let the administrators know.
+            </para>
+          </step>
+        </substeps>
+      </step>
+    </procedure>
 
-  <para>
-   When you have identified the cause of your network trouble, you can resolve
-   it yourself (if the problem is located on your machine) or let the system
-   administrators of your network know about your findings so they can
-   reconfigure the services or repair the necessary systems.
-  </para>
-
-  <sect2 xml:id="sec-trouble-networkmanager">
-   <title>&nm; problems</title>
-   <remark>This is a bit small, needs more text.</remark>
-   <para>
-    If you have a problem with network connectivity, narrow it down as
-    described in <xref linkend="proc-trouble-config-net"/>. If &nm; seems to be
-    the culprit, proceed as follows to get logs providing hints on why &nm;
-    fails:
-   </para>
-   <procedure>
-    <step>
-     <para>
-      Open a shell and log in as
-      <systemitem class="username">root</systemitem>.
-     </para>
-    </step>
-    <step>
-     <para>
-      Restart the NetworkManager:
-     </para>
-<screen>&prompt.sudo;systemctl restart NetworkManager</screen>
-    </step>
-    <step>
-     <para>
-      Open a Web page, for example,
-      <link xlink:href="http://www.opensuse.org"/> as normal user to see, if
-      you can connect.
-     </para>
-    </step>
-    <step>
-     <para>
-      Collect any information about the state of NetworkManager in
-      <filename>/var/log/NetworkManager</filename>.
-     </para>
-    </step>
-   </procedure>
-   <para>
-    For more information about NetworkManager, refer to
-    <xref linkend="cha-nm"/>.
-   </para>
-  </sect2>
- </sect1>
- <sect1 xml:id="sec-trouble-data">
-  <title>Data problems</title>
-
-  <para>
-   Data problems are when the machine may or may not boot properly but, in
-   either case, it is clear that there is data corruption on the system and
-   that the system needs to be recovered. These situations call for a backup of
-   your critical data, enabling you to recover the system state from before
-   your system failed.
-  </para>
-
-  <sect2 xml:id="sec-trouble-data-partitions">
-   <title>Managing partition images</title>
-   <para>
-    Sometimes you need to perform a backup from an entire partition or even
-    hard disk. Linux comes with the <command>dd</command> tool which can create
-    an exact copy of your disk. Combined with <command>gzip</command> you save
-    space.
-   </para>
-   <procedure>
-    <title>Backing up and restoring hard disks</title>
-    <step>
-     <para>
-      Start a Shell as user &rootuser;.
-     </para>
-    </step>
-    <step>
-     <para>
-      Select your source device. Typically this is something like
-      <filename>/dev/sda</filename> (labeled as
-      <replaceable>SOURCE</replaceable>).
-     </para>
-    </step>
-    <step>
-     <para>
-      Decide where you want to store your image (labeled as
-      <replaceable>BACKUP_PATH</replaceable>). It must be different from your
-      source device. In other words: if you make a backup from
-      <filename>/dev/sda</filename>, your image file must not to be stored
-      under <filename>/dev/sda</filename>.
-     </para>
-    </step>
-    <step>
-     <para>
-      Run the commands to create a compressed image file:
-     </para>
-<screen>&prompt.root;dd if=/dev/<replaceable>SOURCE</replaceable> | gzip &gt; /<replaceable>BACKUP_PATH</replaceable>/image.gz </screen>
-    </step>
-    <step>
-     <para>
-      Restore the hard disk with the following commands:
-     </para>
-<screen>&prompt.root;gzip -dc /<replaceable>BACKUP_PATH</replaceable>/image.gz | dd of=/dev/<replaceable>SOURCE</replaceable></screen>
-    </step>
-   </procedure>
-   <para>
-    If you only need to back up a partition, replace the
-    <replaceable>SOURCE</replaceable> placeholder with your respective
-    partition. In this case, your image file can lie on the same hard disk, but
-    on a different partition.
-   </para>
-  </sect2>
-
-<!-- TODO: please move this section to admin guide. Requirement from fate
-    #305036 is:
-- how and what to backup / recommendations
-  o System configuration with YaST
-- backup/restore recommentation:
-  o customized config settings
-  o ssh keys, certificates
-  o system data backup (hints)
-  o available backup tools
-  o 3rd party backup tools (marketing task)
--->
-
-<!-- 2014-063-14 tbazant: commenting out (FATE#308682)
-  <sect2 id="sec-trouble-data-backup">
-   <title>Backing up critical data</title>
-   <procedure id="proc-trouble-data-backup">
     <para>
-     System backups can be easily managed using the &yast; System Backup
-     module:
+      When you have identified the cause of your network trouble, you can
+      resolve it yourself (if the problem is located on your machine) or let
+      the system administrators of your network know about your findings so
+      they can reconfigure the services or repair the necessary systems.
     </para>
-    <step>
-     <para>
+
+    <sect2 xml:id="sec-trouble-networkmanager">
+      <title>&nm; problems</title>
+      <remark>This is a bit small, needs more text.</remark>
+      <para>
+        If you have a problem with network connectivity, narrow it down as
+        described in <xref linkend="proc-trouble-config-net"/>. If &nm; seems
+        to be the culprit, proceed as follows to get logs providing hints on
+        why &nm; fails:
+      </para>
+      <procedure>
+        <step>
+          <para>
+            Open a shell and log in as &rootuser;.
+          </para>
+        </step>
+        <step>
+          <para>
+            Restart the NetworkManager:
+          </para>
+<screen>&prompt.sudo;systemctl restart NetworkManager</screen>
+        </step>
+        <step>
+          <para>
+            Open a Web page, for example,
+            <link xlink:href="http://www.opensuse.org"/> as normal user to see,
+            if you can connect.
+          </para>
+        </step>
+        <step>
+          <para>
+            Collect any information about the state of NetworkManager in
+            <filename>/var/log/NetworkManager</filename>.
+          </para>
+        </step>
+      </procedure>
+      <para>
+        For more information about NetworkManager, refer to
+        <xref linkend="cha-nm"/>.
+      </para>
+    </sect2>
+  </sect1>
+  <sect1 xml:id="sec-trouble-data">
+    <title>Data problems</title>
+
+    <para>
+      Data problems are when the machine may or may not boot properly but, in
+      either case, it is clear that there is data corruption on the system and
+      that the system needs to be recovered. These situations call for a backup
+      of your critical data, enabling you to recover the system state from
+      before your system failed.
+    </para>
+
+    <sect2 xml:id="sec-trouble-data-partitions">
+      <title>Managing partition images</title>
+      <para>
+        Sometimes you need to perform a backup from an entire partition or even
+        hard disk. Linux comes with the <command>dd</command> tool which can
+        create an exact copy of your disk. Combined with
+        <command>gzip</command> you save space.
+      </para>
+      <procedure>
+        <title>Backing up and restoring hard disks</title>
+        <step>
+          <para>
+            Start a Shell as user &rootuser;.
+          </para>
+        </step>
+        <step>
+          <para>
+            Select your source device. Typically this is something like
+            <filename>/dev/sda</filename> (labeled as
+            <replaceable>SOURCE</replaceable>).
+          </para>
+        </step>
+        <step>
+          <para>
+            Decide where you want to store your image (labeled as
+            <replaceable>BACKUP_PATH</replaceable>). It must be different from
+            your source device. In other words: if you make a backup from
+            <filename>/dev/sda</filename>, your image file must not to be
+            stored under <filename>/dev/sda</filename>.
+          </para>
+        </step>
+        <step>
+          <para>
+            Run the commands to create a compressed image file:
+          </para>
+<screen>&prompt.root;dd if=/dev/<replaceable>SOURCE</replaceable> | gzip &gt; /<replaceable>BACKUP_PATH</replaceable>/image.gz </screen>
+        </step>
+        <step>
+          <para>
+            Restore the hard disk with the following commands:
+          </para>
+<screen>&prompt.root;gzip -dc /<replaceable>BACKUP_PATH</replaceable>/image.gz | dd of=/dev/<replaceable>SOURCE</replaceable></screen>
+        </step>
+      </procedure>
+      <para>
+        If you only need to back up a partition, replace the
+        <replaceable>SOURCE</replaceable> placeholder with your respective
+        partition. In this case, your image file can lie on the same hard disk,
+        but on a different partition.
+      </para>
+    </sect2>
+
+    <!-- TODO: please move this section to admin guide. Requirement from fate
+      #305036 is:
+      - how and what to backup / recommendations
+      o System configuration with YaST
+      - backup/restore recommentation:
+      o customized config settings
+      o ssh keys, certificates
+      o system data backup (hints)
+      o available backup tools
+      o 3rd party backup tools (marketing task)
+      -->
+
+    <!-- 2014-063-14 tbazant: commenting out (FATE#308682)
+      <sect2 id="sec-trouble-data-backup">
+      <title>Backing up critical data</title>
+      <procedure id="proc-trouble-data-backup">
+      <para>
+      System backups can be easily managed using the &yast; System Backup
+      module:
+      </para>
+      <step>
+      <para>
       As &rootuser;, start &yast; and select <menuchoice>
       <guimenu>System</guimenu> <guimenu>System Backup</guimenu>
       </menuchoice>.
-     </para>
-    </step>
-    <step>
-     <para>
+      </para>
+      </step>
+      <step>
+      <para>
       Create a backup profile holding all details needed for the backup,
       file name of the archive file, scope, and type of the backup:
-     </para>
-     <substeps>
+      </para>
+      <substeps>
       <step>
-       <para>
-        Select <menuchoice> <guimenu>Profile Management</guimenu>
-        <guimenu>Add</guimenu> </menuchoice>.
-       </para>
+      <para>
+      Select <menuchoice> <guimenu>Profile Management</guimenu>
+      <guimenu>Add</guimenu> </menuchoice>.
+      </para>
       </step>
       <step>
-       <para>
-        Enter a name for the archive.
-       </para>
+      <para>
+      Enter a name for the archive.
+      </para>
       </step>
       <step>
-       <para>
-        Enter the path to the location of the backup if you want to keep a
-        local backup. For your backup to be archived on a network server
-        (via NFS), enter the IP address or name of the server and the
-        directory that should hold your archive.
-       </para>
+      <para>
+      Enter the path to the location of the backup if you want to keep a
+      local backup. For your backup to be archived on a network server
+      (via NFS), enter the IP address or name of the server and the
+      directory that should hold your archive.
+      </para>
       </step>
       <step>
-       <para>
-        Determine the archive type and click <guimenu>Next</guimenu>.
-       </para>
+      <para>
+      Determine the archive type and click <guimenu>Next</guimenu>.
+      </para>
       </step>
       <step>
-       <para>
-        Determine the backup options to use, such as whether files not
-        belonging to any package should be backed up and whether a list of
-        files should be displayed prior to creating the archive. Also
-        determine whether changed files should be identified using the
-        time-consuming MD5 mechanism.
-       </para>
-       <para>
-        Use <guimenu>Expert</guimenu> to enter a dialog for the backup of
-        entire hard disk areas. Currently, this option only applies to the
-        Ext2 file system.
-       </para>
+      <para>
+      Determine the backup options to use, such as whether files not
+      belonging to any package should be backed up and whether a list of
+      files should be displayed prior to creating the archive. Also
+      determine whether changed files should be identified using the
+      time-consuming MD5 mechanism.
+      </para>
+      <para>
+      Use <guimenu>Expert</guimenu> to enter a dialog for the backup of
+      entire hard disk areas. Currently, this option only applies to the
+      Ext2 file system.
+      </para>
       </step>
       <step>
-       <para>
-        Finally, set the search constraints to exclude certain system areas
-        from the backup area that do not need to be backed up, such as lock
-        files or cache files. Add, edit, or delete items until your needs
-        are met and leave with <guimenu>OK</guimenu>.
-       </para>
+      <para>
+      Finally, set the search constraints to exclude certain system areas
+      from the backup area that do not need to be backed up, such as lock
+      files or cache files. Add, edit, or delete items until your needs
+      are met and leave with <guimenu>OK</guimenu>.
+      </para>
       </step>
-     </substeps>
-    </step>
-    <step>
-     <para>
+      </substeps>
+      </step>
+      <step>
+      <para>
       Once you have finished the profile settings, you can start the backup
       right away with <guimenu>Create Backup</guimenu> or configure
       automatic backup. It is also possible to create other profiles
       tailored for various other purposes.
-     </para>
-    </step>
-   </procedure>
-   <procedure id="proc-trouble-data-profile">
-    <para>
-     To configure automatic backup for a given profile, proceed as follows:
-    </para>
-    <step>
-     <para>
+      </para>
+      </step>
+      </procedure>
+      <procedure id="proc-trouble-data-profile">
+      <para>
+      To configure automatic backup for a given profile, proceed as follows:
+      </para>
+      <step>
+      <para>
       Select <guimenu>Automatic Backup</guimenu> from the <guimenu>Profile
       Management</guimenu> menu.
-     </para>
-    </step>
-    <step>
-     <para>
+      </para>
+      </step>
+      <step>
+      <para>
       Select <guimenu>Start Backup Automatically</guimenu>.
-     </para>
-    </step>
-    <step>
-     <para>
+      </para>
+      </step>
+      <step>
+      <para>
       Determine the backup frequency. Choose <guimenu>daily</guimenu>,
       <guimenu>weekly</guimenu>, or <guimenu>monthly</guimenu>.
-     </para>
-    </step>
-    <step>
-     <para>
+      </para>
+      </step>
+      <step>
+      <para>
       Determine the backup start time. These settings depend on the backup
       frequency selected.
-     </para>
-    </step>
-    <step>
-     <para>
+      </para>
+      </step>
+      <step>
+      <para>
       Decide whether to keep old backups and how many should be kept. To
       receive an automatically generated status message of the backup
       process, check <guimenu>Send Summary Mail to User root</guimenu>.
-     </para>
-    </step>
-    <step>
-     <para>
+      </para>
+      </step>
+      <step>
+      <para>
       Click <guimenu>OK</guimenu> to apply your settings and have the first
       backup start at the time specified.
-     </para>
-    </step>
-   </procedure>
-  </sect2>
-
-  <sect2 id="sec-trouble-data-replay">
-   <title>Restoring a system backup</title>
-   <para>
-    Use the &yast; System Restoration module to restore the system
-    configuration from a backup. Restore the entire backup or select
-    specific components that were corrupted and need to be reset to their
-    old state.
-   </para>
-   <procedure id="proc-trouble-data-replay">
-    <step>
-     <para>
+      </para>
+      </step>
+      </procedure>
+      </sect2>
+      <sect2 id="sec-trouble-data-replay">
+      <title>Restoring a system backup</title>
+      <para>
+      Use the &yast; System Restoration module to restore the system
+      configuration from a backup. Restore the entire backup or select
+      specific components that were corrupted and need to be reset to their
+      old state.
+      </para>
+      <procedure id="proc-trouble-data-replay">
+      <step>
+      <para>
       Start <menuchoice> <guimenu>&yast;</guimenu> <guimenu>System</guimenu>
       <guimenu>System Restoration</guimenu> </menuchoice>.
-     </para>
-    </step>
-    <step>
-     <para>
+      </para>
+      </step>
+      <step>
+      <para>
       Enter the location of the backup file. This could be a local file, a
       network mounted file, or a file on a removable device. Then click
       <guimenu>Next</guimenu>.
-     </para>
-     <para>
+      </para>
+      <para>
       The following dialog displays a summary of the archive properties,
       such as the file name, date of creation, type of backup, and optional
       comments.
-     </para>
-    </step>
-    <step>
-     <para>
+      </para>
+      </step>
+      <step>
+      <para>
       Review the archived content by clicking <guimenu>Archive
       Content</guimenu>. Clicking <guimenu>OK</guimenu> returns you to the
       <guimenu>Archive Properties</guimenu> dialog.
-     </para>
-    </step>
-    <step>
-     <para>
+      </para>
+      </step>
+      <step>
+      <para>
       <guimenu>Expert Options</guimenu> opens a dialog in which to fine-tune
       the restore process. Return to the <guimenu>Archive
       Properties</guimenu> dialog by clicking <guimenu>OK</guimenu>.
-     </para>
-    </step>
-    <step>
-     <para>
+      </para>
+      </step>
+      <step>
+      <para>
       Click <guimenu>Next</guimenu> to open the view of packages to restore.
       Press <guimenu>Accept</guimenu> to restore all files in the archive or
       use the various <guimenu>Select All</guimenu>, <guimenu>Deselect
@@ -1742,21 +1741,21 @@ networks: files dns
       fine-tune your selection. Only use the <guimenu>Restore RPM
       Database</guimenu> option if the RPM database is corrupted or deleted
       and this file is included in the backup.
-     </para>
-    </step>
-    <step>
-     <para>
+      </para>
+      </step>
+      <step>
+      <para>
       After you click <guimenu>Accept</guimenu>, the backup is restored.
       Click <guimenu>Finish</guimenu> to leave the module after the restore
       process is completed.
-     </para>
-    </step>
-   </procedure>
-  </sect2>
-  -->
+      </para>
+      </step>
+      </procedure>
+      </sect2>
+      -->
 
-  <xi:include href="system_repair.xml"/>
- </sect1>
- <xi:include os="sles" arch="zseries" href="zseries_rescue_initrd.xml"/>
- <xi:include os="sles" arch="zseries" href="zseries_boot_new_kernel.xml"/>
+    <xi:include href="system_repair.xml"/>
+  </sect1>
+  <xi:include os="sles" arch="zseries" href="zseries_rescue_initrd.xml"/>
+  <xi:include os="sles" arch="zseries" href="zseries_boot_new_kernel.xml"/>
 </chapter>

--- a/xml/troubleshooting.xml
+++ b/xml/troubleshooting.xml
@@ -29,12 +29,6 @@
       </menuchoice>).
     </para>
 
-    <!-- fs 2010-05-21:
-      Weird location for this paragraph - completely out of context (support).
-      Move to a better location
-      Profiling, since the support query module is not available for openSUSE.
-      -->
-
     <para>
       &yast; offers the possibility to collect all system information needed by
       the support team. Use <menuchoice>
@@ -107,19 +101,6 @@
               </para>
             </entry>
           </row>
-          <!-- 2014-06-04 tbazant: now part of journald
-            <row>
-            <entry>
-            <para>
-            <filename>/var/log/boot.msg</filename>
-            </para>
-            </entry>
-            <entry>
-            <para>
-            Messages from the kernel reported during the boot process.
-            </para>
-            </entry>
-            </row> -->
           <row>
             <entry>
               <para>
@@ -624,19 +605,6 @@
         these issues. If the graphical system still does not come up, consider
         reinstalling the graphical desktop.
       </para>
-      <!--
-        2014-08-20, tiwai
-        startx doesn't work for normal user any longer.  Only root can do.
-        <tip>
-        <title>Starting X window system manually</title>
-        <para>
-        One quick test: the <command>startx</command> command should force the
-        X Window System to start with the configured defaults if the user is
-        currently logged in on the console. If that does not work, it should
-        log errors to the console.
-        </para>
-        </tip>
-        -->
     </sect2>
 
     <sect2 xml:id="sec-trouble-boot-btrfs">
@@ -1475,201 +1443,6 @@ networks: files dns
         but on a different partition.
       </para>
     </sect2>
-
-    <!-- TODO: please move this section to admin guide. Requirement from fate
-      #305036 is:
-      - how and what to backup / recommendations
-      o System configuration with YaST
-      - backup/restore recommentation:
-      o customized config settings
-      o ssh keys, certificates
-      o system data backup (hints)
-      o available backup tools
-      o 3rd party backup tools (marketing task)
-      -->
-
-    <!-- 2014-063-14 tbazant: commenting out (FATE#308682)
-      <sect2 id="sec-trouble-data-backup">
-      <title>Backing up critical data</title>
-      <procedure id="proc-trouble-data-backup">
-      <para>
-      System backups can be easily managed using the &yast; System Backup
-      module:
-      </para>
-      <step>
-      <para>
-      As &rootuser;, start &yast; and select <menuchoice>
-      <guimenu>System</guimenu> <guimenu>System Backup</guimenu>
-      </menuchoice>.
-      </para>
-      </step>
-      <step>
-      <para>
-      Create a backup profile holding all details needed for the backup,
-      file name of the archive file, scope, and type of the backup:
-      </para>
-      <substeps>
-      <step>
-      <para>
-      Select <menuchoice> <guimenu>Profile Management</guimenu>
-      <guimenu>Add</guimenu> </menuchoice>.
-      </para>
-      </step>
-      <step>
-      <para>
-      Enter a name for the archive.
-      </para>
-      </step>
-      <step>
-      <para>
-      Enter the path to the location of the backup if you want to keep a
-      local backup. For your backup to be archived on a network server
-      (via NFS), enter the IP address or name of the server and the
-      directory that should hold your archive.
-      </para>
-      </step>
-      <step>
-      <para>
-      Determine the archive type and click <guimenu>Next</guimenu>.
-      </para>
-      </step>
-      <step>
-      <para>
-      Determine the backup options to use, such as whether files not
-      belonging to any package should be backed up and whether a list of
-      files should be displayed prior to creating the archive. Also
-      determine whether changed files should be identified using the
-      time-consuming MD5 mechanism.
-      </para>
-      <para>
-      Use <guimenu>Expert</guimenu> to enter a dialog for the backup of
-      entire hard disk areas. Currently, this option only applies to the
-      Ext2 file system.
-      </para>
-      </step>
-      <step>
-      <para>
-      Finally, set the search constraints to exclude certain system areas
-      from the backup area that do not need to be backed up, such as lock
-      files or cache files. Add, edit, or delete items until your needs
-      are met and leave with <guimenu>OK</guimenu>.
-      </para>
-      </step>
-      </substeps>
-      </step>
-      <step>
-      <para>
-      Once you have finished the profile settings, you can start the backup
-      right away with <guimenu>Create Backup</guimenu> or configure
-      automatic backup. It is also possible to create other profiles
-      tailored for various other purposes.
-      </para>
-      </step>
-      </procedure>
-      <procedure id="proc-trouble-data-profile">
-      <para>
-      To configure automatic backup for a given profile, proceed as follows:
-      </para>
-      <step>
-      <para>
-      Select <guimenu>Automatic Backup</guimenu> from the <guimenu>Profile
-      Management</guimenu> menu.
-      </para>
-      </step>
-      <step>
-      <para>
-      Select <guimenu>Start Backup Automatically</guimenu>.
-      </para>
-      </step>
-      <step>
-      <para>
-      Determine the backup frequency. Choose <guimenu>daily</guimenu>,
-      <guimenu>weekly</guimenu>, or <guimenu>monthly</guimenu>.
-      </para>
-      </step>
-      <step>
-      <para>
-      Determine the backup start time. These settings depend on the backup
-      frequency selected.
-      </para>
-      </step>
-      <step>
-      <para>
-      Decide whether to keep old backups and how many should be kept. To
-      receive an automatically generated status message of the backup
-      process, check <guimenu>Send Summary Mail to User root</guimenu>.
-      </para>
-      </step>
-      <step>
-      <para>
-      Click <guimenu>OK</guimenu> to apply your settings and have the first
-      backup start at the time specified.
-      </para>
-      </step>
-      </procedure>
-      </sect2>
-      <sect2 id="sec-trouble-data-replay">
-      <title>Restoring a system backup</title>
-      <para>
-      Use the &yast; System Restoration module to restore the system
-      configuration from a backup. Restore the entire backup or select
-      specific components that were corrupted and need to be reset to their
-      old state.
-      </para>
-      <procedure id="proc-trouble-data-replay">
-      <step>
-      <para>
-      Start <menuchoice> <guimenu>&yast;</guimenu> <guimenu>System</guimenu>
-      <guimenu>System Restoration</guimenu> </menuchoice>.
-      </para>
-      </step>
-      <step>
-      <para>
-      Enter the location of the backup file. This could be a local file, a
-      network mounted file, or a file on a removable device. Then click
-      <guimenu>Next</guimenu>.
-      </para>
-      <para>
-      The following dialog displays a summary of the archive properties,
-      such as the file name, date of creation, type of backup, and optional
-      comments.
-      </para>
-      </step>
-      <step>
-      <para>
-      Review the archived content by clicking <guimenu>Archive
-      Content</guimenu>. Clicking <guimenu>OK</guimenu> returns you to the
-      <guimenu>Archive Properties</guimenu> dialog.
-      </para>
-      </step>
-      <step>
-      <para>
-      <guimenu>Expert Options</guimenu> opens a dialog in which to fine-tune
-      the restore process. Return to the <guimenu>Archive
-      Properties</guimenu> dialog by clicking <guimenu>OK</guimenu>.
-      </para>
-      </step>
-      <step>
-      <para>
-      Click <guimenu>Next</guimenu> to open the view of packages to restore.
-      Press <guimenu>Accept</guimenu> to restore all files in the archive or
-      use the various <guimenu>Select All</guimenu>, <guimenu>Deselect
-      All</guimenu>, and <guimenu>Select Files</guimenu> buttons to
-      fine-tune your selection. Only use the <guimenu>Restore RPM
-      Database</guimenu> option if the RPM database is corrupted or deleted
-      and this file is included in the backup.
-      </para>
-      </step>
-      <step>
-      <para>
-      After you click <guimenu>Accept</guimenu>, the backup is restored.
-      Click <guimenu>Finish</guimenu> to leave the module after the restore
-      process is completed.
-      </para>
-      </step>
-      </procedure>
-      </sect2>
-      -->
 
     <xi:include href="system_repair.xml"/>
   </sect1>

--- a/xml/troubleshooting.xml
+++ b/xml/troubleshooting.xml
@@ -1019,26 +1019,6 @@
             authentication problems for this user. Try graphical login again.
           </para>
         </step>
-        <!--
-          <step>
-          <para>
-          If graphical login still fails, do a console login with <keycombo>
-          <keycap function="control"/>
-          <keycap function="alt"/> <keycap>F1</keycap> </keycombo>.
-          Try to start an X session on another display&mdash;the first one
-          (<literal>:0</literal>) is already in use:
-          </para>
-          <screen>startx -\- :1</screen>
-          <para>
-          This should bring up a graphical screen and your desktop. If it does
-          not, check the log files of the X Window System
-          (<filename>/var/log/Xorg.<replaceable>DISPLAYNUMBER</replaceable>.log</filename>)
-          or the log file for your desktop applications
-          (<filename>.xsession-errors</filename> in the user's home directory)
-          for any irregularities.
-          </para>
-          </step>
-          -->
         <step>
           <para>
             If the desktop could not start because of corrupt configuration


### PR DESCRIPTION
### PR creator: Description

Fixing grub rescue target instructions


### PR creator: Are there any relevant issues/feature requests?

* bsc#1193363


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
