### PR TITLE
Removed cron from SLE

### DIFF
--- a/xml/adm_support.xml
+++ b/xml/adm_support.xml
@@ -1165,7 +1165,7 @@ Creating Tar Ball
      <para>
       After the appliance is set up and running, no more manual interaction is
       required. This way of setting up the appliance is therefore ideal for
-      using cron jobs to create and upload Supportconfig archives.
+      using &systemd; timers to create and upload Supportconfig archives.
      </para>
      <step>
       <para>
@@ -1603,7 +1603,7 @@ vsftpd yast2 yast2-ftp-server
      <title>Updates of SCA patterns</title>
      <para>
       By default, all <systemitem class="resource">sca-patterns-*</systemitem>
-      packages are updated regularly by a &rootuser; cron job that executes the
+      packages are updated regularly by a &systemd; timer that executes the
       <filename>sdagent-patterns</filename> script nightly, which in turn runs
       <command>zypper update sca-patterns-*</command>. A regular system update
       will update all SCA appliance and pattern packages. To update the SCA

--- a/xml/audit_components.xml
+++ b/xml/audit_components.xml
@@ -1701,7 +1701,7 @@ Syscall Report
 =======================================
 # date time syscall pid comm auid event
 =======================================
-1. 16/02/09 17:45:01 2 20343 cron -1 2279
+1. 16/02/09 17:45:01 2 20343 auditctl -1 2279
 2. 16/02/09 17:45:02 83 20350 mktemp 0 2284
 3. 16/02/09 17:45:02 83 20351 mkdir 0 2285</screen>
      </listitem>
@@ -2234,7 +2234,7 @@ Syscall Report
 =======================================
 # date time syscall pid comm auid event
 =======================================
-1. 16/02/09 17:45:01 open 20343 cron unset 2279
+1. 16/02/09 17:45:01 open 20343 auditctl unset 2279
 2. 16/02/09 17:45:02 mkdir 20350 mktemp root 2284
 3. 16/02/09 17:45:02 mkdir 20351 mkdir root 2285
 ...</screen>

--- a/xml/audit_setup.xml
+++ b/xml/audit_setup.xml
@@ -597,8 +597,8 @@ type=SYSCALL msg=audit(1234885703.090:7889): arch=c000003e syscall=191 success=n
   </tip>
 
   <para>
-   All steps (except for the last one) can be run automatically and would
-   easily be scriptable and configured as cron jobs. Any of the
+   All steps (except for the last one) can be run automatically and would easily
+   be scriptable and configured as &systemd; timers. Any of the
    <literal>--failed --summary</literal> reports could be transformed easily
    into a bar chart that plots files versus failed access attempts. For more
    information about visualizing audit report data, refer to
@@ -610,9 +610,9 @@ type=SYSCALL msg=audit(1234885703.090:7889): arch=c000003e syscall=191 success=n
 
   <para>
    Using the scripts <command>mkbar</command> and <command>mkgraph</command>
-   you can illustrate your audit statistics with various graphs and charts.
-   As with any other <command>aureport</command> command, the plotting
-   commands are scriptable and can easily be configured to run as cron jobs.
+   you can illustrate your audit statistics with various graphs and charts. As
+   with any other <command>aureport</command> command, the plotting commands are
+   scriptable and can easily be configured to run as &systemd; timers.
   </para>
 
   <para>

--- a/xml/chrony.xml
+++ b/xml/chrony.xml
@@ -40,16 +40,10 @@
   reference clocks, such as radio-controlled clocks.
  </para>
  <para>
