### PR TITLE
fix line overflow

### DIFF
--- a/xml/art_modules.xml
+++ b/xml/art_modules.xml
@@ -1637,8 +1637,8 @@ Following packages were found in following modules:
 
 Package  Module or Repository
            SUSEConnect Activation Command
---- -------------------------------------------------------------------------------------
----------- ------------------------------------------------------------------------------
+--- ----------------------------------------------------------------------------
+---------- ---------------------------------------------------------------------
 vim Basesystem Module (sle-module-basesystem/15.4/x86_64)
       SUSEConnect --product sle-module-basesystem/15.4/x86_64
 vim Installed
@@ -1650,8 +1650,8 @@ Following packages were found in following modules:
 
 Package Module or Repository
           SUSEConnect Activation Command
------ ----------------------------------------------------------------------------------
---------- ------------------------------------------------------------------------------
+----- --------------------------------------------------------------------------
+--------- ----------------------------------------------------------------------
 emacs Basesystem Module (sle-module-basesystem/15.4/x86_64)
         SUSEConnect --product sle-module-basesystem/15.4/x86_64
 emacs Available in repo Basesystem_Module_15_SP4_x86_64:SLE-Module-Basesystem15-SP4-Pool</screen>


### PR DESCRIPTION
PR creator: Description

Fixed line overflow for PDF version of _Modules and Extensions Quick Start_. 
I noticed it in zh-cn (see https://documentation.suse.com/zh-cn/sles/15-SP5/pdf/article-modules_zh_cn.pdf) Chapter 4, Example 3. But it also occurs in the English Guide.
Please review @cwickert 


PR creator: Are there any relevant issues/feature requests?

- https://jira.suse.com/browse/DOCTEAM-1018


PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
