### PR TITLE
Virtualization Guide: integrate proofing corrections

### DIFF
--- a/xml/libvirt_guest_installation.xml
+++ b/xml/libvirt_guest_installation.xml
@@ -120,7 +120,7 @@
               <para>
                 Provide the <guimenu>URL</guimenu> pointing to the installation
                 source. Valid URL prefixes are, for example,
-                <literal>ftp://</literal>, <literal>http://</literal>, and
+                <literal>ftp://</literal>, <literal>http://</literal> and
                 <literal>https://</literal>.
               </para>
               <para>
@@ -163,7 +163,7 @@
             <listitem>
               <para>
                 This installation method is suitable to create a virtual
-                machine, manually configure its components, and install its OS
+                machine, manually configure its components and install its OS
                 later. To adjust the VM to a specific product version, start
                 typing its name&mdash;for example,
                 <literal>sles</literal>&mdash;and select the desired version
@@ -572,7 +572,7 @@ network=vnet_nated</screen>
     </para>
 
     <sect2 xml:id="cha-kvm-inst-virtman-advanced-uefi">
-      <title>Advanced UEFI Configuration</title>
+      <title>Advanced UEFI configuration</title>
       <para>
         The UEFI firmware used by virtual machines is provided by
         <emphasis>OVMF</emphasis> (<emphasis>Open Virtual Machine Firmware</emphasis>).
@@ -649,7 +649,7 @@ network=vnet_nated</screen>
       <para>
         The <package>qemu-ovmf-x86_64</package> package contains several UEFI
         firmware images. For example, the following subset supports SMM,
-        &uefisecboot;, and has either Microsoft, openSUSE, or SUSE UEFI CA keys
+        &uefisecboot;, and has either Microsoft, openSUSE or SUSE UEFI CA keys
         enrolled:
       </para>
 
@@ -688,7 +688,7 @@ network=vnet_nated</screen>
         to a per-VM path under <filename>/var/lib/libvirt/qemu/nvram/</filename>
         when first creating the VM. Files without <literal>code</literal> or
         <literal>vars</literal> in the name can be used as a single UEFI image.
-        They are not as useful since no UEFI variables persist across power
+        They are not as useful, since no UEFI variables persist across power
         cycles of the VM.
       </para>
 

--- a/xml/libvirt_managing.xml
+++ b/xml/libvirt_managing.xml
@@ -1017,7 +1017,7 @@ Metadata:       yes
         <para>
           The post-copy live migration (not supported or recommended for production) requires setting the
           <varname>unprivileged_userfaultfd</varname> system value to
-          <literal>1</literal> since kernel version 5.11.
+          <literal>1</literal> from kernel version 5.11 onward.
         </para>
 <screen>&prompt.sudo;sysctl -w vm.unprivileged_userfaultfd=1</screen>
         <para>
@@ -1075,7 +1075,7 @@ Metadata:       yes
         <listitem>
           <para>
             All &vmhost;s participating in migration must have the same UID for
-            the qemu user and the same GIDs for the kvm, qemu, and libvirt
+            the qemu user and the same GIDs for the kvm, qemu and libvirt
             groups.
           </para>
         </listitem>

--- a/xml/libvirt_overview.xml
+++ b/xml/libvirt_overview.xml
@@ -22,7 +22,7 @@
     always provided the single monolithic daemon &libvirtd;. It includes the
     primary hypervisor drivers and all secondary drivers needed for managing
     storage, networking, node devices, etc. The monolithic &libvirtd; also
-    provides secure remote access for external clients. Over time &libvirt;
+    provides secure remote access for external clients. Over time, &libvirt;
     added support for modular daemons, where each driver runs in its own
     daemon, allowing users to customize their &libvirt; deployment. Modular
     daemons are enabled by default, but a deployment can be switched to the
@@ -160,7 +160,7 @@
       <systemitem class="daemon">virtnetworkd</systemitem>,
       <systemitem class="daemon">virtnodedevd</systemitem>,
       <systemitem class="daemon">virtnwfilterd</systemitem>,
-      <systemitem class="daemon">virtstoraged</systemitem>, and
+      <systemitem class="daemon">virtstoraged</systemitem> and
       <systemitem class="daemon">virtsecretd</systemitem> are also enabled in
       the presets, ensuring the daemons are enabled and available when the
       corresponding packages are installed. Although enabled in presets for

--- a/xml/pv2fv.xml
+++ b/xml/pv2fv.xml
@@ -118,7 +118,7 @@ ln -sf /dev/xvda1 /dev/hda1
           </listitem>
           <listitem>
             <para>
-              On &slsa; 12, 15, and &opensuse; open or create
+              On &slsa; 12, 15 and &opensuse;, open or create
               <filename>/etc/dracut.conf.d/10-virt.conf</filename> and add the
               modules with <literal>force_drivers</literal> by adding a line as
               in the example below (mind the leading whitespace):

--- a/xml/qemu_guest_installation.xml
+++ b/xml/qemu_guest_installation.xml
@@ -71,7 +71,7 @@
       <callout arearefs="co-qemu-img-size">
         <para>
           The size of the image&mdash;8 GB in this case. The image is created
-          as a <xref linkend="gloss-vt-storage-sparse"/> file that grows when
+          as a <xref linkend="gloss-vt-storage-sparse"/> that grows when
           the disk is filled with data. The specified size defines the maximum
           size to which the image file can grow.
         </para>

--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -1508,7 +1508,7 @@
         </para>
       </note>
       <note>
-        <title>Intel flexMigration</title>
+        <title>Intel FlexMigration</title>
         <para>
           For machines that support Intel FlexMigration, CPU-ID masking and
           faulting allow for more flexibility in cross-CPU migration.

--- a/xml/xen2kvm.xml
+++ b/xml/xen2kvm.xml
@@ -657,7 +657,7 @@ Id Name                 State
             </para>
 <screen>INITRD_MODULES="virtio_blk virtio_pci virtio_net virtio_balloon"</screen>
             <para>
-              For &slsa; 12, 15, and &opensuse; search for <literal>xenblk xennet</literal> in
+              For &slsa; 12, 15 and &opensuse;, search for <literal>xenblk xennet</literal> in
               <filename>/etc/dracut.conf.d/*.conf</filename> and replace them
               with <literal>virtio_blk virtio_pci virtio_net
               virtio_balloon</literal>


### PR DESCRIPTION
### PR creator: Description

Integrate proofing corrections for the Virtualization Guide from proofing drop 3.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP6/openSUSE Leap 15.6
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2

- SLE 12
  - [ ] SLE 12 SP5
