### PR TITLE
bump kernel version number (SLE 15 SP7)

### DIFF
--- a/xml/klp.xml
+++ b/xml/klp.xml
@@ -367,7 +367,7 @@ Activate with: SUSEConnect -p sle-module-live-patching/&productnumber-regurl;/x8
       patches</command> command. You can see the currently running patch on the
       line starting with <literal>RPM:</literal>. For example:
      </para>
-<screen>RPM: kernel-livepatch-6_4_0-150600_9-default-1-150600.2.36.x86_64</screen>
+<screen>RPM: kernel-livepatch-6_4_0-150700_38-default-1-150700.1.23.x86_64</screen>
      <para>
       The <literal>6_4_0-150600_9-default</literal> in the example above denotes
       the exact running kernel version.

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -12,7 +12,7 @@
 
 
 <!ENTITY php-version            "8">
-<!ENTITY kernel-version         "6.4.0-150600.9">
+<!ENTITY kernel-version         "6.4.0-150700.38">
 <!ENTITY kernel-version-base    "6.4.0">
 
 <!-- PROJECT REPOSITORY URL -->


### PR DESCRIPTION
### PR creator: Description

Update kernel version number for SLE 15 SP7 (checked against internal Snapshot-202412-2.1). Also checked the output of `klp -v patches` to update the string in the KLP chapter.

### PR creator: Are there any relevant issues/feature requests?

Nope.


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*


### PR reviewer only: Have all backports been applied?

No backporting!
