### PR TITLE
[WIP]:BZ1211727:adds sssd as auth example

### DIFF
--- a/xml/security_pam.xml
+++ b/xml/security_pam.xml
@@ -731,7 +731,7 @@ DISPLAY     DEFAULT=${REMOTEHOST}:0.0  OVERRIDE=${DISPLAY}
       --add --sss-debug</command> turns on debugging for SSSD-related PAM
       operations.<phrase os="sles;sled;osuse"> Find the debugging output in the &systemd; journal (see
       <xref linkend="cha-journalctl"/>).</phrase>
-      <phrase>To configure SSSD, refer <xref linkend="sec-security-ldap-server-sssd"/> </phrase>
+      <phrase os="sles;sled">To configure SSSD, refer <xref linkend="sec-security-ldap-server-sssd"/> </phrase>
      </para>
     </formalpara>
    </step>

--- a/xml/security_pam.xml
+++ b/xml/security_pam.xml
@@ -715,9 +715,9 @@ DISPLAY     DEFAULT=${REMOTEHOST}:0.0  OVERRIDE=${DISPLAY}
     <formalpara>
      <title>Add a new authentication method.</title>
      <para>
-      Adding a new authentication method (for example, LDAP) to your stack
+      Adding a new authentication method (for example, SSSD) to your stack
       of PAM modules comes down to a simple <command>pam-config --add
-      --ldap</command> command. LDAP is added wherever appropriate across
+      --sss</command> command. SSSD is added wherever appropriate across
       all <filename>common-*-pc</filename> PAM configuration files.
      </para>
     </formalpara>
@@ -728,7 +728,7 @@ DISPLAY     DEFAULT=${REMOTEHOST}:0.0  OVERRIDE=${DISPLAY}
      <para>
       To make sure the new authentication procedure works as planned, turn
       on debugging for all PAM-related operations. The <command>pam-config
-      --add --ldap-debug</command> turns on debugging for LDAP-related PAM
+      --add --sss-debug</command> turns on debugging for SSSD-related PAM
       operations.<phrase os="sles;sled;osuse"> Find the debugging output in the &systemd; journal (see
       <xref linkend="cha-journalctl"/>).</phrase>
      </para>
@@ -751,7 +751,7 @@ DISPLAY     DEFAULT=${REMOTEHOST}:0.0  OVERRIDE=${DISPLAY}
      <para>
       Finally, remove the debug option from your setup when you are entirely
       satisfied with the performance of it. The <command>pam-config --delete
-      --ldap-debug</command> command turns off debugging for LDAP
+      --sss-debug</command> command turns off debugging for SSSD
       authentication. In case you had debugging options added for other
       modules, use similar commands to turn these off.
      </para>

--- a/xml/security_pam.xml
+++ b/xml/security_pam.xml
@@ -731,7 +731,7 @@ DISPLAY     DEFAULT=${REMOTEHOST}:0.0  OVERRIDE=${DISPLAY}
       --add --sss-debug</command> command turns on debugging for SSSD-related PAM
       operations.<phrase os="sles;sled;osuse"> Find the debugging output in the &systemd; journal (see
       <xref linkend="cha-journalctl"/>).</phrase>
-      <phrase os="sles;sled">To configure SSSD, refer <xref linkend="sec-security-ldap-server-sssd"/> </phrase>
+      <phrase os="sles;sled">To configure SSSD, refer to <xref linkend="sec-security-ldap-server-sssd"/>. </phrase>
      </para>
     </formalpara>
    </step>

--- a/xml/security_pam.xml
+++ b/xml/security_pam.xml
@@ -731,6 +731,7 @@ DISPLAY     DEFAULT=${REMOTEHOST}:0.0  OVERRIDE=${DISPLAY}
       --add --sss-debug</command> turns on debugging for SSSD-related PAM
       operations.<phrase os="sles;sled;osuse"> Find the debugging output in the &systemd; journal (see
       <xref linkend="cha-journalctl"/>).</phrase>
+      <phrase>To configure SSSD, refer <xref linkend="sec-security-ldap-server-sssd"/> </phrase>
      </para>
     </formalpara>
    </step>
@@ -751,8 +752,8 @@ DISPLAY     DEFAULT=${REMOTEHOST}:0.0  OVERRIDE=${DISPLAY}
      <para>
       Finally, remove the debug option from your setup when you are entirely
       satisfied with the performance of it. The <command>pam-config --delete
-      --sss-debug</command> command turns off debugging for SSSD
-      authentication. In case you had debugging options added for other
+      --sss-debug</command> command turns off debugging for the <literal>pam_ssh.so</literal> module.
+      In case you had debugging options added for other
       modules, use similar commands to turn these off.
      </para>
     </formalpara>

--- a/xml/security_pam.xml
+++ b/xml/security_pam.xml
@@ -728,7 +728,7 @@ DISPLAY     DEFAULT=${REMOTEHOST}:0.0  OVERRIDE=${DISPLAY}
      <para>
       To make sure the new authentication procedure works as planned, turn
       on debugging for all PAM-related operations. The <command>pam-config
-      --add --sss-debug</command> turns on debugging for SSSD-related PAM
+      --add --sss-debug</command> command turns on debugging for SSSD-related PAM
       operations.<phrase os="sles;sled;osuse"> Find the debugging output in the &systemd; journal (see
       <xref linkend="cha-journalctl"/>).</phrase>
       <phrase os="sles;sled">To configure SSSD, refer <xref linkend="sec-security-ldap-server-sssd"/> </phrase>
@@ -751,7 +751,7 @@ DISPLAY     DEFAULT=${REMOTEHOST}:0.0  OVERRIDE=${DISPLAY}
      <title>Remove the debug options.</title>
      <para>
       Finally, remove the debug option from your setup when you are entirely
-      satisfied with the performance of it. The <command>pam-config --delete
+      satisfied with its performance. The <command>pam-config --delete
       --sss-debug</command> command turns off debugging for the <literal>pam_ssh.so</literal> module.
       In case you had debugging options added for other
       modules, use similar commands to turn these off.


### PR DESCRIPTION
### PR creator: Description

Describe the overall goals of this pull request.
Replaces ldap wih sssd

### PR creator: Are there any relevant issues/feature requests?

[BZ1211727](https://bugzilla.suse.com/show_bug.cgi?id=1211727)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP5/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
