### PR TITLE
Updated arm entity in Deployment Guide

### DIFF
--- a/xml/deployment_boot_parameters.xml
+++ b/xml/deployment_boot_parameters.xml
@@ -72,11 +72,11 @@
   </para>
  </sect1>
  <sect1 xml:id="sec-boot-parameters-start-x86-64" arch="x86_64">
-  <title>PC (&amd64;/&intel64;/&arm64;)</title>
+  <title>PC (&amd64;/&intel64;/&aarch64;)</title>
 
   <para>
-   This section describes changing the boot parameters for &amd64;, &intel64;,
-   and &arm64;.
+   This section describes changing the boot parameters for &amd64;, &intel64;
+   and &aarch64;.
   </para>
 
   <sect2 xml:id="sec-boot-parameters-screen">
@@ -995,7 +995,7 @@ install=slp:/</screen>
     </step>
     <step>
      <para>
-      Append the <literal>proxy</literal> paramter to the
+      Append the <literal>proxy</literal> parameter to the
       <literal>linux</literal> line in the following format:
      </para>
 <screen>proxy=https://<replaceable>proxy.example.com</replaceable>:<replaceable>PORT</replaceable></screen>
@@ -1112,7 +1112,7 @@ install=slp:/</screen>
      -->
      <title>LUKS 2 Support</title>
      <para>
-       LUKS2 encyrption is supported by the YaST installer as of &sle; 15 SP4, but needs to be
+       LUKS2 encryption is supported by the YaST installer as of &sle; 15 SP4, but needs to be
        enabled explicitly.
      </para>
      <screen>YAST_LUKS2_AVAILABLE</screen>

--- a/xml/deployment_prep_aarch64.xml
+++ b/xml/deployment_prep_aarch64.xml
@@ -13,7 +13,7 @@
   <abstract>
    <para>
     This chapter describes the steps necessary to prepare for the installation
-    of &productname; on &arm64; computers. It introduces the steps required to
+    of &productname; on &aarch64; computers. It introduces the steps required to
     prepare for various installation methods. The list of hardware requirements
     provides an overview of systems supported by &sls;. Find information about
     available installation methods and several common known problems. Also

--- a/xml/deployment_prep_aarch64_choose.xml
+++ b/xml/deployment_prep_aarch64_choose.xml
@@ -19,7 +19,7 @@
 
  <para>
   This section encompasses many factors that need to be considered before
-  installing &productname; on &arm64; hardware.
+  installing &productname; on &aarch64; hardware.
  </para>
 
  <sect2 xml:id="sec-aarch64-prep-considerations-virtualization">

--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -32,7 +32,7 @@
     <sect2 xml:id="sec-kvm-requires-hardware">
       <title>&kvm; hardware requirements</title>
       <para>
-        &suse; supports &kvm; full virtualization on &x86-64;, &arm64;,
+        &suse; supports &kvm; full virtualization on &x86-64;, &aarch64;,
         &zseries; and &linuxone; hosts.
       </para>
       <itemizedlist>
@@ -95,9 +95,9 @@
         hyper-thread for each running guest.
       </para>
       <note os="sles">
-        <title>&arm64;</title>
+        <title>&aarch64;</title>
         <para>
-          &arm64; is a continuously evolving platform. It does not have a
+          &aarch64; is a continuously evolving platform. It does not have a
           traditional standards and compliance certification program to enable
           interoperability with operating systems and hypervisors. Ask your
           vendor for the support statement on &sls;.


### PR DESCRIPTION
Updated the ARM entity in Deployment Guide from `arm64` (resolves to ARM AArch64) to the correct `aarch64` (resolves to AArch64).
