### PR TITLE
Update security_aide.xml - fix AIDE project url

### DIFF
--- a/xml/security_aide.xml
+++ b/xml/security_aide.xml
@@ -530,7 +530,7 @@ dud:ftp://&ftpname;/mhash<replaceable>VERSION</replaceable>.<replaceable>ARCH</r
    <listitem>
     <para>
      The home page of &aide;:
-     <link xlink:href="https://aide.sourceforge.net"/>
+     <link xlink:href="https://aide.github.io/"/>
     </para>
    </listitem>
    <listitem>


### PR DESCRIPTION
AIDE project moved to GitHub some time ago.

* https://aide.github.io/
* https://github.com/aide/aide

### PR creator: Description

Update all documentation to point to the current AIDE project website.


### PR creator: Are there any relevant issues/feature requests?

None that I'm aware of.


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP6/openSUSE Leap 15.6
  - [x] SLE 15 SP5/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2

- SLE 12
  - [x] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
