### PR TITLE
DOCTEAM-1225: adds nftables section

### DIFF
--- a/xml/security_firewall.xml
+++ b/xml/security_firewall.xml
@@ -973,12 +973,7 @@ nfs-rpc
   The advantages of using nftables include:
     </para>
     <itemizedlist mark="bullet" spacing="normal">
-      <listitem>
-       <para>
-
-       </para>
-      </listitem>
-      <listitem>
+        <listitem>
        <para>
         One framework for both the IPv4 and IPv6 protocols
        </para>
@@ -1002,8 +997,8 @@ nfs-rpc
       </listitem>
      </itemizedlist>
         </sect3>
-   <sect3><title></title><example xml:id="config-file"><title>Examples of <emphasis>nftables</emphasis> configuration
-  files</title>
+   <sect3 xml:id="examples-of-nftables-config-files">
+    <title>Examples of nftables config files</title>
   <para><emphasis>A basic nftables configuration file:</emphasis></para>
   <screen>&prompt.user; cat /etc/nftables.conf
     #!/usr/sbin/nft -f
@@ -1025,7 +1020,7 @@ nfs-rpc
             type filter hook output priority 0; policy accept;
         }
     }
-  </screen></example>
+  </screen>
   <para>In the above example, all traffic is allowed because all chains have the policy <emphasis>accept</emphasis>. </para>
   <para><emphasis>A nftables configuration file with some rules applied:</emphasis></para>
   <screen>&prompt.user; cat /etc/nftables.conf
@@ -1066,10 +1061,35 @@ table inet filter {
         type filter hook output priority 0; policy accept;
     }
 }
-  </screen></example>
-  <para>In the above example, all traffic is allowed because all chains have the policy <emphasis>accept</emphasis>. </para>
-</sect3>
-  </sect2>
+  </screen>
+  <para>In the above example: </para>
+  <itemizedlist mark="bullet" spacing="normal">
+    <listitem>
+   <para>
+   The chain policy is to drop and add a reject rule at the end, which means all incoming traffic is blocked.
+    </para>
+  </listitem>
+  <listitem>
+   <para>
+    All traffic on the <literal>localhost</literal> interface is allowed.
+    </para>
+  </listitem>
+  <listitem>
+   <para>
+   The <literal>base_checks</literal> chain handles all packets that are related to established connections.
+   This ensures that incoming packets for outgoing connections are not blocked.
+    </para>
+  </listitem>
+  <listitem>
+   <para>
+
+    ICMP and IGMP packets are allowed by utilizing  a set and type names.
+   </para>
+  </listitem>
+ </itemizedlist>
+
+  </sect3>
+</sect2>
  </sect1>
 
  <sect1 xml:id="sec-security-firewall-upgrade">

--- a/xml/security_firewall.xml
+++ b/xml/security_firewall.xml
@@ -994,10 +994,8 @@ nfs-rpc
       During the rule set retrieval, the VM bytecode in netlink format is translated back into the original ruleset representation.
       </para></listitem>
      </itemizedlist>
-        </sect3>
-   <sect3 xml:id="examples-of-nftables-config-files">
-    <title>Examples of nftables configuration files</title>
-  <para><emphasis role="bold">A basic nftables configuration file:</emphasis></para>
+
+   <para><emphasis role="bold">A basic nftables configuration file:</emphasis></para>
   <screen>&prompt.user; cat /etc/nftables.conf
     #!/usr/sbin/nft -f
 
