### PR TITLE
SLE-23248 Document support limitations for 389-DS

### DIFF
--- a/xml/security_ldap_modules.xml
+++ b/xml/security_ldap_modules.xml
@@ -99,4 +99,29 @@ memberOf: cn=SERVER_ADMINS,ou=groups,dc=ldap1,dc=com</screen>
  <command>fixup</command> command:
 </para>
 <screen>&prompt.sudo;<command>dsconf LDAP1 plugin memberof fixup -f '(objectClass=*)' dc=LDAP1,dc=COM</command></screen>
+
+<sect2 xml:id="sec-security-ldap-modules-unsupported-plugins">
+ <title>Unsupported plug-ins on &ds389;</title>
+ <para>
+  The following plug-ins are not officially supported on &ds389;:
+ </para>
+ <itemizedlist>
+  <listitem>
+   <para>
+    Distributed Numeric Assignment (DNA) plug-in
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    Managed Entries Plug-in (MEP)
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    Posix Winsync plug-in
+   </para>
+  </listitem>
+ </itemizedlist>
+</sect2>
+
 </sect1>

--- a/xml/security_ldap_replication.xml
+++ b/xml/security_ldap_replication.xml
@@ -690,4 +690,33 @@ fschecks:file_perms
 &prompt.sudo;<command>dsconf <replaceable>INSTANCE_NAME</replaceable> repl-tasks list-cleanruv-tasks</command>
 </screen>
  </sect2>
+
+ <sect2 xml:id="sec-security-ldap-replication-limits">
+  <title>Limitations on replication of &ds389;</title>
+  <para>
+   The use of &ds389; is officially supported within the following replication limits:
+  </para>
+  <itemizedlist>
+   <listitem>
+    <para>
+     A maximum of 8 read-write nodes
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     A maximum of 20 replication hubs
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     A maximum of 100 read-only servers
+    </para>
+   </listitem>
+   <listitem>
+    <para>
+     A maximum of 1 Winsync Active Directory consumer as a read-write node member
+    </para>
+   </listitem>
+  </itemizedlist>
+ </sect2>
 </sect1>

--- a/xml/security_ldap_sssd.xml
+++ b/xml/security_ldap_sssd.xml
@@ -197,4 +197,35 @@ session:</screen>
     See <xref linkend="cha-security-auth"/> for information on managing the
     sssd.service with systemctl.
   </para>
+
+  <sect2 xml:id="sec-security-ldap-server-sssd-unsupported-password-hash">
+   <title>Unsupported password hashes and authentication schemes</title>
+   <para>
+    The following are not supported as configuration values in <systemitem>dse.ldif</systemitem> for
+    the settings <systemitem>nsslapd-rootpwstoragescheme</systemitem> or
+    <systemitem>passwordStorageScheme</systemitem>, or as a value of
+    <systemitem>passwordStorageScheme</systemitem> in the account policy objects:
+   </para>
+   <itemizedlist>
+    <listitem><para>SHA</para></listitem>
+    <listitem><para>SSHA</para></listitem>
+    <listitem><para>SHA256</para></listitem>
+    <listitem><para>SSHA256</para></listitem>
+    <listitem><para>SHA384</para></listitem>
+    <listitem><para>SSHA384</para></listitem>
+    <listitem><para>SHA512</para></listitem>
+    <listitem><para>SSHA512</para></listitem>
+    <listitem><para>NS-MTA-MD5</para></listitem>
+    <listitem><para>clear</para></listitem>
+    <listitem><para>MD5</para></listitem>
+    <listitem><para>SMD5</para></listitem>
+   </itemizedlist>
+   <note>
+    <para>
+      Database imports that contain these values are supported if
+      <systemitem>nsslapd-enable-upgrade-hash</systemitem> is set to <systemitem>on</systemitem>
+      (defaults to <systemitem>on</systemitem>).
+    </para>
+   </note>
+  </sect2>
   </sect1>


### PR DESCRIPTION
### PR creator: Description

Document certain limitations for better organizing official support around 389-DS.


### PR creator: Are there any relevant issues/feature requests?

* Bugzilla: 
* JIRA: https://jira.suse.com/browse/SLE-23428


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP4/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
