### PR TITLE
Virt Best Practices: add scsi persistent reservation on multipathed

### DIFF
--- a/xml/art_virtualization-best-practices.xml
+++ b/xml/art_virtualization-best-practices.xml
@@ -3241,6 +3241,239 @@ LC_ALL=C PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
       </para>
 <screen>&prompt.root;<command>echo 1 > /sys/devices/system/cpu/cpu<replaceable>X</replaceable>/online</command></screen>
     </sect2>
+
+    <sect2 xml:id="sec-vm-guest-scsi-pr">
+      <title>SCSI persistent reservation on a multipathed device</title>
+      <para>
+        SCSI persistent reservations allow restricting access to block devices
+        in a shared storage setup, to avoid improper multiple parallel accesses
+        to the same block device from software components on local or remote
+	hosts, which could lead to device damage, data corruption.
+      </para>
+      <para>
+        About how to manage storage multipath I/O, Please refer to
+        <link
+          xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-multipath.html#">Managing multipath I/O for devices</link>
+      </para>
+      <para>
+        About SCSI persistent reservations, Please refer to
+        <link
+          xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-multipath.html#sec-multipath-mpiotools-mpathpersist">SCSI persistent reservations and mpathpersist</link>
+      </para>
+      <para>
+	For virtualization scenario, QEMU's SCSI passthrough devices <literal>scsi-block</literal>
+        and <literal>scsi-generic</literal> support passing guest persistent
+        reservation requests to a privileged external helper program.
+        The <literal>qemu-pr-helper</literal> is that external helper, It needs
+        to start before QEMU, creates a listener socket which will accept
+        incoming connections for communication with QEMU.
+      </para>
+      <note>
+        <title>Live migration scenario with multipathed devices</title>
+        <para>
+          We recommend using the multipath alias instead of wwid, It's helpful
+          in &vmguest; live migration scenario, as it can make sure the storage path
+          are identical between source host and destination host.
+        </para>
+        <para>
+          About aliases for multipath, Please refer to
+          <link
+	    xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-multipath.html#sec-multipath-alias">Setting aliases for multipath maps</link>
+        </para>
+        <para>
+          About wwid for multipath, Please refer to
+          <link
+	    xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-multipath.html#id-1.11.6.6.4.5">Multipath terminology</link>
+        </para>
+      </note>
+      <sect3 xml:id="sec-vm-guest-scsi-pr-guide">
+        <title>Step-by-Step guide</title>
+	<para>
+          How to do scsi persistent reservation in a VM Guest against the related multipathed device in the host:
+        </para>
+	<para>
+          1. In the host, Create Multipath environment, Please refer to
+          <link
+	    xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-multipath.html#sec-multipath-config">Configuring the system for multipathing</link>
+          and
+          <link
+            xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-multipath.html#sec-multipath-conf-file">Multipath configuration</link>
+        </para>
+	<para>
+          2. In the host, Configure <literal>reservations</literal> sub-element of the
+          <literal>source</literal> element of the <literal>disk</literal> element
+          for the passed-through lun in your libvirt domain configuration. Please
+          refer to
+          <link
+            xlink:href="https://libvirt.org/formatdomain.html">Libvirt Domain XML format</link>
+        </para>
+	<para>
+          3. In the &vmguest;, Install the sg3_utils package, Reserve the scsi disks
+          on-demand by sg_persist command.
+        </para>
+      </sect3>
+      <sect3 xml:id="sec-vm-guest-scsi-pr-example">
+        <title>Example</title>
+	<para>
+          1. In the host, Make sure the multipathd.service is running, and we have
+          such a multipathed disk which is named <literal>storage1</literal>:
+        </para>
+<screen>&prompt.user;&sudo; systemctl status multipathd.service
+● multipathd.service - Device-Mapper Multipath Device Controller
+     Loaded: loaded (/usr/lib/systemd/system/multipathd.service; enabled; preset: disabled)
+     Active: active (running) since Sat 2023-08-26 21:34:13 CST; 1 week 1 day ago
+TriggeredBy: ○ multipathd.socket
+   Main PID: 79411 (multipathd)
+     Status: "up"
+      Tasks: 7
+        CPU: 1min 43.514s
+     CGroup: /system.slice/multipathd.service
+             └─79411 /sbin/multipathd -d -s</screen>
+<screen>&prompt.user;&sudo; multipath -ll
+storage1 (36589cfc000000537c47ad3eb2b20216e) dm-6 TrueNAS,iSCSI Disk
+size=50G features='0' hwhandler='1 alua' wp=rw
+|-+- policy='service-time 0' prio=50 status=active
+| `- 16:0:0:0 sdg 8:96  active ready running
+`-+- policy='service-time 0' prio=50 status=enabled
+  `- 17:0:0:0 sdh 8:112 active ready running</screen>
+
+        <para>
+          2. In the host, Add the disk element in the &vmguest; configuration file
+          (by running virsh edit CONFIGURATION):
+	</para>
+<screen>&lt;disk type='block' device='lun'<co xml:id="co-disk-lunpassthrough"/>&gt;
+  &lt;driver name='qemu' type='raw'/&gt;
+  &lt;source dev='/dev/mapper/storage1'&gt;
+    &lt;reservations<co xml:id="co-disk-reserve"/> managed='yes'<co xml:id="co-disk-reserve-managed"/>/&gt;
+  &lt;/source&gt;
+  &lt;target dev='sda' bus='scsi'/&gt;
+  &lt;address type='drive' controller='0' bus='0' target='0' unit='0'<co xml:id="co-disk-scsi-hba-unit"/>/&gt;
+&lt;/disk&gt;</screen>
+        <calloutlist>
+          <callout arearefs="co-disk-lunpassthrough">
+            <para>
+              In order to support persistent reservations, disks must be marked as
+              <literal>lun</literal> with type <literal>block</literal> so that
+              &qemu; does SCSI passthrough.
+            </para>
+          </callout>
+          <callout arearefs="co-disk-reserve">
+            <para>
+              If present it enables persistent reservations for SCSI based disks.
+              The element has one mandatory attribute <literal>managed</literal>
+              with accepted values <literal>yes</literal> and <literal>no</literal>.
+            </para>
+          </callout>
+          <callout arearefs="co-disk-reserve-managed">
+            <para>
+              If <literal>managed</literal> is <literal>yes</literal> libvirt
+              prepares and manages any resources needed.
+            </para>
+            <para>
+              When the value of the attribute <literal>managed</literal> is
+              <literal>no</literal>, then the hypervisor acts as a client and the
+              path to the server socket must be provided in the child element
+              source, which currently accepts only the following attributes:
+              <literal>type</literal> with one value <literal>unix</literal>,
+              <literal>path</literal> with value to the socket, and finally
+              <literal>mode</literal> which accepts the unique valid value
+              <literal>client</literal> specifying the role of hypervisor. It's
+              recommended to allow libvirt manage the persistent reservations.
+            </para>
+          </callout>
+          <callout arearefs="co-disk-scsi-hba-unit">
+            <para>
+              please make sure the virtio-scsi HBA that the disk attaches already
+              exists and has available units(maximum count of units per virtio-scsi
+              HBA is 7), Otherwise you need to manually add a virtio-scsi HBA to
+              avoid automatically adding the LSI HBA by libvirt. For example:
+<screen>&lt;controller type='scsi' index='0' model='virtio-scsi'&gt;
+  &lt;address type='pci' domain='0x0000' bus='0x03' slot='0x00' function='0x0'/&gt;
+&lt;/controller&gt;</screen>
+            </para>
+          </callout>
+        </calloutlist>
+
+<screen>&prompt.user;&sudo; virsh domblklist sles15sp5
+ Target   Source
+---------------------------------------------
+ vda      /mnt/images/sles15sp5/disk0.qcow2
+ sda      /dev/mapper/storage1</screen>
+        <para>
+          3. In the host, Start the &vmguest;, We'll see that libvirt launches
+          a qemu-pr-helper instance as the server role for the &vmguest; sles15sp5,
+          then launches the &vmguest; sles15sp5 as the client role.
+        </para>
+<screen>&prompt.user;&sudo; virsh start sles15sp5
+Domain 'sles15sp5' started</screen>
+
+<screen>&prompt.user;&sudo; virsh list
+ Id   Name        State
+---------------------------
+ 4    sles15sp5   running</screen>
+
+<screen>&prompt.user;&sudo; ps -eo pid,args | grep -v grep | grep qemu-pr-helper
+37063 /usr/bin/qemu-pr-helper -k /var/lib/libvirt/qemu/domain-4-sles15sp5/pr-helper0.sock</screen>
+
+<screen>&prompt.user;&sudo; virsh dumpxml sles15sp5 | grep -A11 "&lt;disk type='block' device='lun'&gt;
+&lt;disk type='block' device='lun'&gt;
+  &lt;driver name='qemu' type='raw'/&gt;
+  &lt;source dev='/dev/mapper/storage1' index='1'&gt;
+    &lt;reservations managed='yes'&gt;
+      &lt;source type='unix' path='/var/lib/libvirt/qemu/domain-4-sles15sp5/pr-helper0.sock' mode='client'/&gt;
+    &lt;/reservations&gt;
+  &lt;/source&gt;
+  &lt;backingStore/&gt;
+  &lt;target dev='sda' bus='scsi'/&gt;
+  &lt;alias name='scsi0-0-0-0'/&gt;
+  &lt;address type='drive' controller='0' bus='0' target='0' unit='0'/&gt;
+&lt;/disk&gt;</screen>
+
+        <para>
+          4. In the &vmguest;, Reserve the scsi disk(sda) with the key <literal>123abc</literal>
+        </para>
+<screen>&prompt.user;lsblk
+NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
+sda      8:0    0   50G  0 disk
+vda    253:0    0   20G  0 disk
+├─vda1 253:1    0    8M  0 part
+├─vda2 253:2    0    2G  0 part [SWAP]
+└─vda3 253:3    0   18G  0 part /</screen>
+
+<screen>&prompt.user;&sudo; sg_persist --verbose --out --register --param-sark=123abc /dev/sda
+    inquiry cdb: [12 00 00 00 24 00]
+  TrueNAS   iSCSI Disk        0123
+  Peripheral device type: disk
+    Persistent reservation out cdb: [5f 00 00 00 00 00 00 00 18 00]
+PR out: command (Register) successful</screen>
+
+<screen>&prompt.user;&sudo; sg_persist --verbose --in -k /dev/sda
+    inquiry cdb: [12 00 00 00 24 00]
+  TrueNAS   iSCSI Disk        0123
+  Peripheral device type: disk
+    Persistent reservation in cdb: [5e 00 00 00 00 00 00 20 00 00]
+  PR generation=0x5, 2 registered reservation keys follow:
+    0x123abc
+    0x123abc</screen>
+
+        <para>
+          5. In the &vmguest;, Release the sda with the key <literal>123abc</literal>
+        </para>
+<screen>&prompt.user;&sudo; sg_persist --verbose --out --clear --param-rk=123abc /dev/sda
+    inquiry cdb: [12 00 00 00 24 00]
+  TrueNAS   iSCSI Disk        0123
+  Peripheral device type: disk
+    Persistent reservation out cdb: [5f 03 00 00 00 00 00 00 18 00]
+PR out: command (Clear) successful</screen>
+
+<screen>&prompt.user;&sudo; sg_persist --verbose --in -k /dev/sda
+    inquiry cdb: [12 00 00 00 24 00]
+  TrueNAS   iSCSI Disk        0123
+  Peripheral device type: disk
+    Persistent reservation in cdb: [5e 00 00 00 00 00 00 20 00 00]
+  PR generation=0x6, there are NO registered reservation keys</screen>
+      </sect3>
+    </sect2>
   </sect1>
   <!-- TODO
     <sect2 id="vt-best-guest-clock">

--- a/xml/art_virtualization-best-practices.xml
+++ b/xml/art_virtualization-best-practices.xml
@@ -3246,77 +3246,82 @@ LC_ALL=C PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
       <title>SCSI persistent reservation on a multipathed device</title>
       <para>
         SCSI persistent reservations allow restricting access to block devices
-        in a shared storage setup, to avoid improper multiple parallel accesses
-        to the same block device from software components on local or remote
-	hosts, which could lead to device damage, data corruption.
+        in a shared storage setup. This avoids improper multiple parallel
+        accesses to the same block device from software components on local or
+        remote hosts, which could lead to device damage, data corruption.
       </para>
       <para>
-        About how to manage storage multipath I/O, Please refer to
-        <link
-          xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-multipath.html#">Managing multipath I/O for devices</link>
+        Find more information on managing storage multipath I/O in
+        <xref linkend="cha-multipath"/>.
       </para>
       <para>
-        About SCSI persistent reservations, Please refer to
-        <link
-          xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-multipath.html#sec-multipath-mpiotools-mpathpersist">SCSI persistent reservations and mpathpersist</link>
+        Find more information about SCSI persistent reservations in
+        <xref linkend="sec-multipath-mpiotools-mpathpersist"/>.
       </para>
       <para>
-	For virtualization scenario, QEMU's SCSI passthrough devices <literal>scsi-block</literal>
-        and <literal>scsi-generic</literal> support passing guest persistent
-        reservation requests to a privileged external helper program.
-        The <literal>qemu-pr-helper</literal> is that external helper, It needs
-        to start before QEMU, creates a listener socket which will accept
-        incoming connections for communication with QEMU.
+        For virtualization scenario, QEMU's SCSI passthrough devices
+        <literal>scsi-block</literal> and <literal>scsi-generic</literal>
+        support passing guest persistent reservation requests to a privileged
+        external helper program. The <literal>qemu-pr-helper</literal> is that
+        external helper, It needs to start before QEMU, creates a listener
+        socket which will accept incoming connections for communication with
+        QEMU.
       </para>
       <note>
         <title>Live migration scenario with multipathed devices</title>
         <para>
           We recommend using the multipath alias instead of wwid, It's helpful
-          in &vmguest; live migration scenario, as it can make sure the storage path
-          are identical between source host and destination host.
+          in &vmguest; live migration scenario, as it can make sure the storage
+          path are identical between source host and destination host.
         </para>
         <para>
           About aliases for multipath, Please refer to
           <link
-	    xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-multipath.html#sec-multipath-alias">Setting aliases for multipath maps</link>
+	    xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-multipath.html#sec-multipath-alias">Setting
+          aliases for multipath maps</link>
         </para>
         <para>
           About wwid for multipath, Please refer to
           <link
-	    xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-multipath.html#id-1.11.6.6.4.5">Multipath terminology</link>
+	    xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-multipath.html#id-1.11.6.6.4.5">Multipath
+          terminology</link>
         </para>
       </note>
       <sect3 xml:id="sec-vm-guest-scsi-pr-guide">
         <title>Step-by-Step guide</title>
-	<para>
-          How to do scsi persistent reservation in a VM Guest against the related multipathed device in the host:
+        <para>
+          How to do scsi persistent reservation in a VM Guest against the
+          related multipathed device in the host:
         </para>
-	<para>
+        <para>
           1. In the host, Create Multipath environment, Please refer to
           <link
-	    xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-multipath.html#sec-multipath-config">Configuring the system for multipathing</link>
-          and
+	    xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-multipath.html#sec-multipath-config">Configuring
+          the system for multipathing</link> and
           <link
-            xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-multipath.html#sec-multipath-conf-file">Multipath configuration</link>
+            xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-multipath.html#sec-multipath-conf-file">Multipath
+          configuration</link>
         </para>
-	<para>
-          2. In the host, Configure <literal>reservations</literal> sub-element of the
-          <literal>source</literal> element of the <literal>disk</literal> element
-          for the passed-through lun in your libvirt domain configuration. Please
-          refer to
+        <para>
+          2. In the host, Configure <literal>reservations</literal> sub-element
+          of the <literal>source</literal> element of the
+          <literal>disk</literal> element for the passed-through lun in your
+          libvirt domain configuration. Please refer to
           <link
-            xlink:href="https://libvirt.org/formatdomain.html">Libvirt Domain XML format</link>
+            xlink:href="https://libvirt.org/formatdomain.html">Libvirt
+          Domain XML format</link>
         </para>
-	<para>
-          3. In the &vmguest;, Install the sg3_utils package, Reserve the scsi disks
-          on-demand by sg_persist command.
+        <para>
+          3. In the &vmguest;, Install the sg3_utils package, Reserve the scsi
+          disks on-demand by sg_persist command.
         </para>
       </sect3>
       <sect3 xml:id="sec-vm-guest-scsi-pr-example">
         <title>Example</title>
-	<para>
-          1. In the host, Make sure the multipathd.service is running, and we have
-          such a multipathed disk which is named <literal>storage1</literal>:
+        <para>
+          1. In the host, Make sure the multipathd.service is running, and we
+          have such a multipathed disk which is named
+          <literal>storage1</literal>:
         </para>
 <screen>&prompt.user;&sudo; systemctl status multipathd.service
 ● multipathd.service - Device-Mapper Multipath Device Controller
@@ -3336,11 +3341,10 @@ size=50G features='0' hwhandler='1 alua' wp=rw
 | `- 16:0:0:0 sdg 8:96  active ready running
 `-+- policy='service-time 0' prio=50 status=enabled
   `- 17:0:0:0 sdh 8:112 active ready running</screen>
