### PR TITLE
vt-doc: Remove note about exceeding 255 vCPUs

### DIFF
--- a/xml/libvirt_configuration_virsh.xml
+++ b/xml/libvirt_configuration_virsh.xml
@@ -301,29 +301,6 @@ current      live           4
 </screen>
         </step>
       </procedure>
-      <important>
-        <title>Exceeding 255 CPUs</title>
-        <para>
-          With &kvm;, it is possible to define a &vmguest; with more than 255
-          CPUs. However, additional configuration is necessary to start and run
-          the &vmguest;. The <literal>ioapic</literal> feature needs to be
-          tuned and an IOMMU device needs to be added to the &vmguest;. Below
-          is an example configuration for 288 CPUs.
-        </para>
-<screen>
-&lt;domain&gt;
- &lt;vcpu placement='static'&gt;288&lt;/vcpu&gt;
- &lt;features&gt;
-  &lt;ioapic driver='qemu'/&gt;
- &lt;/features&gt;
- &lt;devices&gt;
-  &lt;iommu model='intel'&gt;
-   &lt;driver intremap='on' eim='on'/&gt;
-  &lt;/iommu&gt;
- &lt;/devices&gt;
-&lt;/domain&gt;
-</screen>
-      </important>
     </sect2>
 
     <sect2 xml:id="sec-libvirt-cpu-model-virsh">


### PR DESCRIPTION
Starting with libvirt 10.10.0, an iommu and ioapic are configured automatically if needed, e.g. when configuring a VM with >255 vCPUs. For SLE15 SP7 and newer, remove the note about needing to add the configuration manually.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP6/openSUSE Leap 15.6
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
