### PR TITLE
Switch modular daemons

### DIFF
--- a/xml/libvirt_overview.xml
+++ b/xml/libvirt_overview.xml
@@ -282,7 +282,7 @@
       </listitem>
       <listitem>
         <para>
-          <emphasis>libvirtd-ro.socket</emphasis> - The unit file corresponding
+          <filename>libvirtd-ro.socket</filename> - The unit file corresponding
           to the main read-only UNIX socket
           <filename>/var/run/libvirt/libvirt-sock-ro</filename>. We recommend
           enabling this unit on boot.

--- a/xml/libvirt_overview.xml
+++ b/xml/libvirt_overview.xml
@@ -290,7 +290,7 @@
       </listitem>
       <listitem>
         <para>
-          <emphasis>libvirtd-admin.socket</emphasis> - The unit file
+          <filename>libvirtd-admin.socket</filename> - The unit file
           corresponding to the administrative UNIX socket
           <filename>/var/run/libvirt/libvirt-admin-sock</filename>. We
           recommend enabling this unit on boot.
@@ -298,7 +298,7 @@
       </listitem>
       <listitem>
         <para>
-          <emphasis>libvirtd-tcp.socket</emphasis> - The unit file
+          <filename>libvirtd-tcp.socket</filename> - The unit file
           corresponding to the TCP 16509 port for non-TLS remote access. This
           unit should not be configured to start on boot until the
           administrator has configured a suitable authentication mechanism.
@@ -306,7 +306,7 @@
       </listitem>
       <listitem>
         <para>
-          <emphasis>libvirtd-tls.socket</emphasis> - The unit file
+          <filename>libvirtd-tls.socket</filename> - The unit file
           corresponding to the TCP 16509 port for TLS remote access. This unit
           should not be configured to start on boot until the administrator has
           deployed x509 certificates and optionally configured a suitable
@@ -398,7 +398,7 @@
     </itemizedlist>
 
     <important>
-      <title>Conflicting services: <systemitem class="daemon">libvirtd</systemitem> and <systemitem class="daemon">xendomains</systemitem></title>
+      <title>Conflicting services: &libvirtd; and <systemitem class="daemon">xendomains</systemitem></title>
       <para>
         If &libvirtd; fails to start, check if the service
         <systemitem class="daemon">xendomains</systemitem> is loaded:

--- a/xml/libvirt_overview.xml
+++ b/xml/libvirt_overview.xml
@@ -151,9 +151,9 @@
     </para>
 
     <para>
-      The virtqemud and virtxend services are enabled in the &systemd; presets.
-      The sockets for virtnetworkd, virtnodedevd, virtnwfilterd, virtstoraged,
-      and virtsecretd are also enabled in the presets, ensuring the daemons
+      The <systemitem class="daemon">virtqemud</systemitem> and <systemitem class="daemon">virtxend</systemitem> services are enabled in the &systemd; presets.
+      The sockets for <systemitem class="daemon">virtnetworkd</systemitem>, <systemitem class="daemon">virtnodedevd</systemitem>, <systemitem class="daemon">virtnwfilterd</systemitem>, <systemitem class="daemon">virtstoraged</systemitem>,
+      and <systemitem class="daemon">virtsecretd</systemitem> are also enabled in the presets, ensuring the daemons
       are enabled and available when the corresponding packages are installed.
       Although enabled in presets for convenience, the modular daemons can
       also be managed with their &systemd; unit files:

--- a/xml/libvirt_overview.xml
+++ b/xml/libvirt_overview.xml
@@ -24,10 +24,10 @@
     storage, networking, node devices, etc. The monolithic &libvirtd; also
     provides secure remote access for external clients. Over time &libvirt;
     added support for modular daemons, where each driver runs in its own
-    daemon, allowing users to customize their &libvirt; deployment. The
-    monolithic daemon is enabled by default, but a deployment can be
-    switched to modular daemons by disabling &libvirtd; and enabling the
-    desired individual daemons.
+    daemon, allowing users to customize their &libvirt; deployment. Modular
+    daemons are enabled by default, but a deployment can be switched to the
+    traditional monolithic daemon by disabling the individual daemons and
+    enabling &libvirtd;.
   </para>
   <para>
     The modular daemon deployment is useful in scenarios where minimal
