### PR TITLE
Initial draft for new LUKS-related partitioning elements

### DIFF
--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -557,6 +557,11 @@
        </listitem>
        <listitem>
         <para>
+         <literal>luks2</literal>: regular LUKS2 encryption.
+        </para>
+       </listitem>
+       <listitem>
+        <para>
          <literal>pervasive_luks2</literal>: pervasive volume encryption.
         </para>
        </listitem>
@@ -588,6 +593,15 @@
        See <literal>crypt_key</literal> element to learn how to specify the
        encryption password if needed.
       </para>
+      <para>
+       When using regular LUKS encryption, it is possible to customize several aspects
+       of the encryption using <literal>crypt_pbkdf</literal>, <literal>crypt_cipher</literal>
+       or <literal>crypt_key_size</literal>, depending on the exact variant of LUKS that
+       is used. Bear in mind that the encryption method and its corresponding settings may
+       dramatically affect the amount of RAM needed to complete the installation process.
+       Using regular LUKS2 with default parameters typically implies the need of having
+       several gigabytes of RAM in the system in order to encrypt the devices.
+      </para>
      </listitem>
     </varlistentry>
     <varlistentry>
@@ -605,10 +619,65 @@
      <listitem>
       <para>
        Required if <literal>crypt_method</literal> has been set to a method
-       that requires a password (that is, <literal>luks1</literal> or
-       <literal>pervasive_luks2</literal>).
+       that requires a password (that is, <literal>luks1</literal>,
+       <literal>luks2</literal> or <literal>pervasive_luks2</literal>).
       </para>
 <screen>&lt;crypt_key&gt;xxxxxxxx&lt;/crypt_key&gt;</screen>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>crypt_cipher</term>
+     <listitem>
+      <para>
+       Cipher used for LUKS encryption. This value is only honored if the
+       value of <literal>crypt_method</literal> is <literal>luks1</literal>
+       or <literal>luks2</literal>. The format and value of the string must
+       be compatible with the <literal>--cipher</literal> argument of the
+       command cryptsetup.
+      </para>
+<screen>&lt;crypt_cipher&gt;aes-xts-plain64&lt;/crypt_cipher&gt;</screen>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>crypt_key_size</term>
+     <listitem>
+      <para>
+       Key size, in bits, used for LUKS encryption. This value is only
+       honored if the value of <literal>crypt_method</literal> is
+       <literal>luks1</literal> or <literal>luks2</literal>. The value
+       has to be a multiple of 8. The possible key sizes are limited by
+       the used cipher.
+      </para>
+<screen>&lt;crypt_key_size config:type="integer"&gt;256&lt;/crypt_key_size&gt;</screen>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>crypt_pbkdf</term>
+     <listitem>
+      <para>
+       Password-based key derivation function used for LUKS2 encryption.
+       This is only relevant if the <literal>crypt_method</literal> is
+       <literal>luks2</literal>. The possible values are
+       <literal>pbkdf2</literal>, <literal>argon2i</literal> and
+       <literal>argon2id</literal>. If omitted, the device will be encrypted
+       using the default function of the command cryptsetup. Note that both
+       variants of Argon2 are designed to intentionally consume a big amount
+       of memory during the encryption process. Using any of those functions
+       or omitting this setting (which will likely result in the usage of
+       Argon2) implies bigger RAM requirements to complete the installation
+       process, when compared to a non-encrypted setup.
+      </para>
+<screen>&lt;crypt_pbkdf config:type="symbol"&gt;argon2id&lt;/crypt_pbkdf&gt;</screen>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>crypt_label</term>
+     <listitem>
+      <para>
+       LUKS label for the encrypted device. This is only relevant if the
+       <literal>crypt_method</literal> is <literal>luks2</literal>.
+      </para>
+<screen>&lt;crypt_label&gt;crypt_home&lt;/crypt_label&gt;</screen>
      </listitem>
     </varlistentry>
     <varlistentry>

--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -633,7 +633,7 @@
        value of <literal>crypt_method</literal> is <literal>luks1</literal>
        or <literal>luks2</literal>. The format and value of the string must
        be compatible with the <literal>--cipher</literal> argument of the
-       command cryptsetup.
+       command <command>cryptsetup</command>.
       </para>
 <screen>&lt;crypt_cipher&gt;aes-xts-plain64&lt;/crypt_cipher&gt;</screen>
      </listitem>


### PR DESCRIPTION
### PR creator: Description

As requested in the Jira entries mentioned below, https://github.com/yast/yast-storage-ng/pull/1355 implements support for the new `crypt_method` LUKS2 (well, it actually makes that support official) and adds support for four new LUKS-related AutoYaST elements.

The usage of that new method and, especially, the way the other new elements can impact the amount of RAM used during installation.

This pull request adds a first draft documenting all that. Feel free to reorganize the information as needed. But please keep some note somewhere about the RAM implications since the new settings are highly demanded by several users and partners, but they should be aware of the implications.

### PR creator: Are there any relevant issues/feature requests?

* [jsc#PED-3878](https://jira.suse.com/browse/PED-3878)
* [jsc#PED-5518](https://jira.suse.com/browse/PED-5518)

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.6 (and onwards) only

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