-
         <para>
-          2. In the host, Add the disk element in the &vmguest; configuration file
-          (by running virsh edit CONFIGURATION):
-	</para>
+          2. In the host, Add the disk element in the &vmguest; configuration
+          file (by running virsh edit CONFIGURATION):
+        </para>
 <screen>&lt;disk type='block' device='lun'<co xml:id="co-disk-lunpassthrough"/>&gt;
   &lt;driver name='qemu' type='raw'/&gt;
   &lt;source dev='/dev/mapper/storage1'&gt;
@@ -3352,16 +3356,17 @@ size=50G features='0' hwhandler='1 alua' wp=rw
         <calloutlist>
           <callout arearefs="co-disk-lunpassthrough">
             <para>
-              In order to support persistent reservations, disks must be marked as
-              <literal>lun</literal> with type <literal>block</literal> so that
-              &qemu; does SCSI passthrough.
+              In order to support persistent reservations, disks must be marked
+              as <literal>lun</literal> with type <literal>block</literal> so
+              that &qemu; does SCSI passthrough.
             </para>
           </callout>
           <callout arearefs="co-disk-reserve">
             <para>
-              If present it enables persistent reservations for SCSI based disks.
-              The element has one mandatory attribute <literal>managed</literal>
-              with accepted values <literal>yes</literal> and <literal>no</literal>.
+              If present it enables persistent reservations for SCSI based
+              disks. The element has one mandatory attribute
+              <literal>managed</literal> with accepted values
+              <literal>yes</literal> and <literal>no</literal>.
             </para>
           </callout>
           <callout arearefs="co-disk-reserve-managed">