-  Since &productname; 15, &chrony; is the default implementation of NTP.
-  &chrony; includes two parts; &chronyd; is a daemon that can be started at
-  boot time and &chronyc; is a command line interface program to monitor the
-  performance of &chronyd;, and to change various operating parameters at
-  runtime.
- </para>
- <para>
-  Starting with &productname;&nbsp;15.2, the &yast; module for NTP client
-  configuration configures the systemd-timer instead of the cron daemon
-  to execute &chrony;, when it is not configured to run as a daemon.
+  &chrony; is the default implementation of NTP. &chrony; includes two parts;
+  &chronyd; is a daemon that can be started at boot time and &chronyc; is a
+  command line interface program to monitor the performance of &chronyd;, and to
+  change various operating parameters at runtime.
  </para>
  <note os="sled;osuse">
   <para>

--- a/xml/deployment_pxe.xml
+++ b/xml/deployment_pxe.xml
@@ -741,10 +741,10 @@ F10 <replaceable>FILENAME</replaceable></screen>
    </para>
    <para>
        When computers are shut down they usually are not turned all the way off,
-       but remain in a low power mode. When the network interface supports WOL, it
-       listens for the magic packet wakeup signal when the machine is powered off.
-       You can send the magic packet manually, or schedule wakeups in a cron job
-       on the sending machine.
+       but remain in a low power mode. When the network interface supports WOL,
+       it listens for the magic packet wakeup signal when the machine is powered
+       off. You can send the magic packet manually, or schedule wakeups in a
+       &systemd; timer on the sending machine.
    </para>
 
   <sect2 xml:id="sec-deployment-prep-boot-wol-prereqs">

--- a/xml/security_kerberos.xml
+++ b/xml/security_kerberos.xml
@@ -724,8 +724,8 @@ group:          files</screen>
     KDC itself needs to be synchronized to the common time source as well.
     Because running an NTP daemon on this machine would be a security risk, it
     is a good idea to do this by running <command>chronyd -q</command>
-    via a cron job. To configure your machine as an NTP client, proceed as
-    outlined in <xref linkend="sec-ntp-yast"/>.
+    via a &systemd; timer. To configure your machine as an NTP client, proceed
+    as outlined in <xref linkend="sec-ntp-yast"/>.
    </para>
    <para>
     A different way to secure the time service and still use the NTP daemon is

--- a/xml/security_ssh.xml
+++ b/xml/security_ssh.xml
@@ -168,10 +168,10 @@ Host key verification failed.</screen>
      <term>Passphrase-less public key authentication</term>
      <listitem>
       <para>
-       Public key authentication, paired with private identity keys that do
-       not have passphrases. This is useful for automated services, like
-       scripts and cron jobs. You must protect private keys, because anyone
-       who gains access to them can easily masquerade as the key owner.
+       Public key authentication, paired with private identity keys that do not
+       have passphrases. This is useful for automated services, like scripts and
+       &systemd; timers. You must protect private keys, because anyone who gains
+       access to them can easily masquerade as the key owner.
       </para>
      </listitem>
     </varlistentry>
@@ -838,12 +838,12 @@ Have a lot of fun...</screen>
   <sect1 xml:id="sec-ssh-passphrase-less-auth">
   <title>Passphrase-less public key authentication</title>
   <para>
-    This is public key authentication without a passphrase. Create
-    your new private identity keys without a passphrase, and then use them
-    the same way as passphrase-protected keys. This is useful for automated
-    services, such as scripts and cron jobs. However, anyone who succeeds in
-    stealing the private key can easily masquerade as you, so you need to be
-    protective of a passphrase-less private key.
+    This is public key authentication without a passphrase. Create your new
+    private identity keys without a passphrase, and then use them the same way
+    as passphrase-protected keys. This is useful for automated services, such as
+    scripts and &systemd; timers. However, anyone who succeeds in stealing the
+    private key can easily masquerade as you, so you need to be protective of a
+    passphrase-less private key.
   </para>
   <para>
    An alternative to using keys without passphrases is

--- a/xml/snapper.xml
+++ b/xml/snapper.xml
@@ -2224,8 +2224,8 @@ rm -rf /.snapshots/SNAPSHOTNUMBER</screen>
     </para>
    </tip>
    <para>
