### PR TITLE
correction of init-scripts handling

### DIFF
--- a/xml/ay_custom_user_scripts.xml
+++ b/xml/ay_custom_user_scripts.xml
@@ -34,7 +34,7 @@
  </para>
 
  <para>
-  All scripts need to be in the &lt;scripts&gt; section.
+   Except for <literal>init scripts</literal>, all other scripts must be included in the <scripts> section.
  </para>
 
  <itemizedlist mark="bullet" spacing="normal">
@@ -62,13 +62,14 @@
     system, no services running)
    </para>
   </listitem>
-  <listitem os="sles;sled;osuse">
-   <para>
-    <literal>init-scripts</literal> (during the first boot of the installed
-    system, all services up and running)
-   </para>
-  </listitem>
- </itemizedlist>
+</itemizedlist>
+
+<para os="sles;sled;osuse">
+  <literal>Init scripts</literal> (when the installed system is first booted, 
+  when all services are running) are not executed by YaST and therefore have a 
+  special Status. See <xref linkend="init-scripts" /> for further 
+  information about them.
+</para>
 
  <sect2 xml:id="pre-install-scripts">
   <title>Pre-scripts</title>
@@ -190,13 +191,13 @@
   <para>
    The <literal>init-script</literal> elements must be placed as follows:
   </para>
-<screen>&lt;scripts&gt;
-    &lt;init-scripts config:type="list"&gt;
-      &lt;script&gt;
-        ...
-      &lt;/script&gt;
-    &lt;/init-scripts&gt;
-&lt;/scripts&gt;</screen>
+<screen>
+  &lt;init-scripts config:type="list"&gt;
+    &lt;script&gt;
+    ...
+    &lt;/script&gt;
+  &lt;/init-scripts&gt;
+</screen>
   <para>
    Init scripts are different from the other script types because they are not
    executed by &yast;, but after &yast; has finished. For this reason, their

--- a/xml/ay_custom_user_scripts.xml
+++ b/xml/ay_custom_user_scripts.xml
@@ -34,7 +34,7 @@
  </para>
 
  <para>
-   Except for <literal>init scripts</literal>, all other scripts must be included in the <scripts> section.
+   Except for <literal>init scripts</literal>, all scripts must be included in the <scripts> section.
  </para>
 
  <itemizedlist mark="bullet" spacing="normal">
@@ -68,7 +68,7 @@
   <literal>Init scripts</literal> (when the installed system is first booted, 
   when all services are running) are not executed by YaST and therefore have a 
   special Status. See <xref linkend="init-scripts" /> for further 
-  information about them.
+  information.
 </para>
 
  <sect2 xml:id="pre-install-scripts">


### PR DESCRIPTION
### PR creator: Description

Contrary to what was described, the init-scripts section must not be placed in the <script> part. This will cause autoyast to abort with an error message, and all validation methods will not accept this tag in the previously described location. The documentation has been corrected accordingly in both of these critical locations.

### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#...

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ x ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ x ] SLE 15 SP6/openSUSE Leap 15.6
  - [ x ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
