### PR TITLE
Update file_management.xml: for loop with sudo gave syntax error

### DIFF
--- a/xml/file_management.xml
+++ b/xml/file_management.xml
@@ -218,8 +218,8 @@
    in <filename>/home</filename>:
   </para>
   <screen>&prompt.sudo;chmod 755 /home
-&prompt.sudo;for a in /home/*; do \
-echo "Changing rights for directory $a"; chmod 700 ”$a”; done</screen>
+&prompt.sudo;bash -c 'for a in /home/*; do \
+echo "Changing rights for directory $a"; chmod 700 ”$a”; done'</screen>
 
   <!-- cwickert 2021-11-11: the following only works with shadow >= 4.8.1,
    means SLES 15 >= SP3. Beware when backporting! -->


### PR DESCRIPTION
Using the example for loop in
'Changing home directory permissions from 755 to 700' gives a syntax error: 
-bash: syntax error near unexpected token `do

I've added bash -c  to the example.

https://doc.opensuse.org/documentation/leap/security/html/book-security/sec-sec-file-management.html#sec-sec-prot-general-home-permissions

### PR creator: Description

Fix error in documentation, might possibly frustrate.


### PR creator: Are there any relevant issues/feature requests?

Not that know of, I didn't file a bug report.


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