@@ -1111,23 +1109,24 @@ table inet filter {
     </para>
    </listitem>
  </itemizedlist>
-  </sect3>
-  <sect3 xml:id="sec-security-nftables-more-information">
-    <title>More information </title>
-    <para>For more information about nftables, see:</para>
-    <itemizedlist mark="bullet" spacing="normal">
-      <listitem>
-     <para>
-      Upstream documentation <link xlink:href="https://www.netfilter.org/projects/nftables/index.html"> </link>
-      </para>
-    </listitem>
+ <sect4 xml:id="sec-security-nftables-more-information">
+  <title>More information </title>
+  <para>For more information about nftables, see:</para>
+  <itemizedlist mark="bullet" spacing="normal">
     <listitem>
-     <para>
-      nftables man page <link xlink:href="https://www.netfilter.org/projects/nftables/manpage.html"> </link>
-      </para>
-    </listitem>
-  </itemizedlist>
-    </sect3>
+   <para>
+    Upstream documentation <link xlink:href="https://www.netfilter.org/projects/nftables/index.html"> </link>
+    </para>
+  </listitem>
+  <listitem>
+   <para>
+    nftables man page <link xlink:href="https://www.netfilter.org/projects/nftables/manpage.html"> </link>
+    </para>
+  </listitem>
+</itemizedlist>
+  </sect4>
+  </sect3>
+
 </sect2>
  </sect1>
 

--- a/xml/security_firewall.xml
+++ b/xml/security_firewall.xml
@@ -991,10 +991,8 @@ nfs-rpc
       <listitem>
        <para>
       The <command>nft</command> command line tool compiles into VM bytecode in netlink format.
-      During the rule set retrieval, the VM bytecode in netlink format is decompiled back to its original rule set representation
-      nft acts as both a compiler and decompiler.
-       </para>
-      </listitem>
+      During the rule set retrieval, the VM bytecode in netlink format is translated back into the original rule set representation
+      </para></listitem>
      </itemizedlist>
         </sect3>
    <sect3 xml:id="examples-of-nftables-config-files">
@@ -1009,7 +1007,7 @@ nfs-rpc
     table inet filter {
         # chain names are up to you.
         # what part of the traffic they cover,
-        # depends on the type line.
+        # depends on the type table.
         chain input {
             type filter hook input priority 0; policy accept;
         }
@@ -1084,7 +1082,7 @@ table inet filter {
   <listitem>
    <para>
 
-    ICMP and IGMP packets are allowed by utilizing  a set and type names
+    ICMP and IGMP packets are allowed by utilizing a set and type names
    </para>
   </listitem>
  </itemizedlist>

--- a/xml/security_firewall.xml
+++ b/xml/security_firewall.xml
@@ -993,7 +993,14 @@ nfs-rpc
         Monitor trace events in the <emphasis>nft</emphasis> tool and debugging and tracing in the rule set <emphasis>nftrace</emphasis>.
         </para>
       </listitem>
-        </itemizedlist>
+      <listitem>
+       <para>
+      The <command>nft</command> command line tool complies the rule set into a VM bytecode in netlink format.
+      During the rule set retrieval, the VM bytecode in netlink format is decompiled back to its original rule set representation.
+      nft acts as both a compiler and decompiler.
+       </para>
+      </listitem>
+     </itemizedlist>
    </sect3>
   </sect2>
  </sect1>

--- a/xml/security_firewall.xml
+++ b/xml/security_firewall.xml
@@ -1002,8 +1002,9 @@ nfs-rpc
       </listitem>
      </itemizedlist>
         </sect3>
-   <sect3><title></title><example xml:id="config-file"><title>An example of a basic <emphasis>nftables</emphasis> configuration
-  file</title>
+   <sect3><title></title><example xml:id="config-file"><title>Examples of <emphasis>nftables</emphasis> configuration
+  files</title>
+  <para><emphasis>A basic nftables configuration file:</emphasis></para>
   <screen>&prompt.user; cat /etc/nftables.conf
     #!/usr/sbin/nft -f
 
@@ -1024,7 +1025,50 @@ nfs-rpc
             type filter hook output priority 0; policy accept;
         }
     }
-  </screen></example></sect3>
+  </screen></example>
+  <para>In the above example, all traffic is allowed because all chains have the policy <emphasis>accept</emphasis>. </para>
+  <para><emphasis>A nftables configuration file with some rules applied:</emphasis></para>
+  <screen>&prompt.user; cat /etc/nftables.conf
+    #!/usr/sbin/nft -f
+
+flush ruleset
+
+table inet filter {
+    chain base_checks {
+        ## another set, this time for connection tracking states.
+        # allow established/related connections
+        ct state {established, related} accept;
+
+        # early drop of invalid connections
+        ct state invalid drop;
+    }
+
+    chain input {
+        type filter hook input priority 0; policy drop;
+
+        # allow from loopback
+        iif "lo" accept;
+
+        jump base_checks;
+
+        # allow icmp and igmp
+        ip6 nexthdr icmpv6 icmpv6 type { echo-request, echo-reply, packet-too-big, time-exceeded, parameter-problem, destination-unreachable, packet-too-big, mld-listener-query, mld-listener-report, mld-listener-reduction, nd-router-solicit, nd-router-advert, nd-neighbor-solicit, nd-neighbor-advert, ind-neighbor-solicit, ind-neighbor-advert, mld2-listener-report } accept;
+        ip protocol icmp icmp type { echo-request, echo-reply, destination-unreachable, router-solicitation, router-advertisement, time-exceeded, parameter-problem } accept;
+        ip protocol igmp accept;
+
+        # for testing reject with logging
+        counter log prefix "[nftables] input reject " reject;
+    }
+    chain forward {
+        type filter hook forward priority 0; policy accept;
+    }
+    chain output {
+        type filter hook output priority 0; policy accept;
+    }
+}
+  </screen></example>
+  <para>In the above example, all traffic is allowed because all chains have the policy <emphasis>accept</emphasis>. </para>
+</sect3>
   </sect2>
  </sect1>
 

--- a/xml/security_firewall.xml
+++ b/xml/security_firewall.xml
@@ -962,11 +962,11 @@ nfs-rpc
     </para>
    </sect3>
    <sect3 xml:id="sec-security-firewall-firewalld-nftables">
-    <title>nftables as the default backend </title>
+    <title>nftables as the default back-end </title>
     <para>
-  The default backend for &firewalld; is nftables. nftables is a framework by the Linux <systemitem>netfilter</systemitem> project
+  The default back-end for &firewalld; is nftables. nftables is a framework by the Linux <systemitem>netfilter</systemitem> project
   that provides packet filtering, network address translation (NAT) and other similar functionalities. nftables reuses the existing Netfilter
-  subsystems such as the connection tracking system, userspace queueing,logging and the hook infrastructure.
+  subsystems such as the connection tracking system, user space queueing, logging and the hook infrastructure.
   nftables is a replacement for iptables, ip6tables, arptables, ebtables, and ipset.
 </para>
     <para>
@@ -985,18 +985,18 @@ nfs-rpc
       </listitem>
       <listitem>
        <para>
-        Monitor trace events in the <emphasis>nft</emphasis> tool,debug and trace the rule set via <emphasis>nftrace</emphasis>.
+        Monitor trace events in the <emphasis>nft</emphasis> tool, debug and trace the ruleset via <emphasis>nftrace</emphasis>.
         </para>
       </listitem>
       <listitem>
        <para>
       The <command>nft</command> command line tool compiles into VM bytecode in netlink format.
-      During the rule set retrieval, the VM bytecode in netlink format is translated back into the original rule set representation.
+      During the rule set retrieval, the VM bytecode in netlink format is translated back into the original ruleset representation.
       </para></listitem>
      </itemizedlist>
         </sect3>
    <sect3 xml:id="examples-of-nftables-config-files">
-    <title>Examples of nftables config files</title>
+    <title>Examples of nftables configuration files</title>
   <para><emphasis role="bold">A basic nftables configuration file:</emphasis></para>
   <screen>&prompt.user; cat /etc/nftables.conf
     #!/usr/sbin/nft -f
@@ -1020,7 +1020,7 @@ nfs-rpc
     }
   </screen>
   <para>In the above example, all traffic is allowed because all chains have the policy <emphasis>accept</emphasis>.
