### PR TITLE
update kernel versions (recent)

### DIFF
--- a/xml/adm_support.xml
+++ b/xml/adm_support.xml
@@ -61,17 +61,17 @@
 <screen>Welcome to SUSE Linux Enterprise Server 15 SP2 Snapshot8 (x86_64) - Kernel \r (\l).
 
 
-Distribution:             SUSE Linux Enterprise Server 15 SP2
-Current As Of:            Wed 25 Mar 2020 12:09:20 PM PDT
+Distribution:             SUSE Linux Enterprise Server 15 SP6
+Current As Of:            Mon 11 March 2024 10:11:51 AM CET
 Hostname:                 localhost
-Kernel Version:           5.3.18-8-default
+Kernel Version:           Linux 6.4.0-150600.9-default
  Architecture:            x86_64
- Installed:               Thu 19 Mar 2020 11:25:13 AM PDT
+ Installed:               Fri 08 March 2024 04:45:50 PM CET
  Status:                  Not Tainted
-Last Installed Package:   Wed 25 Mar 2020 11:42:24 AM PDT
+Last Installed Package:   Mon 11 March 2024 10:02:13 AM CET
  Patches Needed:          0
  Security:                0
- 3rd Party Packages:      219
+ 3rd Party Packages:      6
 Network Interfaces
  eth0:                    &exampledomain2ip;/24 &exampledomain2ipv6;/64
 Memory

--- a/xml/adm_support.xml
+++ b/xml/adm_support.xml
@@ -61,10 +61,10 @@
 <screen>Welcome to SUSE Linux Enterprise Server 15 SP2 Snapshot8 (x86_64) - Kernel \r (\l).
 
 
-Distribution:             SUSE Linux Enterprise Server 15 SP6
+Distribution:             &sles; &productnumber;
 Current As Of:            Mon 11 March 2024 10:11:51 AM CET
 Hostname:                 localhost
-Kernel Version:           Linux 6.4.0-150600.9-default
+Kernel Version:           &kernel-version;-default
  Architecture:            x86_64
  Installed:               Fri 08 March 2024 04:45:50 PM CET
  Status:                  Not Tainted

--- a/xml/ay_kernel_dumps.xml
+++ b/xml/ay_kernel_dumps.xml
@@ -456,7 +456,7 @@
       auto-detection mechanism (strongly recommended).
      </para>
 <screen>&lt;KDUMP_KERNELVER
-&gt;2.6.27-default&lt;/KDUMP_KERNELVER&gt;</screen>
+&gt;4.6.0-default&lt;/KDUMP_KERNELVER&gt;</screen>
      <para>
       optional (auto-detection if empty)
      </para>

--- a/xml/ay_kernel_dumps.xml
+++ b/xml/ay_kernel_dumps.xml
@@ -456,7 +456,7 @@
       auto-detection mechanism (strongly recommended).
      </para>
 <screen>&lt;KDUMP_KERNELVER
-&gt;4.6.0-default&lt;/KDUMP_KERNELVER&gt;</screen>
+&gt;&kernel-version-base;-default&lt;/KDUMP_KERNELVER&gt;</screen>
      <para>
       optional (auto-detection if empty)
      </para>

--- a/xml/kernel_modules.xml
+++ b/xml/kernel_modules.xml
@@ -52,17 +52,17 @@ nfs_acl                16384  1 nfsv3</screen>
     binary when running <command>modinfo</command> command as a regular user:
   </para>
   <screen>&prompt.user;/sbin/modinfo kvm
-filename:       /lib/modules/6.4.0-150600.9-default/kernel/arch/x86/kvm/kvm.ko.zst
+filename:       /lib/modules/&kernel-version;-default/kernel/arch/x86/kvm/kvm.ko.zst
 license:        GPL
 author:         Qumranet
-suserelease:    SLE15-SP6
+suserelease:    &slea;&product-ga;-SP&product-sp;
 srcversion:     9DACE73AC65F98D556DAD60
 depends:        irqbypass
 supported:      yes
 retpoline:      Y
 intree:         Y
 name:           kvm
-vermagic:       6.4.0-150600.9-default SMP mod_unload modversions
+vermagic:       &kernel-version;-default SMP mod_unload modversions
       </screen>
   </sect1>
   <sect1 xml:id="sec-mod-modprobe">

--- a/xml/kernel_modules.xml
+++ b/xml/kernel_modules.xml
@@ -52,17 +52,17 @@ nfs_acl                16384  1 nfsv3</screen>
     binary when running <command>modinfo</command> command as a regular user:
   </para>
   <screen>&prompt.user;/sbin/modinfo kvm
-filename:       /lib/modules/5.3.18-57-default/kernel/arch/x86/kvm/kvm.ko.xz
+filename:       /lib/modules/6.4.0-150600.9-default/kernel/arch/x86/kvm/kvm.ko.zst
 license:        GPL
 author:         Qumranet
