### PR TITLE
security_ssh.xml - Inconsistency in naming revoked-host-key or revoke…

### DIFF
--- a/xml/security_ssh.xml
+++ b/xml/security_ssh.xml
@@ -1209,7 +1209,7 @@ valid from 2022-08-08T14:20:00 to 2022-09-05T15:21:19
     When you need to revoke a certificate because a server has been
     compromised or retired, add the certificate's corresponding
     public key to a file on every client, for example
-    <filename>/etc/ssh/revoked-host-key</filename>:
+    <filename>/etc/ssh/revoked_keys</filename>:
    </para>
    <screen>ssh-ed25519-cert-v01@openssh.com
     AAAAIHNzaC1lZDI1NTE5LWNlcnQtdjAxQG9wZW5zc2guY29tAAAAIK6hyvFAhFI+0hkKehF/


### PR DESCRIPTION
…d_keys

Inconsistency in naming revoked-host-key or revoked_keys. Changed to revoked_keys.

### PR creator: Description

Minor bugfix


### PR creator: Are there any relevant issues/feature requests?

Not that i know off


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP5/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2

- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