-  Note that in reality, this is a bad practice as firewalls should deny traffic by default.</para>
+  Note that, in reality, this is a bad practice, as firewalls should deny traffic by default.</para>
   <para><emphasis role="bold">A basic nftables configuration file with masquerade:</emphasis></para>
   <screen>&prompt.user; cat /etc/nftables.conf
     #!/sbin/nft -f
@@ -1040,8 +1040,8 @@ nfs-rpc
     }
   </screen>
   <para>If you have a static IP, it would be slightly faster to use source nat (SNAT) instead of masquerade.
-    The router replaces the source with a predefined IP, instead of looking up the outgoing IP for every packet.</para>
-  <para><emphasis role= "bold" >A nftables configuration file with some rules applied:</emphasis></para>
+    The router replaces the source with a predefined IP instead of looking up the outgoing IP for every packet.</para>
+  <para><emphasis role= "bold" >An nftables configuration file with some rules applied:</emphasis></para>
   <screen>&prompt.user; cat /etc/nftables.conf
     #!/usr/sbin/nft -f
 
@@ -1095,13 +1095,13 @@ table inet filter {
   </listitem>
   <listitem>
    <para>
-   The <literal>base_checks</literal> chain handles all packets that are related to established connections
+   The <literal>base_checks</literal> chain handles all packets that are related to established connections.
    This ensures that incoming packets for outgoing connections are not blocked.
     </para>
   </listitem>
   <listitem>
    <para>
-    ICMP and IGMP packets are allowed by utilizing a set and type names.
+    ICMP and IGMP packets are allowed by utilizing a set and specific type names.
    </para>
   </listitem>
   <listitem>

--- a/xml/security_firewall.xml
+++ b/xml/security_firewall.xml
@@ -961,6 +961,18 @@ nfs-rpc
      <command>firewall-rpc-helper.py --help</command>.
     </para>
    </sect3>
+   <sect3 xml:id="sec-security-firewall-firewalld-nftables">
+    <title>nftables as the default backend </title>
+    <para>
+    The default backend for &firewalld; is nftables. nftables is a framework by the Linux <systemitem>netfilter</systemitem> project
+  that provides packet filtering, network address translation (NAT) and other packet mangling. nftables is a replacement for
+  iptables, ip6tables, arptables, ebtables, and ipset.
+</para>
+    <para>
+  There are many advantages of using nftables such as, faster rule updates, built-in sets and a single framework
+  for IPv4 and IPv6 protocols.
+    </para>
+   </sect3>
   </sect2>
  </sect1>
 

--- a/xml/security_firewall.xml
+++ b/xml/security_firewall.xml
@@ -1001,7 +1001,30 @@ nfs-rpc
        </para>
       </listitem>
      </itemizedlist>
-   </sect3>
+        </sect3>
+   <sect3><title></title><example xml:id="config-file"><title>An example of a basic <emphasis>nftables</emphasis> configuration
+  file</title>
+  <screen>&prompt.user; cat /etc/nftables.conf
+    #!/usr/sbin/nft -f
+
+    flush ruleset
+
+    # This matches IPv4 and IPv6
+    table inet filter {
+        # chain names are up to you.
+        # what part of the traffic they cover,
+        # depends on the type line.
+        chain input {
+            type filter hook input priority 0; policy accept;
+        }
+        chain forward {
+            type filter hook forward priority 0; policy accept;
+        }
+        chain output {
+            type filter hook output priority 0; policy accept;
+        }
+    }
+  </screen></example></sect3>
   </sect2>
  </sect1>
 

--- a/xml/security_firewall.xml
+++ b/xml/security_firewall.xml
@@ -980,26 +980,26 @@ nfs-rpc
       </listitem>
       <listitem>
        <para>
-        Rules are applied automatically instead of fetching, updating and storing a complete rule set.
+        Rules are applied automatically instead of fetching, updating and storing a complete rule set
         </para>
       </listitem>
       <listitem>
        <para>
-        Monitor trace events in the <emphasis>nft</emphasis> tool and debugging and tracing in the rule set <emphasis>nftrace</emphasis>.
+        Monitor trace events in the <emphasis>nft</emphasis> tool and debugging and tracing in the rule set <emphasis>nftrace</emphasis>
         </para>
       </listitem>
       <listitem>
        <para>
       The <command>nft</command> command line tool complies the rule set into a VM bytecode in netlink format.
-      During the rule set retrieval, the VM bytecode in netlink format is decompiled back to its original rule set representation.
-      nft acts as both a compiler and decompiler.
+      During the rule set retrieval, the VM bytecode in netlink format is decompiled back to its original rule set representation
+      nft acts as both a compiler and decompiler
        </para>
       </listitem>
      </itemizedlist>
         </sect3>
    <sect3 xml:id="examples-of-nftables-config-files">
     <title>Examples of nftables config files</title>
-  <para><emphasis>A basic nftables configuration file:</emphasis></para>
+  <para><emphasis role="bold">A basic nftables configuration file:</emphasis></para>
   <screen>&prompt.user; cat /etc/nftables.conf
     #!/usr/sbin/nft -f
 
@@ -1022,7 +1022,7 @@ nfs-rpc
     }
   </screen>
   <para>In the above example, all traffic is allowed because all chains have the policy <emphasis>accept</emphasis>. </para>
