### PR TITLE
metadata: add revhistory for 4 deliverables (locdrop 1)

### DIFF
--- a/xml/art_installation-sleds.xml
+++ b/xml/art_installation-sleds.xml
@@ -22,7 +22,16 @@
    <phrase>Installation</phrase>
   </meta>
   <meta name="series" its:translate="no">Product Documentation</meta>
-
+  <revhistory xml:id="rh-article-installation">
+    <revision>
+      <date>2024-06-26</date>
+      <revdescription>
+        <para>
+          Updated for the initial release of &productname; &productnumber;.
+        </para>
+      </revdescription>
+    </revision>
+   </revhistory>
   <abstract>
    <para>
     &abstract_installquick;

--- a/xml/book_autoyast.xml
+++ b/xml/book_autoyast.xml
@@ -23,7 +23,16 @@
    <phrase>Automation</phrase>
   </meta>
   <meta name="series" its:translate="no">Product Documentation</meta>
-
+  <revhistory xml:id="rh-book-autoyast">
+    <revision>
+      <date>2024-06-26</date>
+      <revdescription>
+        <para>
+          Updated for the initial release of &productname; &productnumber;.
+        </para>
+      </revdescription>
+    </revision>
+   </revhistory>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:bugtracker>
     <dm:assignee>fs@suse.com</dm:assignee>

--- a/xml/book_deployment.xml
+++ b/xml/book_deployment.xml
@@ -26,7 +26,16 @@
    <phrase>Installation</phrase>
   </meta>
   <meta name="series" its:translate="no">Product Documentation</meta>
-
+  <revhistory xml:id="rh-book-deployment">
+    <revision>
+      <date>2024-06-26</date>
+      <revdescription>
+        <para>
+          Updated for the initial release of &productname; &productnumber;.
+        </para>
+      </revdescription>
+    </revision>
+   </revhistory>
   <xi:include href="common_copyright_gfdl.xml"/>
   <abstract>
    <para>

--- a/xml/book_upgrade.xml
+++ b/xml/book_upgrade.xml
@@ -24,7 +24,16 @@
    <phrase>Upgrade &amp; Update</phrase>
   </meta>
   <meta name="series" its:translate="no">Product Documentation</meta>
-
+  <revhistory xml:id="rh-book-upgrade">
+    <revision>
+      <date>2024-06-26</date>
+      <revdescription>
+        <para>
+          Updated for the initial release of &productname; &productnumber;.
+        </para>
+      </revdescription>
+    </revision>
+   </revhistory>
   <xi:include href="common_copyright_gfdl.xml"/>
   <abstract>
    <para>


### PR DESCRIPTION
### PR creator: Description

Metadata: add revhistory for 4 deliverables that will be handed over to localization with locdrop 1:

- Install Quick
- Deployment Guide
- Upgrade Guide
- AutoYasT Guide

### PR creator: Are there any relevant issues/feature requests?

[Link to internal page](https://confluence.suse.com/display/documentation/Adding+metadata+to+all+SUSE+documentation)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*

