### PR TITLE
Deployment Guide: integrate proofing corrections

### DIFF
--- a/xml/ay_users_groups.xml
+++ b/xml/ay_users_groups.xml
@@ -106,9 +106,9 @@
        (<literal>uid</literal>) <literal>0</literal> and a name other than &rootuser;, certain
        applications, scripts or third-party products may rely on the existence of a user called
        &rootuser;. While such a configuration always targets individual environments, necessary
-       adjustments could be overwritten by vendor updates, so this becomes an ongoing task, not
+       adjustments could be overwritten by vendor updates, so this becomes an ongoing task rather than
        a one-time setting. This is especially true in very complex setups involving third-party applications, 
-       where it needs to be verified with every involved vendor whether a rename of the &rootuser; account
+       where it needs to be verified with every vendor involved whether a rename of the &rootuser; account
        is supported.
      </para>
      <para>

--- a/xml/common_intro_available_doc.xml
+++ b/xml/common_intro_available_doc.xml
@@ -45,7 +45,7 @@
    <!--based on 'Support Resources' listed at https://www.suse.com/support/kb/-->
    <listitem>
     <para>
-     If you have run into an issue, also check out the Technical Information
+     If you run into an issue, check out the Technical Information
      Documents (TIDs) that are available online at <link xlink:href="https://www.suse.com/support/kb/"/>.
      Search the &suse; Knowledgebase for known solutions driven by customer need.
      </para>

--- a/xml/common_intro_convention.xml
+++ b/xml/common_intro_convention.xml
@@ -106,7 +106,7 @@
    <para>
     Commands can be split into two or multiple lines by a backslash character
     (<literal>\</literal>) at the end of a line. The backslash informs the shell that
-    the command invocation will continue after the line's end:
+    the command invocation will continue after the end of the line:
    </para>
    <screen>&prompt.user;<command>echo</command> a b \
 c d</screen>

--- a/xml/deployment_prep_aarch64_raspi.xml
+++ b/xml/deployment_prep_aarch64_raspi.xml
@@ -243,7 +243,7 @@ dtoverlay=i2c-rtc,ds1307</screen>
      </varlistentry>
    </variablelist>
   <para>
-   For other boards and HATs, consult the documentation of the they are shipped with.
+   For other boards and HATs, consult the documentation they are shipped with.
   </para>
  </sect2>
 

--- a/xml/deployment_yast_installer.xml
+++ b/xml/deployment_yast_installer.xml
@@ -2148,7 +2148,7 @@ sle-live-patching 8c541494</screen>
      <title>The &rootuser; user</title>
      <para>
        &rootuser; is the name of the system administrator or superuser. Its user ID (uid) is
-       <literal>0</literal>. Unlike regular users, &rootuser; account has unlimited privileges.
+       <literal>0</literal>. Unlike regular users, the &rootuser; account has unlimited privileges.
      </para>
      <variablelist>
        <varlistentry>
@@ -2186,8 +2186,8 @@ sle-live-patching 8c541494</screen>
              applications, scripts or third-party products may rely on the existence of a user called
              &rootuser;. While such a configuration always targets individual environments,
              necessary adjustments could be overwritten by vendor updates, so this becomes an
-             ongoing task, not a one-time setting. This is especially true in very complex setups involving
-             third-party applications, where it needs to be verified with every involved vendor whether a
+             ongoing task rather than a one-time setting. This is especially true in very complex setups involving
+             third-party applications, where it needs to be verified with every vendor involved whether a
              rename of the &rootuser; account is supported.
            </para>
            <para>

--- a/xml/yast2_userman.xml
+++ b/xml/yast2_userman.xml
@@ -262,9 +262,9 @@
       While it is technically possible to rename the &rootuser; account, certain applications,
       scripts or third-party products may rely on the existence of a user called &rootuser;. While
       such a configuration always targets individual environments, necessary adjustments could be
-      overwritten by vendor updates, so this becomes an ongoing task, not a one-time setting.
+      overwritten by vendor updates, so this becomes an ongoing task rather than a one-time setting.
       This is especially true in very complex setups involving third-party applications, where it needs to be verified
-      with every involved vendor whether a rename of the &rootuser; account is supported.
+      with every vendor involved whether a rename of the &rootuser; account is supported.
     </para>
     <para>
       As the implications for renaming the &rootuser; account cannot be foreseen, &suse; does not


### PR DESCRIPTION
### PR creator: Description

Integrate proofing corrections for the Deployment Guide from proofing drop 1.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4