### PR TITLE
metadata: revhistory for 3 deliverables (locdrop 2)

### DIFF
--- a/xml/book_administration.xml
+++ b/xml/book_administration.xml
@@ -25,7 +25,16 @@
    <phrase>Administration</phrase>
   </meta>
   <meta name="series" its:translate="no">Product Documentation</meta>
-
+  <revhistory xml:id="rh-book-administration">
+    <revision>
+      <date>2024-06-26</date>
+      <revdescription>
+        <para>
+          Updated for the initial release of &productname; &productnumber;.
+        </para>
+      </revdescription>
+    </revision>
+   </revhistory>
   <xi:include href="common_copyright_gfdl.xml"/>
   <abstract>
    <para>

--- a/xml/book_gnome-user.xml
+++ b/xml/book_gnome-user.xml
@@ -25,7 +25,16 @@
    <phrase>Configuration</phrase>
   </meta>
   <meta name="series" its:translate="no">Product Documentation</meta>
-
+  <revhistory xml:id="rh-book-gnome-user">
+    <revision>
+      <date>2024-06-26</date>
+      <revdescription>
+        <para>
+          Updated for the initial release of &productname; &productnumber;.
+        </para>
+      </revdescription>
+    </revision>
+   </revhistory>
   <xi:include href="common_copyright_gfdl.xml"/>
   <abstract>
    <para>

--- a/xml/book_storage.xml
+++ b/xml/book_storage.xml
@@ -25,7 +25,16 @@
    <phrase>Storage</phrase>
   </meta>
   <meta name="series" its:translate="no">Product Documentation</meta>
-
+  <revhistory xml:id="rh-book-storage">
+    <revision>
+      <date>2024-06-26</date>
+      <revdescription>
+        <para>
+          Updated for the initial release of &productname; &productnumber;.
+        </para>
+      </revdescription>
+    </revision>
+   </revhistory>
   <xi:include href="common_copyright_gfdl.xml"/>
   <abstract>
    <para>


### PR DESCRIPTION
### PR creator: Description

Metadata: add revhistory for 3deliverables that will be handed over to localization with locdrop 2:

- Administration Guide
- GNOME User Guide
- Storage Administation Guide

### PR creator: Are there any relevant issues/feature requests?

[Link to internal page](https://confluence.suse.com/display/documentation/Adding+metadata+to+all+SUSE+documentation)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*