### PR TITLE
Document support for saslauthd while migrating from OpenLDAP to 389-DS

### DIFF
--- a/xml/security_ldap.xml
+++ b/xml/security_ldap.xml
@@ -43,6 +43,7 @@
 
 
   <xi:include href="security_ldap_directory_tree.xml"/>
+  <xi:include href="security_ldap_docker_container.xml"/>
   <xi:include href="security_ldap_install.xml"/>
   <xi:include href="security_ldap_firewall.xml"/>
   <xi:include href="security_ldap_backups.xml"/>

--- a/xml/security_ldap_docker_container.xml
+++ b/xml/security_ldap_docker_container.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect1
+[
+  <!ENTITY % entities SYSTEM "generic-entities.ent">
+    %entities;
+]>
+<sect1 xmlns="http://docbook.org/ns/docbook"
+       xmlns:xi="http://www.w3.org/2001/XInclude"
+       xmlns:xlink="http://www.w3.org/1999/xlink"
+       version="5.0"
+       xml:id="sec-security-ldap-docker-container">
+  <info>
+    <title>Creating and managing a Docker container for &ds389;</title>
+    <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+      <dm:translation>yes</dm:translation>
+    </dm:docmanager>
+  </info>
+
+  <note>
+    <para>
+      This section is <emphasis>OPTIONAL</emphasis>; refer to it only if you
+      use a &ds389; instance as a Docker container. For regular usage of a
+      &ds389; instance, refer to the rest of the sections.
+    </para>
+  </note>
+
+  <para>
+    To create and manage a &ds389; instance as a Docker container, refer to the
+    following examples:
+  </para>
+
+  <variablelist>
+    <varlistentry>
+      <term>Pull the latest &ds389; image</term>
+      <listitem>
+        <para>
+          To pull the latest &ds389; image from the container registry, run the
+          following command:
+        </para>
+<screen>&prompt.user; <command>docker pull 389ds/dirsrv:latest</command></screen>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>Create a new volume</term>
+      <listitem>
+        <para>
+          To create a new volume for the container, run the following example
+          command:
+        </para>
+<screen>&prompt.user; <command>docker volume create <replaceable>VOLUME</replaceable></command></screen>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>Create a container with basic configuration</term>
+      <listitem>
+        <para>
+          To create a container with basic configuration, run the following
+          example command:
+        </para>
+<screen>&prompt.user; <command>docker create \
+ -u <replaceable>USERNAME</replaceable> \
+ -e SUFFIX_NAME="dc=example,dc=com" \
+ -e DS_DM_PASSWORD=<replaceable>PASSWORD</replaceable> \
+ -m 1024M \
+ -p 3389:3389 -p 3636:3636 \
+ -v <replaceable>VOLUME</replaceable>:/data \
+ --name <replaceable>INSTANCE</replaceable> \
+ 389ds/dirsrv:latest
+</command></screen>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>Start the Docker container for &ds389;</term>
+      <listitem>
+        <para>
+          To start the Docker container, run the following example command:
+        </para>
+<screen>&prompt.user; <command>docker start <replaceable>INSTANCE</replaceable></command></screen>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>Execute a command within a running &ds389; container</term>
+      <listitem>
+        <para>
+          Assuming that the primary process of the container (<literal>PID
+          1</literal>) is running, you can run a command within a running
+          &ds389; container by using the following syntax:
+        </para>
+<screen>&prompt.sudo;<command>docker exec -u <replaceable>USERNAME</replaceable> -i -t <replaceable>INSTANCE</replaceable> <replaceable>COMMAND</replaceable></command></screen>
+        <note>
+          <title>The <replaceable>COMMAND</replaceable> must be executable</title>
+          <para>
+            To run a chained command or a command enclosed within quotations,
+            you should first run a shell session in the container. For example,
+            you can run commands in the <literal>sh</literal> shell attached to
+            the container:
+          </para>
+<screen>&prompt.sudo;<command>docker exec -u <replaceable>USERNAME</replaceable> -i -t <replaceable>INSTANCE</replaceable> sh -c <replaceable>"COMMAND"</replaceable></command></screen>
+        </note>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>Stop the Docker container for &ds389;</term>
+      <listitem>
+        <para>
+          To stop the running Docker container, run the following example
+          command:
+        </para>
+<screen>&prompt.user; <command>docker stop <replaceable>INSTANCE</replaceable></command></screen>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>Remove the Docker container for &ds389;</term>
+      <listitem>
+        <para>
+          To remove the Docker container, run the following example command:
+        </para>
+<screen>&prompt.user; <command>docker rm <replaceable>INSTANCE</replaceable></command></screen>
+      </listitem>
+    </varlistentry>
+  </variablelist>
+</sect1>