-  <para><emphasis>A nftables configuration file with some rules applied:</emphasis></para>
+  <para><emphasis role= "bold" >A nftables configuration file with some rules applied:</emphasis></para>
   <screen>&prompt.user; cat /etc/nftables.conf
     #!/usr/sbin/nft -f
 
@@ -1066,29 +1066,44 @@ table inet filter {
   <itemizedlist mark="bullet" spacing="normal">
     <listitem>
    <para>
-   The chain policy is to drop and add a reject rule at the end, which means all incoming traffic is blocked.
+   The chain policy is to drop and add a reject rule at the end, which means all incoming traffic is blocked
     </para>
   </listitem>
   <listitem>
    <para>
-    All traffic on the <literal>localhost</literal> interface is allowed.
+    All traffic on the <literal>localhost</literal> interface is allowed
     </para>
   </listitem>
   <listitem>
    <para>
-   The <literal>base_checks</literal> chain handles all packets that are related to established connections.
-   This ensures that incoming packets for outgoing connections are not blocked.
+   The <literal>base_checks</literal> chain handles all packets that are related to established connections
+   This ensures that incoming packets for outgoing connections are not blocked
     </para>
   </listitem>
   <listitem>
    <para>
 
-    ICMP and IGMP packets are allowed by utilizing  a set and type names.
+    ICMP and IGMP packets are allowed by utilizing  a set and type names
    </para>
   </listitem>
  </itemizedlist>
-
   </sect3>
+  <sect3 xml:id="sec-security-nftables-more-information">
+    <title>More information </title>
+    <para>For more information about nftables, see:</para>
+    <itemizedlist mark="bullet" spacing="normal">
+      <listitem>
+     <para>
+      Upstream documentation <link xlink:href="https://www.netfilter.org/projects/nftables/index.html"> </link>
+      </para>
+    </listitem>
+    <listitem>
+     <para>
+      nftables man page <link xlink:href="https://www.netfilter.org/projects/nftables/manpage.html"> </link>
+      </para>
+    </listitem>
+  </itemizedlist>
+    </sect3>
 </sect2>
  </sect1>
 

--- a/xml/security_firewall.xml
+++ b/xml/security_firewall.xml
@@ -985,12 +985,12 @@ nfs-rpc
       </listitem>
       <listitem>
        <para>
-        Monitor trace events in the <emphasis>nft</emphasis> tool and debugging and tracing in the rule set <emphasis>nftrace</emphasis>
+        Monitor trace events in the <emphasis>nft</emphasis> tool,debug and trace the rule set via <emphasis>nftrace</emphasis>
         </para>
       </listitem>
       <listitem>
        <para>
-      The <command>nft</command> command line tool complies the rule set into a VM bytecode in netlink format.
+      The <command>nft</command> command line tool compiles into VM bytecode in netlink format.
       During the rule set retrieval, the VM bytecode in netlink format is decompiled back to its original rule set representation
       nft acts as both a compiler and decompiler.
        </para>

--- a/xml/security_firewall.xml
+++ b/xml/security_firewall.xml
@@ -965,7 +965,7 @@ nfs-rpc
     <title>nftables as the default backend </title>
     <para>
     The default backend for &firewalld; is nftables. nftables is a framework by the Linux <systemitem>netfilter</systemitem> project
-  that provides packet filtering, network address translation (NAT) and other packet mangling. nftables reuses the existing Netfilter
+  that provides packet filtering, network address translation (NAT) and other similar functionalities. nftables reuses the existing Netfilter
   subsystems such as the connection tracking system, userspace queueing,logging and the hook infrastructure.
   nftables is a replacement for iptables, ip6tables, arptables, ebtables, and ipset.
 </para>
@@ -980,7 +980,7 @@ nfs-rpc
       </listitem>
       <listitem>
        <para>
-        Rules are applied automatically instead of fetching, updating and storing a complete rule set
+        Rules are applied atomically instead of fetching, updating and storing a complete rule set
         </para>
       </listitem>
       <listitem>
@@ -992,7 +992,7 @@ nfs-rpc
        <para>
       The <command>nft</command> command line tool complies the rule set into a VM bytecode in netlink format.
       During the rule set retrieval, the VM bytecode in netlink format is decompiled back to its original rule set representation
-      nft acts as both a compiler and decompiler
+      nft acts as both a compiler and decompiler.
        </para>
       </listitem>
      </itemizedlist>
@@ -1021,7 +1021,8 @@ nfs-rpc
         }
     }
   </screen>
