### PR TITLE
Update tuning_memory.xml -use MALLOC_MMAP_THRESHOLD_

### DIFF
--- a/xml/tuning_memory.xml
+++ b/xml/tuning_memory.xml
@@ -235,7 +235,7 @@
    <para>
     To restore a &productname; 10-like behavior, M_MMAP_THRESHOLD should
     be set to 128*1024. This can be done with mallopt() call from the
-    application, or via setting MALLOC_MMAP_THRESHOLD environment variable
+    application, or via setting MALLOC_MMAP_THRESHOLD_ environment variable
     before running the application.
    </para>
   </sect2>


### PR DESCRIPTION
The variable has a _ at the end, see

strings /lib/ld-2.31.so | grep MMAP_THRE
MALLOC_MMAP_THRESHOLD_

or https://man7.org/linux/man-pages/man3/mallopt.3.html

### PR creator: Description

Document MALLOC_MMAP_THRESHOLD_ (fix the environment variable name).


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#...


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP5/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
