### PR TITLE
Added 'clean packages' command description

### DIFF
--- a/xml/rmt_rmt-cli.xml
+++ b/xml/rmt_rmt-cli.xml
@@ -431,12 +431,69 @@ Purged systems that have not contacted this RMT since 2021-06-16.
      <para>
       Run this regularly on the online &rmt; to mirror the set of repositories
       specified in the <filename>repos.json</filename> at the given path. The
-      mirrored repository files will be stored in subdirectories of the same
-      path.
+      mirrored repository files are stored in subdirectories of the same path.
      </para>
     </listitem>
    </varlistentry>
   </variablelist>
+ </sect2>
+
+ <sect2 xml:id="sec-rmt-tools-rmt-cli-clean">
+  <title><command>clean packages</command></title>
+  <para>
+    The <command>rmt-cli clean packages</command> command removes locally
+    mirrored <quote>dangling</quote> files and their database entries. A file is
+    considered to be dangling if it matches all the following characteristics:
+  </para>
+  <itemizedlist>
+    <listitem>
+      <para>
+        It exists in a repository directory with primary and metadata
+        <filename>repomd.xml</filename> files.
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        It is no longer referenced in the metadata files.
+      </para>
+    </listitem>
+    <listitem>
+      <para>
+        It is at least 2 days old.
+      </para>
+    </listitem>
+  </itemizedlist>
+  <para>
+    You can pass the following options to the <command>rmt-cli clean
+    packages</command> command:
+  </para>
+  <variablelist>
+   <varlistentry>
+    <term>--dry-run</term>
+    <listitem>
+     <para>
+       Generates a report of all affected files without actually cleaning them
+       or their database entries.
+     </para>
+    </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>--verbose</term>
+      <listitem>
+        <para>
+          Prints detailed information about each cleaned file.
+        </para>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term>--non-interactive</term>
+      <listitem>
+        <para>
+          Skips confirmation before proceeding with the cleaning process.
+        </para>
+      </listitem>
+    </varlistentry>
+   </variablelist>
  </sect2>
 
  <sect2 xml:id="sec-rmt-tools-rmt-cli-version">


### PR DESCRIPTION
### PR creator: Description

A new command `rmt-cli clean packages` was introduced. This update describes its usage.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1220226
* jsc#DOCTEAM-1294


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP5/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [x] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