-  <para>In the above example, all traffic is allowed because all chains have the policy <emphasis>accept</emphasis>. </para>
+  <para>In the above example, all traffic is allowed because all chains have the policy <emphasis>accept</emphasis>.
+  Note that in reality, this is a bad practice as firewalls should deny traffic by default.</para>
   <para><emphasis role= "bold" >A nftables configuration file with some rules applied:</emphasis></para>
   <screen>&prompt.user; cat /etc/nftables.conf
     #!/usr/sbin/nft -f

--- a/xml/security_firewall.xml
+++ b/xml/security_firewall.xml
@@ -964,7 +964,7 @@ nfs-rpc
    <sect3 xml:id="sec-security-firewall-firewalld-nftables">
     <title>nftables as the default backend </title>
     <para>
-    The default backend for &firewalld; is nftables. nftables is a framework by the Linux <systemitem>netfilter</systemitem> project
+  The default backend for &firewalld; is nftables. nftables is a framework by the Linux <systemitem>netfilter</systemitem> project
   that provides packet filtering, network address translation (NAT) and other similar functionalities. nftables reuses the existing Netfilter
   subsystems such as the connection tracking system, userspace queueing,logging and the hook infrastructure.
   nftables is a replacement for iptables, ip6tables, arptables, ebtables, and ipset.
