### PR TITLE
Additional clarification about %vmeff exceeding 100% in newer kernels

### DIFF
--- a/xml/utilities.xml
+++ b/xml/utilities.xml
@@ -489,12 +489,12 @@ Average:    92.08    211.70 1097.30     0.26 12010.28      0.00      0.00      0
       </para>
       <para>
        In modern Linux kernels (5.x and higher), changes in memory management and page reclamation
-       accounting makes %vmeff less reliable as a measure of virtual memory efficiency. These
+       accounting make %vmeff less reliable as a measure of virtual memory efficiency. These
        changes include separating background and direct reclaim metrics, tracking memory operations
        with greater granularity, introducing deferred reclamation, and adding support for NUMA-aware
        and cgroup-based memory management. Such updates can cause tools like <command>sar</command>
        to misinterpret metrics like pgsteal and pgscank, resulting in %vmeff value
-       exceeding 100% in certain situatiions.
+       exceeding 100% in certain situations.
       </para>
       <para>
        If %vmeff exceeds 100%, avoid using it as a performance indicator. Instead, analyze memory

--- a/xml/utilities.xml
+++ b/xml/utilities.xml
@@ -479,6 +479,32 @@ Average:    92.08    211.70 1097.30     0.26 12010.28      0.00      0.00      0
       page swapped out is being reused) or 0 (no pages have been scanned).
       The value should not drop below 30.
      </para>
+     <note>
+      <title>Understanding and addressing %vmeff values exceeding 100% in modern Linux
+      kernels</title>
+      <para>
+       A %vmeff value exceeding 100% means that the number of pages reclaimed (pgsteal) is reported
+       as higher than the number of pages scanned (pgscank) during memory reclamation. This is
+       unexpected because under normal circumstances, the kernel should not reclaim more pages than it scans.
+      </para>
+      <para>
+       In modern Linux kernels (5.x and higher), changes in memory management and page reclamation
+       accounting makes %vmeff less reliable as a measure of virtual memory efficiency. These
+       changes include separating background and direct reclaim metrics, tracking memory operations
+       with greater granularity, introducing deferred reclamation, and adding support for NUMA-aware
+       and cgroup-based memory management. Such updates can cause tools like <command>sar</command>
+       to misinterpret metrics like pgsteal and pgscank, resulting in %vmeff value
+       exceeding 100% in certain situatiions.
+      </para>
+      <para>
+       If %vmeff exceeds 100%, avoid using it as a performance indicator. Instead, analyze memory
+       performance by monitoring pgpgin/s and pgpgout/s for paging activity, majflt/s and fault/s
+       for page faults, and memory utilization details in <filename>/proc/meminfo</filename> (for
+       exmaple, Active, Inactive, Dirty and Writeback). Additionally, correlate these metrics with
+       application-level performance and I/O patterns to identify potential memory bottlenecks or
+       inefficiencies.
+      </para>
+     </note>
     </sect4>
     <sect4 xml:id="sec-util-multi-sar-report-disk">
      <title>Block device statistics report: <command>sar</command> <option>-d</option></title>

--- a/xml/utilities.xml
+++ b/xml/utilities.xml
@@ -500,7 +500,7 @@ Average:    92.08    211.70 1097.30     0.26 12010.28      0.00      0.00      0
        If %vmeff exceeds 100%, avoid using it as a performance indicator. Instead, analyze memory
        performance by monitoring pgpgin/s and pgpgout/s for paging activity, majflt/s and fault/s
        for page faults, and memory utilization details in <filename>/proc/meminfo</filename> (for
-       exmaple, Active, Inactive, Dirty and Writeback). Additionally, correlate these metrics with
+       example, Active, Inactive, Dirty and Writeback). Additionally, correlate these metrics with
        application-level performance and I/O patterns to identify potential memory bottlenecks or
        inefficiencies.
       </para>

--- a/xml/utilities.xml
+++ b/xml/utilities.xml
@@ -480,27 +480,27 @@ Average:    92.08    211.70 1097.30     0.26 12010.28      0.00      0.00      0
       The value should not drop below 30.
      </para>
      <note>
-      <title>Understanding and addressing %vmeff values exceeding 100% in modern Linux
+      <title>Understanding and addressing <guimenu>%vmeff</guimenu> values exceeding 100% in modern Linux
       kernels</title>
       <para>
-       A %vmeff value exceeding 100% means that the number of pages reclaimed (pgsteal) is reported
-       as higher than the number of pages scanned (pgscank) during memory reclamation. This is
+       A <guimenu>%vmeff</guimenu> value exceeding 100% means that the number of pages reclaimed (<guimenu>pgsteal</guimenu>) is reported
+       as higher than the number of pages scanned (<guimenu>pgscank</guimenu>) during memory reclamation. This is
        unexpected because under normal circumstances, the kernel should not reclaim more pages than it scans.
       </para>
       <para>
        In modern Linux kernels (5.x and higher), changes in memory management and page reclamation
-       accounting make %vmeff less reliable as a measure of virtual memory efficiency. These
+       accounting make <guimenu>%vmeff</guimenu> less reliable as a measure of virtual memory efficiency. These
        changes include separating background and direct reclaim metrics, tracking memory operations
        with greater granularity, introducing deferred reclamation, and adding support for NUMA-aware
        and cgroup-based memory management. Such updates can cause tools like <command>sar</command>
-       to misinterpret metrics like pgsteal and pgscank, resulting in %vmeff value
+       to misinterpret metrics like <guimenu>pgsteal</guimenu> and <guimenu>pgscank</guimenu>, resulting in <guimenu>%vmeff</guimenu> value
        exceeding 100% in certain situations.
       </para>
       <para>
-       If %vmeff exceeds 100%, avoid using it as a performance indicator. Instead, analyze memory
-       performance by monitoring pgpgin/s and pgpgout/s for paging activity, majflt/s and fault/s
+       If <guimenu>%vmeff</guimenu> exceeds 100%, avoid using it as a performance indicator. Instead, analyze memory
+       performance by monitoring <guimenu>pgpgin/s</guimenu> and <guimenu>pgpgout/s</guimenu> for paging activity, <guimenu>majflt/s</guimenu> and <guimenu>fault/s</guimenu>
        for page faults, and memory utilization details in <filename>/proc/meminfo</filename> (for
-       example, Active, Inactive, Dirty and Writeback). Additionally, correlate these metrics with
+       example, <guimenu>Active</guimenu>, <guimenu>Inactive</guimenu>, <guimenu>Dirty</guimenu> and <guimenu>Writeback</guimenu>). Additionally, correlate these metrics with
        application-level performance and I/O patterns to identify potential memory bottlenecks or
        inefficiencies.
       </para>


### PR DESCRIPTION
### PR creator: Description

Clarify how to interpret and act when `%vmeff` value exceeds 100% as part of `sar -B` report, because it doesn't make sense under normal circumstances that the kernel reclaims more virtual memory pages than it scans.


### Preview
* A note should appear at the end of the section https://susedoc.github.io/doc-sle/main/html/SLES-tuning/cha-util.html#sec-util-multi-sar-report-paging


### PR creator: Are there any relevant issues/feature requests?

* bsc#...https://bugzilla.suse.com/show_bug.cgi?id=1218839
* jsc#...https://jira.suse.com/browse/DOCTEAM-1252


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP6/openSUSE Leap 15.6
  - [x] SLE 15 SP5/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2

- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [x] all necessary backports are done
