### PR TITLE
corrected syntax

### DIFF
--- a/xml/apparmor_profiles.xml
+++ b/xml/apparmor_profiles.xml
@@ -2177,14 +2177,16 @@ unsafe Px /example_rule,</screen>
    </varlistentry>
   </variablelist>
 
+  <note>
   <para>
-   <superscript>*</superscript>The nproc rlimit is handled different than
-   all the other rlimits. Instead of indicating the standard process rlimit,
+   The nproc rlimit is handled different than all the other rlimits.
+   Instead of indicating the standard process rlimit,
    it controls the maximum number of processes that can be running under the
    profile at any time. When the limit is exceeded, the creation of new
    processes under the profile fails until the number of currently
    running processes is reduced.
   </para>
+  </note>
 
   <note>
    <para>


### PR DESCRIPTION
### PR creator: Description

Correct the syntax issue which is creating translation issues.


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#...


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
