### PR TITLE
Raspberry Pi QS: final fixes

### DIFF
--- a/xml/art_raspberry-pi.xml
+++ b/xml/art_raspberry-pi.xml
@@ -206,27 +206,27 @@
    <itemizedlist>
     <listitem>
      <para>
-      &rpi3; Model A+, B, or B+, or &rpi4; Model&nbsp;B.
+      &rpi3; Model A+, B, or B+, or &rpi4; Model&nbsp;B
      </para>
     </listitem>
     <listitem>
      <para>
-      &microsd; card with at least 8&nbsp;GB capacity.
+      &microsd; card with at least 8&nbsp;GB capacity
      </para>
     </listitem>
     <listitem>
      <para>
-      USB keyboard, mouse.
+      USB keyboard, mouse
      </para>
     </listitem>
     <listitem>
      <para>
-      &hdmi; cable and monitor.
+      &hdmi; cable and monitor
      </para>
     </listitem>
     <listitem>
      <para>
-      Power supply with at least 2.5&nbsp;A capacity.
+      Power supply with at least 2.5&nbsp;A capacity
      </para>
     </listitem>
    </itemizedlist>
@@ -313,7 +313,7 @@
     <title>Zypper</title>
     <para>
      Zypper is the package manager for &sle;. It is the tool for installing,
-     updating, and removing packages and for managing repositories.
+     updating and removing packages and for managing repositories.
     </para>
     <para>
      The general syntax for Zypper invocations is:
@@ -376,7 +376,7 @@
      </varlistentry>
     </variablelist>
     <para>
-     For other limitations refer to the online version of the Release Notes at
+     For other limitations, refer to the online version of the Release Notes at
      <link xlink:href="https://www.suse.com/releasenotes/aarch64/SUSE-SLES/&product-ga;-SP&product-sp;/"/>.
     </para>
    </sect3>
@@ -890,7 +890,7 @@ Password:
     <title>Evaluation code</title>
     <para>
      Sixty-day evaluation subscriptions may be requested at the following page:
-     <link xlink:href="https://www.suse.com/products/arm/"/>
+     <link xlink:href="https://www.suse.com/products/arm/"/>.
     </para>
    </note>
    <para>
@@ -1214,8 +1214,8 @@ Successfully registered system
   <sect2 xml:id="sec-rpi-bt">
    <title>&bt;</title>
    <para>
-    &rpi3; and later models have a &btreg; controller on-board that can be used for
-    various purposes, such as wireless keyboards, mice, or audio devices.
+    &rpi3; and later models have a &btreg; controller onboard that can be used for
+    various purposes, such as wireless keyboards, mice or audio devices.
    </para>
    <para>
     To use the Bluetooth controller, install the <literal>bluez</literal> package:


### PR DESCRIPTION
### PR creator: Description

Add final fixes for the Raspberry Pi Quick Start.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2

- SLE 12
  - [ ] SLE 12 SP5