@@ -42,6 +42,218 @@
     Modular daemons allow configuring a custom &libvirt; deployment containing
     only the components required for the use case.
   </para>
+  <sect1 xml:id="libvirt-modular-daemon">
+    <title>Starting and stopping the modular daemons</title>
+
+    <para>
+      The modular daemons are named after the driver which they are running,
+      with the pattern <quote>virt<replaceable>DRIVER</replaceable>d</quote>.
+      They are configured via the files
+      <filename>/etc/libvirt/virt<replaceable>DRIVER</replaceable>d.conf</filename>.
+      &suse; supports the virtqemud and virtxend hypervisor daemons, along with
+      all the secondary daemons:
+    </para>
+
+    <itemizedlist>
+      <listitem>
+        <para>
+          <emphasis>virtnetworkd</emphasis> - The virtual network management
+          daemon which provides &libvirt;'s virtual network management APIs.
+          For example, virtnetworkd can be used to create a NAT virtual network
+          on the host for use by virtual machines.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <emphasis>virtnodedevd</emphasis> - The host physical device
+          management daemon which provides &libvirt;'s node device management
+          APIs. For example, virtnodedevd can be used to detach a PCI device
+          from the host for use by a virtual machine.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <emphasis>virtnwfilterd</emphasis> - The host firewall management
+          daemon which provides &libvirt;'s firewall management APIs. For
+          example, virtnwfilterd can be used to configure network traffic
+          filtering rules for virtual machines.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <emphasis>virtsecretd</emphasis> - The host secret management daemon
+          which provides &libvirt;'s secret management APIs. For example,
+          virtsecretd can be used to store a key associated with a LUKs volume.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <emphasis>virtstoraged</emphasis> - The host storage management
+          daemon which provides &libvirt;'s storage management APIs.
+          virtstoraged can be used to create storage pools and create volumes
+          from those pools.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <emphasis>virtinterfaced</emphasis> - The host NIC management daemon
+          which provides &libvirt;'s host network interface management APIs.
+          For example, virtinterfaced can be used to create a bonded network
+          device on the host. &suse; discourages the use of &libvirt;'s interface
+          management APIs in favor of default networking tools like wicked or
+          &nm;. It is recommended to disable virtinterfaced.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <emphasis>virtproxyd</emphasis> - A daemon to proxy connections
+          between the traditional &libvirtd; sockets and the modular daemon
+          sockets. With a modular &libvirt; deployment, virtproxyd allows
+          remote clients to access the &libvirt; APIs similar to the monolithic
+          &libvirtd;. It can also be used by local clients that connect to the
+          monolithic &libvirtd; sockets.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <emphasis>virtlogd</emphasis> - A daemon to manage logs from virtual
+          machine consoles. virtlogd is also used by the monolithic &libvirtd;.
+          The monolithic daemon and virtqemud &systemd; unit files require
+          virtlogd, so it is not necessary to explicitly start virtlogd.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <emphasis>virtlockd</emphasis> - A daemon to manage locks held
+          against virtual machine resources such as disks. virtlockd is also
+          used by the monolithic &libvirtd;. The monolithic daemon, virtqemud,
+          and virtxend &systemd; unit files require virtlockd, so it is not
+          necessary to explicitly start virtlockd.
+        </para>
+      </listitem>
+    </itemizedlist>
+
+    <para>
+      virtlogd and virtlockd are also used by the monolithic &libvirtd;.
+      These daemons have always been separate from &libvirtd; for security
+      reasons.
+    </para>
+
+    <para>
+      By default, the modular daemons listen for connections on the
+      <filename>/var/run/libvirt/virt<replaceable>DRIVER</replaceable>d-sock</filename>
+      and
+      <filename>/var/run/libvirt/virt<replaceable>DRIVER</replaceable>d-sock-ro</filename>
+      Unix Domain Sockets. The client library prefers these sockets over the
+      traditional <filename>/var/run/libvirt/libvirtd-sock</filename>. The
+      virtproxyd daemon is available for remote clients or local clients
+      expecting the traditional &libvirtd; socket.
+    </para>
+
+    <para>
+      The virtqemud and virtxend services are enabled in the &systemd; presets.
+      The sockets for virtnetworkd, virtnodedevd, virtnwfilterd, virtstoraged,
+      and virtsecretd are also enabled in the presets, ensuring the daemons
+      are enabled and available when the corresponding packages are installed.
+      Although enabled in presets for convenience, the modular daemons can
+      also be managed with their &systemd; unit files:
+    </para>
+
+    <itemizedlist>
+      <listitem>
+        <para>
+          <emphasis>virt<replaceable>DRIVER</replaceable>d.service</emphasis> -
+          The main unit file for launching the
+          virt<replaceable>DRIVER</replaceable>d daemon. We recommend
+          configuring the service to start on boot if VMs are also configured
+          to start on host boot.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <emphasis>virt<replaceable>DRIVER</replaceable>d.socket</emphasis> -
+          The unit file corresponding to the main read-write UNIX socket
+          <filename>/var/run/libvirt/virt<replaceable>DRIVER</replaceable>d-sock</filename>.
+          We recommend starting this socket on boot by default.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <emphasis>virt<replaceable>DRIVER</replaceable>d-ro.socket</emphasis>
+          - The unit file corresponding to the main read-only UNIX socket
+          <filename>/var/run/libvirt/virt<replaceable>DRIVER</replaceable>d-sock-ro</filename>.
+          We recommend starting this socket on boot by default.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <emphasis>virt<replaceable>DRIVER</replaceable>d-admin.socket</emphasis>
+          - The unit file corresponding to the administrative UNIX socket
+          <filename>/var/run/libvirt/virt<replaceable>DRIVER</replaceable>d-admin-sock</filename>.
+          We recommend starting this socket on boot by default.
+        </para>
+      </listitem>
+    </itemizedlist>
+
+    <para>
+      When &systemd; socket activation is used, several configuration settings
+      in virt<replaceable>DRIVER</replaceable>d.conf are no longer honored.
+      Instead, these settings must be controlled via the system unit files:
+    </para>
+
+    <itemizedlist>
+      <listitem>
+        <para>
+          <emphasis>unix_sock_group</emphasis> - UNIX socket group owner,
+          controlled via the <option>SocketGroup</option> parameter in the
+          <filename>virt<replaceable>DRIVER</replaceable>d.socket</filename>
+          and
+          <filename>virt<replaceable>DRIVER</replaceable>d-ro.socket</filename>
+          unit files.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <emphasis>unix_sock_ro_perms</emphasis> - Read-only UNIX socket
+          permissions, controlled via the <option>SocketMode</option> parameter
+          in the
+          <filename>virt<replaceable>DRIVER</replaceable>d-ro.socket</filename>
+          unit file.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <emphasis>unix_sock_rw_perms</emphasis> - Read-write UNIX socket
+          permissions, controlled via the <option>SocketMode</option> parameter
+          in the
+          <filename>virt<replaceable>DRIVER</replaceable>d.socket</filename>
+          unit file.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <emphasis>unix_sock_admin_perms</emphasis> - Admin UNIX socket
+          permissions, controlled via the <option>SocketMode</option> parameter
+          in the
+          <filename>virt<replaceable>DRIVER</replaceable>d-admin.socket</filename>
+          unit file.
+        </para>
+      </listitem>
+      <listitem>
+        <para>
+          <emphasis>unix_sock_dir</emphasis> - Directory in which all UNIX
+          sockets are created, independently controlled via the
+          <option>ListenStream</option> parameter in any of the
+          <filename>virt<replaceable>DRIVER</replaceable>d.socket</filename>,
+          <filename>virt<replaceable>DRIVER</replaceable>d-ro.socket</filename>
+          and
+          <filename>virt<replaceable>DRIVER</replaceable>d-admin.socket</filename>
+          unit files.
+        </para>
+      </listitem>
+    </itemizedlist>
+
+  </sect1>
   <sect1 xml:id="libvirt-monolithic-daemon">
     <title>Starting and stopping the monolithic daemon</title>
 
