### PR TITLE
Product renaming (SuMa -> SMLM)

### DIFF
--- a/xml/art_modules.xml
+++ b/xml/art_modules.xml
@@ -1173,7 +1173,7 @@
         steps are part of the installation routine. Following the default installation path, this
         requires network access to contact the &scc; or a local registration server
         (<link
-    xlink:href="https://www.suse.com/products/suse-manager/">&susemgr;</link> or
+    xlink:href="https://www.suse.com/products/multi-linux-manager/">&susemgr;</link> or
         &rmtool;), which provide the respective repositories. Offline installation is supported,
         too. In that case, an additional installation media is required. For detailed information,
         refer to <xref

--- a/xml/art_modules.xml
+++ b/xml/art_modules.xml
@@ -1173,7 +1173,7 @@
         steps are part of the installation routine. Following the default installation path, this
         requires network access to contact the &scc; or a local registration server
         (<link
-    xlink:href="https://www.suse.com/products/multi-linux-manager/">&susemgr;</link> or
+    xlink:href="https://www.suse.com/products/multi-linux-manager/">&smlm;</link> or
         &rmtool;), which provide the respective repositories. Offline installation is supported,
         too. In that case, an additional installation media is required. For detailed information,
         refer to <xref

--- a/xml/ay_configuration_management.xml
+++ b/xml/ay_configuration_management.xml
@@ -377,9 +377,9 @@
  </sect2>
 
  <sect2 xml:id="CreateProfile-ConfigurationManagement-SUMAFormulasSupport">
-  <title>&susemgr; Salt formulas support</title>
+  <title>&smlm; Salt formulas support</title>
   <para>
-   &ay; offers support for &susemgr; Salt formulas when running in stand-alone
+   &ay; offers support for &smlm; Salt formulas when running in stand-alone
    mode. In case a formula is found in the states TAR archive, &ay; displays a
    screen which allows the user to select and configure the formulas to apply.
   </para>

--- a/xml/ay_software.xml
+++ b/xml/ay_software.xml
@@ -81,7 +81,7 @@
       <term>SUSE-manager-server</term>
       <listitem>
        <para>
-        SUSE Manager Server
+        &smlm; Server
        </para>
       </listitem>
      </varlistentry>
@@ -89,7 +89,7 @@
       <term>SUSE-manager-retail-branch-server</term>
       <listitem>
        <para>
-        SUSE Manager for Retail
+        &smlm-retail;
        </para>
       </listitem>
      </varlistentry>
@@ -97,7 +97,7 @@
       <term>SUSE-manager-proxy</term>
       <listitem>
        <para>
-        SUSE Manager Proxy
+        &smlm-proxy;
        </para>
       </listitem>
      </varlistentry>

--- a/xml/klp.xml
+++ b/xml/klp.xml
@@ -297,7 +297,7 @@ Activate with: SUSEConnect -p sle-module-live-patching/&productnumber-regurl;/x8
      appearing, you can filter out kernel updates from the patching operation.
      This can be done by adding package locks with Zypper. &susemgr; also makes
      it possible to filter channel contents (see
-     <link xlink:href="https://documentation.suse.com/suma/4.3/en/suse-manager/administration/live-patching.html">Live
+     <link xlink:href="https://documentation.suse.com/suma/5.0/en/suse-manager/administration/live-patching.html">Live
      Patching with SUSE Manager</link>).
     </para>
    </listitem>

--- a/xml/klp.xml
+++ b/xml/klp.xml
@@ -295,10 +295,10 @@ Activate with: SUSEConnect -p sle-module-live-patching/&productnumber-regurl;/x8
      When the <package>kernel-default</package> package is installed, the update
      manager prompts you to reboot the system. To prevent this message from
      appearing, you can filter out kernel updates from the patching operation.
-     This can be done by adding package locks with Zypper. &susemgr; also makes
+     This can be done by adding package locks with Zypper. &smlm; also makes
      it possible to filter channel contents (see
      <link xlink:href="https://documentation.suse.com/suma/5.0/en/suse-manager/administration/live-patching.html">Live
-     Patching with SUSE Manager</link>).
+     Patching with &smlm;</link>).
     </para>
    </listitem>
    <listitem>