--- a/xml/security_ldap_migrate_test.xml
+++ b/xml/security_ldap_migrate_test.xml
@@ -4,75 +4,85 @@
   <!ENTITY % entities SYSTEM "generic-entities.ent">
     %entities;
 ]>
-
 <sect1 xmlns="http://docbook.org/ns/docbook"
        xmlns:xi="http://www.w3.org/2001/XInclude"
        xmlns:xlink="http://www.w3.org/1999/xlink"
        version="5.0"
        xml:id="sec-security-ldap-migrate">
- <info>
-  <title>Migrating to &ds389; from OpenLDAP</title>
-  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:translation>yes</dm:translation>
-  </dm:docmanager>
- </info>
-   <para>
-     OpenLDAP is deprecated<phrase os="sles;sled"> and no longer supported as of
-     &sle; 15&nbsp;SP3</phrase>.
-     It has been replaced by &ds389;. &suse; provides the
-     <command>openldap_to_ds</command> utility to assist with migration, included
-     in the <package>389-ds</package> package.
-   </para>
-   <para>
-     The <command>openldap_to_ds</command> utility is designed to automate as
-     much of the migration as possible. However, every LDAP deployment is
-     different, and it is not possible to write a tool that satisfies all
-     situations. It is likely there will be manual steps to perform, and
-     you should test your migration procedure thoroughly before attempting a
-     production migration.
-   </para>
+  <info>
+    <title>Migrating to &ds389; from OpenLDAP</title>
+    <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+      <dm:translation>yes</dm:translation>
+    </dm:docmanager>
+  </info>
+
+  <para>
+    OpenLDAP is deprecated<phrase os="sles;sled"> and no longer supported as of
+    &sle; 15&nbsp;SP3</phrase>. It has been replaced by &ds389;. &suse;
+    provides the <command>openldap_to_ds</command> utility to assist with
+    migration, included in the <package>389-ds</package> package.
+  </para>
+
+  <para>
+    The <command>openldap_to_ds</command> utility automates as much of the
+    migration as possible. However, every LDAP deployment is different, and it
+    is impossible to develop a tool that satisfies all situations. When
+    necessary, intervene and perform manual steps. Additionally, test your
+    migration procedure thoroughly before attempting a production migration.
+  </para>
+
+  <important>
+    <title>Read the <command>help</command> page</title>
+    <para>
+      Before using the <command>openldap_to_ds</command> migration tool, we
+      strongly recommend reading the output of <command>openldap_to_ds
+      --help</command>. It helps you learn about the capabilities and
+      limitations of the migration tool, and prevents you from making wrong
+      assumptions.
+    </para>
+  </important>
 
   <sect2 xml:id="sec-security-ldap-migrate-test">
-  <title>Testing migration from OpenLDAP</title>
-   <para>
-     There are enough differences between OpenLDAP and &ds389; that
-     migration involves repeated testing and adjustments.
-     It can be helpful to do a quick migration test to get an idea of what
-     steps are necessary for a successful migration.
-   </para>
-   <para>
-     Prerequisites:
-   </para>
-   <itemizedlist>
-    <listitem>
-      <para>
-        A running &ds389; instance.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-       An OpenLDAP <filename>slapd</filename> configuration file or directory
-       in dynamic ldif format.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-        An ldif file backup of your OpenLDAP database.
-     </para>
-    </listitem>
-   </itemizedlist>
-   <para>
-     If your slapd configuration is not in dynamic ldif format, create a
-     dynamic copy with <command>slaptest</command>. Create a
-     <filename>slapd.d</filename> directory, for example
-     <filename>/root/slapd.d/</filename>, then run the following command:
-   </para>
-   <screen>&prompt.sudo;<command>slaptest -f /etc/openldap/slapd.conf -F /root/slapd.d</command>
+    <title>Testing migration from OpenLDAP</title>
+    <para>
+      There are enough differences between OpenLDAP and &ds389;, so migration
+      involves repeated testing and adjustments. It is helpful to do a quick
+      migration test to get an idea of what steps are necessary for a
+      successful migration.
+    </para>
+    <para>
+      Prerequisites:
+    </para>
+    <itemizedlist>
+      <listitem>
+        <para>
+          A running &ds389; instance
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          An OpenLDAP <filename>slapd</filename> configuration file or
+          directory in dynamic ldif format
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          An ldif file backup of your OpenLDAP database
+        </para>
+      </listitem>
+    </itemizedlist>
+    <para>
+      If your slapd configuration is not in dynamic ldif format, create a
+      dynamic copy with <command>slaptest</command>. Create a
+      <filename>slapd.d</filename> directory, for example
+      <filename>/root/slapd.d/</filename>, then run the following command:
+    </para>
+<screen>&prompt.sudo;<command>slaptest -f /etc/openldap/slapd.conf -F /root/slapd.d</command>
      </screen>
