### PR TITLE
DOCTEAM-1151: Remove hardcoded product names and version from Tuning Guide

### DIFF
--- a/xml/common_intro_support.xml
+++ b/xml/common_intro_support.xml
@@ -29,7 +29,7 @@
  <para>
   If you are entitled to support, find details on how to collect information
   for a support ticket at
-  <link xlink:href="https://documentation.suse.com/html/SLES-all/cha-adm-support.html"/>.
+  <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/cha-adm-support.html"/>.
  </para>
 
  <sect2>

--- a/xml/common_intro_support.xml
+++ b/xml/common_intro_support.xml
@@ -29,7 +29,7 @@
  <para>
   If you are entitled to support, find details on how to collect information
   for a support ticket at
-  <link xlink:href="https://documentation.suse.com/sles-15/html/SLES-all/cha-adm-support.html"/>.
+  <link xlink:href="https://documentation.suse.com/html/SLES-all/cha-adm-support.html"/>.
  </para>
 
  <sect2>

--- a/xml/tuning_memory.xml
+++ b/xml/tuning_memory.xml
@@ -427,6 +427,7 @@
        wait for kernel background flusher threads to reduce the amount of dirty
        memory. The default value is <literal>20</literal> (%).
       </para>
+      <remark>ssarkar 2023-11-28: I checked on SLE 15 SP5 - the dirty_ration is still 20</remark>
      </listitem>
     </varlistentry>
     <varlistentry>


### PR DESCRIPTION
### PR creator: Description

Remove hardcoded product names and version from Tuning Guide.
For detailed information about the actual work behind the solution, see https://jira.suse.com/browse/DOCTEAM-1151?focusedCommentId=1309224&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1309224


### PR creator: Are there any relevant issues/feature requests?

* JIRA: https://jira.suse.com/browse/DOCTEAM-1151

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
