### PR TITLE
EOL: Switch validation to DocBook 5.2

### DIFF
--- a/DC-SLES-admin
+++ b/DC-SLES-admin
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-all
+++ b/DC-SLES-all
@@ -14,3 +14,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-amd-sev
+++ b/DC-SLES-amd-sev
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-autoyast
+++ b/DC-SLES-autoyast
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-deployment
+++ b/DC-SLES-deployment
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-dockerquick
+++ b/DC-SLES-dockerquick
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-gnomeuser
+++ b/DC-SLES-gnomeuser
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-html
+++ b/DC-SLES-html
@@ -14,3 +14,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-installquick
+++ b/DC-SLES-installquick
@@ -18,3 +18,4 @@ FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 # Setting the TOC depth to sect 2
 XSLTPARAM="--param toc.section.depth=3"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-modulesquick
+++ b/DC-SLES-modulesquick
@@ -18,3 +18,4 @@ FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 # Setting the TOC depth to sect 2
 XSLTPARAM="--param toc.section.depth=3"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-rmt
+++ b/DC-SLES-rmt
@@ -14,3 +14,4 @@ PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-rpi-quick
+++ b/DC-SLES-rpi-quick
@@ -18,3 +18,4 @@ FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 # Setting the TOC depth to sect 2
 XSLTPARAM="--param toc.section.depth=2"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-security
+++ b/DC-SLES-security
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-storage
+++ b/DC-SLES-storage
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-tuning
+++ b/DC-SLES-tuning
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-upgrade
+++ b/DC-SLES-upgrade
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-virtualization
+++ b/DC-SLES-virtualization
@@ -18,3 +18,4 @@ FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 ### Sort the glossary
 XSLTPARAM="--param glossary.sort=1" 
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-vt-best-practices
+++ b/DC-SLES-vt-best-practices
@@ -18,3 +18,4 @@ FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 ### Sort the glossary
 XSLTPARAM="--param glossary.sort=1" 
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-xen2kvmquick
+++ b/DC-SLES-xen2kvmquick
@@ -15,3 +15,4 @@ PROFARCH="x86_64;zseries;power;aarch64"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"


### PR DESCRIPTION
### PR creator: Description

This change switches the validation schema from GeekoDoc to DocBook 5.2. This ensures that futures changes of GeekoDoc doesn't affect previous, now unsupported documents.


### PR creator: Are there any relevant issues/feature requests?

* related to https://gitlab.suse.de/susedoc/docserv-config/-/merge_requests/510


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

no backport necessary
