### PR TITLE
[WIP]: removes /usr as a separate fs

### DIFF
--- a/xml/file_management.xml
+++ b/xml/file_management.xml
@@ -24,7 +24,7 @@
    <para>
     Servers should have separate file systems for at least
     <filename>/</filename>, <filename>/boot</filename>,
-    <filename>/usr</filename>, <filename>/var</filename>,
+    <filename>/var</filename>,
     <filename>/tmp</filename>, and <filename>/home</filename>. This prevents,
     for example, logging space and temporary space under
     <filename>/var</filename> and <filename>/tmp</filename> from filling up


### PR DESCRIPTION
### PR creator: Description

Describe the overall goals of this pull request.
Remove /usr as a separate FS

### PR creator: Are there any relevant issues/feature requests?

[BZ](https://bugzilla.suse.com/show_bug.cgi?id=1212851)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP5/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
