### PR TITLE
Revision History: initial entry for FCS of 15 SP7

### DIFF
--- a/xml/art-kubevirt.xml
+++ b/xml/art-kubevirt.xml
@@ -58,7 +58,7 @@
     </meta>
     <revhistory xml:id="rh-article-kubevirt">
       <revision>
-        <date>2024-06-26</date>
+        <date>2025-06-17</date>
         <revdescription>
           <para>
             Updated for the initial release of &productname; &productnumber;.

--- a/xml/art-nvidia-vgpu.xml
+++ b/xml/art-nvidia-vgpu.xml
@@ -28,7 +28,7 @@
   </meta>
   <revhistory xml:id="rh-article-nvidia-vgpu">
     <revision>
-      <date>2024-06-26</date>
+      <date>2025-06-17</date>
       <revdescription>
         <para>
           Updated for the initial release of &productname; &productnumber;.

--- a/xml/art_amd-sev.xml
+++ b/xml/art_amd-sev.xml
@@ -49,7 +49,7 @@
     </meta>
     <revhistory xml:id="rh-article-amd-sev">
       <revision>
-        <date>2024-06-26</date>
+        <date>2025-06-17</date>
         <revdescription>
           <para>
             Updated for the initial release of &productname; &productnumber;.

--- a/xml/art_installation-sleds.xml
+++ b/xml/art_installation-sleds.xml
@@ -35,7 +35,7 @@
   </meta>
   <revhistory xml:id="rh-article-installation">
     <revision>
-      <date>2024-06-26</date>
+      <date>2025-06-17</date>
       <revdescription>
         <para>
           Updated for the initial release of &productname; &productnumber;.

--- a/xml/art_modules.xml
+++ b/xml/art_modules.xml
@@ -31,7 +31,7 @@
     <meta name="task" its:translate="yes"><phrase>Administration</phrase><phrase>Installation</phrase>
     </meta>
     <revhistory xml:id="rh-book-article-modules">
-      <revision><date>2024-06-26</date>
+      <revision><date>2025-06-17</date>
         <revdescription>
           <para>
             Updated for the initial release of &productname; &productnumber;.

--- a/xml/art_raspberry-pi.xml
+++ b/xml/art_raspberry-pi.xml
@@ -44,7 +44,7 @@
   </meta>
   <revhistory xml:id="rh-article-raspberry-pi">
     <revision>
-      <date>2024-06-26</date>
+      <date>2025-06-17</date>
       <revdescription>
         <para>
           Updated for the initial release of &productname; &productnumber;.

--- a/xml/art_virtualization-best-practices.xml
+++ b/xml/art_virtualization-best-practices.xml
@@ -29,7 +29,7 @@
     </meta>
     <revhistory xml:id="rh-article-virtualization-best-practices">
       <revision>
-        <date>2024-06-26</date>
+        <date>2025-06-17</date>
         <revdescription>
           <para>
             Updated for the initial release of &productname; &productnumber;.

--- a/xml/book_administration.xml
+++ b/xml/book_administration.xml
@@ -44,7 +44,7 @@
   </meta>
   <revhistory xml:id="rh-book-administration">
     <revision>
-      <date>2024-06-26</date>
+      <date>2025-06-17</date>
       <revdescription>
         <para>
           Updated for the initial release of &productname; &productnumber;.

--- a/xml/book_autoyast.xml
+++ b/xml/book_autoyast.xml
@@ -42,7 +42,7 @@
   </meta>
   <revhistory xml:id="rh-book-autoyast">
     <revision>
-      <date>2024-06-26</date>
+      <date>2025-06-17</date>
       <revdescription>
         <para>
           Updated for the initial release of &productname; &productnumber;.

--- a/xml/book_deployment.xml
+++ b/xml/book_deployment.xml
@@ -43,7 +43,7 @@
   </meta>
   <revhistory xml:id="rh-book-deployment">
     <revision>
-      <date>2024-06-26</date>
+      <date>2025-06-17</date>
       <revdescription>
         <para>
           Updated for the initial release of &productname; &productnumber;.

--- a/xml/book_gnome-user.xml
+++ b/xml/book_gnome-user.xml
@@ -43,7 +43,7 @@
   </meta>
   <revhistory xml:id="rh-book-gnome-user">
     <revision>
-      <date>2024-06-26</date>
+      <date>2025-06-17</date>
       <revdescription>
         <para>
           Updated for the initial release of &productname; &productnumber;.

--- a/xml/book_rmt.xml
+++ b/xml/book_rmt.xml
@@ -42,7 +42,7 @@
    </meta>
    <revhistory xml:id="rh-book-rmt">
      <revision>
-       <date>2024-06-26</date>
+       <date>2025-06-17</date>
        <revdescription>
          <para>
            Updated for the initial release of &productname; &productnumber;.

--- a/xml/book_security.xml
+++ b/xml/book_security.xml
@@ -41,7 +41,7 @@
   </meta>
   <revhistory xml:id="rh-book-security">
     <revision>
-      <date>2024-06-26</date>
+      <date>2025-06-17</date>
       <revdescription>
         <para>
           Updated for the initial release of &productname; &productnumber;.

--- a/xml/book_storage.xml
+++ b/xml/book_storage.xml
@@ -44,7 +44,7 @@
   </meta>
   <revhistory xml:id="rh-book-storage">
     <revision>
-      <date>2024-06-26</date>
+      <date>2025-06-17</date>
       <revdescription>
         <para>
           Updated for the initial release of &productname; &productnumber;.

--- a/xml/book_tuning.xml
+++ b/xml/book_tuning.xml
@@ -43,7 +43,7 @@
   </meta>
   <revhistory xml:id="rh-book-tuning">
     <revision>
-      <date>2024-06-26</date>
+      <date>2025-06-17</date>
       <revdescription>
         <para>
           Updated for the initial release of &productname; &productnumber;.

--- a/xml/book_upgrade.xml
+++ b/xml/book_upgrade.xml
@@ -41,7 +41,7 @@
   </meta>
   <revhistory xml:id="rh-book-upgrade">
     <revision>
-      <date>2024-06-26</date>
+      <date>2025-06-17</date>
       <revdescription>
         <para>
           Updated for the initial release of &productname; &productnumber;.

--- a/xml/book_virtualization.xml
+++ b/xml/book_virtualization.xml
@@ -40,7 +40,7 @@
   </meta>
   <revhistory xml:id="rh-book-virtualization">
     <revision>
-      <date>2024-06-26</date>
+      <date>2025-06-17</date>
       <revdescription>
         <para>
           Updated for the initial release of &productname; &productnumber;.


### PR DESCRIPTION
### PR creator: Description

Set date in revision history to FCS date for 15 SP7 and keep initial entry as agreed with @lvicoun.



### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
