### PR TITLE
Upgrade Guide: integrate proofing corrections

### DIFF
--- a/xml/common_intro_available_doc.xml
+++ b/xml/common_intro_available_doc.xml
@@ -45,7 +45,7 @@
    <!--based on 'Support Resources' listed at https://www.suse.com/support/kb/-->
    <listitem>
     <para>
-     If you have run into an issue, also check out the Technical Information
+     If you run into an issue, check out the Technical Information
      Documents (TIDs) that are available online at <link xlink:href="https://www.suse.com/support/kb/"/>.
      Search the &suse; Knowledgebase for known solutions driven by customer need.
      </para>

--- a/xml/common_intro_convention.xml
+++ b/xml/common_intro_convention.xml
@@ -106,7 +106,7 @@
    <para>
     Commands can be split into two or multiple lines by a backslash character
     (<literal>\</literal>) at the end of a line. The backslash informs the shell that
-    the command invocation will continue after the line's end:
+    the command invocation will continue after the end of the line:
    </para>
    <screen>&prompt.user;<command>echo</command> a b \
 c d</screen>

--- a/xml/sle_update_finish.xml
+++ b/xml/sle_update_finish.xml
@@ -62,7 +62,7 @@
   <warning>
    <title>Do not remove packages you need</title>
    <para>
-    If packages get renamed, or removed from a pattern or product, <command>zypper</command> may no
+    If packages are renamed or removed from a pattern or product, <command>zypper</command> may no
     longer consider them explicitly installed and mark them as unneeded, even though they are still
     crucial for your installation.
    </para>

--- a/xml/sle_update_preparation.xml
+++ b/xml/sle_update_preparation.xml
@@ -59,20 +59,20 @@
         Mid 2023, the &sle; 15 product family switched over from a RSA 2048-bit signing key to a new
         RSA 4096-bit key. This change covers RPM packages, package repositories and ISO signatures.
         Old repositories that are not updated anymore and RPMs released up to the switch-over date,
-        will still stay signed with the old 2048 bit key.
+        will remain signed with the old 2048-bit key.
       </para>
       <para>
         If you update your system, the new key is automatically imported into the
         RPM keyring from the <package>suse-build-key</package> package on &slea; 15 SP 4 and SP5 as
-        well as the LTSS versions of &slea; 15 SP1, SP2, and SP3.
+        well as the LTSS versions of &slea; 15 SP1, SP2 and SP3.
       </para>
       <para>
-        If the key was not imported yet, you can manually import it with:
+        If the key has not been imported yet, you can manually import it with:
       </para>
 <screen>&prompt.sudo;<command>rpm --import /usr/lib/rpm/gnupg/keys/gpg-pubkey-3fa1d6ce-63c9481c.asc</command></screen>
       <para>
         If you are running an older version of &slea; or did not import the new key, you will be
-        asked to trust it during the upgrade. Please make sure the fingerprint matches:
+        asked to trust it during the upgrade. Make sure the fingerprint matches:
       </para>
 <screen>pub   rsa4096/0xF74F09BC3FA1D6CE 2023-01-19 [SC] [expires: 2027-01-18]
 Key fingerprint = 7F00 9157 B127 B994 D5CF  BE76 F74F 09BC 3FA1 D6CE
@@ -937,8 +937,8 @@ postgres &gt; <command>pg_upgrade</command> \
    On systems that have been installed with &productname; 12 or older, the default  kernel command
    line in <filename>/etc/default/grub</filename> may contain a <parameter>resume</parameter>
    parameter using a device node name such as <filename>/dev/sda1</filename> to refer to the
-   hibernation (&apos;suspend-to-disk&apos;) device. As device node names are not persistent and may
-   change between reboots, it is strongly recommended to fix this, otherwise the upgraded system
+   hibernation (suspend-to-disk) device. As device node names are not persistent and may
+   change between reboots, fixing this is highly recommended. Otherwise, the upgraded system
    may hang on reboot.
   </para>
   <procedure>


### PR DESCRIPTION
### PR creator: Description

Integrate proofing corrections for the Upgrade Guide from proofing drop 1.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4