--- a/xml/phrases-decl.ent
+++ b/xml/phrases-decl.ent
@@ -433,7 +433,7 @@
   &susemgr; documentation. The <citetitle>Client Migration</citetitle>
   procedure is described in the <citetitle>&susemgr; Upgrade Guide</citetitle>,
   available at <link xmlns:xlink="http://www.w3.org/1999/xlink"
-  xlink:href="https://documentation.suse.com/suma/"/>.
+  xlink:href="https://documentation.suse.com/multi-linux-manager/"/>.
  </para>'>
 
  <!ENTITY note-upgrade-reduce-install-size

--- a/xml/phrases-decl.ent
+++ b/xml/phrases-decl.ent
@@ -429,9 +429,9 @@
 
 <!ENTITY upgrade-with-suma-pointer
 '<para xmlns="http://docbook.org/ns/docbook">
-  If your machine is managed by &susemgr;, update it as described in the
-  &susemgr; documentation. The <citetitle>Client Migration</citetitle>
-  procedure is described in the <citetitle>&susemgr; Upgrade Guide</citetitle>,
+  If your machine is managed by &smlm;, update it as described in the
+  &smlm; documentation. The <citetitle>Client Migration</citetitle>
+  procedure is described in the <citetitle>&smlm; Upgrade Guide</citetitle>,
   available at <link xmlns:xlink="http://www.w3.org/1999/xlink"
   xlink:href="https://documentation.suse.com/multi-linux-manager/"/>.
  </para>'>

--- a/xml/planning.xml
+++ b/xml/planning.xml
@@ -100,7 +100,7 @@
       In case you intend to install only several nodes of &slema;, you can
       choose the manual installation or you can directly deploy pre-built
       images. For a large-scale deployment it is recommended to use the
-      automatic installation by using &ay;, &susemgr;, or wherever you can
+      automatic installation by using &ay;, &smlm;, or wherever you can
       easily copy the pre-built images to the desired machines, you can also
       use the pre-built images for a large-scale deployment.
     </para>
@@ -219,9 +219,9 @@
         the desired architecture.
       </para>
       <note>
-        <title>Installing &susemgr;</title>
+        <title>Installing &smlm;</title>
         <para>
-          To install any &susemgr; products, the target machine must have
+          To install any &smlm; products, the target machine must have
           direct access to the &scc; or to an &rmt; server.
         </para>
       </note>
@@ -230,7 +230,7 @@
     <sect2 xml:id="sec-planning-leanos-install-offline">
       <title>Offline installation</title>
       <para>
-        Except for &susemgr;, you do not require access to the Internet, or to
+        Except for &smlm;, you do not require access to the Internet, or to
         the &scc; or to an &rmtool; server, to install the other listed
         products.
       </para>

--- a/xml/product-entities.ent
+++ b/xml/product-entities.ent
@@ -21,11 +21,11 @@
 <!ENTITY repo-readme            "&repo-url;/blob/main/README.adoc">
 
 <!-- SUSE Manager -->
-<!ENTITY susemgr                "&suse; Multi-Linux Manager">
+<!--<!ENTITY susemgr                "&suse; Multi-Linux Manager">
 <!ENTITY suma                   "&susemgr;">
 <!ENTITY susemgrdb              "&susemgr; with Database">
 <!ENTITY susemgrproxy           "&susemgr; Proxy">
-<!ENTITY smr                    "&susemgr; for Retail">
+<!ENTITY smr                    "&susemgr; for Retail">-->
 <!-- START YEAR OF COPYRIGHT -->
 <!ENTITY copyrightstart         "2006">
 <!-- COPYRIGHT HOLDER(S) -->

--- a/xml/rmt_migrate_from_smt.xml
+++ b/xml/rmt_migrate_from_smt.xml
@@ -763,7 +763,7 @@
       <listitem>
         <para>
           Functionality is offered by
-          <link xlink:href="https://documentation.suse.com/suma/">&susemgr;</link>.
+          <link xlink:href="https://documentation.suse.com/multi-linux-manager/">&susemgr;</link>.
         </para>
       </listitem>
       <listitem>

--- a/xml/rmt_migrate_from_smt.xml
+++ b/xml/rmt_migrate_from_smt.xml
@@ -763,7 +763,7 @@
       <listitem>
         <para>
           Functionality is offered by