-suserelease:    SLE15-SP3
-srcversion:     3D8FBA9060D4537359A06FC
+suserelease:    SLE15-SP6
+srcversion:     9DACE73AC65F98D556DAD60
 depends:        irqbypass
 supported:      yes
 retpoline:      Y
 intree:         Y
 name:           kvm
-vermagic:       5.3.18-57-default SMP mod_unload modversions 
+vermagic:       6.4.0-150600.9-default SMP mod_unload modversions
       </screen>
   </sect1>
   <sect1 xml:id="sec-mod-modprobe">

--- a/xml/klp.xml
+++ b/xml/klp.xml
@@ -367,9 +367,9 @@ Activate with: SUSEConnect -p sle-module-live-patching/&productnumber-regurl;/x8
       patches</command> command. You can see the currently running patch on the
       line starting with <literal>RPM:</literal>. For example:
      </para>
-<screen>RPM: kernel-livepatch-5_3_18-24_29-default-2-2.1.x86_64</screen>
+<screen>RPM: kernel-livepatch-6_4_0-150600_9-default-1-150600.2.36.x86_64</screen>
      <para>
-      The <literal>5_3_18-24_29-default</literal> in the example above denotes
+      The <literal>6_4_0-150600_9-default</literal> in the example above denotes
       the exact running kernel version.
      </para>
     </step>

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -12,6 +12,8 @@
 
 
 <!ENTITY php-version            "8">
+<!ENTITY kernel-version         "6.4.0-150600.9">
+<!ENTITY kernel-version-base    "6.4.0">
 
 <!-- PROJECT REPOSITORY URL -->
 <!ENTITY repo-url               "https://github.com/SUSE/doc-sle">

--- a/xml/security_spectre_meltdown_checker.xml
+++ b/xml/security_spectre_meltdown_checker.xml
@@ -85,7 +85,7 @@
 --no-color \
 --kernel <replaceable>vmlinuz-&kernel-version;-default</replaceable> \
 --config <replaceable>config-&kernel-version;-default</replaceable> \
---map <replaceable>config-&kernel-version;-default</replaceable>| tee <replaceable>filename.txt</replaceable>
+--map <replaceable>System.map-&kernel-version;-default</replaceable>| tee <replaceable>filename.txt</replaceable>
     </screen>
 
   <para>

--- a/xml/security_spectre_meltdown_checker.xml
+++ b/xml/security_spectre_meltdown_checker.xml
@@ -83,9 +83,9 @@
 <screen>&prompt.root;cd /boot
 &prompt.root;spectre-meltdown-checker.sh \
 --no-color \
---kernel <replaceable>vmlinuz-6.4.0-150600.9-default</replaceable> \
---config <replaceable>config-6.4.0-150600.9-default</replaceable> \
---map <replaceable>config-6.4.0-150600.9-default</replaceable>| tee <replaceable>filename.txt</replaceable>
+--kernel <replaceable>vmlinuz-&kernel-version;-default</replaceable> \
+--config <replaceable>config-&kernel-version;-default</replaceable> \
+--map <replaceable>config-&kernel-version;-default</replaceable>| tee <replaceable>filename.txt</replaceable>
     </screen>
 
   <para>

--- a/xml/security_spectre_meltdown_checker.xml
+++ b/xml/security_spectre_meltdown_checker.xml
@@ -83,9 +83,9 @@
 <screen>&prompt.root;cd /boot
 &prompt.root;spectre-meltdown-checker.sh \
 --no-color \
---kernel <replaceable>vmlinuz-4.12.14-lp151.28.13-default</replaceable> \
---config <replaceable>config-4.12.14-lp151.28.13-default</replaceable> \
---map <replaceable>System.map-4.12.14-lp151.28.13-default</replaceable>| tee <replaceable>filename.txt</replaceable>
+--kernel <replaceable>vmlinuz-6.4.0-150600.9-default</replaceable> \
+--config <replaceable>config-6.4.0-150600.9-default</replaceable> \
+--map <replaceable>config-6.4.0-150600.9-default</replaceable>| tee <replaceable>filename.txt</replaceable>
     </screen>
 
   <para>

--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -1032,7 +1032,7 @@ gen_context(system_u:object_r:httpd_modules_t,s0)</screen>
 
   <example xml:id="ex-selnx-li-auditlog">
    <title>Example lines from <filename>/var/log/audit/audit.log</filename></title>
