### PR TITLE
Removed Quagga + advised FRR

### DIFF
--- a/xml/net_basic.xml
+++ b/xml/net_basic.xml
@@ -937,8 +937,9 @@ fe80 :                           : 10 : 1000 : 1a4</screen>
     <emphasis>router advertisement protocol</emphasis>, for what prefix and
     gateways should be implemented. The radvd program can be used to set up an
     IPv6 router. This program informs the workstations which prefix to use for
-    the IPv6 addresses and which routers. Alternatively, use zebra/quagga for
-    automatic configuration of both addresses and routing.
+    the IPv6 addresses and which routers. Alternatively, use FRR (see <link
+    xlink:href="https://frrouting.org/"/>) for automatic configuration of both
+    addresses and routing.
    </para>
    <!-- 2014-04-15, ke: Karol will add this man page to the wicked
     package as well -->
@@ -985,7 +986,7 @@ fe80 :                           : 10 : 1000 : 1a4</screen>
      <term><link xlink:href="http://www.bieringer.de/linux/IPv6/"/></term>
      <listitem>
       <para>
-       Here, find the Linux IPv6-HOWTO and many links related to the topic.
+       The Linux IPv6-HOWTO and many links related to the topic.
       </para>
      </listitem>
     </varlistentry>


### PR DESCRIPTION
### PR creator: Description

Quagga tool is no longer maintained, better replace it with FRR

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
