### PR TITLE
Upgrade guide: Disambiguate offline upgrade requiring being online

### DIFF
--- a/xml/sle_update_offline.xml
+++ b/xml/sle_update_offline.xml
@@ -28,7 +28,9 @@ Check with Simona, if this is supported or needed.
     This chapter describes how to upgrade an existing &sle; installation using
     &yast; which is booted from an installation medium. The &yast; installer
     can, for example, be started from a DVD, over the network, or from the hard
-    disk the system resides on.
+    disk the system resides on. In this sense, "offline upgrade" refers to the
+    regular operating system and its services being offline, rather than the
+    network connectivity status specifically.
    </para>
   </abstract>
  </info>


### PR DESCRIPTION
The section titled "Upgrade offline" has a curious statement about having to be online, thus contradicting itself assuming the simplest interpretations.

"""If the system you want to upgrade is registered with the SUSE Customer Center, make sure to have an Internet connection during the following procedure."""

Clarify the term "offline" in the introductory paragraph.


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [*] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [*] SLE 15 SP6/openSUSE Leap 15.6
  - [*] SLE 15 SP5/openSUSE Leap 15.5
  - [*] SLE 15 SP4/openSUSE Leap 15.4
  - [*] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [*] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