@@ -215,275 +427,56 @@
       </para>
     </important>
   </sect1>
-  <sect1 xml:id="libvirt-modular-daemon">
-    <title>Starting and stopping the modular daemons</title>
-
-    <para>
-      The modular daemons are named after the driver which they are running,
-      with the pattern <quote>virt<replaceable>DRIVER</replaceable>d</quote>.
-      They are configured via the files
-      <filename>/etc/libvirt/virt<replaceable>DRIVER</replaceable>d.conf</filename>.
-      &suse; supports the virtqemud and virtxend hypervisor daemons, along with
-      all the secondary daemons:
-    </para>
-
-    <itemizedlist>
-      <listitem>
-        <para>
-          <emphasis>virtnetworkd</emphasis> - The virtual network management
-          daemon which provides &libvirt;'s virtual network management APIs.
-          For example, virtnetworkd can be used to create a NAT virtual network
-          on the host for use by virtual machines.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <emphasis>virtnodedevd</emphasis> - The host physical device
-          management daemon which provides &libvirt;'s node device management
-          APIs. For example, virtnodedevd can be used to detach a PCI device
-          from the host for use by a virtual machine.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <emphasis>virtnwfilterd</emphasis> - The host firewall management
-          daemon which provides &libvirt;'s firewall management APIs. For
-          example, virtnwfilterd can be used to configure network traffic
-          filtering rules for virtual machines.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <emphasis>virtsecretd</emphasis> - The host secret management daemon
-          which provides &libvirt;'s secret management APIs. For example,
-          virtsecretd can be used to store a key associated with a LUKs volume.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <emphasis>virtstoraged</emphasis> - The host storage management
-          daemon which provides &libvirt;'s storage management APIs.
-          virtstoraged can be used to create storage pools and create volumes
-          from those pools.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <emphasis>virtinterfaced</emphasis> - The host NIC management daemon
-          which provides &libvirt;'s host network interface management APIs.
-          For example, virtinterfaced can be used to create a bonded network
-          device on the host. &suse; discourages the use of &libvirt;'s interface
-          management APIs in favor of default networking tools like wicked or
-          &nm;. It is recommended to disable virtinterfaced.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <emphasis>virtproxyd</emphasis> - A daemon to proxy connections
-          between the traditional &libvirtd; sockets and the modular daemon
-          sockets. With a modular &libvirt; deployment, virtproxyd allows
-          remote clients to access the &libvirt; APIs similar to the monolithic
-          &libvirtd;. It can also be used by local clients that connect to the
-          monolithic &libvirtd; sockets.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <emphasis>virtlogd</emphasis> - A daemon to manage logs from virtual
-          machine consoles. virtlogd is also used by the monolithic &libvirtd;.
-          The monolithic daemon and virtqemud &systemd; unit files require
-          virtlogd, so it is not necessary to explicitly start virtlogd.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <emphasis>virtlockd</emphasis> - A daemon to manage locks held
-          against virtual machine resources such as disks. virtlockd is also
-          used by the monolithic &libvirtd;. The monolithic daemon, virtqemud,
-          and virtxend &systemd; unit files require virtlockd, so it is not
-          necessary to explicitly start virtlockd.
-        </para>
-      </listitem>
-    </itemizedlist>
-
-    <para>
-      virtlogd and virtlockd are also used by the monolithic &libvirtd;.
-      These daemons have always been separate from &libvirtd; for security
-      reasons.
-    </para>
-
-    <para>
-      By default, the modular daemons listen for connections on the
-      <filename>/var/run/libvirt/virt<replaceable>DRIVER</replaceable>d-sock</filename>
-      and
-      <filename>/var/run/libvirt/virt<replaceable>DRIVER</replaceable>d-sock-ro</filename>
-      Unix Domain Sockets. The client library prefers these sockets over the
-      traditional <filename>/var/run/libvirt/libvirtd-sock</filename>. The
-      virtproxyd daemon is available for remote clients or local clients
-      expecting the traditional &libvirtd; socket.
-    </para>
-
-    <para>
-      Like the monolithic daemon, the modular daemons are managed with several
-      &systemd; unit files:
-    </para>
-
-    <itemizedlist>
-      <listitem>
-        <para>
-          <emphasis>virt<replaceable>DRIVER</replaceable>d.service</emphasis> -
-          The main unit file for launching the
-          virt<replaceable>DRIVER</replaceable>d daemon. We recommend
-          configuring the service to start on boot if VMs are also configured
-          to start on host boot.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <emphasis>virt<replaceable>DRIVER</replaceable>d.socket</emphasis> -
-          The unit file corresponding to the main read-write UNIX socket
-          <filename>/var/run/libvirt/virt<replaceable>DRIVER</replaceable>d-sock</filename>.
-          We recommend starting this socket on boot by default.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <emphasis>virt<replaceable>DRIVER</replaceable>d-ro.socket</emphasis>
-          - The unit file corresponding to the main read-only UNIX socket
-          <filename>/var/run/libvirt/virt<replaceable>DRIVER</replaceable>d-sock-ro</filename>.
-          We recommend starting this socket on boot by default.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <emphasis>virt<replaceable>DRIVER</replaceable>d-admin.socket</emphasis>
-          - The unit file corresponding to the administrative UNIX socket
-          <filename>/var/run/libvirt/virt<replaceable>DRIVER</replaceable>d-admin-sock</filename>.
-          We recommend starting this socket on boot by default.
-        </para>
-      </listitem>
-    </itemizedlist>
-
-    <para>
-      When &systemd; socket activation is used, several configuration settings
-      in virt<replaceable>DRIVER</replaceable>d.conf are no longer honored.
-      Instead, these settings must be controlled via the system unit files:
-    </para>
-
-    <itemizedlist>
-      <listitem>
-        <para>
-          <emphasis>unix_sock_group</emphasis> - UNIX socket group owner,
-          controlled via the <option>SocketGroup</option> parameter in the
-          <filename>virt<replaceable>DRIVER</replaceable>d.socket</filename>
-          and
-          <filename>virt<replaceable>DRIVER</replaceable>d-ro.socket</filename>
-          unit files.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <emphasis>unix_sock_ro_perms</emphasis> - Read-only UNIX socket
-          permissions, controlled via the <option>SocketMode</option> parameter
-          in the
-          <filename>virt<replaceable>DRIVER</replaceable>d-ro.socket</filename>
-          unit file.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <emphasis>unix_sock_rw_perms</emphasis> - Read-write UNIX socket
-          permissions, controlled via the <option>SocketMode</option> parameter
-          in the
-          <filename>virt<replaceable>DRIVER</replaceable>d.socket</filename>
-          unit file.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <emphasis>unix_sock_admin_perms</emphasis> - Admin UNIX socket
-          permissions, controlled via the <option>SocketMode</option> parameter
-          in the
-          <filename>virt<replaceable>DRIVER</replaceable>d-admin.socket</filename>
-          unit file.
-        </para>
-      </listitem>
-      <listitem>
-        <para>
-          <emphasis>unix_sock_dir</emphasis> - Directory in which all UNIX
-          sockets are created, independently controlled via the
-          <option>ListenStream</option> parameter in any of the
-          <filename>virt<replaceable>DRIVER</replaceable>d.socket</filename>,
-          <filename>virt<replaceable>DRIVER</replaceable>d-ro.socket</filename>
-          and
-          <filename>virt<replaceable>DRIVER</replaceable>d-admin.socket</filename>
-          unit files.
-        </para>
-      </listitem>
-    </itemizedlist>
-  </sect1>
   <sect1 xml:id="libvirt-switch-daemons">
