### PR TITLE
Renamed expaned to Liberty and update RMT support for EL 7

### DIFF
--- a/xml/rmt_migrate_from_smt.xml
+++ b/xml/rmt_migrate_from_smt.xml
@@ -431,8 +431,7 @@
             <entry>
               <para>
                 Red Hat 7 and earlier support
-                (<link xlink:href="https://www.suse.com/products/expandedsupport/">Expanded
-                Support</link>)
+                (<link xlink:href="https://www.suse.com/products/suse-liberty-linux/">SUSE Liberty Linux</link>)
               </para>
             </entry>
             <entry>
@@ -442,7 +441,7 @@
             </entry>
             <entry>
               <para>
-                no
+                yes
               </para>
             </entry>
           </row>
@@ -450,8 +449,7 @@
             <entry>
               <para>
                 Red Hat 8 support
-                (<link xlink:href="https://www.suse.com/products/expandedsupport/">Expanded
-                Support</link>)
+                (<link xlink:href="https://www.suse.com/products/suse-liberty-linux/">SUSE Liberty Linux</link>)
               </para>
             </entry>
             <entry>


### PR DESCRIPTION
RMT now supports also CentOS/RHEL distros so changed false to true in the table. Also changed Expanded Support references to SUSE Liberty Linux as that's the official product name

### PR creator: Description

RMT now support managing RHEL/CentOS 7 repos


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#...


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
