### PR TITLE
PED-11693: adds note for kea server

### DIFF
--- a/xml/net_dhcp.xml
+++ b/xml/net_dhcp.xml
@@ -496,7 +496,7 @@
    <systemitem>wickedd-dhcp6</systemitem>. Both are launched automatically on
    each system boot to watch for a DHCP server. They do not need a
    configuration file to do their job and work out of the box in most standard
-   setups. For more complex situations, use the KEA
+   setups. For more complex situations, use the ISC
    <systemitem>dhcp-client</systemitem>, which is controlled by the
    configuration files <filename>/etc/dhclient.conf</filename> and
    <filename>/etc/dhclient6.conf</filename>.

--- a/xml/net_dhcp.xml
+++ b/xml/net_dhcp.xml
@@ -482,13 +482,21 @@
    ISC) and tools coming with the <systemitem>wicked</systemitem> package.
   </para>
 
+   <note>
+    <title>KEA DHCP replaces ISC DHCP Server</title>
+    <para>
+     The Internet Systems Consortium (ISC) has developed a new DHCP server, KEA
+     which replaces ISC DHCP servers. For more information, refer to <link xlink:href="https://www.isc.org/kea/"/>
+    </para>
+   </note>
+
   <para>
    By default, the <systemitem>wicked</systemitem> tools are installed with the
    services <systemitem>wickedd-dhcp4</systemitem> and
    <systemitem>wickedd-dhcp6</systemitem>. Both are launched automatically on
    each system boot to watch for a DHCP server. They do not need a
    configuration file to do their job and work out of the box in most standard
-   setups. For more complex situations, use the ISC
+   setups. For more complex situations, use the KEA
    <systemitem>dhcp-client</systemitem>, which is controlled by the
    configuration files <filename>/etc/dhclient.conf</filename> and
    <filename>/etc/dhclient6.conf</filename>.
@@ -675,7 +683,7 @@ fixed-address &wsIip;;
   <sect2 xml:id="sec-dhcp-sle">
    <title>The &productname; version</title>
    <para>
-    To improve security, the &productname; version of the ISC's DHCP server
+    To improve security, the &productname; version of the KEA's DHCP server
     comes with the non-root/chroot patch by Ari Edelkind applied. This enables
     dhcpd to run with the user ID
     <systemitem class="username">nobody</systemitem> and run in a chroot

--- a/xml/net_dhcp.xml
+++ b/xml/net_dhcp.xml
@@ -683,7 +683,7 @@ fixed-address &wsIip;;
   <sect2 xml:id="sec-dhcp-sle">
    <title>The &productname; version</title>
    <para>
-    To improve security, the &productname; version of the KEA's DHCP server
+    To improve security, the &productname; version of the ISC's DHCP server
     comes with the non-root/chroot patch by Ari Edelkind applied. This enables
     dhcpd to run with the user ID
     <systemitem class="username">nobody</systemitem> and run in a chroot

--- a/xml/net_dhcp.xml
+++ b/xml/net_dhcp.xml
@@ -485,8 +485,8 @@
    <note>
     <title>KEA DHCP replaces ISC DHCP Server</title>
     <para>
-     The ISC (Internet Systems Consortium) has developed a new DHCP server, KEA
-     which replaces ISC DHCP servers. For more information, refer to <link xlink:href="https://www.isc.org/kea/"/>
+     The ISC (Internet Systems Consortium) has developed a new DHCP server, KEA,
+     which replaces ISC DHCP servers. For more information, refer to <link xlink:href="https://www.isc.org/kea/"/>.
     </para>
    </note>
 

--- a/xml/net_dhcp.xml
+++ b/xml/net_dhcp.xml
@@ -485,7 +485,7 @@
    <note>
     <title>KEA DHCP replaces ISC DHCP Server</title>
     <para>
-     The Internet Systems Consortium (ISC) has developed a new DHCP server, KEA
+     The ISC (Internet Systems Consortium) has developed a new DHCP server, KEA
      which replaces ISC DHCP servers. For more information, refer to <link xlink:href="https://www.isc.org/kea/"/>
     </para>
    </note>


### PR DESCRIPTION
### PR creator: Description

Section 40.3.2 talks about a security patch for isc , since we are replacing with kea , is this section still valid? 

https://documentation.suse.com/sles/15-SP6/html/SLES-all/cha-dhcp.html#sec-dhcp-server

### PR creator: Are there any relevant issues/feature requests?
[PED-11693](https://jira.suse.com/browse/PED-11693)


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [X] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [X] SLE 15 SP6/openSUSE Leap 15.6
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