-    <title>Switching to modular daemons</title>
+    <title>Switching to the monolithic daemon</title>
 
     <para>
-      Several services need to be changed when switching from the monolithic to
-      modular daemons. It is recommended to stop or evict any running virtual
+      Several services need to be changed when switching from modular to the
+      monolithic daemon. It is recommended to stop or evict any running virtual
       machines before switching between the daemon options.
     </para>
 
     <procedure>
       <step>
         <para>
-          Stop the monolithic daemon and its sockets
-        </para>
-<screen>
-&prompt.sudo;systemctl stop libvirtd.service
-&prompt.sudo;systemctl stop libvirtd{,-ro,-admin}.socket
-</screen>
-      </step>
-      <step>
-        <para>
-          Disable future start of the monolithic daemon
-        </para>
-<screen>
-&prompt.sudo;systemctl disable libvirtd.service
-&prompt.sudo;systemctl disable libvirtd{,-ro,-admin}.socket
-</screen>
-      </step>
-      <step>
-        <para>
-          Enable the modular daemons for &kvm; or &xen;, including the desired
-          secondary daemons. The following example enables the &qemu; daemon
-          for &kvm; and all the secondary daemons except the interface daemon:
+          Stop the modular daemons and their sockets. The following example
+	  disables the &qemu; daemon for &kvm; and several secondary daemons.
         </para>
 <screen>
 for drv in qemu network nodedev nwfilter secret storage
 do
