### PR TITLE
[WIP]DOCTEAM-1493: corrects wrong repo link

### DIFF
--- a/xml/selinux.xml
+++ b/xml/selinux.xml
@@ -315,7 +315,7 @@ system_u:object_r:var_t var</screen>
     Copy the repository link that matches your &productname; version, and add it with Zypper:
     </para>
     <screen>&prompt.sudo;<command>zypper ar -f \
-https://download.opensuse.org/repositories/security:/SELinux_legacy/&productnumber-leaprepo;/ \
+https://download.opensuse.org/repositories/security:/SELinux/&productnumber-leaprepo;/ \
 SELinux-Legacy</command></screen>
    </step>
    <step>


### PR DESCRIPTION
### PR creator: Description

Describe the overall goals of this pull request.

Correct the wrong repo link


### PR creator: Are there any relevant issues/feature requests?

[DOCTEAM-1493](https://jira.suse.com/browse/DOCTEAM-1493)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP6/openSUSE Leap 15.6
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2

- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
