### PR TITLE
removes sle12-sp4 checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ When opening a PR, check all versions of the documentation that your PR applies 
   - [ ] SLE 15 SP1
 - SLE 12
   - [ ] SLE 12 SP5
-  - [ ] SLE 12 SP4
+
 
 ### PR reviewer only: Have all backports been applied?
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ When opening a PR, check all versions of the documentation that your PR applies 
   - [ ] SLE 15 SP4/openSUSE Leap 15.4
   - [ ] SLE 15 SP3/openSUSE Leap 15.3
   - [ ] SLE 15 SP2/openSUSE Leap 15.2
-  - [ ] SLE 15 SP1
+
 - SLE 12
   - [ ] SLE 12 SP5
 


### PR DESCRIPTION
### PR creator: Description

Describe the overall goals of this pull request.

Removes the SLE12-SP4  and SLE15-SP1 checkboxs (as its no longer supported) in the PR template


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#...


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2
  - [ ] SLE 15 SP1
- SLE 12
  - [ ] SLE 12 SP5
  - [ ] SLE 12 SP4

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