-<screen>type=DAEMON_START msg=audit(1348173810.874:6248): auditd start, ver=1.7.7 format=raw kernel=3.0.13-0.27-default auid=0 pid=4235 subj=system_u:system_r:auditd_t res=success
+<screen>type=DAEMON_START msg=audit(1348173810.874:6248): auditd start, ver=1.7.7 format=raw kernel=6.4.0-150600.9-default auid=0 pid=4235 subj=system_u:system_r:auditd_t res=success
 type=AVC msg=audit(1348173901.081:292): avc:  denied  { write } for  pid=3426 comm="smartd" name="smartmontools" dev=sda6 ino=581743 scontext=system_u:system_r:fsdaemon_t tcontext=system_u:object_r:var_lib_t tclass=dir
 type=AVC msg=audit(1348173901.081:293): avc:  denied  { remove_name } for  pid=3426 comm="smartd" name="smartd.WDC_WD2500BEKT_75PVMT0-WD_WXC1A21E0454.ata.state~" dev=sda6 ino=582390 scontext=system_u:system_r:fsdaemon_t tcontext=system_u:object_r:var_lib_t tclass=dir
 type=AVC msg=audit(1348173901.081:294): avc:  denied  { unlink } for  pid=3426 comm="smartd" name="smartd.WDC_WD2500BEKT_75PVMT0-WD_WXC1A21E0454.ata.state~" dev=sda6 ino=582390 scontext=system_u:system_r:fsdaemon_t tcontext=system_u:object_r:var_lib_t tclass=file

--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -1032,7 +1032,7 @@ gen_context(system_u:object_r:httpd_modules_t,s0)</screen>
 
   <example xml:id="ex-selnx-li-auditlog">
    <title>Example lines from <filename>/var/log/audit/audit.log</filename></title>
-<screen>type=DAEMON_START msg=audit(1348173810.874:6248): auditd start, ver=1.7.7 format=raw kernel=6.4.0-150600.9-default auid=0 pid=4235 subj=system_u:system_r:auditd_t res=success
+<screen>type=DAEMON_START msg=audit(1348173810.874:6248): auditd start, ver=1.7.7 format=raw kernel=&kernel-version;-default auid=0 pid=4235 subj=system_u:system_r:auditd_t res=success
 type=AVC msg=audit(1348173901.081:292): avc:  denied  { write } for  pid=3426 comm="smartd" name="smartmontools" dev=sda6 ino=581743 scontext=system_u:system_r:fsdaemon_t tcontext=system_u:object_r:var_lib_t tclass=dir
 type=AVC msg=audit(1348173901.081:293): avc:  denied  { remove_name } for  pid=3426 comm="smartd" name="smartd.WDC_WD2500BEKT_75PVMT0-WD_WXC1A21E0454.ata.state~" dev=sda6 ino=582390 scontext=system_u:system_r:fsdaemon_t tcontext=system_u:object_r:var_lib_t tclass=dir
 type=AVC msg=audit(1348173901.081:294): avc:  denied  { unlink } for  pid=3426 comm="smartd" name="smartd.WDC_WD2500BEKT_75PVMT0-WD_WXC1A21E0454.ata.state~" dev=sda6 ino=582390 scontext=system_u:system_r:fsdaemon_t tcontext=system_u:object_r:var_lib_t tclass=file

--- a/xml/slemicro_pcp.xml
+++ b/xml/slemicro_pcp.xml
@@ -631,7 +631,7 @@ percentage of user time across all CPUs, including guest CPU time
 
 Performance Co-Pilot configuration on localhost:
 
- platform: Linux localhost 6.4.0-150600.9-default #1 SMP Wed May 4 11:29:09 UTC 2022 (ea30951) x86_64
+ platform: Linux localhost &kernel-version;-default #1 SMP Wed May 4 11:29:09 UTC 2022 (ea30951) x86_64
  hardware: 1 cpu, 1 disk, 1 node, 1726MB RAM
  timezone: UTC
  services: pmcd pmproxy

--- a/xml/slemicro_pcp.xml
+++ b/xml/slemicro_pcp.xml
@@ -631,7 +631,7 @@ percentage of user time across all CPUs, including guest CPU time
 
 Performance Co-Pilot configuration on localhost:
 
- platform: Linux localhost 5.3.18-150300.59.68-default #1 SMP Wed May 4 11:29:09 UTC 2022 (ea30951) x86_64
+ platform: Linux localhost 6.4.0-150600.9-default #1 SMP Wed May 4 11:29:09 UTC 2022 (ea30951) x86_64
  hardware: 1 cpu, 1 disk, 1 node, 1726MB RAM
  timezone: UTC
  services: pmcd pmproxy

--- a/xml/tuning_kexec.xml
+++ b/xml/tuning_kexec.xml
@@ -194,11 +194,11 @@
   </para>
 
   <para>
-   For example, to load the <filename>/boot/vmlinuz-6.4.0-150600.9-default</filename> kernel image
+   For example, to load the <filename>/boot/vmlinuz-&kernel-version;-default</filename> kernel image
    with the command line of the currently running production kernel and the
    <filename>/boot/initrd</filename> file, run the following command:
   </para>
-<screen>&prompt.root; kexec -l /boot/vmlinuz-6.4.0-150600.9-default \
+<screen>&prompt.root; kexec -l /boot/vmlinuz-&kernel-version;-default \
  --append="$(cat /proc/cmdline)" --initrd=/boot/initrd</screen>
 
   <para>
@@ -991,7 +991,7 @@ cio_ignore=all,!da5d,!f500-f502</screen>
    produced the dump, use a command like this:
   </para>
 