@@ -3371,29 +3376,30 @@ size=50G features='0' hwhandler='1 alua' wp=rw
             </para>
             <para>
               When the value of the attribute <literal>managed</literal> is
-              <literal>no</literal>, then the hypervisor acts as a client and the
-              path to the server socket must be provided in the child element
-              source, which currently accepts only the following attributes:
-              <literal>type</literal> with one value <literal>unix</literal>,
-              <literal>path</literal> with value to the socket, and finally
-              <literal>mode</literal> which accepts the unique valid value
-              <literal>client</literal> specifying the role of hypervisor. It's
-              recommended to allow libvirt manage the persistent reservations.
+              <literal>no</literal>, then the hypervisor acts as a client and
+              the path to the server socket must be provided in the child
+              element source, which currently accepts only the following
+              attributes: <literal>type</literal> with one value
+              <literal>unix</literal>, <literal>path</literal> with value to
+              the socket, and finally <literal>mode</literal> which accepts the
+              unique valid value <literal>client</literal> specifying the role
+              of hypervisor. It's recommended to allow libvirt manage the
+              persistent reservations.
             </para>
           </callout>
           <callout arearefs="co-disk-scsi-hba-unit">
             <para>
-              please make sure the virtio-scsi HBA that the disk attaches already
-              exists and has available units(maximum count of units per virtio-scsi
-              HBA is 7), Otherwise you need to manually add a virtio-scsi HBA to
-              avoid automatically adding the LSI HBA by libvirt. For example:
+              please make sure the virtio-scsi HBA that the disk attaches
+              already exists and has available units(maximum count of units per
+              virtio-scsi HBA is 7), Otherwise you need to manually add a
+              virtio-scsi HBA to avoid automatically adding the LSI HBA by
+              libvirt. For example:
 <screen>&lt;controller type='scsi' index='0' model='virtio-scsi'&gt;
   &lt;address type='pci' domain='0x0000' bus='0x03' slot='0x00' function='0x0'/&gt;
 &lt;/controller&gt;</screen>
             </para>
           </callout>
         </calloutlist>
