### PR TITLE
AutoYAST Guide: integrate proofing corrections

### DIFF
--- a/xml/ay_grub_bootloader.xml
+++ b/xml/ay_grub_bootloader.xml
@@ -56,7 +56,9 @@
   &lt;/device_map&gt;
  &lt;/bootloader&gt;</screen>
  <para>
-    It is not necessary to fill in all settings, you can specify only those you need to change. &ay; will then merge the default values with those specified in the profile.
+  You do not need to fill out all settings. Rather, you only need to define 
+  those that you need to change. &ay; will then merge the default values 
+  with those specified in the profile.
  </para>
 
  <sect2 xml:id="CreateProfile-Bootloader-type-Grub">
@@ -102,7 +104,7 @@
   <para>
    This is an important if optional part. Define here where to install &grub;
    and how the boot process will work. Again,
-   <command>yast2-bootloader</command> proposes a configuration if you do not
+   <command>yast2-bootloader</command> will propose a configuration if you do not
    define one. Usually the &ay; control file includes only this part and all
    other parts are added automatically during installation by
    <command>yast2-bootloader</command>. Unless you have some special
@@ -237,7 +239,7 @@
         <term>cpu_mitigations</term>
         <listitem>
           <para>
-            Allows choosing a default setting of kernel boot command-line
+            Lets you select a default setting of kernel boot command-line
             parameters for CPU mitigation (and, at the same time, strike a
             balance between security and performance).
           </para>

--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -117,7 +117,7 @@
     <term>lvm_vg_reuse</term>
     <listitem>
      <para>
-      Tells the installer whether an existing LVM should be reused during in the proposal. The default is <literal>true</literal>.
+      Tells the installer whether an existing LVM should be reused in the proposal. The default is <literal>true</literal>.
      </para>
 <screen>&lt;lvm_vg_reuse config:type="boolean">false&lt;/lvm_vg_reuse></screen>
     </listitem>
@@ -606,10 +606,10 @@
        When using regular LUKS encryption, it is possible to customize several aspects
        of the encryption using <literal>crypt_pbkdf</literal>, <literal>crypt_cipher</literal>
        or <literal>crypt_key_size</literal>, depending on the exact variant of LUKS that
-       is used. Bear in mind that the encryption method and its corresponding settings may
+       is used. Keep in mind that the encryption method and its corresponding settings may
        dramatically affect the amount of RAM needed to complete the installation process.
-       Using regular LUKS2 with default parameters typically implies the need of having
-       several gigabytes of RAM in the system in order to encrypt the devices.
+       Using regular LUKS2 with default parameters typically means that
+       several gigabytes of RAM are needed in the system in order to encrypt the devices.
       </para>
      </listitem>
     </varlistentry>
@@ -669,12 +669,12 @@
        <literal>luks2</literal>. The possible values are
        <literal>pbkdf2</literal>, <literal>argon2i</literal> and
        <literal>argon2id</literal>. If omitted, the device will be encrypted
-       using the default function of the command cryptsetup. Note that both
-       variants of Argon2 are designed to intentionally consume a big amount
-       of memory during the encryption process. Using any of those functions
-       or omitting this setting (which will likely result in the usage of
-       Argon2) implies bigger RAM requirements to complete the installation
-       process, when compared to a non-encrypted setup.
+       using the default function of the command <command>cryptsetup</command>.
+       Note that both variants of Argon2 are designed to intentionally consume 
+       a large amount of memory during the encryption process. Using any of 
+       those functions or omitting this setting (which will likely result 
+       in the usage of Argon2) means that more RAM is needed to complete 
+       the installation process compared to a non-encrypted setup.
       </para>
 <screen>&lt;crypt_pbkdf config:type="symbol"&gt;argon2id&lt;/crypt_pbkdf&gt;</screen>
      </listitem>