- &prompt.sudo;systemctl enable virt${drv}d.service
- &prompt.sudo;systemctl enable virt${drv}d{,-ro,-admin}.socket
+ &prompt.sudo;systemctl stop virt${drv}d.service
+ &prompt.sudo;systemctl stop virt${drv}d{,-ro,-admin}.socket
 done
 </screen>
       </step>
       <step>
         <para>
-          Start the sockets for the same set of daemons
+          Disable future start of the modular daemons
         </para>
 <screen>
 for drv in qemu network nodedev nwfilter secret storage
 do
- &prompt.sudo;systemctl start virt${drv}d{,-ro,-admin}.socket
+ &prompt.sudo;systemctl disable virt${drv}d.service
+ &prompt.sudo;systemctl disable virt${drv}d{,-ro,-admin}.socket
 done
 </screen>
       </step>
       <step>
         <para>
-          If connections from remote hosts need to be supported, the virtproxyd
-          daemon must be enabled and started:
+          Enable the monolithic &libvirtd; service and sockets
         </para>
 <screen>
-&prompt.sudo;systemctl enable virtproxyd.service
-&prompt.sudo;systemctl enable virtproxyd{,-ro,-admin}.socket
-&prompt.sudo;systemctl start virtproxyd{,-ro,-admin}.socket
+&prompt.sudo;systemctl enable libvirtd.service
+&prompt.sudo;systemctl enable libvirtd{,-ro,-admin}.socket
+</screen>
+      </step>
+      <step>
+        <para>
+          Start the monolithic &libvirtd; sockets
+        </para>
+<screen>
+&prompt.sudo;systemctl start libvirtd{,-ro,-admin}.socket
 </screen>
       </step>
     </procedure>