-    Snapshots are also automatically deleted by a daily cron job. Refer to
-    <xref linkend="sec-snapper-manage-metadata-cleanup"/> for details.
+    Snapshots are also automatically deleted daily by a &systemd; timer. Refer
+    to <xref linkend="sec-snapper-manage-metadata-cleanup"/> for details.
    </para>
   </sect2>
  </sect1>

--- a/xml/suse_sw_packages.xml
+++ b/xml/suse_sw_packages.xml
@@ -16,9 +16,8 @@
  </info>
 
  <para>
-  The following chapter provides basic information about the following tools: <systemitem
-  class="resource">bash</systemitem>, <systemitem
-  class="resource">cron</systemitem>, <systemitem
+  The following chapter provides basic information about the following tools:
+  <systemitem class="resource">bash</systemitem>, <systemitem
   class="resource">logrotate</systemitem>, <systemitem
   class="resource">locate</systemitem>, <systemitem
   class="resource">ulimit</systemitem> and <systemitem
@@ -71,98 +70,6 @@
 &prompt.user;cp /etc/skel/.profile ~/.profile</screen>
   <para>
    Then copy personal adjustments back from the <literal>*.old</literal> files.
-  </para>
- </sect2>
-
- <sect2 xml:id="sec-suse-packages-cron">
-  <title>The <phrase>cron</phrase> package</title>
-  <para>
-   Use <systemitem class="daemon">cron</systemitem> to automatically run
-   commands in the background at predefined times. <systemitem
-    class="daemon">cron</systemitem> uses specially formatted time tables, and
-   the tool comes with several default ones. Users can also specify custom
-   tables, if needed.
-  </para>
-  <para>
-   The cron tables are located in <filename>/var/spool/cron/tabs</filename>.
-   <filename>/etc/crontab</filename> serves as a systemwide cron table. Enter
-   the user name to run the command directly after the time table and before
-   the command. In <xref linkend="ex-suse-packages-cron"/>,
-   <systemitem class="username">root</systemitem> is entered. Package-specific
-   tables, located in <filename>/etc/cron.d</filename>, have the same format.
-   See the <command>cron</command> man page (<command>man cron</command>).
-  </para>
-  <example xml:id="ex-suse-packages-cron">
-   <title>Entry in /etc/crontab</title>
-<screen>1-59/5 * * * *   root   test -x /usr/sbin/atrun &amp;&amp; /usr/sbin/atrun</screen>
-  </example>
-  <para>
-   You cannot edit <filename>/etc/crontab</filename> by calling the command
-   <command>crontab -e</command>. This file must be loaded directly into an
-   editor, then modified and saved.
-  </para>
-  <para>
-   Several packages install shell scripts to the directories
-   <filename>/etc/cron.hourly</filename>, <filename>/etc/cron.daily</filename>,
-   <filename>/etc/cron.weekly</filename> and
-   <filename>/etc/cron.monthly</filename>, whose execution is controlled by
-   <filename>/usr/lib/cron/run-crons</filename>.
-   <filename>/usr/lib/cron/run-crons</filename> is run every 15 minutes from
-   the main table (<filename>/etc/crontab</filename>). This guarantees that
-   processes that may have been neglected can be run at the proper time.
-  </para>
-  <para>
-   To run the <filename>hourly</filename>, <filename>daily</filename> or other
-   periodic maintenance scripts at custom times, remove the time stamp files
-   regularly using <filename>/etc/crontab</filename> entries (see
-   <xref linkend="ex-suse-packages-cron-time"/>, which removes the
-   <filename>hourly</filename> one before every full hour, the
-   <filename>daily</filename> one once a day at 2:14 a.m., etc.).
-  </para>
-  <example xml:id="ex-suse-packages-cron-time">
-   <title>/etc/crontab: remove time stamp files</title>
-<screen>59 *  * * *     root  rm -f /var/spool/cron/lastrun/cron.hourly
-14 2  * * *     root  rm -f /var/spool/cron/lastrun/cron.daily
-29 2  * * 6     root  rm -f /var/spool/cron/lastrun/cron.weekly
-44 2  1 * *     root  rm -f /var/spool/cron/lastrun/cron.monthly</screen>
-  </example>
-  <para>
-   Or you can set <literal>DAILY_TIME</literal> in
-   <filename>/etc/sysconfig/cron</filename> to the time at which
-   <filename>cron.daily</filename> should start. The setting of
-   <literal>MAX_NOT_RUN</literal> ensures that the daily tasks get triggered to
-   run, even if the user did not turn on the computer at the specified
-   <literal>DAILY_TIME</literal> for a longer time. The maximum value of
-   <literal>MAX_NOT_RUN</literal> is 14 days.
-  </para>
-  <para>
-   The daily system maintenance jobs are distributed to various scripts for
-   reasons of clarity. They are contained in the package
-   <systemitem class="resource">aaa_base</systemitem>.
-   <filename>/etc/cron.daily</filename> contains, for example, the components
-   <filename>suse.de-backup-rpmdb</filename>,
-   <filename>suse.de-clean-tmp</filename> or
-   <filename>suse.de-cron-local</filename>.
-   <remark role="trans">"suse.de" is just a prefix to avoid naming clashes with
-   third party provided scripts; read it as: these are scripts provided by
-   SUSE.  They are not German packages and you must not localize these filename
-   in any way.</remark>
-  </para>
- </sect2>
-
- <sect2 xml:id="sec-suse-packages-cronstatus">
-  <title>Stopping cron status messages</title>
-  <para>
-   To avoid the mail flood caused by cron status messages, the default value of
-   <literal>SEND_MAIL_ON_NO_ERROR</literal> in
-   <filename>/etc/sysconfig/cron</filename> is set to "<literal>no</literal>"
-   for new installations. Even with this setting to "<literal>no</literal>",
-   cron data output will still be sent to the <literal>MAILTO</literal>
-   address, as documented in the cron man page.
-  </para>
-  <para>
-   In the update case it is recommended to set these values according to your
-   needs.
   </para>
  </sect2>
 

