### PR TITLE
Document hot-replacement to resize mdadm partitions

### DIFF
--- a/xml/storage_mdadm-resize.xml
+++ b/xml/storage_mdadm-resize.xml
@@ -318,6 +318,39 @@
      </para>
     </step>
    </procedure>
+   <para>
+    Alternatively, if you are replacing the disks and can install the new disks
+    temporarily alongside the existing array, you can hot-replace the
+    partitions. This will keep them in service until a new partition has been
+    rebuilt as a spare, so the array does not enter a degraded state and
+    remains fault-tolerant during the process. The following steps replace
+    steps 3&ndash;5 in the above procedure.
+   </para>
+   <procedure>
+    <step>
+     <para>
+      Mark a component partition for replacement. For example, to replace
+      <filename>/dev/sda1</filename>, enter
+     </para>
+<screen>&prompt.sudo;mdadm /dev/md0 --replace /dev/sda1</screen>
+    </step>
+    <step>
+     <para>
+      Add a replacement partition to the RAID array. For example, to add
+      <filename>/dev/sdd1</filename>, enter
+     </para>
+<screen>&prompt.sudo;mdadm -a /dev/md0 /dev/sdd1</screen>
+    </step>
+    <step>
+     <para>
+      Once the new partition has been added and has finished rebuilding, the
+      partition marked for replacement will be automatically marked as faulty,
+      and can be removed from the array. For example, to remove
+      <filename>/dev/sda1</filename>, enter
+     </para>
+<screen>&prompt.sudo;mdadm /dev/md0 --remove /dev/sda1</screen>
+    </step>
+   </procedure>
   </sect2>
 
   <sect2 xml:id="sec-raid-resize-incr-raid">


### PR DESCRIPTION
### PR creator: Description

With mdadm 3.3 or newer, partitions can be hot-replaced with new disks so that the array remains fault-tolerant through the replacement process. This could be a useful alternative to note in the resizing guide.


### PR creator: Are there any relevant issues/feature requests?


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP6/openSUSE Leap 15.6
  - [x] SLE 15 SP5/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2

- SLE 12
  - [x] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