-<screen><command>crash</command> <replaceable>/boot/vmlinux-6.4.0-150600.9-default.gz</replaceable> \
+<screen><command>crash</command> <replaceable>/boot/vmlinux-&kernel-version;-default.gz</replaceable> \
 <replaceable>/var/crash/2024-04-23-11\:17/vmcore</replaceable></screen>
 
   <para>
@@ -1114,7 +1114,7 @@ cio_ignore=all,!da5d,!f500-f502</screen>
      Regardless of the computer on which you analyze the dump, the crash
      utility produces output similar to this:
     </para>
-<screen>&prompt.user;<command>crash</command> <replaceable>/boot/vmlinux-6.4.0-150600.9-default.gz</replaceable> \
+<screen>&prompt.user;<command>crash</command> <replaceable>/boot/vmlinux-&kernel-version;-default.gz</replaceable> \
 <replaceable>/var/crash/2024-04-23-11\:17/vmcore</replaceable>
 crash 7.2.1
 Copyright (C) 2002-2017  Red Hat, Inc.
@@ -1138,8 +1138,8 @@ There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
 and "show warranty" for details.
 This GDB was configured as "x86_64-unknown-linux-gnu".
 
-      KERNEL: /boot/vmlinux-6.4.0-150600.9-default.gz
-   DEBUGINFO: /usr/lib/debug/boot/vmlinux-6.4.0-150600.9-default.debug
+      KERNEL: /boot/vmlinux-&kernel-version;-default.gz
+   DEBUGINFO: /usr/lib/debug/boot/vmlinux-&kernel-version;-default.debug
     DUMPFILE: /var/crash/2024-04-23-11:17/vmcore
         CPUS: 2
         DATE: Thu Apr 23 13:17:01 2024
@@ -1147,7 +1147,7 @@ This GDB was configured as "x86_64-unknown-linux-gnu".
 LOAD AVERAGE: 0.01, 0.09, 0.09
        TASKS: 42
     NODENAME: eros
-     RELEASE: 6.4.0-150600.9-default
+     RELEASE: &kernel-version;-default
      VERSION: #1 SMP 2024-03-31 14:50:44 +0200
      MACHINE: x86_64  (2999 Mhz)
       MEMORY: 16 GB

--- a/xml/tuning_kexec.xml
+++ b/xml/tuning_kexec.xml
@@ -194,11 +194,11 @@
   </para>
 
   <para>
-   For example, to load the <filename>/boot/vmlinuz-5.14.21-150500.53-default</filename> kernel image
+   For example, to load the <filename>/boot/vmlinuz-6.4.0-150600.9-default</filename> kernel image
    with the command line of the currently running production kernel and the
    <filename>/boot/initrd</filename> file, run the following command:
   </para>
-<screen>&prompt.root; kexec -l /boot/vmlinuz-5.14.21-150500.53-default \
+<screen>&prompt.root; kexec -l /boot/vmlinuz-6.4.0-150600.9-default \
  --append="$(cat /proc/cmdline)" --initrd=/boot/initrd</screen>
 
   <para>
@@ -991,8 +991,8 @@ cio_ignore=all,!da5d,!f500-f502</screen>
    produced the dump, use a command like this:
   </para>
 
-<screen><command>crash</command> <replaceable>/boot/vmlinux-2.6.32.8-0.1-default.gz</replaceable> \
-<replaceable>/var/crash/2010-04-23-11\:17/vmcore</replaceable></screen>
+<screen><command>crash</command> <replaceable>/boot/vmlinux-6.4.0-150600.9-default.gz</replaceable> \
+<replaceable>/var/crash/2024-04-23-11\:17/vmcore</replaceable></screen>
 
   <para>
    The first parameter represents the kernel image. The second parameter is the
@@ -1114,8 +1114,8 @@ cio_ignore=all,!da5d,!f500-f502</screen>
      Regardless of the computer on which you analyze the dump, the crash
      utility produces output similar to this:
     </para>
-<screen>&prompt.user;<command>crash</command> <replaceable>/boot/vmlinux-5.3.18-8-default.gz</replaceable> \
-<replaceable>/var/crash/2020-04-23-11\:17/vmcore</replaceable>
+<screen>&prompt.user;<command>crash</command> <replaceable>/boot/vmlinux-6.4.0-150600.9-default.gz</replaceable> \
+<replaceable>/var/crash/2024-04-23-11\:17/vmcore</replaceable>
 crash 7.2.1
 Copyright (C) 2002-2017  Red Hat, Inc.
 Copyright (C) 2004, 2005, 2006, 2010  IBM Corporation
@@ -1138,17 +1138,17 @@ There is NO WARRANTY, to the extent permitted by law.  Type "show copying"
 and "show warranty" for details.
 This GDB was configured as "x86_64-unknown-linux-gnu".
 
