### PR TITLE
Update docs about userspace livepatching

### DIFF
--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -31,18 +31,6 @@
       </para>
     </important>
 
-    <note os="slemicro">
-      <title>Live patching on &slema;</title>
-      <para>
-        Only the currently running processes are affected by the live patches.
-        As the libraries are changed in the new snapshot and
-        <emphasis role="bold">not</emphasis> in the current one, new processes
-        started in the current snapshot still use the non-patched libraries
-        until you reboot. After the reboot, the system switches to the new
-        snapshot and all started processes will use the patched libraries.
-      </para>
-    </note>
-
     <para>
       User space live patching (&ulpa;) refers to the process of applying
       patches to the libraries used by a running process without interrupting
@@ -50,6 +38,14 @@
       services will be secured after applying the live patch without restarting
       the processes.
     </para>
+
+    <para>
+      &ulpa; is supported on the following architectures:
+    </para> 
+    <itemizedlist>
+      <listitem><para>&x86-64;</para></listitem>
+      <listitem><para>&ppc64le; (starting with &productname; 15 SP7)</para></listitem>
+    </itemizedlist>
 
     <para>
       Live patching operations are performed using the
@@ -116,12 +112,10 @@
         <systemitem>openssl</systemitem> (<systemitem>openssl1_1</systemitem> and <systemitem>openssl-3</systemitem>)
         are supported. Additional packages will be available after they are
         prepared for live patching. To receive <systemitem>glibc</systemitem>
-        and <systemitem>openssl</systemitem> live patches, install both
-        <package>glibc-livepatches</package> and
-        <package>openssl-livepatches</package> packages:
+        and <systemitem>openssl</systemitem> live patches, install the following packages:
       </para>
-<screen os="sled;sles">&prompt.user;zypper install glibc-livepatches openssl-livepatches</screen>
-<screen os="slemicro">&prompt.user;transactional-update pkg in glibc-livepatches openssl-livepatches</screen>
+<screen os="sled;sles">&prompt.user;zypper install glibc-livepatches openssl-livepatches openssl-3-livepatches</screen>
+<screen os="slemicro">&prompt.user;transactional-update pkg in glibc-livepatches openssl-livepatches openssl-3-livepatches</screen>
       <para os="slemicro">
         After successful installation, reboot your system.
       </para>
@@ -160,7 +154,11 @@
       <sect3 xml:id="sec-ulp-apply-livepatch">
         <title>Applying live patches</title>
         <para>
-          Live patches are applied using the <command>ulp trigger</command>
+          Live patches provided by &suse; are shipped through usual updates if the following packages are installed:
+          <package>glibc-livepatches</package> <package>openssl-livepatches</package> <package>openssl-3-livepatches</package>.
+        </para>
+        <para>
+          Custom live patches are applied using the <command>ulp trigger</command>
           command, for example:
         </para>
 <screen>&prompt.user;ulp trigger -p <replaceable>PID</replaceable> <replaceable>LIVEPATCH</replaceable>.so</screen>


### PR DESCRIPTION
(note: I am not able to compile the docs, there seems to be something wrong with the shipped openSUSE environment).

### PR creator: Description

This update the documentation about userspace livepatching with the following information:

1- Remove the paragraph stating that on Micro new processes will run
   unpatched software.  This is not true anymore since libpulp 0.3.8.

2- State that ulp is available on x86_64 and powerpc64le.

3- State that for openssl-3 we have openssl-3-livepatches.

### PR creator: Are there any relevant issues/feature requests?

* jsc#PED-12221

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP6/openSUSE Leap 15.6
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
