### PR TITLE
RMT Guide: integrate proofing corrections

### DIFF
--- a/xml/rmt_config_files.xml
+++ b/xml/rmt_config_files.xml
@@ -93,7 +93,7 @@
         <para>
           A list of domains that should <emphasis>not</emphasis> go through the
           proxy, separated by commas. For example:
-          <literal>localhost,.mylocaldomain</literal>.
+          <literal>localhost.mylocaldomain</literal>.
         </para>
       </listitem>
     </varlistentry>

--- a/xml/rmt_install.xml
+++ b/xml/rmt_install.xml
@@ -131,7 +131,7 @@
       </para>
       <para>
         Installing &rmt; on &minvm; is the same as installing it on an
-        existing system (see <xref linkend="sec-rmt-installation-zypper"/>.
+        existing system (see <xref linkend="sec-rmt-installation-zypper"/>).
         To install &rmt; on
         &minvm;, run the following command from the &minvm; command line as
         &rootuser;:

--- a/xml/rmt_migrate_from_smt.xml
+++ b/xml/rmt_migrate_from_smt.xml
@@ -746,7 +746,7 @@
     <orderedlist>
       <listitem>
         <para>
-          Support via &sliberty; &mdash; find more details in <link
+          Support via &sliberty;&mdash;find more details in <link
           xlink:href="https://www.suse.com/products/suse-liberty-linux/"/>.
         </para>
       </listitem>

--- a/xml/rmt_migrate_from_smt.xml
+++ b/xml/rmt_migrate_from_smt.xml
@@ -746,7 +746,7 @@
     <orderedlist>
       <listitem>
         <para>
-          Support via &sliberty;, find more details in <link
+          Support via &sliberty; &mdash; find more details in <link
           xlink:href="https://www.suse.com/products/suse-liberty-linux/"/>.
         </para>
       </listitem>

--- a/xml/rmt_rmt-cli.xml
+++ b/xml/rmt_rmt-cli.xml
@@ -442,7 +442,7 @@ Purged systems that have not contacted this RMT since 2021-06-16.
   <title><command>clean packages</command></title>
   <para>
     The <command>rmt-cli clean packages</command> command removes locally
-    mirrored <quote>dangling</quote> files and their database entries. A file is
+    mirrored <emphasis>dangling</emphasis> files and their database entries. A file is
     considered to be dangling if it matches all the following characteristics:
   </para>
   <itemizedlist>
@@ -459,7 +459,7 @@ Purged systems that have not contacted this RMT since 2021-06-16.
     </listitem>
     <listitem>
       <para>
-        It is at least 2 days old.
+        It is at least two days old.
       </para>
     </listitem>
   </itemizedlist>


### PR DESCRIPTION
### PR creator: Description

Integrate proofing corrections for the RMT Guide from proofing drop 3.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP6/openSUSE Leap 15.6
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2

- SLE 12
  - [ ] SLE 12 SP5