-      KERNEL: /boot/vmlinux-5.3.18-8-default.gz
-   DEBUGINFO: /usr/lib/debug/boot/vmlinux-5.3.18-8-default.debug
-    DUMPFILE: /var/crash/2020-04-23-11:17/vmcore
+      KERNEL: /boot/vmlinux-6.4.0-150600.9-default.gz
+   DEBUGINFO: /usr/lib/debug/boot/vmlinux-6.4.0-150600.9-default.debug
+    DUMPFILE: /var/crash/2024-04-23-11:17/vmcore
         CPUS: 2
-        DATE: Thu Apr 23 13:17:01 2020
+        DATE: Thu Apr 23 13:17:01 2024
       UPTIME: 00:10:41
 LOAD AVERAGE: 0.01, 0.09, 0.09
        TASKS: 42
     NODENAME: eros
-     RELEASE: 5.3.18-8-default
-     VERSION: #1 SMP 2020-03-31 14:50:44 +0200
+     RELEASE: 6.4.0-150600.9-default
+     VERSION: #1 SMP 2024-03-31 14:50:44 +0200
      MACHINE: x86_64  (2999 Mhz)
       MEMORY: 16 GB
        PANIC: "SysRq : Trigger a crashdump"

--- a/xml/tuning_multikernel.xml
+++ b/xml/tuning_multikernel.xml
@@ -352,51 +352,54 @@
 <screen><?dbsuse-fo font-size="7pt"?>
 S  | Name                 | Type    | Version           | Arch   | Repository
 ---+----------------------+---------+-------------------+--------+------------------------------------------------------
-i+ | kernel-default              | package | 5.14.21-150400.6.3              | x86_64 | SLE-Module-Basesystem15-SP4-Pool
-   | kernel-default-base         | package | 5.14.21-150400.6.3.150400.22.27 | x86_64 | SLE-Module-Basesystem15-SP4-Pool
-   | kernel-default-devel        | package | 5.14.21-150400.6.3              | x86_64 | SLE-Module-Basesystem15-SP4-Pool
-   | kernel-devel                | package | 5.14.21-150400.6.4              | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-all         | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-amdgpu      | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-ath10k      | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-ath11k      | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-atheros     | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-bluetooth   | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-bnx2        | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-brcm        | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-chelsio     | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-dpaa2       | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-i915        | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-intel       | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-iwlwifi     | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-liquidio    | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-marvell     | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-media       | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-mediatek    | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-mellanox    | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-mwifiex     | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-network     | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-nfp         | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-nvidia      | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-platform    | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-prestera    | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-qcom        | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-qlogic      | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-radeon      | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-realtek     | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-serial      | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-sound       | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-ti          | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-ueagle      | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-i  | kernel-firmware-usb-network | package | 20220119-150400.1.1             | noarch | SLE-Module-Basesystem15-SP4-Pool
-   | kernel-macros               | package | 5.14.21-150400.6.4              | noarch | SLE-Module-Basesystem15-SP4-Pool
+i+ | kernel-default                          | package | 6.4.0-150600.9.2              | x86_64 | SLE-Module-Basesystem15-SP6-Pool
+   | kernel-default-base                     | package | 6.4.0-150600.9.2.150600.10.40 | x86_64 | SLE-Module-Basesystem15-SP6-Pool
+   | kernel-default-devel                    | package | 6.4.0-150600.9.2              | x86_64 | SLE-Module-Basesystem15-SP6-Pool
+   | kernel-devel                            | package | 6.4.0-150600.9.2              | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-all                     | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-amdgpu                  | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-ath10k                  | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-ath11k                  | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-ath12k                  | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-atheros                 | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-bluetooth               | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-bnx2                    | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-brcm                    | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-chelsio                 | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-dpaa2                   | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-i915                    | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-intel                   | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-iwlwifi                 | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-liquidio                | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-marvell                 | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-media                   | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-mediatek                | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-mellanox                | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-mwifiex                 | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-network                 | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-nfp                     | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-nvidia                  | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+   | kernel-firmware-nvidia-gsp-G06          | package | 525.116.04-150500.1.1         | x86_64 | SLE-Module-Basesystem15-SP6-Pool
+   | kernel-firmware-nvidia-gspx-G06         | package | 550.54.14-150600.1.1          | x86_64 | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-platform                | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-prestera                | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-qcom                    | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-qlogic                  | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-radeon                  | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-realtek                 | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-serial                  | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-sound                   | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-ti                      | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-ueagle                  | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+i  | kernel-firmware-usb-network             | package | 20240201-150600.1.1           | noarch | SLE-Module-Basesystem15-SP6-Pool
+   | kernel-macros                           | package | 6.4.0-150600.9.2              | noarch | SLE-Module-Basesystem15-SP6-Pool
 </screen>
    </step>
    <step>
     <para>
      Specify the exact version when installing:
     </para>
-<screen>&prompt.sudo;zypper in kernel-default-5.3.18-53.3</screen>
+<screen>&prompt.sudo;zypper in kernel-default-6.4.0-150600.9.2</screen>
    </step>
    <step>
     <para>

