### PR TITLE
Fix for BSC#1218169.

### DIFF
--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -2458,7 +2458,7 @@ size=40G features='0' hwhandler='0' wp=rw
 &lt;profile&gt;</screen>
    <para>
     Each disk needs to be configured in a separate <literal>listentry</literal>
-    section.
+    section that needs to provide the following elements:
    </para>
    <variablelist>
     <varlistentry>
@@ -2470,29 +2470,11 @@ size=40G features='0' hwhandler='0' wp=rw
 <screen>&lt;controller_id&gt;0.0.fc00&lt;/controller_id&gt;</screen>
      </listitem>
     </varlistentry>
-   </variablelist>
-   <para>
-    The <literal>controller_id</literal> element is required.
-   </para>
-   <para>
-    There are two optional elements: <literal>wwpn</literal> (Worldwide Port
-    Number, the target port through which the SCSI device is attached) and
-    <literal>fcp_lun</literal> (logical unit number of the SCSI device). It is
-    not necessary to specify these for FCP devices running in NPIV (Node Port
-    ID Virtualization) mode, and when the zfcp module parameter
-    <literal>allow_lun_scan</literal> is set to 1 (the default setting), which
-    enables automatic LUN scanning by the zfcp device driver.
-   </para>
-   <para>
-    If automatic LUN scanning is not available, set the <literal>wwpn</literal>
-    and <literal>fcp_lun</literal> options manually.
-   </para>
-   <variablelist>
     <varlistentry>
      <term>wwpn</term>
      <listitem>
       <para>
-       Worldwide port number
+       Worldwide port number, the target port through which the SCSI device is attached
       </para>
 <screen>&lt;wwpn&gt;0x500507630300c562&lt;/wwpn&gt;</screen>
      </listitem>
@@ -2506,7 +2488,7 @@ size=40G features='0' hwhandler='0' wp=rw
 <screen>&lt;fcp_lun&gt;0x4010403200000000&lt;/fcp_lun&gt;</screen>
      </listitem>
     </varlistentry>
-   </variablelist>
+   </variablelist>   
    <para>
     See the IBM documentation for more information,
     <link xlink:href=" https://www.ibm.com/docs/en/linux-on-systems?topic=wsd-configuring-devices"/>.


### PR DESCRIPTION
### PR creator: Description

Changing zFCP disk disk in AY.

### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#...


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP6/openSUSE Leap 15.6
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [ ] SLE 15 SP2/openSUSE Leap 15.2

- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
