### PR TITLE
Confidential computing module ped 8169

### DIFF
--- a/xml/art_modules.xml
+++ b/xml/art_modules.xml
@@ -321,35 +321,43 @@
     with SP7. Remove 'tech preview' and update lifecycle and support levels. -->
    <title>Confidential Computing Technology Preview</title>
    <para>
-    This module contains Confidential Computing related packages.
-    Access to the Confidential Computing module is included in your &sle; subscription.
+    This module contains a Secure Virtual Machine Service Module (SVSM) which aims to provide secure
+    services and device emulations to guest operating systems in confidential virtual machines
+    (CVMs).
    </para>
    <important>
     <title>Technology preview</title>
     <para>
-     The module is a technology preview and is not supported.
+     The module is a technology preview and is not supported. Its lifecycle and support options
+     will be defined at a later stage.
     </para>
    </important>
+   <note>
+    <title>&amdsev; required</title>
+    <para>
+     The SVSM requires AMD Secure Encrypted Virtualization (&amdsev;) with Secure Nested Paging. It
+     will only work on AMD systems.
+    </para>
+   </note>
    <itemizedlist>
     <listitem>
      <para>
-      <emphasis role="bold">Depends on</emphasis>: Basesystem
+      <emphasis role="bold">Depends on</emphasis>: Server Applications
      </para>
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">Available for:</emphasis> &slsa;, &sleda;, &sles4sapa;,
-      &slert;
+      <emphasis role="bold">Available for:</emphasis> &slsa; on &x86-64; 
      </para>
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">Lifecycle:</emphasis> 10 years
+      <emphasis role="bold">Lifecycle:</emphasis> until the release of &slea; 15 SP7
      </para>
     </listitem>
     <listitem>
      <para>
-      <emphasis role="bold">Extended support:</emphasis> 3 years LTSS
+      <emphasis role="bold">Extended support:</emphasis> none
      </para>
     </listitem>
     <listitem>

--- a/xml/art_modules.xml
+++ b/xml/art_modules.xml
@@ -151,6 +151,11 @@
    </listitem>
    <listitem os="sles">
     <para>
+     <xref xrefstyle="select:title" linkend="art-modules-confidential-computing"/>
+    </para>
+   </listitem>
+   <listitem os="sles" >
+    <para>
      <xref xrefstyle="select:title" linkend="art-modules-containers"/>
     </para>
    </listitem>
@@ -307,6 +312,50 @@
     <listitem>
      <para>
       <emphasis role="bold">Support level:</emphasis> L3
+     </para>
+    </listitem>
+   </itemizedlist>
+  </sect2>
+  <sect2 os="sles" xml:id="art-modules-confidential-computing">
+   <!-- FIXME cwickert 2024-05-03: Revisit this when leaves tech preview to become supported 
+    with SP7. Remove 'tech preview' and update lifecycle and support levels. -->
+   <title>Confidential Computing Technology Preview</title>
+   <para>
+    This module contains Confidential Computing related packages.
+    Access to the Confidential Computing module is included in your &sle; subscription.
+   </para>
+   <important>
+    <title>Technology preview</title>
+    <para>
+     The module is a technology preview and is not supported.
+    </para>
+   </important>
+   <itemizedlist>
+    <listitem>
+     <para>
+      <emphasis role="bold">Depends on</emphasis>: Basesystem
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <emphasis role="bold">Available for:</emphasis> &slsa;, &sleda;, &sles4sapa;,
+      &slert;
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <emphasis role="bold">Lifecycle:</emphasis> 10 years
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <emphasis role="bold">Extended support:</emphasis> 3 years LTSS
+     </para>
+    </listitem>
+    <listitem>
+     <para>
+      <emphasis role="bold">Support level:</emphasis> This module is a technology preview and is
+      not supported.
      </para>
     </listitem>
    </itemizedlist>

--- a/xml/phrases-decl.ent
+++ b/xml/phrases-decl.ent
@@ -156,7 +156,7 @@
        </listitem>
       </varlistentry>
       <varlistentry os="sles">
-       <term>Confidential Computing</term>
+       <term>Confidential Computing Technical Preview</term>
        <listitem>
         <para>
          Contains packages related to confidential computing.

--- a/xml/phrases-decl.ent
+++ b/xml/phrases-decl.ent
@@ -156,6 +156,17 @@
        </listitem>
       </varlistentry>
       <varlistentry os="sles">
+       <term>Confidential Computing</term>
+       <listitem>
+        <para>
+         Contains packages related to confidential computing.
+        </para>
+        <para>
+         <emphasis>Dependencies:</emphasis> Basesystem
+        </para>
+       </listitem>
+      </varlistentry>
+      <varlistentry os="sles">
        <term>Containers Module</term>
        <listitem>
         <para>

--- a/xml/phrases-decl.ent
+++ b/xml/phrases-decl.ent
@@ -151,7 +151,7 @@
          Contains the FIPS certification packages.
         </para>
         <para>
-         <emphasis>Dependencies:</emphasis> Basesystem
+         <emphasis>Dependencies:</emphasis> Server Applications
         </para>
        </listitem>
       </varlistentry>


### PR DESCRIPTION
### PR creator: Description

This adds the confidential computing module to the Modules & Extensions guides as well as the Deployment and Installation Quickstart guides.

### PR creator: Are there any relevant issues/feature requests?

* [jsc#PED-8169](https://jira.suse.com/browse/PED-8169)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2

- SLE 12
  - [ ] SLE 12 SP5