--- a/xml/tuning_taskscheduler.xml
+++ b/xml/tuning_taskscheduler.xml
@@ -828,7 +828,7 @@ kernel.sched_wakeup_granularity_ns = 10000000</screen>
               respectively.
             </para>
 <screen>&prompt.root;cat /proc/sched_debug
-Sched Debug Version: v0.11, 6.4.0-150600.9-default #1
+Sched Debug Version: v0.11, &kernel-version;-default #1
 ktime                                   : 23533900.395978
 sched_clk                               : 23543587.726648
 cpu_clk                                 : 23533900.396165

--- a/xml/tuning_taskscheduler.xml
+++ b/xml/tuning_taskscheduler.xml
@@ -828,7 +828,7 @@ kernel.sched_wakeup_granularity_ns = 10000000</screen>
               respectively.
             </para>
 <screen>&prompt.root;cat /proc/sched_debug
-Sched Debug Version: v0.11, 4.4.21-64-default #1
+Sched Debug Version: v0.11, 6.4.0-150600.9-default #1
 ktime                                   : 23533900.395978
 sched_clk                               : 23543587.726648
 cpu_clk                                 : 23533900.396165

--- a/xml/utilities.xml
+++ b/xml/utilities.xml
@@ -402,7 +402,7 @@ sar -f sa01 -f sa02              # queries files /var/log/sa/0[12]</screen>
       see statistics for individual CPUs.
      </para>
 <screen>&prompt.root;sar 10 5
-Linux 6.4.0-150600.9-default (&wsI;)         03/11/2024        _x86_64_        (2 CPU)
+Linux &kernel-version;-default (&wsI;)         03/11/2024        _x86_64_        (2 CPU)
 
 17:51:29        CPU     %user     %nice   %system   %iowait    %steal     %idle
 17:51:39        all     57,93      0,00      9,58      1,01      0,00     31,47
@@ -427,7 +427,7 @@ Average:        all     49,62      0,00      5,51      0,24      0,00     44,62<
       option <option>-r</option>:
      </para>
 <screen><?dbsuse-fo font-size="7pt"?>&prompt.root;sar -r 10 5
-Linux 6.4.0-150600.9-default (&wsI;)         03/11/2024        _x86_64_        (2 CPU)
+Linux &kernel-version;-default (&wsI;)         03/11/2024        _x86_64_        (2 CPU)
 
 17:55:27 kbmemfree kbmemused %memused kbbuffers kbcached kbcommit %commit kbactive kbinact kbdirty
 17:55:37    104232   1834624    94.62        20   627340  2677656   66.24   802052  828024    1744
@@ -451,7 +451,7 @@ Average:     96086   1842770    95.04        20   611254  2709579   67.03   8158
       statistics.
      </para>
 <screen><?dbsuse-fo font-size="7pt"?>&prompt.root;sar -B 10 5
-Linux 6.4.0-150600.9-default (&wsI;)         03/11/2024        _x86_64_        (2 CPU)
+Linux &kernel-version;-default (&wsI;)         03/11/2024        _x86_64_        (2 CPU)
 
 18:23:01 pgpgin/s pgpgout/s fault/s majflt/s pgfree/s pgscank/s pgscand/s pgsteal/s %vmeff
 18:23:11   366.80     11.60  542.50     1.10  4354.80      0.00      0.00      0.00   0.00
@@ -489,7 +489,7 @@ Average:    92.08    211.70 1097.30     0.26 12010.28      0.00      0.00      0
       <guimenu>DEV</guimenu> column readable.
      </para>
 <screen><?dbsuse-fo font-size="7pt"?>&prompt.root;sar -d -p 10 5
- Linux 6.4.0-150600.9-default (&wsI;)         03/11/2024        _x86_64_        (2 CPU)
+ Linux &kernel-version;-default (&wsI;)         03/11/2024        _x86_64_        (2 CPU)
 
 18:46:09 DEV   tps rd_sec/s  wr_sec/s  avgrq-sz  avgqu-sz     await     svctm     %util
 18:46:19 sda  1.70    33.60      0.00     19.76      0.00      0.47      0.47      0.08
@@ -609,7 +609,7 @@ Average: sr0  0.00     0.00      0.00      0.00      0.00      0.00      0.00   
     previous report.
    </para>
 <screen>&prompt.user;iostat
-Linux 6.4.0-150600.9-default (&wsI;)         03/11/2024        _x86_64_        (4 CPU)
+Linux &kernel-version;-default (&wsI;)         03/11/2024        _x86_64_        (4 CPU)
 
 avg-cpu:  %user   %nice %system %iowait  %steal   %idle
           17.68    4.49    4.24    0.29    0.00   73.31
@@ -689,7 +689,7 @@ sdc               0.02         0.14         0.00      13641         37</screen>
     intervals.
    </para>
 <screen><?dbsuse-fo font-size="7pt"?>&prompt.root;mpstat 2 5