-     <para>
-       This results in several files similar to the following example:
-     </para>
-     <screen>&prompt.sudo;<command>ls /root/slapd.d/*</command>
+    <para>
+      This results in several files similar to the following example:
+    </para>
+<screen>&prompt.sudo;<command>ls /root/slapd.d/*</command>
 
 /root/slapd.d/cn=config.ldif
 
@@ -80,28 +90,27 @@
 cn=module{0}.ldif  cn=schema.ldif                 olcDatabase={0}config.ldif
 cn=schema          olcDatabase={-1}frontend.ldif  olcDatabase={1}mdb.ldif
 </screen>
-   <para>
-     Create one ldif file per suffix. In the following examples, the suffix
-     is
-     dc=<replaceable>LDAP1</replaceable>,dc=<replaceable>COM</replaceable>. If you are using the
-     <filename>/etc/openldap/slapd.conf</filename>
-     format, use the following command to create the ldif backup file:
-   </para>
-   <screen>
+    <para>
+      Create one ldif file per suffix. In the following examples, the suffix is
+      dc=<replaceable>LDAP1</replaceable>,dc=<replaceable>COM</replaceable>. If
+      you are using the <filename>/etc/openldap/slapd.conf</filename> format,
+      use the following command to create the ldif backup file:
+    </para>
+<screen>
 &prompt.sudo;<command>slapcat -f /etc/openldap/slapd.conf -b dc=<replaceable>LDAP1</replaceable>,dc=<replaceable>COM</replaceable></command> \
 <command>-l <replaceable>/root/LDAP1-COM</replaceable>.ldif</command>
    </screen>
-   <para>
-     Use <command>openldap_to_ds</command> to analyze the configuration and
-     files, and show a migration plan without changing anything:
-   </para>
-   <screen>&prompt.sudo;<command>openldap_to_ds <replaceable>LDAP1</replaceable></command>\
+    <para>
+      Use <command>openldap_to_ds</command> to analyze the configuration and
+      files, and show a migration plan without changing anything:
+    </para>
+<screen>&prompt.sudo;<command>openldap_to_ds <replaceable>LDAP1</replaceable></command>\
 <command>/root/slapd.d <replaceable>/root/LDAP1-COM</replaceable>.ldif.ldif</command></screen>
-   <para>
-     This performs a dry run and does not change anything. The output looks
-     like this:
-   </para>
-   <screen>Examining OpenLDAP Configuration ...
+    <para>
+      This performs a dry run and does not change anything. The output looks
+      like this:
+    </para>
+<screen>Examining OpenLDAP Configuration ...
 Completed OpenLDAP Configuration Parsing.
 Examining Ldifs ...
 Completed Ldif Metadata Parsing.
@@ -121,11 +130,11 @@ The following migration steps will be performed:
 excluding entry attributes = [{'structuralobjectclass', 'entrycsn'}]
 No actions taken. To apply migration plan, use '--confirm'
 </screen>
-   <para>
-     The following example performs the migration, and the output looks
-     different from the dry run:
-   </para>
-   <screen>&prompt.sudo;<command>openldap_to_ds <replaceable>LDAP1</replaceable> /root/slapd.d <replaceable>/root/LDAP1-COM</replaceable>.ldif --confirm</command>
+    <para>
+      The following example performs the migration, and the output looks
+      different from the dry run:
+    </para>
+<screen>&prompt.sudo;<command>openldap_to_ds <replaceable>LDAP1</replaceable> /root/slapd.d <replaceable>/root/LDAP1-COM</replaceable>.ldif --confirm</command>
 Starting Migration ... This may take some time ...
 migration: 1 / 40 complete ...
 migration: 2 / 40 complete ...
@@ -144,195 +153,481 @@ You should now review your instance configuration and data:
  * [ ] - Review Schema Inconistent ObjectClass -> pilotOrganization (0.9.2342.19200300.100.4.20)
  * [ ] - Review Database Imported Content is Correct -> dc=ldap1,dc=com
 </screen>
-
-   <para>
-     When the migration is complete, <command>openldap_to_ds</command>
-     creates a checklist of post-migration tasks that must be completed.
-     It is a best practice to document your post-migration steps,
-     so that you can reproduce them in your post-production procedures.
-     Then test clients and application integrations to the migrated &ds389;
-     instance.
-   </para>
-   <important>
-     <title>Develop a rollback plan</title>
-     <para>
-       Develop a rollback plan in case of any failures.
-       This plan should define a successful migration, the tests to determine
-       what worked and what needs to be fixed, which steps are critical, what
-       can be deferred until later, how to decide when to undo any changes,
-       how to undo them with minimal disruption, and which other teams need to be involved.
-     </para>
-   </important>
-   <para>
-     Due to the variability of deployments, it is difficult to provide
-     a recipe for a successful production migration. After you have
-     thoroughly tested the migration process and verified that you
-     get good results, the following general steps help:
-   </para>
-   <itemizedlist>
-    <listitem>
+    <para>
+      When the migration is complete, <command>openldap_to_ds</command> creates
+      a checklist of post-migration tasks that must be completed. It is a best
+      practice to document your post-migration steps, so that you can reproduce
+      them in your post-production procedures. Then test clients and
+      application integrations to the migrated &ds389; instance.
+    </para>
+    <important>
+      <title>Develop a rollback plan</title>
       <para>
-        Lower all hostname/DNS TTLs to 5 minutes 48 hours before the change, to
-        allow a fast rollback to your existing OpenLDAP deployment.
+        Develop a rollback plan in case of any failures. This plan should
+        define a successful migration, the tests to determine what worked and
+        what needs to be fixed, which steps are critical, what can be deferred
+        until later, how to decide when to undo any changes, how to undo them
+        with minimal disruption, and which other teams need to be involved.
       </para>
-    </listitem>
-    <listitem>
-      <para>
-        Pause all data synchronization and incoming data processes, so that data
-        in the OpenLDAP environment does not change during the migration process.
-      </para>
-    </listitem>
-    <listitem>
-      <para>
-        Have all &ds389; hosts ready for deployment before the migration.
-      </para>
-    </listitem>
-    <listitem>
-      <para>
-        Have your test migration documentation available.
-      </para>
-    </listitem>
-   </itemizedlist>
+    </important>
+    <para>
+      Due to the variability of deployments, it is difficult to provide a
+      recipe for a successful production migration. After you have thoroughly
+      tested the migration process and verified that you get good results, the
+      following general steps help:
+    </para>
+    <itemizedlist>
+      <listitem>
+        <para>
+          Lower all hostname/DNS TTLs to 5 minutes 48 hours before the change,
+          to allow a fast rollback to your existing OpenLDAP deployment.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Pause all data synchronization and incoming data processes, so that
+          the data in the OpenLDAP environment does not change during the
+          migration.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Have all &ds389; hosts ready for deployment before the migration.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Have your test migration documentation available.
+        </para>
+      </listitem>
+    </itemizedlist>
   </sect2>
- <sect2 xml:id="sec-security-ldap-migrate-plan">
-  <title>Planning your migration</title>
-  <para>
-   As OpenLDAP is a <quote>box of parts</quote> and highly customizable, it is
-   not possible to prescribe a <quote>one size fits all</quote> migration.
-   It is necessary to assess your
-   current environment and configuration with OpenLDAP and other integrations.
-   This includes, and is not limited to:
-  </para>
-  <itemizedlist>
-   <listitem>
+
+  <sect2 xml:id="sec-security-ldap-migrate-saslauthd">
+    <title>Testing migration of OpenLDAP servers that use <literal>saslauthd</literal></title>
     <para>
-     Replication topology
+      In OpenLDAP deployments, it is common to use <literal>saslauthd</literal>
+      for passthrough authentication of users. The authentication process
+      involves the following components:
     </para>
-   </listitem>
-   <listitem>
+<screen>
+ ┌─────────────────┐
+ │                 │
+ │   LDAP client   │
+ │                 │
+ └─────────────────┘
+          │
+      binds to
+          │
+          ▼
+ ┌─────────────────┐
+ │    OpenLDAP     │
+ │     server      │
+ │                 │
+ └─────────────────┘
+          │
+          │
+          ▼
+ ┌─────────────────┐
+ │                 │
+ │    saslauthd    │
+ │                 │
+ └─────────────────┘
+          │
+          │
+          ▼
+ ┌─────────────────┐
+ │                 │
+ │  External auth  │
+ │                 │
+ └─────────────────┘
+</screen>
     <para>
-     High availability and load balancer configurations
+      For checking the correctness of configuration and subsequent
+      troubleshooting, the following information is important:
     </para>
-   </listitem>
-   <listitem>
+    <itemizedlist>
+      <listitem>
+        <para>
+          OpenLDAP discovers that a user is allowed passthrough authentication
+          if the <literal>userPassword</literal> attribute has a value with the
+          <literal>userPassword:
+          {SASL}<replaceable>USERNAME@REALM</replaceable></literal> format. The
+          prerequisite is to build the OpenLDAP server with the
+          <literal>--enable-spasswd</literal> option to enable passthrough
+          authentication.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          OpenLDAP configures its connection to <literal>saslauthd</literal>
+          from <filename>/usr/lib/sasl2/slapd.conf</filename>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>saslauthd</literal> discovers the relevant modules using its
+          command-line parameters configured in
+          <literal>/etc/sysconfig/saslauthd</literal>.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          The backend modules of <literal>saslauthd</literal> use their own
+          configuration, as documented in <command>man saslauthd</command>.
+        </para>
+      </listitem>
+    </itemizedlist>
     <para>
-     External data flows (IGA, HR, AD, etc.)
+      Detailed information about passthrough authentication using OpenLDAP is
+      available in the official
+      <link
+   xlink:href="https://openldap.org/doc/admin24/security.html#Pass-Through%20authentication">OpenLDAP
+      Admin Guide</link>.
     </para>
-   </listitem>
-   <listitem>
+    <sect3 xml:id="sec-security-ldap-migrate-saslauthd-procedure">
+      <title>Migrating SASL passthrough authentication from OpenLDAP to &ds389;</title>
+      <para>
+        As a best practice for correctly migrating SASL passthrough
+        authentication from OpenLDAP to &ds389; refer to the following steps:
+      </para>
+      <procedure>
+        <step>
+          <para>
+            Before migration, ensure that you can successfully run
+            <command>testsaslauthd</command> on the OpenLDAP server.
+          </para>
+<screen>&prompt.sudo;<command>testsaslauthd -u <replaceable>USERNAME@REALM</replaceable> -p <replaceable>PASSWORD</replaceable></command></screen>
+          <para>
+            The realm routes the authentication to the correct backend in
+            <literal>saslauthd</literal>, and the user name is then used to
+            check the identity.
+          </para>
+        </step>
+        <step>
+          <para>
+            Install the <package>pam_saslauthd</package> package that enables
+            &ds389; to connect with <literal>saslauthd</literal>.
+          </para>
+<screen>&prompt.sudo;<command>zypper install -y pam_saslauthd</command></screen>
+        </step>
+        <step>
+          <para>
+            Migrate from OpenLDAP to &ds389; by running the
+            <command>openldap_to_ds</command> command-line tool. For detailed
+            information on the migration process, refer to the section
+            <xref linkend="sec-security-ldap-migrate-test"></xref>.
+          </para>
+          <note>
+            <para>
+              While the <command>openldap_to_ds</command> process is running,
+              if a user is detected as having the value of the
+              <literal>userPssword</literal> attribute in the
+              <literal>userPassword:
+              {SASL}<replaceable>USERNAME@REALM</replaceable></literal> format,
+              it is removed and placed as the value of the
+              <literal>nsSaslauthId</literal> attribute in the
+              <literal>nsSaslauthId:
+              <replaceable>USERNAME@REALM</replaceable></literal> format.
+              Additionally, the attribute value <literal>objectClass:
+              nsSaslauthAccount</literal> is automatically added to support the
+              modification.
+            </para>
+          </note>
+        </step>
+        <step>
+          <para>
+            After completion of the migration, check whether the PAM
+            passthrough authentication is configured correctly by running the
+            following commands:
+          </para>
+<screen>&prompt.sudo;<command>dsconf <replaceable>INSTANCE</replaceable> plugin pam-passthrough-auth show</command></screen>
+<screen>&prompt.sudo;<command>dsconf <replaceable>INSTANCE</replaceable> plugin pam-passthrough-auth list</command></screen>
+        </step>
+      </procedure>
+      <para>
+        After successful migration, the passthrough authentication flow
+        involves the following components:
+      </para>
+<screen>
+  ┌─────────────────┐
+  │                 │
+  │   LDAP client   │
+  │                 │
+  └─────────────────┘
+           │
+       binds to
+           │
+           ▼
+  ┌─────────────────┐
+  │     389-DS      │
+  │     server      │
+  │                 │
+  └─────────────────┘
+           │
+           ▼
+  ┌─────────────────┐
+  │                 │
+  │  pam saslauthd  │
+  │                 │
+  └─────────────────┘
+           │
+           ▼
+  ┌─────────────────┐
+  │                 │
+  │    saslauthd    │
+  │                 │
+  └─────────────────┘
+           │
+           │
+           ▼
+  ┌─────────────────┐
+  │                 │
+  │  External auth  │
+  │                 │
+  └─────────────────┘
+
+</screen>
+    </sect3>
+    <sect3 xml:id="sec-security-ldap-troubleshoot-saslauthd">
+      <title>Troubleshooting <literal>saslauthd</literal> passthrough authentication</title>
+      <para>
+        To troubleshoot problems with <literal>saslauthd</literal> passthrough
+        authentication before and after the migration from OpenLDAP to &ds389;,
+        refer to the following tips:
+      </para>
+      <variablelist>
+        <varlistentry>
+          <term>Ensure that <command>testsaslauthd</command> works with <replaceable>USERNAME@REALM</replaceable>.</term>
+          <listitem>
+            <para>
+              Refer to the step for running <command>testsaslauthd</command> in
+              the
+              <xref
+        linkend="sec-security-ldap-migrate-saslauthd"></xref>
+              section.
+            </para>
+            <para>
+              In case of problems, try the following:
+            </para>
+            <itemizedlist>
+              <listitem>
+                <para>
+                  Check <filename>/etc/sysconfig/saslauthd</filename> to ensure
+                  the <literal>saslauthd</literal> backend modules are
+                  configured correctly. For detailed information on the backend
+                  modules of <literal>saslauthd</literal> and their
+                  configurations, run <command>man saslauthd</command>.
+                </para>
+              </listitem>
+              <listitem>
+                <para>
+                  Turn on debug logging by adding
+                  <literal>SASLAUTHD_PARAMS="-d"</literal> in
+                  <filename>/etc/sysconfig/saslauthd</filename>.
+                </para>
+              </listitem>
+              <listitem>
+                <para>
+                  View the <literal>saslauthd</literal> logs that are available
+                  as part of the output of <command>journalctl</command>.
+                </para>
+              </listitem>
+            </itemizedlist>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Ensure that PAM <literal>saslauthd</literal> works correctly.</term>
+          <listitem>
+            <para>
+              To check if PAM <literal>saslauthd</literal> works correctly, you
+              can use the <command>pam_tester</command> tool available at
+              <link xlink:href="https://github.com/kanidm/pam_tester"></link>.
+            </para>
+            <note>
+              <para>
+                The <command>pam_tester</command> tool is NOT officially
+                supported.
+              </para>
+            </note>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Ensure that the PAM Pass Through Auth plugin is enabled.</term>
+          <listitem>
+            <para>
+              Check the status of the PAM Pass Through Auth plugin by running
+              the following command:
+            </para>
+<screen>&prompt.sudo;<command>dsconf <replaceable>INSTANCE</replaceable> plugin pam-passthrough-auth status</command></screen>
+            <para>
+              To enable the plugin, run the following command:
+            </para>
+<screen>&prompt.sudo;<command>dsconf <replaceable>INSTANCE</replaceable> plugin pam-passthrough-auth enable</command></screen>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Check the configuration of the PAM Pass Through Auth plugin.</term>
+          <listitem>
+            <para>
+              To check the configuration of the PAM Pass Through Auth plugin
+              for the server instance, run the following command:
+            </para>
+<screen>&prompt.sudo;<command>dsconf <replaceable>INSTANCE</replaceable> plugin pam-passthrough-auth show</command></screen>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Check the error logs for the user of the server instance.</term>
+          <listitem>
+            <para>
+              Check the logs available in
+              <filename>/var/lib/<replaceable>SERVER_USER_NAME</replaceable>/<replaceable>INSTANCE</replaceable>/error</filename>.
+            </para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </sect3>
+  </sect2>
+
+  <sect2 xml:id="sec-security-ldap-migrate-plan">
+    <title>Planning your migration</title>
     <para>
-     Configured overlays (plug-ins in &ds389;)
+      As OpenLDAP is a <quote>box of parts</quote> and highly customizable, it
+      is not possible to prescribe a <quote>one size fits all</quote>
+      migration. It is necessary to assess your current environment and
+      configuration with OpenLDAP and other integrations. This includes, and is
+      not limited to:
     </para>
-   </listitem>
-   <listitem>
+    <itemizedlist>
+      <listitem>
+        <para>
+          Replication topology
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          High availability and load balancer configurations
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          External data flows (IGA, HR, AD, etc.)
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Configured overlays (plug-ins in &ds389;)
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Client configuration and expected server features
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          Customized schema
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          TLS configuration
+        </para>
+      </listitem>
+    </itemizedlist>
     <para>
-     Client configuration and expected server features
+      Plan what your &ds389; deployment will look like in the end. This
+      includes the same list, except replace overlays with plugins. Once you
+      have assessed your current environment and planned what your &ds389;
+      environment will look like, you can then form a migration plan. We
+      recommended building the &ds389; environment in parallel to your OpenLDAP
+      environment to allow switching between them.
     </para>
-   </listitem>
-   <listitem>
     <para>
-     Customized schema
+      Migrating from OpenLDAP to &ds389; is a one-way migration. There are
+      enough differences between the two that they cannot interoperate, and
+      there is not a migration path from &ds389; to OpenLDAP. The following
+      table highlights the major similarities and differences.
     </para>
-   </listitem>
-   <listitem>
-    <para>
-     TLS configuration
-    </para>
-   </listitem>
-  </itemizedlist>
-  <para>
-   Plan what your &ds389; deployment will look like in the end. This includes
-   the same list, except replace overlays with plugins. Once you have assessed
-   your current environment, and planned what your &ds389; environment will
-   look like, you can then form a migration plan. We recommended building
-   the &ds389; environment in parallel to your OpenLDAP environment to allow
-   switching between them.
-  </para>
-  <para>
-   Migrating from OpenLDAP to &ds389; is a one-way migration. There are enough
-   differences between the two that they cannot interoperate, and there is not
-   a migration path from &ds389; to OpenLDAP. The following table highlights
-   the major similarities and differences.
-  </para>
-  <informaltable>
-   <tgroup cols="4">
-    <thead>
-     <row>
-      <entry>Feature</entry>
-      <entry>OpenLDAP</entry>
-      <entry>&ds389;</entry>
-      <entry>Compatible</entry>
-     </row>
-    </thead>
-    <tbody>
-     <row>
-      <entry>Two-way replication</entry>
-      <entry>SyncREPL</entry>
-      <entry>&ds389a;-specific system</entry>
-      <entry>No</entry>
-     </row>
-     <row>
-      <entry>MemberOf</entry>
-      <entry>Overlay</entry>
-      <entry>Plug-in</entry>
-      <entry>Yes, simple configurations only</entry>
-     </row>
-     <row>
-      <entry>External Auth</entry>
-      <entry>Proxy</entry>
-      <entry>-</entry>
-      <entry>No</entry>
-     </row>
-     <row>
-      <entry>Active Directory Synchronization</entry>
-      <entry>-</entry>
-      <entry>Winsync Plug-in</entry>
-      <entry>No</entry>
-     </row>
-     <row>
-      <entry>Inbuilt Schema</entry>
-      <entry>OLDAP Schemas</entry>
-      <entry>389 Schemas</entry>
-      <entry>Yes, supported by migration tool</entry>
-     </row>
-     <row>
-      <entry>Custom Schema</entry>
-      <entry>OLDAP Schemas</entry>
-      <entry>389 Schemas</entry>
-      <entry>Yes, supported by migration tool</entry>
-     </row>
-     <row>
-      <entry>Database Import</entry>
-      <entry>LDIF</entry>
-      <entry>LDIF</entry>
-      <entry>Yes, supported by migration tool</entry>
-     </row>
-     <row>
-      <entry>Password hashes</entry>
-      <entry>Varies</entry>
-      <entry>Varies</entry>
-      <entry>Yes, all formats supported excluding Argon2</entry>
-     </row>
-     <row>
-      <entry>OpenLDAP to &ds389a; replication</entry>
-      <entry>-</entry>
-      <entry>-</entry>
-      <entry>No mechanism to replicate to &ds389a; is possible</entry>
-     </row>
-     <row>
-      <entry>Time-based one-time password (TOTP)</entry>
-      <entry>TOTP overlay</entry>
-      <entry>-</entry>
-      <entry>No, currently not supported</entry>
-     </row>
-     <row>
-      <entry>entryUUID</entry>
-      <entry>Part of OpenLDAP</entry>
-      <entry>Plug-in</entry>
-      <entry>Yes</entry>
-     </row>
-    </tbody>
-   </tgroup>
-  </informaltable>
- </sect2>
+    <informaltable>
+      <tgroup cols="4">
+        <thead>
+          <row>
+            <entry>Feature</entry>
+            <entry>OpenLDAP</entry>
+            <entry>&ds389;</entry>
+            <entry>Compatible</entry>
+          </row>
+        </thead>
+        <tbody>
+          <row>
+            <entry>Two-way replication</entry>
+            <entry>SyncREPL</entry>
+            <entry>&ds389a;-specific system</entry>
+            <entry>No</entry>
+          </row>
+          <row>
+            <entry>MemberOf</entry>
+            <entry>Overlay</entry>
+            <entry>Plug-in</entry>
+            <entry>Yes, simple configurations only</entry>
+          </row>
+          <row>
+            <entry>External Auth</entry>
+            <entry>Proxy</entry>
+            <entry>-</entry>
+            <entry>No</entry>
+          </row>
+          <row>
+            <entry>Active Directory Synchronization</entry>
+            <entry>-</entry>
+            <entry>Winsync Plug-in</entry>
+            <entry>No</entry>
+          </row>
+          <row>
+            <entry>Inbuilt Schema</entry>
+            <entry>OLDAP Schemas</entry>
+            <entry>389 Schemas</entry>
+            <entry>Yes, supported by migration tool</entry>
+          </row>
+          <row>
+            <entry>Custom Schema</entry>
+            <entry>OLDAP Schemas</entry>
+            <entry>389 Schemas</entry>
+            <entry>Yes, supported by migration tool</entry>
+          </row>
+          <row>
+            <entry>Database Import</entry>
+            <entry>LDIF</entry>
+            <entry>LDIF</entry>
+            <entry>Yes, supported by migration tool</entry>
+          </row>
+          <row>
+            <entry>Password hashes</entry>
+            <entry>Varies</entry>
+            <entry>Varies</entry>
+            <entry>Yes, all formats supported excluding Argon2</entry>
+          </row>
+          <row>
+            <entry>OpenLDAP to &ds389a; replication</entry>
+            <entry>-</entry>
+            <entry>-</entry>
+            <entry>No mechanism to replicate to &ds389a; is possible</entry>
+          </row>
+          <row>
+            <entry>Time-based one-time password (TOTP)</entry>
+            <entry>TOTP overlay</entry>
+            <entry>-</entry>
+            <entry>No, currently not supported</entry>
+          </row>
+          <row>
+            <entry>entryUUID</entry>
+            <entry>Part of OpenLDAP</entry>
+            <entry>Plug-in</entry>
+            <entry>Yes</entry>
+          </row>
+        </tbody>
+      </tgroup>
+    </informaltable>
+  </sect2>
 </sect1>


### PR DESCRIPTION
### PR creator: Description

Document support for saslauthd while migrating from OpenLDAP to 389-DS. Also, some other miscellaneous enhancements, primarily related to running 389-DS as a docker container.


### PR creator: Are there any relevant issues/feature requests?

* JIRA: https://jira.suse.com/browse/DOCTEAM-897
* Bugzilla: https://bugzilla.suse.com/show_bug.cgi?id=1207273


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.5 - https://github.com/SUSE/doc-sle/commit/587801f1490c18668d7feace0588d3afdeca1737
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [x] all necessary backports are done
