### PR TITLE
Update ay_networking.xml

### DIFF
--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -645,6 +645,7 @@
       &lt;bonding_master&gt;yes&lt;/bonding_master&gt;
       &lt;bonding_module_opts&gt;mode=active-backup miimon=100&lt;/bonding_module_opts&gt;
       &lt;bonding_slave0&gt;eth1&lt;/bonding_slave0&gt;
+&lt;bonding_module_opts&gt;mode=balance-rr miimon=100&lt;/bonding_module_opts&gt;
       &lt;bonding_slave1&gt;eth2&lt;/bonding_slave1&gt;
       &lt;bootproto&gt;static&lt;/bootproto&gt;
       &lt;name&gt;bond0&lt;/name&gt;

--- a/xml/ay_networking.xml
+++ b/xml/ay_networking.xml
@@ -645,8 +645,7 @@
       &lt;bonding_master&gt;yes&lt;/bonding_master&gt;
       &lt;bonding_module_opts&gt;mode=active-backup miimon=100&lt;/bonding_module_opts&gt;
       &lt;bonding_slave0&gt;eth1&lt;/bonding_slave0&gt;
-      &lt;bonding_slave0&gt;eth2&lt;/bonding_slave0&gt;
-      &lt;bondoption&gt;mode=balance-rr miimon=100&lt;/bondoption&gt;
+      &lt;bonding_slave1&gt;eth2&lt;/bonding_slave1&gt;
       &lt;bootproto&gt;static&lt;/bootproto&gt;
       &lt;name&gt;bond0&lt;/name&gt;
       &lt;ipaddr&gt;&subnetI;.61&lt;/ipaddr&gt;


### PR DESCRIPTION
### PR creator: Description

- bootoption is not valid when checking with jing
- "bonding_slaveX": Each port needs to have a unique number.


### PR creator: Which product versions do the changes apply to?
I guess SLES 15 SP5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