-
 <screen>&prompt.user;&sudo; virsh domblklist sles15sp5
  Target   Source
 ---------------------------------------------
@@ -3401,20 +3407,17 @@ size=50G features='0' hwhandler='1 alua' wp=rw
  sda      /dev/mapper/storage1</screen>
         <para>
           3. In the host, Start the &vmguest;, We'll see that libvirt launches
-          a qemu-pr-helper instance as the server role for the &vmguest; sles15sp5,
-          then launches the &vmguest; sles15sp5 as the client role.
+          a qemu-pr-helper instance as the server role for the &vmguest;
+          sles15sp5, then launches the &vmguest; sles15sp5 as the client role.
         </para>
 <screen>&prompt.user;&sudo; virsh start sles15sp5
 Domain 'sles15sp5' started</screen>
-
 <screen>&prompt.user;&sudo; virsh list
  Id   Name        State
 ---------------------------
  4    sles15sp5   running</screen>
-
 <screen>&prompt.user;&sudo; ps -eo pid,args | grep -v grep | grep qemu-pr-helper
 37063 /usr/bin/qemu-pr-helper -k /var/lib/libvirt/qemu/domain-4-sles15sp5/pr-helper0.sock</screen>
-
 <screen>&prompt.user;&sudo; virsh dumpxml sles15sp5 | grep -A11 "&lt;disk type='block' device='lun'&gt;
 &lt;disk type='block' device='lun'&gt;
   &lt;driver name='qemu' type='raw'/&gt;
@@ -3428,9 +3431,9 @@ Domain 'sles15sp5' started</screen>
   &lt;alias name='scsi0-0-0-0'/&gt;
   &lt;address type='drive' controller='0' bus='0' target='0' unit='0'/&gt;
 &lt;/disk&gt;</screen>
-
         <para>
-          4. In the &vmguest;, Reserve the scsi disk(sda) with the key <literal>123abc</literal>
+          4. In the &vmguest;, Reserve the scsi disk(sda) with the key
+          <literal>123abc</literal>
         </para>
 <screen>&prompt.user;lsblk
 NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
@@ -3439,14 +3442,12 @@ vda    253:0    0   20G  0 disk
 ├─vda1 253:1    0    8M  0 part
 ├─vda2 253:2    0    2G  0 part [SWAP]
 └─vda3 253:3    0   18G  0 part /</screen>
-
 <screen>&prompt.user;&sudo; sg_persist --verbose --out --register --param-sark=123abc /dev/sda
     inquiry cdb: [12 00 00 00 24 00]
   TrueNAS   iSCSI Disk        0123
   Peripheral device type: disk
     Persistent reservation out cdb: [5f 00 00 00 00 00 00 00 18 00]
 PR out: command (Register) successful</screen>
-
 <screen>&prompt.user;&sudo; sg_persist --verbose --in -k /dev/sda
     inquiry cdb: [12 00 00 00 24 00]
   TrueNAS   iSCSI Disk        0123
@@ -3455,9 +3456,9 @@ PR out: command (Register) successful</screen>
   PR generation=0x5, 2 registered reservation keys follow:
     0x123abc
     0x123abc</screen>
-
         <para>
-          5. In the &vmguest;, Release the sda with the key <literal>123abc</literal>
+          5. In the &vmguest;, Release the sda with the key
+          <literal>123abc</literal>
         </para>
 <screen>&prompt.user;&sudo; sg_persist --verbose --out --clear --param-rk=123abc /dev/sda
     inquiry cdb: [12 00 00 00 24 00]
@@ -3465,7 +3466,6 @@ PR out: command (Register) successful</screen>
   Peripheral device type: disk
     Persistent reservation out cdb: [5f 03 00 00 00 00 00 00 18 00]
 PR out: command (Clear) successful</screen>
-
 <screen>&prompt.user;&sudo; sg_persist --verbose --in -k /dev/sda
     inquiry cdb: [12 00 00 00 24 00]
   TrueNAS   iSCSI Disk        0123

--- a/xml/art_virtualization-best-practices.xml
+++ b/xml/art_virtualization-best-practices.xml
@@ -344,7 +344,7 @@
               Mount <literal>hugetlbfs</literal> to
               <filename>/dev/hugepages</filename>:
             </para>
-<screen>&prompt.user;&sudo; mount -t hugetlbfs hugetlbfs /dev/hugepages</screen>
+<screen>&prompt.sudo; mount -t hugetlbfs hugetlbfs /dev/hugepages</screen>
           </step>
           <step>
             <para>
@@ -354,7 +354,7 @@
               1&nbsp;GB (1,048,576&nbsp;KB) for your &vmguest;, you need
               <emphasis>1,048,576/2048=512</emphasis> pages in the pool:
             </para>
-<screen>&prompt.user;&sudo; sysctl vm.nr_hugepages=<replaceable>512</replaceable></screen>
+<screen>&prompt.sudo; sysctl vm.nr_hugepages=<replaceable>512</replaceable></screen>
             <para>
               The value is written to
               <filename>/proc/sys/vm/nr_hugepages</filename> and represents the
@@ -480,7 +480,7 @@ always madvise [never]</screen>
           first make sure that the package <package>qemu-ksm</package> is
           installed, then run the command:
         </para>
-<screen>&prompt.user;&sudo; systemctl enable --now ksm.service</screen>
+<screen>&prompt.sudo; systemctl enable --now ksm.service</screen>
         <para>
           Alternatively, it can also be started by running the command:
         </para>
@@ -560,7 +560,7 @@ always madvise [never]</screen>
             applications and &vmguest; are heterogeneous and do not share any
             common data, it is preferable to disable KSM. To do that, run:
           </para>
