### PR TITLE
virt_support.xml: start listing of features that are explicitly not s…

### DIFF
--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -1030,8 +1030,27 @@
   </sect1>
   <sect1 xml:id="virt-support-feature-support">
     <title>Feature support</title>
-
     <para/>
+    <title>Nested virtualization: Tech Preview</title>
+    <para>
+      Nested virtualization allows you to run a virtual machine inside another
+      VM while still using hardware acceleration from the host. It has low
+      performance and adds more complexity while debugging. Nested
+      virtualization is normally used for testing purposes. In &sls;, nested
+      virtualization is a Technology Preview. It is only provided for testing
+      purposes and is not supported. Bugs can be reported but they are treated
+      with low priority. Any attempt to live-migrate or to save or restore VMs
+      in the presence of nested virtualization is also explicitly unsupported.
+    </para>
+    <title>Post-Copy Live migration: Tech Preview</title>
+    <para>
+     Post-Copy is a method to live migrate Virtual Machines that is intended to get VMs running as soon as possible on the destination host,
+     and have the VM RAM be transferred gradually in the background over time as needed.
+     Under some conditions, this can be an optimization compared to the traditional Pre-Copy method.
+     However this comes with a major drawback: an error occurring during the migration (especially a network failure) can cause the whole VM RAM contents to be lost.
+     
+     Therefore, it is recommended to only use Pre-Copy in production, while Post-Copy can be used for testing and experimentation in case losing the VM state is not a major concern.
+    </para>
 
     <sect2 xml:id="virt-support-feature-support-host">
       <title>&xen; host (Dom0)</title>
@@ -1377,20 +1396,6 @@
         </tgroup>
       </informaltable>
     </sect2>
-  </sect1>
-  <sect1 xml:id="vt-support-nested">
-    <title>Nested virtualization</title>
-
-    <para>
-      Nested virtualization allows you to run a virtual machine inside another
-      VM while still using hardware acceleration from the host. It has low
-      performance and adds more complexity while debugging. Nested
-      virtualization is normally used for testing purposes. In &sls;, nested
-      virtualization is a Technology Preview. It is only provided for testing
-      purposes and is not supported. Bugs can be reported but they are treated
-      with low priority. Any attempt to live-migrate or to save or restore VMs
-      in the presence of nested virtualization is also explicitly unsupported.
-    </para>
   </sect1>
   <!-- End X86_64 only -->
 </chapter>


### PR DESCRIPTION
…upported

currently the major virtualization features that are not supported are spread throughout the documentation. Start to move them (at least the most important ones) into the dedicated support section.

### PR creator: Description

start to improve the support chapter collecting pieces from other sections of the guide.

### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#...


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