-Linux 6.4.0-150600.9-default (&wsI;)         03/11/2024        _x86_64_        (2 CPU)
+Linux &kernel-version;-default (&wsI;)         03/11/2024        _x86_64_        (2 CPU)
 
 13:51:10  CPU   %usr  %nice  %sys  %iowait  %irq  %soft  %steal  %guest  %gnice   %idle
 13:51:12  all   8,27   0,00  0,50     0,00  0,00   0,00    0,00    0,00    0,00   91,23
@@ -769,7 +769,7 @@ Average:  all  47,85   0,00  3,34     0,00  0,00   0,40    0,00    0,00    0,00 
     two second intervals.
    </para>
 <screen>&prompt.root;pidstat -C firefox 2 3
-Linux 6.4.0-150600.9-default (&wsI;)         03/11/2024        _x86_64_        (2 CPU)
+Linux &kernel-version;-default (&wsI;)         03/11/2024        _x86_64_        (2 CPU)
 
 14:09:11      UID       PID    %usr %system  %guest    %CPU   CPU  Command
 14:09:13     1000       387   22,77    0,99    0,00   23,76     1  firefox

--- a/xml/utilities.xml
+++ b/xml/utilities.xml
@@ -402,7 +402,7 @@ sar -f sa01 -f sa02              # queries files /var/log/sa/0[12]</screen>
       see statistics for individual CPUs.
      </para>
 <screen>&prompt.root;sar 10 5
-Linux 4.4.21-64-default (&wsI;)         10/12/16        _x86_64_        (2 CPU)
+Linux 6.4.0-150600.9-default (&wsI;)         03/11/2024        _x86_64_        (2 CPU)
 
 17:51:29        CPU     %user     %nice   %system   %iowait    %steal     %idle
 17:51:39        all     57,93      0,00      9,58      1,01      0,00     31,47
@@ -427,7 +427,7 @@ Average:        all     49,62      0,00      5,51      0,24      0,00     44,62<
       option <option>-r</option>:
      </para>
 <screen><?dbsuse-fo font-size="7pt"?>&prompt.root;sar -r 10 5
-Linux 4.4.21-64-default (&wsI;)         10/12/16        _x86_64_        (2 CPU)
+Linux 6.4.0-150600.9-default (&wsI;)         03/11/2024        _x86_64_        (2 CPU)
 
 17:55:27 kbmemfree kbmemused %memused kbbuffers kbcached kbcommit %commit kbactive kbinact kbdirty
 17:55:37    104232   1834624    94.62        20   627340  2677656   66.24   802052  828024    1744
@@ -451,7 +451,7 @@ Average:     96086   1842770    95.04        20   611254  2709579   67.03   8158
       statistics.
      </para>
 <screen><?dbsuse-fo font-size="7pt"?>&prompt.root;sar -B 10 5
-Linux 4.4.21-64-default (&wsI;)         10/12/16        _x86_64_        (2 CPU)
+Linux 6.4.0-150600.9-default (&wsI;)         03/11/2024        _x86_64_        (2 CPU)
 
 18:23:01 pgpgin/s pgpgout/s fault/s majflt/s pgfree/s pgscank/s pgscand/s pgsteal/s %vmeff
 18:23:11   366.80     11.60  542.50     1.10  4354.80      0.00      0.00      0.00   0.00
@@ -489,7 +489,7 @@ Average:    92.08    211.70 1097.30     0.26 12010.28      0.00      0.00      0
       <guimenu>DEV</guimenu> column readable.
      </para>
 <screen><?dbsuse-fo font-size="7pt"?>&prompt.root;sar -d -p 10 5
- Linux 4.4.21-64-default (&wsI;)         10/12/16        _x86_64_        (2 CPU)
+ Linux 6.4.0-150600.9-default (&wsI;)         03/11/2024        _x86_64_        (2 CPU)
 
 18:46:09 DEV   tps rd_sec/s  wr_sec/s  avgrq-sz  avgqu-sz     await     svctm     %util
 18:46:19 sda  1.70    33.60      0.00     19.76      0.00      0.47      0.47      0.08
@@ -609,7 +609,7 @@ Average: sr0  0.00     0.00      0.00      0.00      0.00      0.00      0.00   
     previous report.
    </para>
 <screen>&prompt.user;iostat
-Linux 4.4.21-64-default (&wsI;)         10/12/16        _x86_64_        (4 CPU)
+Linux 6.4.0-150600.9-default (&wsI;)         03/11/2024        _x86_64_        (4 CPU)
 
 avg-cpu:  %user   %nice %system %iowait  %steal   %idle
           17.68    4.49    4.24    0.29    0.00   73.31
@@ -689,7 +689,7 @@ sdc               0.02         0.14         0.00      13641         37</screen>
     intervals.
    </para>
 <screen><?dbsuse-fo font-size="7pt"?>&prompt.root;mpstat 2 5
