### PR TITLE
Changed filename of /etc/password to /etc/passwd

### DIFF
--- a/xml/file_management.xml
+++ b/xml/file_management.xml
@@ -354,7 +354,7 @@ UMASK           022</screen>
 
     <para>
      For individual users, add the umask to the 'gecos' field in
-     <filename>/etc/password</filename> like this:
+     <filename>/etc/passwd</filename> like this:
     </para>
 <screen>&exampleuser_plain;:x:1000:100:&exampleuserfull;,UMASK=<replaceable>022</replaceable>:/home/tux:/bin/bash</screen>
     <para>
@@ -365,7 +365,7 @@ UMASK           022</screen>
     </para>
     <para>
      The settings made in <filename>/etc/login.defs</filename> and
-     <filename>/etc/password</filename> are applied by the PAM module
+     <filename>/etc/passwd</filename> are applied by the PAM module
      <filename>pam_umask.so</filename>. For additional configuration options,
      refer to <command>man pam_umask</command>.
     </para>


### PR DESCRIPTION
### PR creator: Description

/etc/password should be /etc/passwd


### PR creator: Are there any relevant issues/feature requests?

Not that I know off.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [X] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
