### PR TITLE
Update security_vpnserver.xml

### DIFF
--- a/xml/security_vpnserver.xml
+++ b/xml/security_vpnserver.xml
@@ -433,7 +433,7 @@ cd /etc/openvpn
      <para>
       Open a shell, become &rootuser; and create the VPN secret key:
      </para>
-<screen>&prompt.root;openvpn --genkey --secret /etc/openvpn/secret.key</screen>
+<screen>&prompt.root;openvpn --genkey secret /etc/openvpn/secret.key</screen>
     </step>
     <step>
      <para>


### PR DESCRIPTION
This update fixes this error:

 "DEPRECATED OPTION: The option --secret is deprecated.
WARNING: Using --genkey --secret filename is DEPRECATED.  Use --genkey secret filename instead."

### PR creator: Description

Fixes an erroneous command


### PR creator: Are there any relevant issues/feature requests?

No


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
