### PR TITLE
adds <?dbfo keep-together=always?> to screen

### DIFF
--- a/xml/apparmor_profiles.xml
+++ b/xml/apparmor_profiles.xml
@@ -332,7 +332,7 @@
     The default &aa; profile is attached to a program by its name, so a
     profile name must match the path to the application it is to confine.
    </para>
-<screen>/usr/bin/foo {
+<screen><?dbfo keep-together="always"?>/usr/bin/foo {
 ...
 }
 </screen>
@@ -386,7 +386,7 @@
     in a parent profile and begin with the <literal>profile</literal>
     keyword:
    </para>
-<screen>/parent/profile {
+<screen><?dbfo keep-together="always"?>/parent/profile {
    ...
    profile /local/profile {
       ...
@@ -1628,7 +1628,7 @@ ptrace (trace) peer=/usr/bin/foo,</screen>
   <para>
    Example signal rules:
   </para>
-<screen># Allow all signal access
+<screen><?dbfo keep-together="always"?># Allow all signal access
 signal,
 
 # Explicitly deny sending the HUP and INT signals

--- a/xml/apparmor_profiles_man.xml
+++ b/xml/apparmor_profiles_man.xml
@@ -1103,7 +1103,7 @@ Severity: unknown
         </para>
         <example xml:id="ex-apparmor-commandline-profiling-summary-genprof-perms">
          <title>Learning mode exception: defining permissions for an entry</title>
-<screen>Profile:  /usr/sbin/httpd2-prefork
+<screen><?dbfo keep-together="always"?>Profile:  /usr/sbin/httpd2-prefork
 Path:     /var/run/nscd/dbSz9CTr
 Mode:     r
 Severity: 3

--- a/xml/apparmor_whatimmunize.xml
+++ b/xml/apparmor_whatimmunize.xml
@@ -449,7 +449,7 @@
    Below is a sample <command>aa-unconfined</command> output:
   </para>
 
-<screen>3702<co xml:id="co-apparmor-concept-network-id"/> /usr/sbin/sshd<co xml:id="co-apparmor-concept-network-string"/> confined
+<screen><?dbfo keep-together="always"?>3702<co xml:id="co-apparmor-concept-network-id"/> /usr/sbin/sshd<co xml:id="co-apparmor-concept-network-string"/> confined
    by '/usr/sbin/sshd<co xml:id="co-apparmor-concept-network-confine"/> (enforce)'
 4040 /usr/sbin/smbd confined by '/usr/sbin/smbd (enforce)'
 4373 /usr/lib/postfix/master confined by '/usr/lib/postfix/master (enforce)'

--- a/xml/audit_components.xml
+++ b/xml/audit_components.xml
@@ -1550,7 +1550,7 @@ Login Report
        <command>aureport</command> to the statistics of failed events, use
        <command>aureport</command> <option>--failed</option>:
       </para>
-<screen>&prompt.sudo;<command>aureport --failed</command>
+<screen><?dbfo keep-together="always"?>&prompt.sudo;<command>aureport --failed</command>
 
 Failed Summary Report
 ======================
@@ -1624,7 +1624,7 @@ Number of events: 3739</screen>
        area of interest only. Not all reports support this option, however.
        This example creates a summary report for user login events:
       </para>
-<screen>&prompt.sudo;<command>aureport -u -i --summary</command>
+<screen><?dbfo keep-together="always"?>&prompt.sudo;<command>aureport -u -i --summary</command>
 
 User Summary Report
 ===========================
@@ -1674,7 +1674,7 @@ Event Report
        process ID, name of the executable, system call, audit ID, and event
        number.
       </para>
-<screen><command>aureport -p</command>
+<screen><?dbfo keep-together="always"?><command>aureport -p</command>
 
 Process ID Report
 ======================================
@@ -1738,7 +1738,7 @@ Executable Report
        call accessing it, success or failure of the command, the executable
        accessing the file, audit ID, and event number.
       </para>
-<screen>&prompt.sudo;<command>aureport -f</command>
+<screen><?dbfo keep-together="always"?>&prompt.sudo;<command>aureport -f</command>
 
 File Report
 ===============================================
@@ -1802,7 +1802,7 @@ Login Report
        the logs have been rotated in by running <command>aureport</command>
        <option>-t</option>:
       </para>
-<screen><command>aureport -t</command>
+<screen><?dbfo keep-together="always"?><command>aureport -t</command>
 
 Log Time Range Report
 =====================
@@ -1948,7 +1948,7 @@ Login Report
      <para>
       Use a command similar to the following:
      </para>
-<screen>&prompt.sudo;<command>ausearch -a 5207</command>
+<screen><?dbfo keep-together="always"?>&prompt.sudo;<command>ausearch -a 5207</command>
 ----
 time-&gt;Tue Feb 17 13:43:58 2009
 type=PATH msg=audit(1234874638.599:5207): item=0 name="/var/log/audit/audit.log" inode=1219041 dev=08:06 mode=0100644 ouid=0 ogid=0 rdev=00:00

--- a/xml/audit_scenarios.xml
+++ b/xml/audit_scenarios.xml
@@ -93,7 +93,7 @@
  <sect1 xml:id="sec-audit-scenbasic">
   <title>Adding basic audit configuration parameters</title>
 
-<screen>-D<co xml:id="co-auctld"/>
+<screen><?dbfo keep-together="always"?>-D<co xml:id="co-auctld"/>
 -b 8192<co xml:id="co-auctlb"/>
 -f 2<co xml:id="co-auctlf"/></screen>
 
@@ -558,7 +558,7 @@ w /etc/pam.d/
    a0=<replaceable>SYSCALL_NUMBER</replaceable></option>.
   </para>
 
-<screen>-a entry,always -S socketcall -F a0=1 -F a1=10<co xml:id="co-audit-socket1"/>
+<screen><?dbfo keep-together="always"?>-a entry,always -S socketcall -F a0=1 -F a1=10<co xml:id="co-audit-socket1"/>
 ## Use this line on x86_64, ia64 instead
 #-a entry,always -S socket -F a0=10
 

--- a/xml/audit_setup.xml
+++ b/xml/audit_setup.xml
@@ -138,7 +138,7 @@
    configuration.
   </para>
 
-<screen>log_file = /var/log/audit/audit.log
+<screen><?dbfo keep-together="always"?>log_file = /var/log/audit/audit.log
 log_format = RAW
 log_group = root
 priority_boost = 4
@@ -460,7 +460,7 @@ be queried with -w anyway</remark>
      because of insufficient permissions to access a file or a file not
      being there:
     </para>
-  <screen>&prompt.sudo;<command>aureport</command>
+  <screen><?dbfo keep-together="always"?>&prompt.sudo;<command>aureport</command>
 
 Summary Report
 ======================

--- a/xml/security_firewall.xml
+++ b/xml/security_firewall.xml
@@ -702,7 +702,7 @@ dhcp
        &firewalld; can also enable port forwarding. The following command will
        forward local TCP connections on port 80 to another host:
       </para>
-      <screen>&prompt.root;<command>firewall-cmd --zone=public \
+      <screen><?dbfo keep-together="always"?>&prompt.root;<command>firewall-cmd --zone=public \
     --add-forward-port=port=80:proto=tcp:toport=80:toaddr=192.168.1.10</command></screen>
      </listitem>
     </itemizedlist>

--- a/xml/security_kerberos.xml
+++ b/xml/security_kerberos.xml
@@ -838,7 +838,7 @@ group:          files</screen>
     </para>
     <example xml:id="sec-security-kerberos-example-config">
      <title>Example KDC configuration, <filename>/etc/krb5.conf</filename></title>
-<screen>[libdefaults]
+<screen><?dbfo keep-together="always"?>[libdefaults]
  dns_canonicalize_hostname = false
  rdns = false
  default_realm = &exampledomain;
@@ -1547,7 +1547,7 @@ GSSAPICleanupCredentials yes</screen>
      <para>
       Add the following:
      </para>
-<screen>[Service]
+<screen><?dbfo keep-together="always"?>[Service]
   Environment=KRB5_KTNAME=/etc/dirsrv/slapd-<replaceable>INSTANCE</replaceable>/krb5.keytab</screen>
     </step>
     <step>
@@ -1596,7 +1596,7 @@ dn: uid=testuser,ou=People,dc=example,dc=com
       <para>
        To list the existing SASL maps:
       </para>
-<screen>&prompt.user;dsconf <replaceable>INSTANCE</replaceable> sasl list
+<screen><?dbfo keep-together="always"?>&prompt.user;dsconf <replaceable>INSTANCE</replaceable> sasl list
 Kerberos uid mapping
 rfc 2829 dn syntax
 rfc 2829u syntax

--- a/xml/security_ldap_docker_container.xml
+++ b/xml/security_ldap_docker_container.xml
@@ -57,7 +57,7 @@
           To create a container with basic configuration, run the following
           example command:
         </para>
-<screen>&prompt.user; <command>docker create \
+<screen><?dbfo keep-together="always"?>&prompt.user; <command>docker create \
  -u <replaceable>USERNAME</replaceable> \
  -e SUFFIX_NAME="dc=example,dc=com" \
  -e DS_DM_PASSWORD=<replaceable>PASSWORD</replaceable> \

--- a/xml/security_ldap_migrate_test.xml
+++ b/xml/security_ldap_migrate_test.xml
@@ -134,7 +134,8 @@ No actions taken. To apply migration plan, use '--confirm'
       The following example performs the migration, and the output looks
       different from the dry run:
     </para>
-<screen>&prompt.sudo;<command>openldap_to_ds <replaceable>LDAP1</replaceable> /root/slapd.d <replaceable>/root/LDAP1-COM</replaceable>.ldif --confirm</command>
+    <screen><?dbfo keep-together="always"?>
+  &prompt.sudo;<command>openldap_to_ds <replaceable>LDAP1</replaceable> /root/slapd.d <replaceable>/root/LDAP1-COM</replaceable>.ldif --confirm</command>
 Starting Migration ... This may take some time ...
 migration: 1 / 40 complete ...
 migration: 2 / 40 complete ...
@@ -349,7 +350,7 @@ You should now review your instance configuration and data:
         After successful migration, the passthrough authentication flow
         involves the following components:
       </para>
-<screen>
+<screen><?dbfo keep-together="always"?>
   ┌─────────────────┐
   │                 │
   │   LDAP client   │

--- a/xml/security_ldap_replication.xml
+++ b/xml/security_ldap_replication.xml
@@ -150,6 +150,7 @@
    <example xml:id="ex-ldap-replication-two-replicas">
     <title>Two supplier replicas</title>
 <screen>
+  <?dbfo keep-together="always"?>
 ┌────┐       ┌────┐
 │ S1 │◀─────▶│ S2 │
 └────┘       └────┘
@@ -182,6 +183,7 @@
    <example xml:id="ex-ldap-replication-four-replicas">
     <title>Four supplier replicas</title>
 <screen>
+  <?dbfo keep-together="always"?>
 ┌────┐       ┌────┐
 │ S1 │◀─────▶│ S2 │
 └────┘       └────┘
@@ -208,6 +210,7 @@
    <example xml:id="ex-ldap-replication-six-replicas">
     <title>Six replicas</title>
 <screen>
+  <?dbfo keep-together="always"?>
                   ┌────┐       ┌────┐
                   │ S1 │◀─────▶│ S2 │
                   └────┘       └────┘
@@ -420,7 +423,7 @@ First, configure RW1:
    RW1 and RW2 are now both configured to have replication metadata. The next
    step is to create the first agreement for outbound data from RW1 to RW2.
   </para>
-<screen>
+<screen><?dbfo keep-together="always"?>
 &prompt.sudo;<command>dsconf <replaceable>INSTANCE-NAME</replaceable> repl-agmt create</command> \
 <command>--suffix <replaceable>dc=example,dc=com</replaceable></command> \
 <command>--host=<replaceable>RW2</replaceable> --port=636 --conn-protocol LDAPS --bind-dn "cn=replication manager,cn=config"</command> \
@@ -542,7 +545,7 @@ First, configure RW1:
   replica status directly on the replicas, or from other hosts. The following example commands are run on RW1,
   checking the status on two remote replicas, and then on itself:
 </para>
-<screen>
+<screen><?dbfo keep-together="always"?>
 &prompt.sudo;<command>dsconf -D "cn=Directory Manager" ldap://<replaceable>RW2</replaceable> replication monitor</command>
 &prompt.sudo;<command>dsconf -D "cn=Directory Manager" ldap://<replaceable>RO3</replaceable> replication monitor</command>
 &prompt.sudo;<command>dsconf -D "cn=Directory Manager" ldap://<replaceable>RW1</replaceable> replication monitor</command>
@@ -668,7 +671,7 @@ fschecks:file_perms
 <para>
   On the replica you are removing, which in the following example is RW2, remove all outbound agreements:
 </para>
-<screen>
+<screen><?dbfo keep-together="always"?>
 &prompt.sudo;<command>dsconf <replaceable>INSTANCE_NAME</replaceable> repl-agmt delete</command> \
 <command>--suffix <replaceable>dc=EXAMPLE,dc=COM</replaceable> <replaceable>RW2_to_RW1</replaceable></command>
 &prompt.sudo;<command>dsconf <replaceable>INSTANCE_NAME</replaceable> repl-agmt delete</command> \

--- a/xml/security_pam.xml
+++ b/xml/security_pam.xml
@@ -352,6 +352,7 @@
   <example xml:id="dat-pam-sshd">
    <title>PAM configuration for sshd (<filename>/etc/pam.d/sshd</filename>)</title>
 <screen>#%PAM-1.0 <co xml:id="co-security-pam-sshd-pam-line"/>
+  <?dbfo keep-together="always"?>
 auth     requisite      pam_nologin.so                              <co xml:id="co-security-pam-sshd-pam-nologin"/>
 auth     include        common-auth                                 <co xml:id="co-security-pam-sshd-common-auth"/>
 account  requisite      pam_nologin.so                              <xref xrefstyle="select:nopage" linkend="co-security-pam-sshd-pam-nologin"/>
@@ -420,7 +421,7 @@ session  optional       pam_lastlog.so   silent noupdate showfailed <co xml:id="
 
   <example xml:id="dat-pam-common-auth">
    <title>Default configuration for the <literal>auth</literal> section (<filename>common-auth</filename>)</title>
-<screen>auth  required  pam_env.so                   <co xml:id="co-security-pam-sshd-pam-env"/>
+<screen><?dbfo keep-together="always"?>auth  required  pam_env.so                   <co xml:id="co-security-pam-sshd-pam-env"/>
 auth  optional  pam_gnome_keyring.so         <co xml:id="co-security-pam-sshd-gnome"/>
 auth  required  pam_unix.so  try_first_pass <co xml:id="co-security-pam-sshd-pam-unix"/></screen>
   </example>
@@ -482,7 +483,7 @@ auth  required  pam_unix.so  try_first_pass <co xml:id="co-security-pam-sshd-pam
   <example os="slemicro" xml:id="dat-pam-common-password-slemicro">
    <title>Default configuration for the <literal>password</literal> section (<filename>common-password</filename>)</title>
 <screen>password  requisite  pam_cracklib.so
-password  requisite   pam_cracklib.so  
+password  requisite   pam_cracklib.so
 password  required   pam_unix.so  use_authtok nullok shadow try_first_pass</screen>
   </example>
 
@@ -529,7 +530,7 @@ session  optional  pam_env.so</screen>
 
   <example os="slemicro" xml:id="dat-pam-common-session-slemicro">
    <title>Default configuration for the <literal>session</literal> section (<filename>common-session</filename>)</title>
-<screen>session  required  pam_selinux.so  close
+<screen><?dbfo keep-together="always"?>session  required  pam_selinux.so  close
 session  optional  pam_systemd.so
 session  required  pam_limits.so
 session  required  pam_unix.so  try_first_pass

--- a/xml/security_ssh.xml
+++ b/xml/security_ssh.xml
@@ -521,7 +521,7 @@ MaxAuthTries <replaceable>4</replaceable>
       bits), use the <command>ssh-keygen</command> command with no options.
       Protect your private key with a strong passphrase:
      </para>
-     <screen>&prompt.user;<command>ssh-keygen</command>
+     <screen><?dbfo keep-together="always"?>&prompt.user;<command>ssh-keygen</command>
 Generating public/private rsa key pair.
 Enter file in which to save the key (/home/tux/.ssh/id_rsa):
 Enter passphrase (empty for no passphrase):
@@ -587,7 +587,7 @@ The key's randomart image is:
       OpenSSH automatically generates a set of host keys when it is
       installed, like the following example:
     </para>
-    <screen>&prompt.user;<command>ls -l /etc/ssh</command>
+    <screen><?dbfo keep-together="always"?>&prompt.user;<command>ls -l /etc/ssh</command>
 total 608
 -rw------- 1 root root 577834 2021-05-06 04:48 moduli
 -rw-r--r-- 1 root root   2403 2021-05-06 04:48 ssh_config


### PR DESCRIPTION
### PR creator: Description

The scope of this PR is to add the tag <?dbfo keep-together=always?> to <screen> to avoid breakage of a diagram or command outputs . 


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#...


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