--- a/xml/libvirt_overview.xml
+++ b/xml/libvirt_overview.xml
@@ -20,20 +20,21 @@
     daemons to be installed and active on the host. &libvirt; provides two
     daemon deployment options: monolithic or modular daemons. &libvirt; has
     always provided the single monolithic daemon &libvirtd;. It includes the
-    primary hypervisor drivers and all supporting secondary drivers needed for
-    storage, such as networking, node device and management. The
-    monolithic &libvirtd; also provides secure remote access for external
-    clients. With modular daemons, each driver runs in its own daemon, allowing
-    users to customize their &libvirt; deployment. By default, the monolithic
-    daemon is enabled, but a deployment can be switched to modular daemons by
-    managing the corresponding &systemd; service files.
+    primary hypervisor drivers and all secondary drivers needed for managing
+    storage, networking, node devices, etc. The monolithic &libvirtd; also
+    provides secure remote access for external clients. Over time &libvirt;
+    added support for modular daemons, where each driver runs in its own
+    daemon, allowing users to customize their &libvirt; deployment. The
+    monolithic daemon is enabled by default, but a deployment can be
+    switched to modular daemons by disabling &libvirtd; and enabling the
+    desired individual daemons.
   </para>
   <para>
     The modular daemon deployment is useful in scenarios where minimal
     &libvirt; support is needed. For example, if virtual machine storage and
     networking is not provided by &libvirt;, the
     <package>libvirt-daemon-driver-storage</package> and