@@ -1887,7 +1887,7 @@
        Can be expressed as a number with the corresponding units (for example,
        32M) or just as a number. If the unit is omitted, kilobytes are used as
        the default unit. Do not specify <literal>chunk_size</literal> for RAID1.
-       Bear in mind that <literal>raid1</literal> is the default type.
+       Keep in mind that <literal>raid1</literal> is the default type.
       </para>
 <screen>&lt;chunk_size&gt;4&lt;/chunk_size&gt;</screen>
      </listitem>
@@ -1907,7 +1907,7 @@
        <literal>right_asymmetric_6</literal>,
        <literal>right_symmetric_6</literal>,
        <literal>near_2</literal>, <literal>offset_2</literal>, <literal>far_2</literal>,
-       <literal>near_3</literal>, <literal>offset_3</literal>, or <literal>far_3</literal>.
+       <literal>near_3</literal>, <literal>offset_3</literal> and <literal>far_3</literal>.
       </para>
       <para>
        For backwards compatibility with previous versions of AutoYaST, the following aliases
@@ -1917,10 +1917,10 @@
        <literal>parity_first</literal>, <literal>parity_last</literal>,
        <literal>parity_first_6</literal>,
        <literal>n2</literal>, <literal>o2</literal>, <literal>f2</literal>,
-       <literal>n3</literal>, <literal>o3</literal>, <literal>f3</literal>.
+       <literal>n3</literal>, <literal>o3</literal> and <literal>f3</literal>.
       </para>
       <para>
-       The accepted values for each RAID depend on the RAID level (eg. <literal>raid5</literal>)
+       The accepted values for each RAID depend on the RAID level (for example, <literal>raid5</literal>)
        and the number of devices in the RAID. Given that RAID0 or RAID1 do not provide
        any parity, do not specify this option for such devices.
       </para>

--- a/xml/ay_running_system.xml
+++ b/xml/ay_running_system.xml
@@ -19,7 +19,7 @@ xml:id="InstalledSystem">
  </info>
 
    <para>
-    In some cases it is useful to run &ay; in a running system. Bear in mind that the
+    In some cases it is useful to run &ay; in a running system. Keep in mind that the
     <literal>partitioning</literal> section is ignored in this scenario.
    </para>
    <para>

--- a/xml/common_intro_available_doc.xml
+++ b/xml/common_intro_available_doc.xml
@@ -45,7 +45,7 @@
    <!--based on 'Support Resources' listed at https://www.suse.com/support/kb/-->
    <listitem>
     <para>
-     If you have run into an issue, also check out the Technical Information
+     If you run into an issue, check out the Technical Information
      Documents (TIDs) that are available online at <link xlink:href="https://www.suse.com/support/kb/"/>.
      Search the &suse; Knowledgebase for known solutions driven by customer need.
      </para>

--- a/xml/common_intro_convention.xml
+++ b/xml/common_intro_convention.xml
@@ -106,7 +106,7 @@
    <para>
     Commands can be split into two or multiple lines by a backslash character
     (<literal>\</literal>) at the end of a line. The backslash informs the shell that
-    the command invocation will continue after the line's end:
+    the command invocation will continue after the end of the line:
    </para>
    <screen>&prompt.user;<command>echo</command> a b \
 c d</screen>

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -2186,8 +2186,8 @@ sle-live-patching 8c541494</screen>
              applications, scripts or third-party products may rely on the existence of a user called
              &rootuser;. While such a configuration always targets individual environments,
              necessary adjustments could be overwritten by vendor updates, so this becomes an
-             ongoing task, not a one-time setting. This is especially true in very complex setups involving
-             third-party applications, where it needs to be verified with every involved vendor whether a
+             ongoing task rather than a one-time setting. This is especially true in very complex setups involving
+             third-party applications, where it needs to be verified with every vendor involved whether a
              rename of the &rootuser; account is supported.
            </para>
            <para>


### PR DESCRIPTION
### PR creator: Description

Integrate proofing corrections for the AutoYAST Guide from proofing drop 1.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4