-<screen>&prompt.user;&sudo; systemctl disable --now ksm.service</screen>
+<screen>&prompt.sudo; systemctl disable --now ksm.service</screen>
           <para>
             Alternatively, it can also be disabled by running the command:
           </para>
@@ -1236,7 +1236,7 @@ w /sys/block/sdb/queue/scheduler - - - - none
           multi-threaded workloads. Use the <command>nfsstat</command> tool to
           get RPC statistics on your server:
         </para>
-<screen>&prompt.user;&sudo; nfsstat -rc
+<screen>&prompt.sudo; nfsstat -rc
 Client rpc stats:
 calls      retrans    authrefrsh
 6401066    198          0          0</screen>
@@ -1458,13 +1458,13 @@ VCPU: CPU Affinity
             collection of all hosts' capabilities in
             <literal>all-hosts-caps.xml</literal>.
           </para>
-<screen>&prompt.user;&sudo; virsh capabilities >> all-hosts-cpu-caps.xml</screen>
+<screen>&prompt.sudo; virsh capabilities >> all-hosts-cpu-caps.xml</screen>
           <para>
             With the capabilities of each host collected in all-hosts-caps.xml,
             use <command>virsh cpu-baseline</command> to create a virtual CPU
             definition that will be compatible across all hosts.
           </para>
-<screen>&prompt.user;&sudo; virsh cpu-baseline all-hosts-caps.xml</screen>
+<screen>&prompt.sudo; virsh cpu-baseline all-hosts-caps.xml</screen>
           <para>
             The resulting virtual CPU definition can be used as the
             <literal>cpu</literal> element in the &vmguest; configuration file.
@@ -1506,7 +1506,7 @@ VCPU: CPU Affinity
       <para>
         <command>numactl</command> is used to check for host NUMA capabilities:
       </para>
-<screen>&prompt.user;&sudo; numactl --hardware
+<screen>&prompt.sudo; numactl --hardware
 available: 4 nodes (0-3)
 node 0 cpus: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 72 73 74 75 76 77 78
 79 80 81 82 83 84 85 86 87 88 89
@@ -1559,7 +1559,7 @@ node   0   1   2   3
           directives control the thresholds for scan delays and the number of
           pages scanned:
         </para>
-<screen>&prompt.user;&sudo; sysctl -a | grep numa_balancing
+<screen>&prompt.sudo; sysctl -a | grep numa_balancing
 kernel.numa_balancing = 1<co xml:id="co-numa-balancing"/>
 kernel.numa_balancing_scan_delay_ms = 1000<co xml:id="co-numa-delay"/>
 kernel.numa_balancing_scan_period_max_ms = 60000<co xml:id="co-numa-pmax"/>
@@ -1649,7 +1649,7 @@ kernel.numa_balancing_scan_size_mb = 256<co xml:id="co-numa-size"/></screen>
           <command>cgset</command> tool from the
           <package>libcgroup-tools</package> package:
         </para>
-<screen>&prompt.user;&sudo; cgset -r cpuset.mems=<replaceable>NODE</replaceable> sysdefault/libvirt/qemu/<replaceable>KVM_NAME</replaceable>/emulator</screen>
+<screen>&prompt.sudo; cgset -r cpuset.mems=<replaceable>NODE</replaceable> sysdefault/libvirt/qemu/<replaceable>KVM_NAME</replaceable>/emulator</screen>
         <para>
           To migrate pages to a node, use the <command>migratepages</command>
           tool:
