### PR TITLE
Updated QEMU support statement

### DIFF
--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -17,7 +17,13 @@
   </info>
   <important>
     <para>
-      The &qemu; emulation is only supported on &kvm; and &xen; hypervisors.
+      &qemu; is only supported when used for virtualization together with the
+      &kvm; or &xen; hypervisors. The TCG accelerator is not supported, even
+      when it is distributed within &suse; products. Users must not rely on
+      &qemu; TCG to provide guest isolation, or for any security guarantees. See
+      also
+      <link
+      xlink:href="https://qemu-project.gitlab.io/qemu/system/security.html"/>.
     </para>
   </important>
   <sect1 xml:id="sec-architecture-support">


### PR DESCRIPTION
### PR creator: Description

QEMU support statement is clearer now

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ x SLE 15 SP1
- SLE 12
  - [x] SLE 12 SP5
  - [x] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
