### PR TITLE
EOL SLE 15 SP2: Switch validation to DocBook 5.2

### DIFF
--- a/DC-SLED-admin
+++ b/DC-SLED-admin
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLED-all
+++ b/DC-SLED-all
@@ -14,3 +14,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLED-deployment
+++ b/DC-SLED-deployment
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLED-gnomeuser
+++ b/DC-SLED-gnomeuser
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLED-html
+++ b/DC-SLED-html
@@ -14,3 +14,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLED-installquick
+++ b/DC-SLED-installquick
@@ -18,3 +18,4 @@ FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 # Setting the TOC depth to sect 3
 XSLTPARAM="--param toc.section.depth=3"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLED-modulesquick
+++ b/DC-SLED-modulesquick
@@ -18,3 +18,4 @@ FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 # Setting the TOC depth to sect 2
 XSLTPARAM="--param toc.section.depth=3"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLED-security
+++ b/DC-SLED-security
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLED-tuning
+++ b/DC-SLED-tuning
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLED-upgrade
+++ b/DC-SLED-upgrade
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-admin
+++ b/DC-SLES-admin
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-all
+++ b/DC-SLES-all
@@ -14,3 +14,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-amd-sev
+++ b/DC-SLES-amd-sev
@@ -16,3 +16,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-autoyast
+++ b/DC-SLES-autoyast
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-deployment
+++ b/DC-SLES-deployment
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-gnomeuser
+++ b/DC-SLES-gnomeuser
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-html
+++ b/DC-SLES-html
@@ -14,3 +14,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-installquick
+++ b/DC-SLES-installquick
@@ -18,3 +18,4 @@ FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 # Setting the TOC depth to sect 2
 XSLTPARAM="--param toc.section.depth=3"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-jeos
+++ b/DC-SLES-jeos
@@ -18,3 +18,4 @@ FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 # Setting the TOC depth to sect 2
 XSLTPARAM="--param toc.section.depth=2"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-modulesquick
+++ b/DC-SLES-modulesquick
@@ -18,3 +18,4 @@ FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 # Setting the TOC depth to sect 2
 XSLTPARAM="--param toc.section.depth=3"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-rmt
+++ b/DC-SLES-rmt
@@ -14,3 +14,4 @@ PROFCONDITION="suse-product"
 
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-rpi-quick
+++ b/DC-SLES-rpi-quick
@@ -18,3 +18,4 @@ FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 # Setting the TOC depth to sect 2
 XSLTPARAM="--param toc.section.depth=2"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-security
+++ b/DC-SLES-security
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-storage
+++ b/DC-SLES-storage
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-tuning
+++ b/DC-SLES-tuning
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-upgrade
+++ b/DC-SLES-upgrade
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-virtualization
+++ b/DC-SLES-virtualization
@@ -18,3 +18,4 @@ FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 ### Sort the glossary
 XSLTPARAM="--param glossary.sort=1" 
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-vt-best-practices
+++ b/DC-SLES-vt-best-practices
@@ -18,3 +18,4 @@ FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 ### Sort the glossary
 XSLTPARAM="--param glossary.sort=1" 
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-SLES-xen2kvmquick
+++ b/DC-SLES-xen2kvmquick
@@ -15,3 +15,4 @@ PROFCONDITION="suse-product"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2022-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse2021-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-opensuse-all
+++ b/DC-opensuse-all
@@ -14,3 +14,4 @@ PROFCONDITION="community-project"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/opensuse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-opensuse-autoyast
+++ b/DC-opensuse-autoyast
@@ -15,3 +15,4 @@ PROFCONDITION="community-project"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/opensuse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-opensuse-gnomeuser
+++ b/DC-opensuse-gnomeuser
@@ -15,3 +15,4 @@ PROFCONDITION="community-project"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/opensuse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-opensuse-reference
+++ b/DC-opensuse-reference
@@ -15,3 +15,4 @@ PROFCONDITION="community-project"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/opensuse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-opensuse-security
+++ b/DC-opensuse-security
@@ -15,3 +15,4 @@ PROFCONDITION="community-project"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/opensuse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-opensuse-startup
+++ b/DC-opensuse-startup
@@ -18,3 +18,4 @@ HTMLROOT="sles15"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/opensuse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-opensuse-tuning
+++ b/DC-opensuse-tuning
@@ -15,3 +15,4 @@ PROFCONDITION="community-project"
 ## stylesheet location
 STYLEROOT="/usr/share/xml/docbook/stylesheet/opensuse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"

--- a/DC-opensuse-virtualization
+++ b/DC-opensuse-virtualization
@@ -17,3 +17,4 @@ STYLEROOT="/usr/share/xml/docbook/stylesheet/opensuse2013-ns"
 FALLBACK_STYLEROOT="/usr/share/xml/docbook/stylesheet/suse-ns"
 
 XSLTPARAM="--param glossary.sort=1"
+DOCBOOK5_RNG_URI="http://docbook.org/xml/5.2/rng/docbookxi.rng"


### PR DESCRIPTION
### Description

This change switches the validation schema from GeekoDoc to DocBook 5.2. This ensures that futures changes of GeekoDoc doesn't affect previous, now unsupported documents.


### Are there any relevant issues/feature requests?

See www.suse.com/lifecycle


### Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP6/openSUSE Leap 15.6
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  - [x] SLE 15 SP2/openSUSE Leap 15.2

- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

No backport necessary, applies only to SLE 15 SP2.