-Linux 4.4.21-64-default (&wsI;)         10/12/16        _x86_64_        (2 CPU)
+Linux 6.4.0-150600.9-default (&wsI;)         03/11/2024        _x86_64_        (2 CPU)
 
 13:51:10  CPU   %usr  %nice  %sys  %iowait  %irq  %soft  %steal  %guest  %gnice   %idle
 13:51:12  all   8,27   0,00  0,50     0,00  0,00   0,00    0,00    0,00    0,00   91,23
@@ -769,7 +769,7 @@ Average:  all  47,85   0,00  3,34     0,00  0,00   0,40    0,00    0,00    0,00 
     two second intervals.
    </para>
 <screen>&prompt.root;pidstat -C firefox 2 3
-Linux 4.4.21-64-default (&wsI;)         10/12/16        _x86_64_        (2 CPU)
+Linux 6.4.0-150600.9-default (&wsI;)         03/11/2024        _x86_64_        (2 CPU)
 
 14:09:11      UID       PID    %usr %system  %guest    %CPU   CPU  Command
 14:09:13     1000       387   22,77    0,99    0,00   23,76     1  firefox

--- a/xml/xen2kvm.xml
+++ b/xml/xen2kvm.xml
@@ -684,14 +684,14 @@ Id Name                 State
               The kernel we are going to use to boot the guest under &kvm; must
               have <emphasis>virtio</emphasis> (paravirtualized) drivers
               available. Run the following command to find out. Do not forget
-              to replace <literal>6.4.0-150600.9</literal> with your kernel version:
+              to replace <literal>&kernel-version;</literal> with your kernel version:
             </para>
-<screen>&prompt.sudo;sudo find /lib/modules/6.4.0-150600.9-default/kernel/drivers/ -name virtio*
-/lib/modules/6.4.0-150600.9-default/kernel/drivers/block/virtio_blk.ko.zst
-/lib/modules/6.4.0-150600.9-default/kernel/drivers/bluetooth/virtio_bt.ko.zst
-/lib/modules/6.4.0-150600.9-default/kernel/drivers/char/hw_random/virtio-rng.ko.zst
-/lib/modules/6.4.0-150600.9-default/kernel/drivers/crypto/virtio
-/lib/modules/5.3.18-8-default/kernel/drivers/block/virtio_blk.ko
+<screen>&prompt.sudo;sudo find /lib/modules/&kernel-version;-default/kernel/drivers/ -name virtio*
+/lib/modules/&kernel-version;-default/kernel/drivers/block/virtio_blk.ko.zst
+/lib/modules/&kernel-version;-default/kernel/drivers/bluetooth/virtio_bt.ko.zst
+/lib/modules/&kernel-version;-default/kernel/drivers/char/hw_random/virtio-rng.ko.zst
+/lib/modules/&kernel-version;-default/kernel/drivers/crypto/virtio
+/lib/modules/&kernel-version;/kernel/drivers/block/virtio_blk.ko
 ...</screen>
           </listitem>
           <listitem>

--- a/xml/xen2kvm.xml
+++ b/xml/xen2kvm.xml
@@ -684,13 +684,14 @@ Id Name                 State
               The kernel we are going to use to boot the guest under &kvm; must
               have <emphasis>virtio</emphasis> (paravirtualized) drivers
               available. Run the following command to find out. Do not forget
-              to replace <literal>5.3.18-8</literal> with your kernel version:
+              to replace <literal>6.4.0-150600.9</literal> with your kernel version:
             </para>
-<screen>&prompt.sudo;sudo find /lib/modules/5.3.18-8-default/kernel/drivers/ -name virtio*
+<screen>&prompt.sudo;sudo find /lib/modules/6.4.0-150600.9-default/kernel/drivers/ -name virtio*
+/lib/modules/6.4.0-150600.9-default/kernel/drivers/block/virtio_blk.ko.zst
+/lib/modules/6.4.0-150600.9-default/kernel/drivers/bluetooth/virtio_bt.ko.zst
+/lib/modules/6.4.0-150600.9-default/kernel/drivers/char/hw_random/virtio-rng.ko.zst
+/lib/modules/6.4.0-150600.9-default/kernel/drivers/crypto/virtio
 /lib/modules/5.3.18-8-default/kernel/drivers/block/virtio_blk.ko
-/lib/modules/5.3.18-8-default/kernel/drivers/char/hw_random/virtio-rng.ko
-/lib/modules/5.3.18-8-default/kernel/drivers/char/virtio_console.ko
-/lib/modules/5.3.18-8-default/kernel/drivers/crypto/virtio
 ...</screen>
           </listitem>
           <listitem>


### PR DESCRIPTION
### PR creator: Description

Update code examples etc. to SLE 15 SP6 kernel version. Affects the following guides:

- Admin Guide
- AY Guide
- Security & Hardening Guide
- Tuning Guide
- Virtualization Guide


### PR creator: Are there any relevant issues/feature requests?

* jsc#PED-4595


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
 
No backporting!
