### PR TITLE
sev-doc: Fix ovmf firmware paths

### DIFF
--- a/xml/art_amd-sev.xml
+++ b/xml/art_amd-sev.xml
@@ -131,8 +131,8 @@
       use UEFI firmware. &libvirt; can automatically select an appropriate SEV
       or SEV-ES enabled UEFI firmware, or one can be specified manually.
       Currently, the only firmware supported are
-      <filename>/usr/share/qemu/ovmf-x86_64-code.bin</filename> and
-      <filename>/usr/share/qemu/ovmf-x86_64-4m-code.bin</filename>. See
+      <filename>/usr/share/qemu/ovmf-x86_64-sev.bin</filename> and
+      <filename>/usr/share/qemu/ovmf-x86_64-sev-code.bin</filename>. See
       <xref linkend="cha-kvm-inst-virtman-advanced-uefi"/> for more details on
       using UEFI firmware and the auto-selection feature.
     </para>
@@ -171,8 +171,7 @@
     &lt;/memoryBacking&gt;
     &lt;os&gt;
     &lt;type arch='x86_64' machine='pc-q35-2.11'&gt;hvm&lt;/type&gt;
-    &lt;loader readonly='yes' type='pflash'&gt;/usr/share/qemu/ovmf-x86_64-ms-4m-code.bin&lt;/loader&gt;
-    &lt;nvram&gt;/var/lib/libvirt/qemu/nvram/sles15-sev-guest_VARS.fd&lt;/nvram&gt;
+    &lt;loader readonly='yes' stateless='yes' type='pflash'&gt;/usr/share/qemu/ovmf-x86_64-sev.bin&lt;/loader&gt;
     &lt;boot dev='hd'/&gt;
     &lt;/os&gt;
     &lt;launchSecurity <co xml:id="sec-amd-sev-ex-launchsecurity"/> type='sev'&gt;
@@ -564,7 +563,7 @@ sev-policy     : 7</screen>
     </para>
 
 <screen>&prompt.root;virt-qemu-sev-validate --api-major 1 --api-minor 51 --build-id 3 --policy 7 \
- --firmware /usr/share/qemu/ovmf-x86_64-4m.bin --tik sevtest_tik.bin --tek sevtest_tek.bin --num-cpus 4 \
+ --firmware /usr/share/qemu/ovmf-x86_64-sev.bin --tik sevtest_tik.bin --tek sevtest_tek.bin --num-cpus 4 \
  --cpu-family 25 --cpu-model 1 --cpu-stepping 1 \
  --measurement QJ0oDpFmWj+bGZzFoMPbAxTuC6QD44W5w88x/hQM8toVsB75ci7V1YDfYoI9GTk</screen>
 


### PR DESCRIPTION
Fixing bug#1232762 and other related bugs in the ovmf package requires removing SEV support from ovmf-x86_64-4m-{code,vars}.bin and ovmf-x86_64-{code,vars}.bin. New firmwares specificly for SEV, SEV-ES, and SEV-SNP have been introduced. Update the documentation to use the new SEV-specific firmware.

* bsc#1232762

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP6/openSUSE Leap 15.6
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2

- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