--- a/xml/utilities.xml
+++ b/xml/utilities.xml
@@ -2586,11 +2586,10 @@ Ctrl-c - Quit   TAB - Tuning
    </note>
    <para>
     The <systemitem class="resource">mcelog</systemitem> package logs and
-    parses/translates Machine Check Exceptions (MCE) on hardware errors, including
-    I/O, CPU, and memory errors. Additionally, mcelog handles predictive bad page
-    offlining and automatic core offlining when cache errors happen.
-    Formerly this was managed by a cron job executed hourly. Now hardware
-    errors are immediately processed by an mcelog daemon.
+    parses/translates Machine Check Exceptions (MCE) on hardware errors,
+    including I/O, CPU, and memory errors. Additionally, mcelog handles
+    predictive bad page offlining and automatic core offlining when cache errors
+    happen. Hardware errors are immediately processed by an mcelog daemon.
    </para>
    <note>
     <title>Support for AMD scalable MCA</title>

--- a/xml/zypper.xml
+++ b/xml/zypper.xml
@@ -336,7 +336,7 @@ Zypper subcommands available from elsewhere on your $PATH
    </para>
 <screen>&prompt.sudo;zypper <option>--non-interactive</option> install <replaceable>PACKAGE_NAME</replaceable></screen>
    <para>
-    This option allows the use of Zypper in scripts and cron jobs.
+    This option allows the use of Zypper in scripts and &systemd; timers.
    </para>
   </sect3>
   <sect3 xml:id="sec-zypper-softman-sources">


### PR DESCRIPTION
### PR creator: Description

cron is going to be replaced by systemd timers. this update reflects it


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