@@ -975,23 +975,23 @@ nfs-rpc
     <itemizedlist mark="bullet" spacing="normal">
         <listitem>
        <para>
-        One framework for both the IPv4 and IPv6 protocols
+        One framework for both the IPv4 and IPv6 protocols.
        </para>
       </listitem>
       <listitem>
        <para>
-        Rules are applied atomically instead of fetching, updating and storing a complete rule set
+        Rules are applied atomically instead of fetching, updating and storing a complete rule set.
         </para>
       </listitem>
       <listitem>
        <para>
-        Monitor trace events in the <emphasis>nft</emphasis> tool,debug and trace the rule set via <emphasis>nftrace</emphasis>
+        Monitor trace events in the <emphasis>nft</emphasis> tool,debug and trace the rule set via <emphasis>nftrace</emphasis>.
         </para>
       </listitem>
       <listitem>
        <para>
       The <command>nft</command> command line tool compiles into VM bytecode in netlink format.
-      During the rule set retrieval, the VM bytecode in netlink format is translated back into the original rule set representation
+      During the rule set retrieval, the VM bytecode in netlink format is translated back into the original rule set representation.
       </para></listitem>
      </itemizedlist>
         </sect3>
@@ -1085,23 +1085,23 @@ table inet filter {
   <itemizedlist mark="bullet" spacing="normal">
     <listitem>
    <para>
-   The chain policy is to drop and add a reject rule at the end, which means all incoming traffic is blocked
+   The chain policy is to drop and add a reject rule at the end, which means all incoming traffic is blocked.
     </para>
   </listitem>
   <listitem>
    <para>
-    All traffic on the <literal>localhost</literal> interface is allowed
+    All traffic on the <literal>localhost</literal> interface is allowed.
     </para>
   </listitem>
   <listitem>
    <para>
    The <literal>base_checks</literal> chain handles all packets that are related to established connections
-   This ensures that incoming packets for outgoing connections are not blocked
+   This ensures that incoming packets for outgoing connections are not blocked.
     </para>
   </listitem>
   <listitem>
    <para>
-    ICMP and IGMP packets are allowed by utilizing a set and type names
+    ICMP and IGMP packets are allowed by utilizing a set and type names.
    </para>
   </listitem>
   <listitem>

--- a/xml/security_firewall.xml
+++ b/xml/security_firewall.xml
@@ -965,13 +965,35 @@ nfs-rpc
     <title>nftables as the default backend </title>
     <para>
     The default backend for &firewalld; is nftables. nftables is a framework by the Linux <systemitem>netfilter</systemitem> project
-  that provides packet filtering, network address translation (NAT) and other packet mangling. nftables is a replacement for
-  iptables, ip6tables, arptables, ebtables, and ipset.
+  that provides packet filtering, network address translation (NAT) and other packet mangling. nftables reuses the existing Netfilter
+  subsystems such as the connection tracking system, userspace queueing,logging and the hook infrastructure.
+  nftables is a replacement for iptables, ip6tables, arptables, ebtables, and ipset.
 </para>
     <para>
-  There are many advantages of using nftables such as, faster rule updates, built-in sets and a single framework
-  for IPv4 and IPv6 protocols.
+  The advantages of using nftables include:
     </para>
+    <itemizedlist mark="bullet" spacing="normal">
+      <listitem>
+       <para>
+
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        One framework for both the IPv4 and IPv6 protocols
+       </para>
+      </listitem>
+      <listitem>
+       <para>
+        Rules are applied automatically instead of fetching, updating and storing a complete rule set.
+        </para>
+      </listitem>
+      <listitem>
+       <para>
+        Monitor trace events in the <emphasis>nft</emphasis> tool and debugging and tracing in the rule set <emphasis>nftrace</emphasis>.
+        </para>
+      </listitem>
+        </itemizedlist>
    </sect3>
   </sect2>
  </sect1>

--- a/xml/security_firewall.xml
+++ b/xml/security_firewall.xml
@@ -1021,6 +1021,26 @@ nfs-rpc
   </screen>
   <para>In the above example, all traffic is allowed because all chains have the policy <emphasis>accept</emphasis>.
   Note that in reality, this is a bad practice as firewalls should deny traffic by default.</para>
+  <para><emphasis role="bold">A basic nftables configuration file with masquerade:</emphasis></para>
+  <screen>&prompt.user; cat /etc/nftables.conf
+    #!/sbin/nft -f
+
+    flush ruleset
+
+    table ip nat {
+      chain prerouting {
+        type nat hook prerouting priority 0; policy accept;
+      }
+
+      # for all packets to WAN, after routing, replace source address with primary IP of WAN interface
+      chain postrouting {
+        type nat hook postrouting priority 100; policy accept;
+        oifname "wan0" masquerade
+      }
+    }
+  </screen>
+  <para>If you have a static IP, it would be slightly faster to use source nat (SNAT) instead of masquerade.
+    The router replaces the source with a predefined IP, instead of looking up the outgoing IP for every packet.</para>
   <para><emphasis role= "bold" >A nftables configuration file with some rules applied:</emphasis></para>
   <screen>&prompt.user; cat /etc/nftables.conf
     #!/usr/sbin/nft -f
@@ -1081,10 +1101,15 @@ table inet filter {
   </listitem>
   <listitem>
    <para>
-
     ICMP and IGMP packets are allowed by utilizing a set and type names
    </para>
   </listitem>
+  <listitem>
+    <para>
+    A counter keeps a count of both the total number of packets and bytes it has seen since it was last reset.
+    With nftables, you must specify a counter for each rule you want to count.
+    </para>
+   </listitem>
  </itemizedlist>
   </sect3>
   <sect3 xml:id="sec-security-nftables-more-information">


### PR DESCRIPTION
### PR creator: Description

Describe the overall goals of this pull request.
Document nftables as the default backend for firewalld

### PR creator: Are there any relevant issues/feature requests?

[DOCTEAM-1225](https://jira.suse.com/browse/DOCTEAM-1225)

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP5/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2

- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