-    <package>libvirt-daemon-driver-network</package> type of packages are not
+    <package>libvirt-daemon-driver-network</package> packages are not
     required. &kube; is an example of an extreme case, where it handles all
     networking, storage, cgroups and namespace integration, etc. Only the
     <package>libvirt-daemon-driver-&qemu;</package> package, providing
@@ -223,7 +224,7 @@
       They are configured via the files
       <filename>/etc/libvirt/virt<replaceable>DRIVER</replaceable>d.conf</filename>.
       &suse; supports the virtqemud and virtxend hypervisor daemons, along with
-      all the supporting secondary daemons:
+      all the secondary daemons:
     </para>
 
     <itemizedlist>
@@ -306,8 +307,9 @@
     </itemizedlist>
 
     <para>
-      &libvirt; contains two modular daemons that are also used by the
-      monolithic &libvirtd;, virtlockd and virtlogd.
+      virtlogd and virtlockd are also used by the monolithic &libvirtd;.
+      These daemons have always been separate from &libvirtd; for security
+      reasons.
     </para>
 
     <para>
@@ -450,9 +452,9 @@
       </step>
       <step>
         <para>
-          Enable the new daemons for &kvm; or &xen;, including the required
-          secondary drivers. The following example enables the &qemu; driver
-          for &kvm; and all the required secondary drivers:
+          Enable the modular daemons for &kvm; or &xen;, including the desired
+          secondary daemons. The following example enables the &qemu; daemon
+          for &kvm; and all the secondary daemons except the interface daemon:
         </para>
 <screen>
 for drv in qemu network nodedev nwfilter secret storage

--- a/xml/libvirt_overview.xml
+++ b/xml/libvirt_overview.xml
@@ -266,7 +266,7 @@
     <itemizedlist>
       <listitem>
         <para>
-          <emphasis>libvirtd.service</emphasis> - The main &systemd; unit file
+          <filename>libvirtd.service</filename> - The main &systemd; unit file
           for launching &libvirtd;. We recommend configuring
           <filename>libvirtd.service</filename> to start on boot if VMs are
           also configured to start on host boot.

--- a/xml/libvirt_overview.xml
+++ b/xml/libvirt_overview.xml
@@ -274,7 +274,7 @@
       </listitem>
       <listitem>
         <para>
-          <emphasis>libvirtd.socket</emphasis> - The unit file corresponding to
+          <filename>libvirtd.socket</filename> - The unit file corresponding to
           the main read-write UNIX socket
           <filename>/var/run/libvirt/libvirt-sock</filename>. We recommend
           enabling this unit on boot.

--- a/xml/libvirt_overview.xml
+++ b/xml/libvirt_overview.xml
@@ -134,7 +134,7 @@
     </itemizedlist>
 
     <para>
-      virtlogd and virtlockd are also used by the monolithic &libvirtd;.
+      <systemitem class="daemon">virtlogd</systemitem> and <systemitem class="daemon">virtlockd</systemitem> are also used by the monolithic &libvirtd;.
       These daemons have always been separate from &libvirtd; for security
       reasons.
     </para>

--- a/xml/libvirt_overview.xml
+++ b/xml/libvirt_overview.xml
@@ -50,7 +50,7 @@
       with the pattern <quote>virt<replaceable>DRIVER</replaceable>d</quote>.
       They are configured via the files
       <filename>/etc/libvirt/virt<replaceable>DRIVER</replaceable>d.conf</filename>.
-      &suse; supports the virtqemud and virtxend hypervisor daemons, along with
+      &suse; supports the <systemitem class="daemon">virtqemud</systemitem> and <systemitem class="daemon">virtxend</systemitem> hypervisor daemons, along with
       all the secondary daemons:
     </para>
 


### PR DESCRIPTION
### PR creator: Description

Change the libvirt daemons chapter to reflect modular daemons are now enabled by default. This change is based on top of https://github.com/SUSE/doc-sle/pull/1589 and is only valid for SLE15 SP6 and newer. The change in PR#1589 should also be applied to SLE15 SP4 and SP5.

### PR creator: Are there any relevant issues/feature requests?

* jsc#PED-4303


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP4/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
