### PR TITLE
Tuning Guide: integrate proofing corrections

### DIFF
--- a/xml/tuning_cgroups.xml
+++ b/xml/tuning_cgroups.xml
@@ -37,7 +37,7 @@
     <para>
       Every process is assigned exactly one administrative cgroup. cgroups are
       ordered in a hierarchical tree structure. You can set resource
-      limitations such as CPU, memory, disk I/O, or network bandwidth usage,
+      limitations, such as CPU, memory, disk I/O or network bandwidth usage,
       for single processes or for whole branches of the hierarchy tree.
     </para>
 
@@ -73,7 +73,7 @@
 
     <para>
       The default mode is unified. There is a hybrid mode that provides
-      backwards compatibility for applications that need it.
+      backward compatibility for applications that need it.
     </para>
 
     <para>
@@ -538,15 +538,15 @@ r
         <filename>/etc/systemd/system/user@.service.d/60-delegate.conf</filename>
         adds controllers to all users, while
         <filename>/etc/systemd/system/user@<replaceable>uid</replaceable>.service.d/60-delegate.conf</filename>
-        adds controllers only to particular user. The content of the file
-        should be like following:
+        adds controllers only to a particular user. The content of the file
+        should be like the following:
       </para>
 <screen>
 [Service]
 Delegate=pids memory
 </screen>
       <para>
-        Both the &systemd; instance and affected user instance must be notified
+        Both the &systemd; instance and the affected user instance must be notified
         to reload the new configuration.
       </para>
 <screen>
@@ -554,8 +554,8 @@ Delegate=pids memory
 &prompt.user;<command>systemctl --user daemon-reexec</command>
 </screen>
       <para>
-        Alternatively, the affected user may log out and log in instead of the
-        second line to restart their user instance.
+        Alternatively, the affected user may log out and log in instead of applying
+        the second line to restart their user instance.
       </para>
     </sect2>
   </sect1>

--- a/xml/tuning_dynamic_debug.xml
+++ b/xml/tuning_dynamic_debug.xml
@@ -84,7 +84,7 @@
 
     <para>
       For supported kernel versions that are installed by default, dynamic
-      debug is already built-in. To check the status of dynamic debug, run the
+      debug is already built in. To check the status of dynamic debug, run the
       following command as the root user:
     </para>
 

--- a/xml/tuning_memory.xml
+++ b/xml/tuning_memory.xml
@@ -251,7 +251,7 @@
    <para>
     Reducing the requirements of the user space workload reduces the
     kernel memory usage (fewer processes, fewer open files and sockets,
-    etc.)
+    etc.).
    </para>
   </sect2>
 
@@ -611,7 +611,7 @@ always madvise [never]</screen>
       If disabled, the value <literal>never</literal> is shown
       in square brackets like in the example above. A value of
       <literal>always</literal> mandatorily tries and uses THP at fault
-      time but defer to <command>khugepaged</command> if the allocation
+      time but defers to <command>khugepaged</command> if the allocation
       fails. A value of <literal>madvise</literal> will only allocate THP
       for address spaces explicitly specified by an application.
      </para>

--- a/xml/tuning_network.xml
+++ b/xml/tuning_network.xml
@@ -265,7 +265,7 @@
 
   <para>
    For more information, see the home page of the Netfilter and iptables
-   project, <link xlink:href="https://www.netfilter.org"/>
+   project, <link xlink:href="https://www.netfilter.org"/>.
   </para>
  </sect1>
  <sect1 xml:id="sec-tuning-network-rps">

--- a/xml/tuning_power.xml
+++ b/xml/tuning_power.xml
@@ -869,7 +869,7 @@ powerreport-20200108-104431.html
   <para>
    Test this carefully before launching the &systemd; service,
    to see if it gives the results that you want.
-   You should not use USB keyboards and mice should not enter power save mode to avoid constantly
+   You should not use USB keyboards, and mice should not enter power save mode to avoid constantly
    waking them up and disturbing other devices. For easier testing and configuration editing,
    extract the commands from an HTML report with <command>awk</command>:
   </para>

--- a/xml/tuning_ptp.xml
+++ b/xml/tuning_ptp.xml
@@ -15,7 +15,7 @@
  <para>
   For network environments, it is vital to keep the computer and other devices'
   clocks synchronized and accurate. There are several solutions to achieve
-  the synchronicity and accuracy, for example, the widely used &ntp; (NTP) described in
+  synchronicity and accuracy, for example, the widely used &ntp; (NTP) described in
   <xref linkend="cha-ntp"/>.
  </para>
  <para>

--- a/xml/tuning_taskscheduler.xml
+++ b/xml/tuning_taskscheduler.xml
@@ -703,8 +703,8 @@ kernel.sched_wakeup_granularity_ns = 10000000</screen>
         <title>A few scheduler parameters have been moved to <systemitem>debugfs</systemitem></title>
         <para>
           If the default Linux kernel version of your operating system is 5.13
-          or later (can be checked using the command <code>rpm -q
-          kernel-default</code>), you might notice the messages in the kernel
+          or later (which can be checked using the command <code>rpm -q
+          kernel-default</code>), you might notice messages in the kernel
           logs that are similar to the following example:
         </para>
 <screen>


### PR DESCRIPTION
### PR creator: Description

Integrate proofing corrections for the Tuning Guide from proofing drop 3.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP6/openSUSE Leap 15.6
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2

- SLE 12
  - [ ] SLE 12 SP5