### PR TITLE
removes redundant statement

### DIFF
--- a/xml/security_firewall.xml
+++ b/xml/security_firewall.xml
@@ -28,9 +28,6 @@
   &productname; <phrase os="sles;sled">15 GA</phrase><phrase os="osuse">15.0</phrase>
   introduces &firewalld; as the new default software firewall, replacing
   &susefirewall;.
-  &susefirewall; has not been removed from &productname;
-  <phrase os="sles;sled">15 GA</phrase><phrase os="osuse">15.0</phrase>
-  and is still part of the main repository, though not installed by default.
   This chapter provides guidance for configuring &firewalld;, and migrating
   from &susefirewall; for users who have upgraded from older &productname;
   releases.
@@ -289,9 +286,6 @@
     &productname; <phrase os="sles;sled">15 GA</phrase><phrase os="osuse">15.0</phrase>
     introduces &firewalld; as the new default software firewall, replacing
     &susefirewall;.
-    &susefirewall; has not been removed from &productname;
-    <phrase os="sles;sled">15 GA</phrase><phrase os="osuse">15.0</phrase>
-    and is still part of the main repository, though not installed by default.
     If you are upgrading from a release older than &productname;
     <phrase os="sles;sled">15 GA</phrase><phrase os="osuse">15.0</phrase>,
     &susefirewall; will be unchanged and you must manually upgrade to
@@ -391,14 +385,14 @@
     use the <literal>Firewall Zone</literal> drop-down box.
    </para>
   </sect2>
-  
+
   <sect2 xml:id="sec-security-firewall-firewalld-yast" os="sles;sled">
    <title>Configuring the Firewall with &yast;</title>
    <para>
-     The <command>yast firewall</command> module supports a basic 
-     configuration of &firewalld;. It provides a zone 
+     The <command>yast firewall</command> module supports a basic
+     configuration of &firewalld;. It provides a zone
      selector, services selector, and ports selector. It does not support
-     creating custom iptables rules, and limits zone creation and 
+     creating custom iptables rules, and limits zone creation and
      customization to selecting services and ports.
    </para>
   </sect2>


### PR DESCRIPTION
### PR creator: Description

Describe the overall goals of this pull request.
Removes redundant statement and cherry-pick to maintenance/sp2

### PR creator: Are there any relevant issues/feature requests?

[DOCTEAM-898](https://jira.suse.com/browse/DOCTEAM-898)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
