### PR TITLE
security_ssh.xml - sshd_config was named sshd_configuration

### DIFF
--- a/xml/security_ssh.xml
+++ b/xml/security_ssh.xml
@@ -1660,7 +1660,7 @@ cd path                            Change remote directory to 'path'
       </para>
       <para>
        To apply explicit permissions for uploaded files on an SFTP server,
-       edit the file <filename>/etc/ssh/sshd_configuration</filename>.
+       edit the file <filename>/etc/ssh/sshd_config</filename>.
        Search for the line beginning with <literal>Subsystem sftp</literal>
        and add the <option>-m</option> parameter with the desired setting,
        for example:


### PR DESCRIPTION
security_ssh.xml - sshd_config was named sshd_configuration in the sftp section

### PR creator: Description

Apologies for the extra branch. Would I've spotted this earlier I would have created a more general branch. 
Anyway: another bug in naming: sshd_config was named sshd_configuration in the section about sftp (22.16.2).


### PR creator: Are there any relevant issues/feature requests?

Not that I know off.


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2

- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