@@ -3156,7 +3156,7 @@ error: internal error: process exited while connecting to monitor: ((null):26929
           </para>
         </callout>
       </calloutlist>
-<screen>&prompt.user;&sudo; virsh domxml-to-native qemu-argv /etc/libvirt/qemu/SLE15.xml
+<screen>&prompt.sudo; virsh domxml-to-native qemu-argv /etc/libvirt/qemu/SLE15.xml
 LC_ALL=C PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
    QEMU_AUDIO_DRV=none /usr/bin/qemu-system-x86_64 -name SLE15 -machine \
    pc-i440fx-2.3,accel=kvm,usb=off -cpu SandyBridge -m 4048 -realtime \
@@ -3248,103 +3248,98 @@ LC_ALL=C PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
         SCSI persistent reservations allow restricting access to block devices
         in a shared storage setup. This avoids improper multiple parallel
         accesses to the same block device from software components on local or
-        remote hosts, which could lead to device damage, data corruption.
+        remote hosts, which could lead to device damage and data corruption.
       </para>
       <para>
         Find more information on managing storage multipath I/O in
-        <xref linkend="cha-multipath"/>.
-      </para>
-      <para>
-        Find more information about SCSI persistent reservations in
+        <xref linkend="cha-multipath"/>. Find more information about SCSI
+        persistent reservations in
         <xref linkend="sec-multipath-mpiotools-mpathpersist"/>.
       </para>
       <para>
-        For virtualization scenario, QEMU's SCSI passthrough devices
+        For virtualization scenario, &qemu;'s SCSI passthrough devices
         <literal>scsi-block</literal> and <literal>scsi-generic</literal>
         support passing guest persistent reservation requests to a privileged
-        external helper program. The <literal>qemu-pr-helper</literal> is that
-        external helper, It needs to start before QEMU, creates a listener
-        socket which will accept incoming connections for communication with
-        QEMU.
+        external helper program <literal>qemu-pr-helper</literal>. It needs to
+        start before &qemu; and creates a listener socket that accepts incoming
+        connections for communication with QEMU.
       </para>
       <note>
         <title>Live migration scenario with multipathed devices</title>
         <para>
-          We recommend using the multipath alias instead of wwid, It's helpful
-          in &vmguest; live migration scenario, as it can make sure the storage
-          path are identical between source host and destination host.
+          We recommend using the multipath alias instead of
+          <literal>wwid</literal>. It is useful in &vmguest; live migration
+          scenario, because it makes sure that the storage paths are identical
+          between the source and destination hosts.
         </para>
         <para>
-          About aliases for multipath, Please refer to
-          <link
-	    xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-multipath.html#sec-multipath-alias">Setting
-          aliases for multipath maps</link>
-        </para>
-        <para>
-          About wwid for multipath, Please refer to
-          <link
-	    xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-multipath.html#id-1.11.6.6.4.5">Multipath
-          terminology</link>
+          Find more information about multipath in
+          <xref linkend="sec-multipath-alias"/>.
         </para>
       </note>
-      <sect3 xml:id="sec-vm-guest-scsi-pr-guide">
-        <title>Step-by-Step guide</title>
-        <para>
-          How to do scsi persistent reservation in a VM Guest against the
-          related multipathed device in the host:
-        </para>
-        <para>
-          1. In the host, Create Multipath environment, Please refer to
-          <link
-	    xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-multipath.html#sec-multipath-config">Configuring
-          the system for multipathing</link> and
-          <link
-            xlink:href="https://documentation.suse.com/sles/15-SP5/html/SLES-all/cha-multipath.html#sec-multipath-conf-file">Multipath
-          configuration</link>
-        </para>
-        <para>
-          2. In the host, Configure <literal>reservations</literal> sub-element
-          of the <literal>source</literal> element of the
-          <literal>disk</literal> element for the passed-through lun in your
-          libvirt domain configuration. Please refer to
-          <link
-            xlink:href="https://libvirt.org/formatdomain.html">Libvirt
-          Domain XML format</link>
-        </para>
-        <para>
-          3. In the &vmguest;, Install the sg3_utils package, Reserve the scsi
-          disks on-demand by sg_persist command.
-        </para>
-      </sect3>
-      <sect3 xml:id="sec-vm-guest-scsi-pr-example">
-        <title>Example</title>
-        <para>
-          1. In the host, Make sure the multipathd.service is running, and we
-          have such a multipathed disk which is named
-          <literal>storage1</literal>:
-        </para>
-<screen>&prompt.user;&sudo; systemctl status multipathd.service
-● multipathd.service - Device-Mapper Multipath Device Controller
-     Loaded: loaded (/usr/lib/systemd/system/multipathd.service; enabled; preset: disabled)
-     Active: active (running) since Sat 2023-08-26 21:34:13 CST; 1 week 1 day ago
-TriggeredBy: ○ multipathd.socket
-   Main PID: 79411 (multipathd)
-     Status: "up"
-      Tasks: 7
-        CPU: 1min 43.514s
-     CGroup: /system.slice/multipathd.service
-             └─79411 /sbin/multipathd -d -s</screen>
-<screen>&prompt.user;&sudo; multipath -ll
-storage1 (36589cfc000000537c47ad3eb2b20216e) dm-6 TrueNAS,iSCSI Disk
-size=50G features='0' hwhandler='1 alua' wp=rw
-|-+- policy='service-time 0' prio=50 status=active
-| `- 16:0:0:0 sdg 8:96  active ready running
-`-+- policy='service-time 0' prio=50 status=enabled
-  `- 17:0:0:0 sdh 8:112 active ready running</screen>
-        <para>
-          2. In the host, Add the disk element in the &vmguest; configuration
-          file (by running virsh edit CONFIGURATION):
-        </para>
+      <procedure>
+        <title>Adding an SCSI persistent reservation in a &vmguest; against the related multipathed device in the &vmhost;:</title>
+        <step>
+          <para>
+            In the &vmhost;, create multipath environment. For more
+            information, refer to <xref linkend="sec-multipath-config"/> and
+            <xref
+            linkend="sec-multipath-conf-file"/>.
+          </para>
+        </step>
+        <step>
+          <para>
+            In the &vmhost;, configure the
+            <literal>&lt;reservations/></literal> sub-element of the
+            <literal>&lt;source/></literal> element of the
+            <literal>&lt;disk/></literal> element for the passed-through lun in
+            your &libvirt; domain configuration. Refer to
+            <link xlink:href="https://libvirt.org/formatdomain.html">&libvirt;
+            Domain XML format</link>
+          </para>
+        </step>
+        <step>
+          <para>
+            In the &vmguest;, install the <package>sg3_utils</package> package
+            and reserve the SCSI disks on-demand by the
+            <command>sg_persist</command> command.
+          </para>
+        </step>
+      </procedure>
+      <example>
+        <title>Practical example</title>
+        <procedure>
+          <step>
+            <para>
+              In the &vmhost;, verify that the
+              <systemitem class="daemon">multipathd.service</systemitem> is
+              running, and that a multipathed disk exists and is named, for
+              example, <literal>storage1</literal>.
+            </para>
+<screen>&prompt.sudo; systemctl status multipathd.service
+  ● multipathd.service - Device-Mapper Multipath Device Controller
+        Loaded: loaded (/usr/lib/systemd/system/multipathd.service; enabled; preset: disabled)
+        Active: active (running) since Sat 2023-08-26 21:34:13 CST; 1 week 1 day ago
+  TriggeredBy: ○ multipathd.socket
+      Main PID: 79411 (multipathd)
+        Status: "up"
+        Tasks: 7
+          CPU: 1min 43.514s
+        CGroup: /system.slice/multipathd.service
+                └─79411 /sbin/multipathd -d -s</screen>
+<screen>&prompt.sudo; multipath -ll
+  storage1 (36589cfc000000537c47ad3eb2b20216e) dm-6 TrueNAS,iSCSI Disk
+  size=50G features='0' hwhandler='1 alua' wp=rw
+  |-+- policy='service-time 0' prio=50 status=active
+  | `- 16:0:0:0 sdg 8:96  active ready running
+  `-+- policy='service-time 0' prio=50 status=enabled
+    `- 17:0:0:0 sdh 8:112 active ready running</screen>
+          </step>
+          <step>
+            <para>
+              In the &vmhost;, add a &lt;disk/> element in the &vmguest;
+              configuration file by running <command>virsh edit</command>.
+            </para>
 <screen>&lt;disk type='block' device='lun'<co xml:id="co-disk-lunpassthrough"/>&gt;
   &lt;driver name='qemu' type='raw'/&gt;
   &lt;source dev='/dev/mapper/storage1'&gt;
@@ -3353,88 +3348,115 @@ size=50G features='0' hwhandler='1 alua' wp=rw
   &lt;target dev='sda' bus='scsi'/&gt;
   &lt;address type='drive' controller='0' bus='0' target='0' unit='0'<co xml:id="co-disk-scsi-hba-unit"/>/&gt;
 &lt;/disk&gt;</screen>
-        <calloutlist>
-          <callout arearefs="co-disk-lunpassthrough">
-            <para>
-              In order to support persistent reservations, disks must be marked
-              as <literal>lun</literal> with type <literal>block</literal> so
-              that &qemu; does SCSI passthrough.
-            </para>
-          </callout>
-          <callout arearefs="co-disk-reserve">
-            <para>
-              If present it enables persistent reservations for SCSI based
-              disks. The element has one mandatory attribute
-              <literal>managed</literal> with accepted values
-              <literal>yes</literal> and <literal>no</literal>.
-            </para>
-          </callout>
-          <callout arearefs="co-disk-reserve-managed">
-            <para>
-              If <literal>managed</literal> is <literal>yes</literal> libvirt
-              prepares and manages any resources needed.
-            </para>
-            <para>
-              When the value of the attribute <literal>managed</literal> is
-              <literal>no</literal>, then the hypervisor acts as a client and
-              the path to the server socket must be provided in the child
-              element source, which currently accepts only the following
-              attributes: <literal>type</literal> with one value
-              <literal>unix</literal>, <literal>path</literal> with value to
-              the socket, and finally <literal>mode</literal> which accepts the
-              unique valid value <literal>client</literal> specifying the role
-              of hypervisor. It's recommended to allow libvirt manage the
-              persistent reservations.
-            </para>
-          </callout>
-          <callout arearefs="co-disk-scsi-hba-unit">
-            <para>
-              please make sure the virtio-scsi HBA that the disk attaches
-              already exists and has available units(maximum count of units per
-              virtio-scsi HBA is 7), Otherwise you need to manually add a
-              virtio-scsi HBA to avoid automatically adding the LSI HBA by
-              libvirt. For example:
+            <calloutlist>
+              <callout arearefs="co-disk-lunpassthrough">
+                <para>
+                  To support persistent reservations, the disks must be marked
+                  as <literal>lun</literal> with type <literal>block</literal>
+                  so that &qemu; does SCSI passthrough.
+                </para>
+              </callout>
+              <callout arearefs="co-disk-reserve">
+                <para>
+                  If present, it enables persistent reservations for SCSI based
+                  disks. The element has one mandatory attribute
+                  <literal>managed</literal> with accepted values
+                  <literal>yes</literal> and <literal>no</literal>.
+                </para>
+              </callout>
+              <callout arearefs="co-disk-reserve-managed">
+                <para>
+                  If <literal>managed</literal> is <literal>yes</literal>,
+                  &libvirt; prepares and manages any resources needed.
+                </para>
+                <para>
+                  When the value of the attribute <literal>managed</literal> is
+                  <literal>no</literal>, then the hypervisor acts as a client
+                  and the path to the server socket must be provided in the
+                  child element source, which currently accepts only the
+                  following attributes:
+                </para>
+                <variablelist>
+                  <varlistentry>
+                    <term>type</term>
+                    <listitem>
+                      <para>
+                        The only valid option is <literal>unix</literal>.
+                      </para>
+                    </listitem>
+                  </varlistentry>
+                  <varlistentry>
+                    <term>path</term>
+                    <listitem>
+                      <para>
+                        The path to the server socket.
+                      </para>
+                    </listitem>
+                  </varlistentry>
+                  <varlistentry>
+                    <term>mode</term>
+                    <listitem>
+                      <para>
+                        The role of the hypervisor. Valid is
+                        <literal>client</literal>.
+                      </para>
+                    </listitem>
+                  </varlistentry>
+                </variablelist>
+              </callout>
+              <callout arearefs="co-disk-scsi-hba-unit">
+                <para>
+                  Verify that the virtio-scsi HBA that the disk attaches
+                  already exists and has available units (maximum count of
+                  units per virtio-scsi HBA is 7). Otherwise, you need to
+                  manually add a virtio-scsi HBA to avoid automatically adding
+                  the LSI HBA by &libvirt;. For example:
+                </para>
 <screen>&lt;controller type='scsi' index='0' model='virtio-scsi'&gt;
   &lt;address type='pci' domain='0x0000' bus='0x03' slot='0x00' function='0x0'/&gt;
 &lt;/controller&gt;</screen>
-            </para>
-          </callout>
-        </calloutlist>
-<screen>&prompt.user;&sudo; virsh domblklist sles15sp5
- Target   Source
+              </callout>
+            </calloutlist>
+<screen>&prompt.sudo; virsh domblklist sles15sp5
+  Target   Source
 ---------------------------------------------
- vda      /mnt/images/sles15sp5/disk0.qcow2
- sda      /dev/mapper/storage1</screen>
-        <para>
-          3. In the host, Start the &vmguest;, We'll see that libvirt launches
-          a qemu-pr-helper instance as the server role for the &vmguest;
-          sles15sp5, then launches the &vmguest; sles15sp5 as the client role.
-        </para>
-<screen>&prompt.user;&sudo; virsh start sles15sp5
-Domain 'sles15sp5' started</screen>
-<screen>&prompt.user;&sudo; virsh list
- Id   Name        State
----------------------------
- 4    sles15sp5   running</screen>
-<screen>&prompt.user;&sudo; ps -eo pid,args | grep -v grep | grep qemu-pr-helper
-37063 /usr/bin/qemu-pr-helper -k /var/lib/libvirt/qemu/domain-4-sles15sp5/pr-helper0.sock</screen>
-<screen>&prompt.user;&sudo; virsh dumpxml sles15sp5 | grep -A11 "&lt;disk type='block' device='lun'&gt;
-&lt;disk type='block' device='lun'&gt;
-  &lt;driver name='qemu' type='raw'/&gt;
-  &lt;source dev='/dev/mapper/storage1' index='1'&gt;
-    &lt;reservations managed='yes'&gt;
-      &lt;source type='unix' path='/var/lib/libvirt/qemu/domain-4-sles15sp5/pr-helper0.sock' mode='client'/&gt;
-    &lt;/reservations&gt;
-  &lt;/source&gt;
-  &lt;backingStore/&gt;
-  &lt;target dev='sda' bus='scsi'/&gt;
-  &lt;alias name='scsi0-0-0-0'/&gt;
-  &lt;address type='drive' controller='0' bus='0' target='0' unit='0'/&gt;
-&lt;/disk&gt;</screen>
-        <para>
-          4. In the &vmguest;, Reserve the scsi disk(sda) with the key
-          <literal>123abc</literal>
-        </para>
+  vda      /mnt/images/sles15sp5/disk0.qcow2
+  sda      /dev/mapper/storage1</screen>
+          </step>
+          <step>
+            <para>
+              In the &vmhost;, start the &vmguest;. &libvirt; launches a
+              qemu-pr-helper instance as the server role for the &vmguest;
+              sles15sp5, then launches the &vmguest; sles15sp5 as the client
+              role.
+            </para>
+<screen>&prompt.sudo; virsh start sles15sp5
+    Domain 'sles15sp5' started</screen>
+<screen>&prompt.sudo; virsh list
+     Id   Name        State
+    ---------------------------
+     4    sles15sp5   running</screen>
+<screen>&prompt.sudo; ps -eo pid,args | grep -v grep | grep qemu-pr-helper
+    37063 /usr/bin/qemu-pr-helper -k /var/lib/libvirt/qemu/domain-4-sles15sp5/pr-helper0.sock</screen>
+<screen>&prompt.sudo; virsh dumpxml sles15sp5 | grep -A11 "&lt;disk type='block' device='lun'&gt;
+  &lt;disk type='block' device='lun'&gt;
+    &lt;driver name='qemu' type='raw'/&gt;
+    &lt;source dev='/dev/mapper/storage1' index='1'&gt;
+      &lt;reservations managed='yes'&gt;
+        &lt;source type='unix' path='/var/lib/libvirt/qemu/domain-4-sles15sp5/pr-helper0.sock' mode='client'/&gt;
+      &lt;/reservations&gt;
+    &lt;/source&gt;
+    &lt;backingStore/&gt;
+    &lt;target dev='sda' bus='scsi'/&gt;
+    &lt;alias name='scsi0-0-0-0'/&gt;
+    &lt;address type='drive' controller='0' bus='0' target='0' unit='0'/&gt;
+  &lt;/disk&gt;</screen>
+          </step>
+          <step>
+            <para>
+              In the &vmguest;, reserve the scsi disk, for example,
+              <literal>sda</literal>, with the key <literal>123abc</literal>
+            </para>
 <screen>&prompt.user;lsblk
 NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
 sda      8:0    0   50G  0 disk
@@ -3442,13 +3464,13 @@ vda    253:0    0   20G  0 disk
 ├─vda1 253:1    0    8M  0 part
 ├─vda2 253:2    0    2G  0 part [SWAP]
 └─vda3 253:3    0   18G  0 part /</screen>
-<screen>&prompt.user;&sudo; sg_persist --verbose --out --register --param-sark=123abc /dev/sda
+<screen>&prompt.sudo; sg_persist --verbose --out --register --param-sark=123abc /dev/sda
     inquiry cdb: [12 00 00 00 24 00]
   TrueNAS   iSCSI Disk        0123
   Peripheral device type: disk
     Persistent reservation out cdb: [5f 00 00 00 00 00 00 00 18 00]
 PR out: command (Register) successful</screen>
-<screen>&prompt.user;&sudo; sg_persist --verbose --in -k /dev/sda
+<screen>&prompt.sudo; sg_persist --verbose --in -k /dev/sda
     inquiry cdb: [12 00 00 00 24 00]
   TrueNAS   iSCSI Disk        0123
   Peripheral device type: disk
@@ -3456,23 +3478,27 @@ PR out: command (Register) successful</screen>
   PR generation=0x5, 2 registered reservation keys follow:
     0x123abc
     0x123abc</screen>
-        <para>
-          5. In the &vmguest;, Release the sda with the key
-          <literal>123abc</literal>
-        </para>
-<screen>&prompt.user;&sudo; sg_persist --verbose --out --clear --param-rk=123abc /dev/sda
+          </step>
+          <step>
+            <para>
+              In the &vmguest;, release the <literal>sda</literal> disk with
+              the key <literal>123abc</literal>.
+            </para>
+<screen>&prompt.sudo; sg_persist --verbose --out --clear --param-rk=123abc /dev/sda
     inquiry cdb: [12 00 00 00 24 00]
   TrueNAS   iSCSI Disk        0123
   Peripheral device type: disk
     Persistent reservation out cdb: [5f 03 00 00 00 00 00 00 18 00]
 PR out: command (Clear) successful</screen>
-<screen>&prompt.user;&sudo; sg_persist --verbose --in -k /dev/sda
+<screen>&prompt.sudo; sg_persist --verbose --in -k /dev/sda
     inquiry cdb: [12 00 00 00 24 00]
   TrueNAS   iSCSI Disk        0123
   Peripheral device type: disk
     Persistent reservation in cdb: [5e 00 00 00 00 00 00 20 00 00]
   PR generation=0x6, there are NO registered reservation keys</screen>
-      </sect3>
+          </step>
+        </procedure>
+      </example>
     </sect2>
   </sect1>
   <!-- TODO

--- a/xml/art_virtualization-best-practices.xml
+++ b/xml/art_virtualization-best-practices.xml
@@ -3257,7 +3257,7 @@ LC_ALL=C PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
         <xref linkend="sec-multipath-mpiotools-mpathpersist"/>.
       </para>
       <para>
-        For virtualization scenario, &qemu;'s SCSI passthrough devices
+        For the virtualization scenario, &qemu;'s SCSI passthrough devices
         <literal>scsi-block</literal> and <literal>scsi-generic</literal>
         support passing guest persistent reservation requests to a privileged
         external helper program <literal>qemu-pr-helper</literal>. It needs to
@@ -3268,7 +3268,7 @@ LC_ALL=C PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
         <title>Live migration scenario with multipathed devices</title>
         <para>
           We recommend using the multipath alias instead of
-          <literal>wwid</literal>. It is useful in &vmguest; live migration
+          <literal>wwid</literal>. It is useful in the &vmguest; live migration
           scenario, because it makes sure that the storage paths are identical
           between the source and destination hosts.
         </para>
@@ -3278,10 +3278,10 @@ LC_ALL=C PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
         </para>
       </note>
       <procedure>
-        <title>Adding an SCSI persistent reservation in a &vmguest; against the related multipathed device in the &vmhost;:</title>
+        <title>Adding a SCSI persistent reservation in a &vmguest; against the related multipathed device in the &vmhost;:</title>
         <step>
           <para>
-            In the &vmhost;, create multipath environment. For more
+            In the &vmhost;, create a multipath environment. For more
             information, refer to <xref linkend="sec-multipath-config"/> and
             <xref
             linkend="sec-multipath-conf-file"/>.
@@ -3295,13 +3295,13 @@ LC_ALL=C PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
             <literal>&lt;disk/></literal> element for the passed-through lun in
             your &libvirt; domain configuration. Refer to
             <link xlink:href="https://libvirt.org/formatdomain.html">&libvirt;
-            Domain XML format</link>
+            Domain XML format</link>.
           </para>
         </step>
         <step>
           <para>
             In the &vmguest;, install the <package>sg3_utils</package> package
-            and reserve the SCSI disks on-demand by the
+            and reserve the SCSI disks on demand by the
             <command>sg_persist</command> command.
           </para>
         </step>
@@ -3407,7 +3407,7 @@ LC_ALL=C PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
               <callout arearefs="co-disk-scsi-hba-unit">
                 <para>
                   Verify that the virtio-scsi HBA that the disk attaches
-                  already exists and has available units (maximum count of
+                  already exists and has available units (the maximum count of
                   units per virtio-scsi HBA is 7). Otherwise, you need to
                   manually add a virtio-scsi HBA to avoid automatically adding
                   the LSI HBA by &libvirt;. For example:
@@ -3455,7 +3455,7 @@ LC_ALL=C PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
           <step>
             <para>
               In the &vmguest;, reserve the scsi disk, for example,
-              <literal>sda</literal>, with the key <literal>123abc</literal>
+              <literal>sda</literal>, with the key <literal>123abc</literal>.
             </para>
 <screen>&prompt.user;lsblk
 NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS


### PR DESCRIPTION
### PR creator: Description

Describe the overall goals of this pull request.
multipath iSCSI update to virt best practices


### PR creator: Are there any relevant issues/feature requests?

* bsc#1210642

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [x] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
