### PR TITLE
Administration Guide: Integrate proofing corrections

### DIFF
--- a/xml/adm_sudo.xml
+++ b/xml/adm_sudo.xml
@@ -239,7 +239,7 @@ root's password:
     <sect2 xml:id="sudo-creating-custom-configuration-bp">
       <title>&sudo; configuration best practices</title>
       <para>
-        Before your start, a few ground rules for maintaining &sudo; configurations follow:
+        Before you start, here are a few ground rules for maintaining &sudo; configurations:
       </para>
       <variablelist>
         <varlistentry>
@@ -374,7 +374,7 @@ root's password:
                 <para>
                   In the example above, you would want to either allow all
                   options and subcommands or limit them to a few for security 
-                  reasons, but forbidding a user to specify any option at all 
+                  reasons, but forbidding a user from specifying any option at all 
                   would be pointless in this context.
                 </para>
               </callout>

--- a/xml/system_repair.xml
+++ b/xml/system_repair.xml
@@ -243,14 +243,14 @@
     </listitem>
     <listitem>
       <para>
-        The following article <link
-        xlink:href="https://www.suse.com/support/kb/doc/?id=000018769"/>
-        describes how to recover from Btrfs errors.
+        The following article describes how to recover from Btrfs 
+        errors <link
+        xlink:href="https://www.suse.com/support/kb/doc/?id=000018769"/>.
       </para>
     </listitem>
     <listitem>
       <para>
-        The following article includes links to multiple Btrfs related topics
+        The following article includes links to multiple Btrfs-related topics
         <link xlink:href="https://www.suse.com/support/kb/doc/?id=000018779"/>.
       </para>
     </listitem>

--- a/xml/systemd.xml
+++ b/xml/systemd.xml
@@ -1479,7 +1479,7 @@ TimeoutSec=300
           If you use the <option>--full</option> option in the <command>systemctl edit --full
           <replaceable>SERVICE</replaceable></command> command, a copy of the original unit file is
           created where you can modify specific options. We do not recommend such customization
-          because, when the unit file is updated by &suse;, its changes are overridden by the
+          because when the unit file is updated by &suse;, its changes are overridden by the
           customized copy in the <filename>/etc/systemd/system/</filename> directory. Moreover, if
           &suse; provides updates to distribution drop-ins, they override the copy of the unit file
           created with <option>--full</option>. To prevent this confusion and always have your
@@ -1591,7 +1591,7 @@ RateLimitIntervalSec=0</screen>
           </listitem>
           <listitem>
             <para>
-              <literal>40-49</literal> is reserved for third party packages.
+              <literal>40-49</literal> is reserved for third-party packages.
             </para>
           </listitem>
           <listitem>


### PR DESCRIPTION
### PR creator: Description

Integrate proofing corrections for the Administration Guide from proofing drop 2.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2

- SLE 12
  - [ ] SLE 12 SP5