-          <link xlink:href="https://documentation.suse.com/multi-linux-manager/">&susemgr;</link>.
+          <link xlink:href="https://documentation.suse.com/multi-linux-manager/">&smlm;</link>.
         </para>
       </listitem>
       <listitem>

--- a/xml/sle_update_background.xml
+++ b/xml/sle_update_background.xml
@@ -136,7 +136,7 @@
      <para>
       Modules are fully supported parts of &productname; with a different lifecycle.
       They have a clearly defined scope and are delivered via online
-      channel only. Registering at the &scc;, &rmt; (&rmtool;), or &susemgr; is
+      channel only. Registering at the &scc;, &rmt; (&rmtool;), or &smlm; is
       a prerequisite for being able to subscribe to these channels.
      </para>
     </listitem>

--- a/xml/sle_update_offline.xml
+++ b/xml/sle_update_offline.xml
@@ -422,7 +422,7 @@ Check with Simona, if this is supported or needed.
    &susemgr; is a server solution for providing updates, patches, and
    security fixes for &sle; clients. It comes with a set of tools and a
    Web-based user interface for management tasks. See <link
-   xlink:href="https://www.suse.com/products/suse-manager/"/> for more
+   xlink:href="https://www.suse.com/products/multi-linux-manager/"/> for more
    information about &susemgr;.
   </para>
   <para>

--- a/xml/sle_update_offline.xml
+++ b/xml/sle_update_offline.xml
@@ -417,16 +417,16 @@ Check with Simona, if this is supported or needed.
  </sect1>
 
  <sect1 xml:id="sec-upgrade-offline-manager">
-  <title>Upgrading with &susemgr;</title>
+  <title>Upgrading with &smlm;</title>
   <para>
-   &susemgr; is a server solution for providing updates, patches, and
+   &smlm; is a server solution for providing updates, patches, and
    security fixes for &sle; clients. It comes with a set of tools and a
    Web-based user interface for management tasks. See <link
    xlink:href="https://www.suse.com/products/multi-linux-manager/"/> for more
-   information about &susemgr;.
+   information about &smlm;.
   </para>
   <para>
-   You can perform a system upgrade using &susemgr;. The &ay; technology allows
+   You can perform a system upgrade using &smlm;. The &ay; technology allows
    upgrades from one major version to the next.
   </para>
 <!-- taroth 2019-05-02: see also https://bugzilla.suse.com/show_bug.cgi?id=1133927 -->

--- a/xml/sle_update_online.xml
+++ b/xml/sle_update_online.xml
@@ -116,7 +116,7 @@
     If the system to upgrade is a &susemgr; client, it cannot be upgraded by
     &yast; online migration or <command>zypper migration</command>. Use the
     <citetitle>Client Migration</citetitle> procedure instead. It is described
-    in the <link xlink:href="https://documentation.suse.com/suma/">
+    in the <link xlink:href="https://documentation.suse.com/multi-linux-manager/">
     <citetitle>&susemgr; Upgrade Guide</citetitle></link>.
    </para>
   </important>

--- a/xml/sle_update_online.xml
+++ b/xml/sle_update_online.xml
@@ -111,13 +111,13 @@
   </warning>
 
   <important os="sles;sled">
-   <title>Upgrading &susemgr; clients</title>
+   <title>Upgrading &smlm; clients</title>
    <para>
-    If the system to upgrade is a &susemgr; client, it cannot be upgraded by
+    If the system to upgrade is a &smlm; client, it cannot be upgraded by
     &yast; online migration or <command>zypper migration</command>. Use the
     <citetitle>Client Migration</citetitle> procedure instead. It is described
     in the <link xlink:href="https://documentation.suse.com/multi-linux-manager/">
-    <citetitle>&susemgr; Upgrade Guide</citetitle></link>.
+    <citetitle>&smlm; Upgrade Guide</citetitle></link>.
    </para>
   </important>
  </sect1>
@@ -131,7 +131,7 @@
 
   <para>
    Before you can start a service pack migration, your system must be
-   registered at the &scc; or a local &rmt; server. &suse; Manager can also be
+   registered at the &scc; or a local &rmt; server. &smlm; can also be
    used.
   </para>
 
@@ -751,15 +751,15 @@ Continue? [y/n/? shows all options] (y):</screen>
   </para>
  </sect1>
  <sect1 os="sles;sled" xml:id="sec-upgrade-online-manager">
