### PR TITLE
fix hostname-Attribute for autoyast Rules

### DIFF
--- a/xml/ay_rules_classes.xml
+++ b/xml/ay_rules_classes.xml
@@ -435,7 +435,7 @@ fi;
       <row>
        <entry>
         <para>
-         <literal>host name</literal>
+         <literal>hostname</literal>
         </para>
        </entry>
        <entry>


### PR DESCRIPTION
correcture of the "hostname" attribute

I testing the previous Value "host name" on three different suse/sles installations, but only the corrected "hostname" works. I think thats a typo or translation error.

### PR creator: Description

With the actual "host name"-Value, it's not possible to use the Value for working autoyast-Installations.

### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#...

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP6/openSUSE Leap 15.6
  - [x] SLE 15 SP5/openSUSE Leap 15.5

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
