### PR TITLE
fix JSON and YAML syntax

### DIFF
--- a/xml/deployment_images_ignition.xml
+++ b/xml/deployment_images_ignition.xml
@@ -165,27 +165,27 @@
         "disks": [
             {
                 "device": "/dev/vda",
-                "wipe_table": true,
+                "wipeTable": true,
                 "partitions": [
                     {
                         "label": "root",
                         "number": 1,
-                        "type_guid": "4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709"
+                        "typeGuid": "4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709"
                     },
                     {
                         "label": "boot",
                         "number": 2,
-                        "type_guid": "BC13C2FF-59E6-4262-A352-B275FD6F7172"
+                        "typeGuid": "BC13C2FF-59E6-4262-A352-B275FD6F7172"
                     },
                     {
                         "label": "swap",
                         "number": 3,
-                        "type_guid": "0657FD6D-A4AB-43C4-84E5-0933C84B4F4F"
+                        "typeGuid": "0657FD6D-A4AB-43C4-84E5-0933C84B4F4F"
                     },
                     {
                         "label": "home",
                         "number": 4,
-                        "type_guid": "933AC7E1-2EB4-4F13-B844-0E14E2AEF915"
+                        "typeGuid": "933AC7E1-2EB4-4F13-B844-0E14E2AEF915"
                     }
                 ]
             }
@@ -202,20 +202,20 @@ version: 1.4.0
 storage:
   disks:
     - device: "/dev/vda"
-      wipeTable: true
+      wipe_table: true
       partitions: 
         - label: root
           number: 1
-          typeGuid: 4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709
+          type_guid: 4F68BCE3-E8CD-4DB1-96E7-FBCAF984B709
         - label: boot
           number: 2
-          typeGuid: BC13C2FF-59E6-4262-A352-B275FD6F7172
+          type_guid: BC13C2FF-59E6-4262-A352-B275FD6F7172
         - label: swap
           number: 3
-          typeGuid: 0657FD6D-A4AB-43C4-84E5-0933C84B4F4F
+          type_guid: 0657FD6D-A4AB-43C4-84E5-0933C84B4F4F
         - label: home
           number: 4
-          typeGuid: 933AC7E1-2EB4-4F13-B844-0E14E2AEF915
+          type_guid: 933AC7E1-2EB4-4F13-B844-0E14E2AEF915
  </screen>
         </sect4>
         <sect4 xml:id="sec-storage-raid">


### PR DESCRIPTION
### PR creator: Description

`typeGuid` and `wipeTable` have been reversed

### PR creator: Which product versions do the changes apply to?

  - [x] SLE 15 SP5/openSUSE Leap 15.5