-  <title>Upgrading with &susemgr;</title>
+  <title>Upgrading with &smlm;</title>
 
   <para>
-   &susemgr; is a server solution for providing updates, patches, and security
+   &smlm; is a server solution for providing updates, patches, and security
    fixes for &sle; clients. It comes with a set of tools and a Web-based user
    interface for management tasks. See
    <link
-   xlink:href="https://www.suse.com/products/suse-manager/"/> for more
-   information about &susemgr;.
+   xlink:href="https://www.suse.com/products/multi-linux-manager/"/> for more
+   information about &smlm;.
   </para>
 
   <para>

--- a/xml/sle_update_upgrading.xml
+++ b/xml/sle_update_upgrading.xml
@@ -41,7 +41,6 @@
     need to check if system settings and default values still fit their
     requirements.
    </para>
-
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
    <dm:translation>yes</dm:translation>
@@ -93,7 +92,7 @@
       Upgrades that are executed from the running operating system itself
       (system up and running state). Examples: online update with Zypper or
       &yast;, connected through &scc; or &rmtool; (&rmt;), Salt Policy via
-      &susemgr;.
+      &smlm;.
      </para>
      <para>
       For details, see <xref linkend="cha-upgrade-online" />.
@@ -123,7 +122,7 @@
   </variablelist>
 
   <important>
-   <title>&susemgr; clients</title>
+   <title>&smlm; clients</title>
    <!-- taroth 2019-05-02: see also https://bugzilla.suse.com/show_bug.cgi?id=1133927 -->
    &upgrade-with-suma-pointer;
   </important>

--- a/xml/software_management.xml
+++ b/xml/software_management.xml
@@ -198,7 +198,7 @@
     tool&mdash;&yast; Online Update. &suse; has also created the &rmtool;
     (&rmt;), an efficient way to maintain a local repository of
     available/released patches/updates/fixes that systems can then pull from
-    (reducing Internet traffic). &suse; also offers &susemgr; for the
+    (reducing Internet traffic). &suse; also offers &smlm; for the
     maintenance, patching, reporting and centralized management of Linux
     systems, not only &suse;, but other distributions as well.
    </para>
@@ -330,14 +330,14 @@
    </sect2>
 
    <sect2 xml:id="sec-sec-prot-general-patching-suma" os="sles;sled;slemicro">
-    <title>&susemgr;</title>
+    <title>&smlm;</title>
     <para>
-     &susemgr; automates Linux server management, allowing you to provision
+     &smlm; automates Linux server management, allowing you to provision
      and maintain your servers faster and more accurately. It monitors the
      health of each Linux server from a single console so you can identify
      server performance issues before they impact your business. And it lets
      you comprehensively manage your Linux servers across physical, virtual
-     and cloud environments while improving data center efficiency. &susemgr;
+     and cloud environments while improving data center efficiency. &smlm;
      delivers complete lifecycle management for Linux:
     </para>
     <itemizedlist>
@@ -373,7 +373,7 @@
      </listitem>
     </itemizedlist>
     <para>
-     For more information on &susemgr;, refer to
+     For more information on &smlm;, refer to
      <link
      xlink:href="https://www.suse.com/products/multi-linux-manager/"/>.
     </para>

--- a/xml/software_management.xml
+++ b/xml/software_management.xml
@@ -375,7 +375,7 @@
     <para>
      For more information on &susemgr;, refer to
      <link
-     xlink:href="https://www.suse.com/products/suse-manager/"/>.
+     xlink:href="https://www.suse.com/products/multi-linux-manager/"/>.
     </para>
    </sect2>
   </sect1>


### PR DESCRIPTION
### PR creator: Description

With the upcoming version 5.1, **SUSE Manager** will be renamed to **SUSE Multi-Linux Manager** (already released SuMa versions keep their name and their documentation URLs).

The SLE 15 SP7 documentation needs to reflect the product name change. 

Also, the 'generic' URL `https://documentation.suse.com/suma` (which always redirects to the docs for the latest released SuMa version) will be replaced with `https://documentation.suse.com/multi-linux-manager` moving forward.


### PR creator: Are there any relevant issues/feature requests?

https://jira.suse.com/browse/DOCTEAM-1754

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  
15 SP7 only - NO backports to older versions!