### PR TITLE
vt-doc: Improve libvirt daemons description

### DIFF
--- a/xml/libvirt_overview.xml
+++ b/xml/libvirt_overview.xml
@@ -20,20 +20,21 @@
     daemons to be installed and active on the host. &libvirt; provides two
     daemon deployment options: monolithic or modular daemons. &libvirt; has
     always provided the single monolithic daemon &libvirtd;. It includes the
-    primary hypervisor drivers and all supporting secondary drivers needed for
-    storage, such as networking, node device and management. The
-    monolithic &libvirtd; also provides secure remote access for external
-    clients. With modular daemons, each driver runs in its own daemon, allowing
-    users to customize their &libvirt; deployment. By default, the monolithic
-    daemon is enabled, but a deployment can be switched to modular daemons by
-    managing the corresponding &systemd; service files.
+    primary hypervisor drivers and all secondary drivers needed for managing
+    storage, networking, node devices, etc. The monolithic &libvirtd; also
+    provides secure remote access for external clients. Over time &libvirt;
+    added support for modular daemons, where each driver runs in its own
+    daemon, allowing users to customize their &libvirt; deployment. The
+    monolithic daemon is enabled by default, but a deployment can be
+    switched to modular daemons by disabling &libvirtd; and enabling the
+    desired individual daemons.
   </para>
   <para>
     The modular daemon deployment is useful in scenarios where minimal
     &libvirt; support is needed. For example, if virtual machine storage and
     networking is not provided by &libvirt;, the
     <package>libvirt-daemon-driver-storage</package> and
-    <package>libvirt-daemon-driver-network</package> type of packages are not
+    <package>libvirt-daemon-driver-network</package> packages are not
     required. &kube; is an example of an extreme case, where it handles all
     networking, storage, cgroups and namespace integration, etc. Only the
     <package>libvirt-daemon-driver-&qemu;</package> package, providing
@@ -223,7 +224,7 @@
       They are configured via the files
       <filename>/etc/libvirt/virt<replaceable>DRIVER</replaceable>d.conf</filename>.
       &suse; supports the virtqemud and virtxend hypervisor daemons, along with
-      all the supporting secondary daemons:
+      all the secondary daemons:
     </para>
 
     <itemizedlist>
@@ -306,8 +307,9 @@
     </itemizedlist>
 
     <para>
-      &libvirt; contains two modular daemons that are also used by the
-      monolithic &libvirtd;, virtlockd and virtlogd.
+      virtlogd and virtlockd are also used by the monolithic &libvirtd;.
+      These daemons have always been separate from &libvirtd; for security
+      reasons.
     </para>
 
     <para>
@@ -450,9 +452,9 @@
       </step>
       <step>
         <para>
-          Enable the new daemons for &kvm; or &xen;, including the required
-          secondary drivers. The following example enables the &qemu; driver
-          for &kvm; and all the required secondary drivers:
+          Enable the modular daemons for &kvm; or &xen;, including the desired
+          secondary daemons. The following example enables the &qemu; daemon
+          for &kvm; and all the secondary daemons except the interface daemon:
         </para>
 <screen>
 for drv in qemu network nodedev nwfilter secret storage

--- a/xml/libvirt_overview.xml
+++ b/xml/libvirt_overview.xml
@@ -307,7 +307,7 @@
     </itemizedlist>
 
     <para>
-      virtlogd and virtlockd are also used by the monolithic &libvirtd;.
+      <systemitem class="daemon">virtlogd</systemitem> and <systemitem class="daemon">virtlockd</systemitem> are also used by the monolithic &libvirtd;.
       These daemons have always been separate from &libvirtd; for security
       reasons.
     </para>


### PR DESCRIPTION
### PR creator: Description

Along with some wording improvements, prefer the use of 'daemon' over 'driver' when referring to modular daemons.


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
