### PR TITLE
Doc Bug Fix: NVIDIA vGPU driver v16.2 failed to be installed on SLE 15 SP7 KVM host

### DIFF
--- a/xml/art-nvidia-vgpu.xml
+++ b/xml/art-nvidia-vgpu.xml
@@ -223,9 +223,8 @@ BOOT_IMAGE=/boot/vmlinuz-default [...] intel_iommu=on [...]
         </step>
         <step>
           <para>
-            <emphasis>OPTIONAL:</emphasis> Uninstall any manually installed &nvidia; drivers that
-            you have installed using <filename>.run</filename> files downloaded from &nvidia;'s web
-            site.
+            Uninstall any manually installed proprietary &nvidia; drivers that you have installed
+            using <filename>.run</filename> files downloaded from &nvidia;'s Web site.
           </para>
 <screen>&prompt.sudo;<command><replaceable>/PATH/TO/NVIDIA-Linux-x86_64-XXX.XX.XX.run</replaceable> --uninstall</command></screen>
         </step>
@@ -263,13 +262,6 @@ BOOT_IMAGE=/boot/vmlinuz-default [...] intel_iommu=on [...]
           </para>
 <screen>&prompt.sudo;<command>modprobe nvidia-modprobe</command></screen>
         </step>
-        <!-- step>
-          <para>
-            Reboot the system to ensure that all changes take effect and no conflicting driver
-            components remain loaded.
-          </para>
-<screen>&prompt.sudo;<command>systemctl reboot</command></screen>
-        </step -->
       </procedure>
     </sect2>
 

--- a/xml/art-nvidia-vgpu.xml
+++ b/xml/art-nvidia-vgpu.xml
@@ -12,207 +12,201 @@
   xmlns:its="http://www.w3.org/2005/11/its"
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>&sle_vgpu_kvm_guide;</title>
- <info><productname>&productname;</productname>
-  <productnumber>&productnumber;</productnumber>
-  <date><?dbtimestamp format="B d, Y" ?></date>
-  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
-   <dm:translation>yes</dm:translation>
-  </dm:docmanager>
-  <meta name="title" its:translate="yes">&sle_vgpu_kvm_guide;</meta>
-  <meta name="series" its:translate="no">Products &amp; Solutions</meta>
-  <meta name="description" its:translate="yes">How to configure the NVIDIA Virtual GPU (vGPU) for KVM guests</meta>
-  <meta name="social-descr" its:translate="yes">Configure NVIDIA vGPU for KVM guests</meta>
-  <meta name="task" its:translate="no">
-    <phrase>Virtualization</phrase>
-  </meta>
-  <revhistory xml:id="rh-article-nvidia-vgpu">
-    <revision>
-      <date>2025-06-17</date>
-      <revdescription>
-        <para>
-          Updated for the initial release of &productname; &productnumber;.
-        </para>
-      </revdescription>
-    </revision>
-  </revhistory>
- </info>
- <sect1 xml:id="configure-nvidia-vgpu-introduction">
-  <title>Introduction</title>
-  <para>
-   &nvidia; virtual GPU (vGPU) is a graphics virtualization solution that
-   provides multiple virtual machines (VMs) simultaneous access to one physical
-   Graphics Processing Unit (GPU) on the &vmhost;. This article refers to the
-   Volta and Ampere GPU architecture.
-  </para>
- </sect1>
- <sect1 xml:id="configure-nvidia-vgpu-configuring-host">
-  <title>Configuring vGPU manager in &vmhost;</title>
+  <title>&sle_vgpu_kvm_guide;</title>
+  <info><productname>&productname;</productname>
+    <productnumber>&productnumber;</productnumber><date>
+<?dbtimestamp format="B d, Y" ?></date>
+    <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+      <dm:translation>yes</dm:translation>
+    </dm:docmanager>
+    <meta name="title" its:translate="yes">&sle_vgpu_kvm_guide;</meta>
+    <meta name="series" its:translate="no">Products &amp; Solutions</meta>
+    <meta name="description" its:translate="yes">How to configure the NVIDIA Virtual GPU (vGPU) for KVM guests</meta>
+    <meta name="social-descr" its:translate="yes">Configure NVIDIA vGPU for KVM guests</meta>
+    <meta name="task" its:translate="no"><phrase>Virtualization</phrase>
+    </meta>
+    <revhistory xml:id="rh-article-nvidia-vgpu">
+      <revision><date>2025-06-17</date>
+        <revdescription>
+          <para>
+            Updated for the initial release of &productname; &productnumber;.
+          </para>
+        </revdescription>
+      </revision>
+    </revhistory>
+  </info>
+  <sect1 xml:id="configure-nvidia-vgpu-introduction">
+    <title>Introduction</title>
 
-  <sect2 xml:id="configure-nvidia-vgpu-verify-host">
-   <title>Prepare &vmhost; environment</title>
-   <procedure>
-    <step>
-     <para>
-      Verify that you have a compatible server and GPU cards. Check
-      specifications for details:
-     </para>
-     <itemizedlist>
-      <listitem>
-       <para>
-        <link xlink:href="https://docs.nvidia.com/grid/gpus-supported-by-vgpu.html"/>
-       </para>
-      </listitem>
-      <listitem>
-       <para>
-        <link xlink:href="https://docs.nvidia.com/grid/index.html"/>
-       </para>
-      </listitem>
-     </itemizedlist>
-    </step>
-    <step>
-     <para>
-      Verify that &vmhost; is &sls; 15 SP3 or newer:
-     </para>
+    <para>
+      &nvidia; virtual GPU (vGPU) is a graphics virtualization solution that provides multiple
+      virtual machines (VMs) simultaneous access to one physical Graphics Processing Unit (GPU) on
+      the &vmhost;. This article refers to the Volta and Ampere GPU architecture.
+    </para>
+  </sect1>
+  <sect1 xml:id="configure-nvidia-vgpu-configuring-host">
+    <title>Configuring vGPU manager in &vmhost;</title>
+
+    <sect2 xml:id="configure-nvidia-vgpu-verify-host">
+      <title>Prepare &vmhost; environment</title>
+      <procedure>
+        <step>
+          <para>
+            Verify that you have a compatible server and GPU cards. Check specifications for
+            details:
+          </para>
+          <itemizedlist>
+            <listitem>
+              <para>
+                <link xlink:href="https://docs.nvidia.com/grid/gpus-supported-by-vgpu.html"/>
+              </para>
+            </listitem>
+            <listitem>
+              <para>
+                <link xlink:href="https://docs.nvidia.com/grid/index.html"/>
+              </para>
+            </listitem>
+          </itemizedlist>
+        </step>
+        <step>
+          <para>
+            Verify that &vmhost; is &sls; 15 SP3 or newer:
+          </para>
 <screen>
 &prompt.user;cat /etc/issue
 Welcome to SUSE Linux Enterprise Server 15 SP3  (x86_64) - Kernel \r (\l).
 </screen>
-    </step>
-    <step>
-     <para>
-      Get the vGPU drivers from &nvidia;. In order to get the software, please
-      follow the steps at
-      <link
+        </step>
+        <step>
+          <para>
+            Get the vGPU drivers from &nvidia;. To get the software, please follow the steps at
+            <link
       xlink:href="https://docs.nvidia.com/grid/latest/grid-software-quick-start-guide/index.html#redeeming-pak-and-downloading-grid-software"/>.
-      For example, for vGPU 13.0 installation, you will need the following
-      files:
-     </para>
+            For example, to install vGPU 13.0, you need the following files:
+          </para>
 <screen>
 NVIDIA-Linux-x86_64-470.63-vgpu-kvm.run  # vGPU manager for the VM host
 NVIDIA-Linux-x86_64-470.63.01-grid.run   # vGPU driver for the VM guest
 </screen>
-    </step>
-    <step>
-     <para>
-      If you are using Ampere architecture GPU cards, verify that &vmhost;
-      supports VT-D/IOMMU and SR-IOV technologies, and that they are enabled in
-      BIOS.
-     </para>
-    </step>
-    <step>
-     <para>
-      Enable IOMMU. Verify that it is included in the boot command line:
-     </para>
+        </step>
+        <step>
+          <para>
+            If you are using Ampere architecture GPU cards, verify that &vmhost; supports
+            VT-D/IOMMU and SR-IOV technologies, and that they are enabled in BIOS.
+          </para>
+        </step>
+        <step>
+          <para>
+            Enable IOMMU. Verify that it is included in the boot command line:
+          </para>
 <screen>
 cat /proc/cmdline
 BOOT_IMAGE=/boot/vmlinuz-default [...] intel_iommu=on [...]
 </screen>
-     <para>
-      If not, add the following line to <filename>/etc/default/grub</filename>.
-     </para>
-     <itemizedlist>
-      <listitem>
-       <para>
-        For Intel CPUs:
-       </para>
+          <para>
+            If not, add the following line to <filename>/etc/default/grub</filename>.
+          </para>
+          <itemizedlist>
+            <listitem>
+              <para>
+                For Intel CPUs:
+              </para>
 <screen>GRUB_CMDLINE_LINUX="intel_iommu=on"</screen>
-       <para>
-        For AMD CPUs:
-       </para>
+              <para>
+                For AMD CPUs:
+              </para>
 <screen>GRUB_CMDLINE_LINUX="amd_iommu=on"</screen>
-      </listitem>
-     </itemizedlist>
-     <para>
-      Then generate new &grub; configuration file and reboot:
-     </para>
+            </listitem>
+          </itemizedlist>
+          <para>
+            Then generate new &grub; configuration file and reboot:
+          </para>
 <screen>
 &prompt.sudo;grub2-mkconfig -o /boot/grub2/grub.cfg
 &prompt.sudo;systemctl reboot
 </screen>
-     <tip>
-      <para>
-       You can verify that IOMMU is loaded by running the following command:
-      </para>
+          <tip>
+            <para>
+              You can verify that IOMMU is loaded by running the following command:
+            </para>
 <screen>sudo dmesg | grep -e IOMMU</screen>
-     </tip>
-    </step>
-    <step>
-     <!-- 2021-09-21 tbazant: this seems out of place here:
-      "After finishing the driver installation, run
-      /usr/lib/nvidia/sriov-manage -e slot:bus:domain.function"
-      -->
-     <para>
-      Enable SR-IOV. Refer to
-      <link
+          </tip>
+        </step>
+        <step>
+          <!-- 2021-09-21 tbazant: this seems out of place here:
+            "After finishing the driver installation, run
+            /usr/lib/nvidia/sriov-manage -e slot:bus:domain.function"
+            -->
+          <para>
+            Enable SR-IOV. Refer to
+            <link
       xlink:href="https://docs.nvidia.com/grid/13.0/grid-vgpu-user-guide/index.html#vgpu-types-tesla-v100-pcie"/>
-      for useful information.
-     </para>
-    </step>
-    <step>
-     <para>
-      Disable the nouveau kernel module by adding the following line it to the
-      top of the <filename>/etc/modprobe.d/50-blacklist.conf</filename> file:
-     </para>
+            for useful information.
+          </para>
+        </step>
+        <step>
+          <para>
+            Disable the nouveau kernel module by adding the following line it to the top of the
+            <filename>/etc/modprobe.d/50-blacklist.conf</filename> file:
+          </para>
 <screen>blacklist nouveau</screen>
-    </step>
-   </procedure>
-  </sect2>
+        </step>
+      </procedure>
+    </sect2>
 
-  <sect2 xml:id="configure-nvidia-vgpu-kvm-driver">
-   <title>Install the &nvidia; &kvm; driver</title>
-   <procedure>
-    <step>
-     <para>
-      Exit from the graphical mode:
-     </para>
+    <sect2 xml:id="configure-nvidia-vgpu-kvm-driver">
+      <title>Install the &nvidia; &kvm; driver</title>
+      <procedure>
+        <step>
+          <para>
+            Exit from the graphical mode:
+          </para>
 <screen>&prompt.sudo;init 3</screen>
-    </step>
-    <step>
-     <para>
-      Install <package>kernel-default-devel</package> and <package>gcc</package>
-      packages and their dependencies:
-     </para>
+        </step>
+        <step>
+          <para>
+            Install <package>kernel-default-devel</package> and <package>gcc</package> packages and
+            their dependencies:
+          </para>
 <screen>&prompt.sudo;zypper in kernel-default-devel gcc</screen>
-    </step>
-    <step>
-     <para>
-      Download the vGPU software from the &nvidia; portal. Make the &nvidia;
-      vGPU driver executable and run it:
-     </para>
+        </step>
+        <step>
+          <para>
+            Download the vGPU software from the &nvidia; portal. Make the &nvidia; vGPU driver
+            executable and run it:
+          </para>
 <screen>
 &prompt.user;chmod +x NVIDIA-Linux-x86_64-450.55-vgpu-kvm.run
 &prompt.sudo;./NVIDIA-Linux-x86_64-450.55-vgpu-kvm.run
 </screen>
-     <para>
-      You can find detailed information about the installation process in the
-      log file <filename>/var/log/nvidia-installer.log</filename>
-     </para>
-     <tip>
-      <para>
-       To enable dynamic kernel-module support, and thus have the module
-       rebuilt automatically when a new kernel is installed, add the
-       <option>--dkms</option> option:
-      </para>
+          <para>
+            You can find detailed information about the installation process in the log file
+            <filename>/var/log/nvidia-installer.log</filename>
+          </para>
+          <tip>
+            <para>
+              To enable dynamic kernel-module support, and thus have the module rebuilt
+              automatically when a new kernel is installed, add the <option>--dkms</option> option:
+            </para>
 <screen>&prompt.sudo;./NVIDIA-Linux-x86_64-450.55-vgpu-kvm.run --dkms</screen>
-     </tip>
-    </step>
-    <step>
-     <para>
-      When the driver installation is finished, reboot the system:
-     </para>
+          </tip>
+        </step>
+        <step>
+          <para>
+            When the driver installation is finished, reboot the system:
+          </para>
 <screen>&prompt.sudo;systemctl reboot</screen>
-    </step>
-   </procedure>
-  </sect2>
+        </step>
+      </procedure>
+    </sect2>
 
-  <sect2 xml:id="configure-nvidia-vgpu-verify-driver-installation">
-   <title>Verify the driver installation</title>
-   <procedure>
-    <step>
-     <para>
-      Verify loaded kernel modules:
-     </para>
+    <sect2 xml:id="configure-nvidia-vgpu-verify-driver-installation">
+      <title>Verify the driver installation</title>
+      <procedure>
+        <step>
+          <para>
+            Verify loaded kernel modules:
+          </para>
 <screen>
 &prompt.user;lsmod | grep nvidia
 nvidia_vgpu_vfio       49152  9
@@ -220,16 +214,15 @@ nvidia              14393344  229 nvidia_vgpu_vfio
 mdev                   20480  2 vfio_mdev,nvidia_vgpu_vfio
 vfio                   32768  6 vfio_mdev,nvidia_vgpu_vfio,vfio_iommu_type1
 </screen>
-     <para>
-      The modules containing the <literal>vfio</literal> string are required
-      dependencies.
-     </para>
-    </step>
-    <step>
-     <para>
-      Print the GPU device status with the <command>nvidia-smi</command>
-      command. The output should be similar to the following one:
-     </para>
+          <para>
+            The modules containing the <literal>vfio</literal> string are required dependencies.
+          </para>
+        </step>
+        <step>
+          <para>
+            Print the GPU device status with the <command>nvidia-smi</command> command. The output
+            should be similar to the following one:
+          </para>
 <screen>
 &prompt.user;nvidia-smi
 +-----------------------------------------------------------------------------+
@@ -252,83 +245,82 @@ vfio                   32768  6 vfio_mdev,nvidia_vgpu_vfio,vfio_iommu_type1
 |  No running processes found                                                 |
 +-----------------------------------------------------------------------------+
 </screen>
-    </step>
-    <step>
-     <para>
-      Check the sysfs file system. For Volta and earlier GPU cards, new
-      directory <filename>mdev_supported_types</filename> is added, for
-      example:
-     </para>
+        </step>
+        <step>
+          <para>
+            Check the sysfs file system. For Volta and earlier GPU cards, new directory
+            <filename>mdev_supported_types</filename> is added, for example:
+          </para>
 <screen>cd /sys/bus/pci/devices/00000000\:31\:00.0/mdev_supported_types</screen>
-     <para>
-      For Ampere GPU cards, the directory will be created automatically for each virtual function
-      after SR-IOV is enabled.
-     </para>
-    </step>
-   </procedure>
-  </sect2>
- </sect1>
- <sect1 xml:id="configure-nvidia-vgpu-passthrough">
-  <title>Creating a vGPU device</title>
+          <para>
+            For Ampere GPU cards, the directory gets created automatically for each virtual
+            function after SR-IOV is enabled.
+          </para>
+        </step>
+      </procedure>
+    </sect2>
+  </sect1>
+  <sect1 xml:id="configure-nvidia-vgpu-passthrough">
+    <title>Creating a vGPU device</title>
 
-  <sect2 xml:id="configure-nvidia-vgpu-passthrough-without-sriov">
-   <title>Create a legacy vGPU device without support for SR-IOV</title>
-   <para>
-    All the &nvidia; Volta and earlier architecture GPUs work in this mode.
-   </para>
-   <procedure>
-    <step>
-     <para>
-      Obtain the Bus/Device/Function (BDF) numbers of the host GPU device:
-     </para>
+    <sect2 xml:id="configure-nvidia-vgpu-passthrough-without-sriov">
+      <title>Create a legacy vGPU device without support for SR-IOV</title>
+      <para>
+        All the &nvidia; Volta and earlier architecture GPUs work in this mode.
+      </para>
+      <procedure>
+        <step>
+          <para>
+            Obtain the Bus/Device/Function (BDF) numbers of the host GPU device:
+          </para>
 <screen>
 &prompt.user;lspci | grep NVIDIA
 84:00.0 3D controller: NVIDIA Corporation GV100GL [Tesla V100 PCIe 16GB] (rev a1)
 </screen>
-    </step>
-    <step>
-     <para>
-      Check for the mdev supported devices and detailed information:
-     </para>
+        </step>
+        <step>
+          <para>
+            Check for the mdev supported devices and detailed information:
+          </para>
 <screen>
 &prompt.user;ls /sys/bus/pci/devices/0000:84:00.0/mdev_supported_types/
 nvidia-105  nvidia-106  nvidia-107  nvidia-108  nvidia-109  nvidia-110 [...]
 </screen>
-     <para>
-      The map of vGPU mdev devices and their type is as follows:
-     </para>
-     <itemizedlist>
-      <listitem>
-       <para>
-        nvidia-105 to nvidia-109: 1Q 2Q 4Q 8Q 16Q
-       </para>
-      </listitem>
-      <listitem>
-       <para>
-        nvidia-110 to nvidia-114: 1A 2A 4A 8A 16A
-       </para>
-      </listitem>
-      <listitem>
-       <para>
-        nvidia-115, nvidia-163, nvidia-217, nvidia-247: 1B 2B 2B4 1B4
-       </para>
-      </listitem>
-      <listitem>
-       <para>
-        nvidia-299 to nvidia-301: 4C 8C 16C
-       </para>
-      </listitem>
-     </itemizedlist>
-     <para>
-      Refer to
-      <link xlink:href="https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html#vgpu-types-tesla-v100-pcie"/>
-      for more details.
-     </para>
-    </step>
-    <step>
-     <para>
-      Inspect a vGPU device:
-     </para>
+          <para>
+            The map of vGPU mdev devices and their type is as follows:
+          </para>
+          <itemizedlist>
+            <listitem>
+              <para>
+                nvidia-105 to nvidia-109: 1Q 2Q 4Q 8Q 16Q
+              </para>
+            </listitem>
+            <listitem>
+              <para>
+                nvidia-110 to nvidia-114: 1A 2A 4A 8A 16A
+              </para>
+            </listitem>
+            <listitem>
+              <para>
+                nvidia-115, nvidia-163, nvidia-217, nvidia-247: 1B 2B 2B4 1B4
+              </para>
+            </listitem>
+            <listitem>
+              <para>
+                nvidia-299 to nvidia-301: 4C 8C 16C
+              </para>
+            </listitem>
+          </itemizedlist>
+          <para>
+            Refer to
+            <link xlink:href="https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html#vgpu-types-tesla-v100-pcie"/>
+            for more details.
+          </para>
+        </step>
+        <step>
+          <para>
+            Inspect a vGPU device:
+          </para>
 <screen>
 &prompt.user;cd /sys/bus/pci/devices/0000:03:00.0/mdev_supported_types/
 &prompt.user;ls nvidia-105
@@ -337,22 +329,22 @@ num_heads=2, frl_config=60, framebuffer=1024M, max_resolution=4096x2160, max_ins
 &prompt.user;cat nvidia-105/name
 GRID V100-1Q
 </screen>
-    </step>
-    <step>
-     <para>
-      Generate a unique ID and create an mdev device based on it:
-     </para>
+        </step>
+        <step>
+          <para>
+            Generate a unique ID and create an mdev device based on it:
+          </para>
 <screen>
       &prompt.user;uuidgen
       4f3b6e47-0baa-4900-b0b1-284c1ecc192f
       &prompt.sudo;echo "4f3b6e47-0baa-4900-b0b1-284c1ecc192f" > nvidia-105/create
      </screen>
-    </step>
-    <step>
-     <para>
-      Verify the new mdev device. You can inspect the content of the
-      <filename>/sys/bus/mdev/devices</filename> directory:
-     </para>
+        </step>
+        <step>
+          <para>
+            Verify the new mdev device. You can inspect the content of the
+            <filename>/sys/bus/mdev/devices</filename> directory:
+          </para>
 <screen>
 &prompt.user;cd /sys/bus/mdev/devices
 &prompt.user;ls -l
@@ -365,9 +357,9 @@ lrwxrwxrwx 1 root root 0 Aug 30 23:03 86380ffb-8f13-4685-9c48-0e0f4e65fb89 \
 lrwxrwxrwx 1 root root 0 Aug 30 23:03 86380ffb-8f13-4685-9c48-0e0f4e65fb90 \
  -> ../../../devices/pci0000:80/0000:80:02.0/0000:84:00.0/86380ffb-8f13-4685-9c48-0e0f4e65fb90
 </screen>
-     <para>
-      Or you can use the <command>mdevctl</command> command:
-     </para>
+          <para>
+            Or you can use the <command>mdevctl</command> command:
+          </para>
 <screen>
 &prompt.sudo;mdevctl list
 86380ffb-8f13-4685-9c48-0e0f4e65fb90 0000:84:00.0 nvidia-299
@@ -375,11 +367,11 @@ lrwxrwxrwx 1 root root 0 Aug 30 23:03 86380ffb-8f13-4685-9c48-0e0f4e65fb90 \
 86380ffb-8f13-4685-9c48-0e0f4e65fb87 0000:84:00.0 nvidia-299
 86380ffb-8f13-4685-9c48-0e0f4e65fb88 0000:84:00.0 nvidia-299
 </screen>
-    </step>
-    <step>
-     <para>
-      Query the new vGPU device capability:
-     </para>
+        </step>
+        <step>
+          <para>
+            Query the new vGPU device capability:
+          </para>
 <screen>
 &prompt.sudo;nvidia-smi vgpu -q
 GPU 00000000:84:00.0
@@ -416,41 +408,40 @@ vGPU ID                           : 3251634323
        Average FPS               : 0
        Average Latency           : 0
 </screen>
-    </step>
-   </procedure>
-  </sect2>
+        </step>
+      </procedure>
+    </sect2>
 
-  <sect2 xml:id="configure-nvidia-vgpu-passthrough-with-sriov">
-   <title>Create a vGPU device with support for SR-IOV</title>
-   <para>
-    All &nvidia; Ampere and newer architecture GPUs work in this mode.
-   </para>
-   <procedure>
-    <step>
-     <para>
-      Obtain the Bus/Device/Function (BDF) numbers of the host GPU device:
-     </para>
+    <sect2 xml:id="configure-nvidia-vgpu-passthrough-with-sriov">
+      <title>Create a vGPU device with support for SR-IOV</title>
+      <para>
+        All &nvidia; Ampere and newer architecture GPUs work in this mode.
+      </para>
+      <procedure>
+        <step>
+          <para>
+            Obtain the Bus/Device/Function (BDF) numbers of the host GPU device:
+          </para>
 <screen>
 &prompt.user;lspci | grep NVIDIA
 b1:00.0 3D controller: NVIDIA Corporation GA100 [A100 PCIe 40GB] (rev a1)
 </screen>
-    </step>
-    <step>
-     <para>
-      Enable virtual functions:
-     </para>
+        </step>
+        <step>
+          <para>
+            Enable virtual functions:
+          </para>
 <screen>&prompt.sudo;/usr/lib/nvidia/sriov-manage -e 00:b1:0000.0</screen>
-     <note>
-      <para>
-       This configuration is not persistent and must be re-enabled after the
-       host reboot.
-      </para>
-     </note>
-    </step>
-    <step>
-     <para>
-      Obtain the Bus/Domain/Function (BDF) of virtual functions on the GPU:
-     </para>
+          <note>
+            <para>
+              This configuration is not persistent and must be re-enabled after the host reboot.
+            </para>
+          </note>
+        </step>
+        <step>
+          <para>
+            Obtain the Bus/Domain/Function (BDF) of virtual functions on the GPU:
+          </para>
 <screen>
 &prompt.user;ls -l /sys/bus/pci/devices/0000:b1:00.0/ | grep virtfn
 lrwxrwxrwx 1 root root           0 Sep 21 11:58 virtfn0 -> ../0000:b1:00.4
@@ -470,19 +461,18 @@ lrwxrwxrwx 1 root root           0 Sep 21 11:58 virtfn7 -> ../0000:b1:01.3
 lrwxrwxrwx 1 root root           0 Sep 21 11:58 virtfn8 -> ../0000:b1:01.4
 lrwxrwxrwx 1 root root           0 Sep 21 11:58 virtfn9 -> ../0000:b1:01.5
 </screen>
-    </step>
-    <step>
-     <para>
-      <emphasis>Create a vGPU device.</emphasis> Select the virtual function
-      (VF) that you want to use to create the vGPU device and assign it a
-      unique ID.
-     </para>
-     <important>
-      <para>
-       Each VF can only create one vGPU instance. If you want to create more
-       vGPU instances, you need to use a different VF.
-      </para>
-     </important>
+        </step>
+        <step>
+          <para>
+            <emphasis>Create a vGPU device.</emphasis> Select the virtual function (VF) that you
+            want to use to create the vGPU device and assign it a unique ID.
+          </para>
+          <important>
+            <para>
+              Each VF can only create one vGPU instance. To create more vGPU instances, you need to
+              use a different VF.
+            </para>
+          </important>
 <screen>
 &prompt.user;cd /sys/bus/pci/devices/0000:b1:00.0/virtfn1/mdev_supported_types
 &prompt.user;for i in *; do echo "$i" $(cat $i/name) available: $(cat $i/avail*); done
@@ -510,21 +500,21 @@ f715f63c-0d00-4007-9c5a-b07b0c6c05de
 [ 3626.345530] vfio_mdev f715f63c-0d00-4007-9c5a-b07b0c6c05de: Adding to iommu group 322
 [ 3626.353383] vfio_mdev f715f63c-0d00-4007-9c5a-b07b0c6c05de: MDEV: group_id = 322
 </screen>
-    </step>
-    <step>
-     <para>
-      Verify the new vGPU device:
-     </para>
+        </step>
+        <step>
+          <para>
+            Verify the new vGPU device:
+          </para>
 <screen>
 &prompt.user;cd /sys/bus/mdev/devices/
 &prompt.user;ls
 f715f63c-0d00-4007-9c5a-b07b0c6c05de
 </screen>
-    </step>
-    <step>
-     <para>
-      Query the new vGPU device capability:
-     </para>
+        </step>
+        <step>
+          <para>
+            Query the new vGPU device capability:
+          </para>
 <screen>
 &prompt.sudo;nvidia-smi vgpu -q
 GPU 00000000:B1:00.0
@@ -561,32 +551,32 @@ vGPU ID                           : 3251634265
       Average FPS               : 0
       Average Latency           : 0
 </screen>
-    </step>
-   </procedure>
-  </sect2>
+        </step>
+      </procedure>
+    </sect2>
 
-  <sect2 xml:id="configure-nvidia-vgpu-passthrough-mig-backed">
-   <title>Creating a MIG-backed vGPU</title>
-   <important>
-    <para>
-     SR-IOV is required to be enabled if you want to create vGPUs and assign them to guest VMs.
-    </para>
-   </important>
-   <procedure>
-    <step>
-     <para>
-      Enable MIG mode for a GPU:
-     </para>
+    <sect2 xml:id="configure-nvidia-vgpu-passthrough-mig-backed">
+      <title>Creating a MIG-backed vGPU</title>
+      <important>
+        <para>
+          SR-IOV must be enabled to create vGPUs and assign them to guest VMs.
+        </para>
+      </important>
+      <procedure>
+        <step>
+          <para>
+            Enable MIG mode for a GPU:
+          </para>
 <screen>
 &prompt.sudo;nvidia-smi -i 0 -mig 1
 Enabled MIG Mode for GPU 00000000:B1:00.0
 All done.
 </screen>
-    </step>
-    <step>
-     <para>
-      Query the GPU instance profile:
-     </para>
+        </step>
+        <step>
+          <para>
+            Query the GPU instance profile:
+          </para>
 <screen>
 &prompt.sudo;nvidia-smi mig -lgip
 +-----------------------------------------------------------------------------+
@@ -613,23 +603,23 @@ All done.
 |                                                             7     1     1   |
 +-----------------------------------------------------------------------------+
 </screen>
-    </step>
-    <step>
-     <para>
-      Create a GPU instance specifying '5' as a GPU profile instance ID and optionally create a
-      Compute Instance on it, either on the host server or within the guest:
-     </para>
+        </step>
+        <step>
+          <para>
+            Create a GPU instance specifying '5' as a GPU profile instance ID and optionally create
+            a Compute Instance on it, either on the host server or within the guest:
+          </para>
 <screen>
 &prompt.sudo;nvidia-smi mig -cgi 5
 Successfully created GPU instance ID  1 on GPU  0 using profile MIG 4g.20gb (ID  5)
 &prompt.sudo;nvidia-smi mig -cci -gi 1
 Successfully created compute instance ID  0 on GPU  0 GPU instance ID  1 using profile MIG 4g.20gb (ID  3)
 </screen>
-    </step>
-    <step>
-     <para>
-      Verify the GPU instance:
-     </para>
+        </step>
+        <step>
+          <para>
+            Verify the GPU instance:
+          </para>
 <screen>
 &prompt.sudo;nvidia-smi
 Tue Sep 21 11:19:36 2021
@@ -664,54 +654,54 @@ Tue Sep 21 11:19:36 2021
 |  No running processes found                                                 |
 +-----------------------------------------------------------------------------+
 </screen>
-    </step>
-    <step>
-     <para>
-      Use the MIG instance. You can use the instance directly with the
-      UUID&mdash;for example, assign it to a container or CUDA process.
-     </para>
-     <para>
-      You can also create a vGPU on top of it and assign it to a VM guest. The
-      procedure is the same as for the vGPU with SR-IOV support. Refer to
-      <xref linkend="configure-nvidia-vgpu-passthrough-with-sriov"/>.
-     </para>
+        </step>
+        <step>
+          <para>
+            Use the MIG instance. You can use the instance directly with the UUID&mdash;for
+            example, assign it to a container or CUDA process.
+          </para>
+          <para>
+            You can also create a vGPU on top of it and assign it to a VM guest. The procedure is
+            the same as for the vGPU with SR-IOV support. Refer to
+            <xref linkend="configure-nvidia-vgpu-passthrough-with-sriov"/>.
+          </para>
 <screen>
 &prompt.sudo;nvidia-smi -L
 GPU 0: NVIDIA A100-PCIE-40GB (UUID: GPU-ee14e29d-dd5b-2e8e-eeaf-9d3debd10788)
  MIG 4g.20gb     Device  0: (UUID: MIG-fed03f85-fd95-581b-837f-d582496d0260)
 </screen>
-    </step>
-   </procedure>
-  </sect2>
- </sect1>
- <sect1 xml:id="configure-nvidia-vgpu-passthrough-vm">
-  <title>Assign the vGPU device to a &vmguest;</title>
+        </step>
+      </procedure>
+    </sect2>
+  </sect1>
+  <sect1 xml:id="configure-nvidia-vgpu-passthrough-vm">
+    <title>Assign the vGPU device to a &vmguest;</title>
 
-  <sect2 xml:id="configure-nvidia-vgpu-passthrough-to-vm-libvirt">
-   <title>Assign by &libvirt;</title>
-   <procedure>
-    <step>
-     <para>
-      Create a &libvirt;-based virtual machine (VM) with UEFI support and a
-      normal VGA display.
-     </para>
-    </step>
-    <step>
-     <para>
-      Edit the VM's configuration by running <command>virsh edit
-      <replaceable>VM-NAME</replaceable></command>.
-     </para>
-    </step>
-    <step>
-     <para>
-      Add the new mdev device with the unique ID you used when creating the
-      vGPU device to the &lt;devices/> section.
-     </para>
-     <note>
-      <para>
-       If you are using Q-series, use <literal>display='on'</literal> instead.
-      </para>
-     </note>
+    <sect2 xml:id="configure-nvidia-vgpu-passthrough-to-vm-libvirt">
+      <title>Assign by &libvirt;</title>
+      <procedure>
+        <step>
+          <para>
+            Create a &libvirt;-based virtual machine (VM) with UEFI support and a normal VGA
+            display.
+          </para>
+        </step>
+        <step>
+          <para>
+            Edit the VM's configuration by running <command>virsh edit
+            <replaceable>VM-NAME</replaceable></command>.
+          </para>
+        </step>
+        <step>
+          <para>
+            Add the new mdev device with the unique ID you used when creating the vGPU device to
+            the &lt;devices/> section.
+          </para>
+          <note>
+            <para>
+              If you are using Q-series, use <literal>display='on'</literal> instead.
+            </para>
+          </note>
 <screen>
 &lt;hostdev mode='subsystem' type='mdev' managed='no' model='vfio-pci' display='off'>
   &lt;source>
@@ -720,86 +710,85 @@ GPU 0: NVIDIA A100-PCIE-40GB (UUID: GPU-ee14e29d-dd5b-2e8e-eeaf-9d3debd10788)
   &lt;address type='pci' domain='0x0000' bus='0x00' slot='0x0a' function='0x0'/>
 &lt;/hostdev>
 </screen>
-    </step>
-   </procedure>
-  </sect2>
+        </step>
+      </procedure>
+    </sect2>
 
-  <sect2 xml:id="configure-nvidia-vgpu-passthrough-to-vm-qemu">
-   <title>Assign by &qemu;</title>
-   <para>
-    Add the following device to the &qemu; command line. Use the unique ID that
-    you used when creating the vGPU device:
-   </para>
-<screen>-device vfio-pci,sysfsdev=/sys/bus/mdev/devices/4f3b6e47-0baa-4900-b0b1-284c1ecc192f</screen>
-  </sect2>
- </sect1>
- <sect1 xml:id="configure-nvidia-vgpu-configure-guest">
-  <title>Configuring vGPU in &vmguest;</title>
-
-  <sect2 xml:id="configure-nvidia-vgpu-passthrough-to-vm">
-   <title>Prepare the &vmguest;</title>
-   <itemizedlist>
-    <listitem>
-     <para>
-      During &vmguest; installation, disable secure boot, enable the SSH
-      service, and select <literal>wicked</literal> for networking.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      Disable the <literal>nouveau</literal> video driver. Edit the file
-      <filename>/etc/modprobe.d/50-blacklist.conf</filename> and add the
-      following line to its upper section:
-     </para>
-<screen>blacklist nouveau</screen>
-     <important>
+    <sect2 xml:id="configure-nvidia-vgpu-passthrough-to-vm-qemu">
+      <title>Assign by &qemu;</title>
       <para>
-       Disabling <literal>nouveau</literal> will work after you re-generate the
-       initrd image with dracut, and then reboot the &vmguest;.
+        Add the following device to the &qemu; command line. Use the unique ID that you used when
+        creating the vGPU device:
       </para>
-     </important>
-    </listitem>
-   </itemizedlist>
-  </sect2>
+<screen>-device vfio-pci,sysfsdev=/sys/bus/mdev/devices/4f3b6e47-0baa-4900-b0b1-284c1ecc192f</screen>
+    </sect2>
+  </sect1>
+  <sect1 xml:id="configure-nvidia-vgpu-configure-guest">
+    <title>Configuring vGPU in &vmguest;</title>
 
-  <sect2 xml:id="configure-nvidia-vgpu-configure-guest-install-driver">
-   <title>Install the vGPU driver in the &vmguest;</title>
-   <procedure>
-    <step>
-     <para>
-      Install the following packages and their dependencies:
-     </para>
+    <sect2 xml:id="configure-nvidia-vgpu-passthrough-to-vm">
+      <title>Prepare the &vmguest;</title>
+      <itemizedlist>
+        <listitem>
+          <para>
+            During &vmguest; installation, disable secure boot, enable the SSH service, and select
+            <literal>wicked</literal> for networking.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            Disable the <literal>nouveau</literal> video driver. Edit the file
+            <filename>/etc/modprobe.d/50-blacklist.conf</filename> and add the following line to
+            its upper section:
+          </para>
+<screen>blacklist nouveau</screen>
+          <important>
+            <para>
+              Disabling <literal>nouveau</literal> works after you re-generate the initrd image
+              with dracut, and then reboot the &vmguest;.
+            </para>
+          </important>
+        </listitem>
+      </itemizedlist>
+    </sect2>
+
+    <sect2 xml:id="configure-nvidia-vgpu-configure-guest-install-driver">
+      <title>Install the vGPU driver in the &vmguest;</title>
+      <procedure>
+        <step>
+          <para>
+            Install the following packages and their dependencies:
+          </para>
 <screen>&prompt.sudo;zypper install kernel-default-devel libglvnd-devel</screen>
-    </step>
-    <step>
-     <para>
-      Download the vGPU software from the &nvidia; portal. Make the &nvidia;
-      vGPU driver executable and run it:
-     </para>
+        </step>
+        <step>
+          <para>
+            Download the vGPU software from the &nvidia; portal. Make the &nvidia; vGPU driver
+            executable and run it:
+          </para>
 <screen>
       &prompt.user;chmod +x NVIDIA-Linux-x86_64-470.63.01-grid.run
       &prompt.sudo;./NVIDIA-Linux-x86_64-470.63.01-grid.run
       </screen>
-     <tip>
-      <para>
-       To enable dynamic kernel module support in order to get the module
-       rebuilt automatically when a new kernel is installed, add the
-       <option>--dkms</option> option:
-      </para>
+          <tip>
+            <para>
+              To enable dynamic kernel module support to get the module rebuilt automatically when
+              a new kernel is installed, add the <option>--dkms</option> option:
+            </para>
 <screen>&prompt.sudo;./NVIDIA-Linux-x86_64-470.63.01-grid.run --dkms</screen>
-     </tip>
-    </step>
-    <step>
-     <para>
-      During driver installation, select to run the
-      <command>nvidia-xconfig</command> utility.
-     </para>
-    </step>
-    <step>
-     <para>
-      Verify the driver installation by checking the output of the
-      <command>nvidia-smi</command> command:
-     </para>
+          </tip>
+        </step>
+        <step>
+          <para>
+            During driver installation, select to run the <command>nvidia-xconfig</command>
+            utility.
+          </para>
+        </step>
+        <step>
+          <para>
+            Verify the driver installation by checking the output of the
+            <command>nvidia-smi</command> command:
+          </para>
 <screen>
 &prompt.sudo;nvidia-smi
 +-----------------------------------------------------------------------------+
@@ -822,132 +811,129 @@ GPU 0: NVIDIA A100-PCIE-40GB (UUID: GPU-ee14e29d-dd5b-2e8e-eeaf-9d3debd10788)
 |  No running processes found                                                 |
 +-----------------------------------------------------------------------------+
 </screen>
-    </step>
-   </procedure>
-  </sect2>
- </sect1>
- <sect1 xml:id="configure-nvidia-vgpu-licensing">
-  <title>Licensing vGPU in the &vmguest;</title>
+        </step>
+      </procedure>
+    </sect2>
+  </sect1>
+  <sect1 xml:id="configure-nvidia-vgpu-licensing">
+    <title>Licensing vGPU in the &vmguest;</title>
 
-  <procedure>
-   <step>
-    <para>
-     Create the configuration file <filename>/etc/nvidia/gridd.conf</filename>
-     based on <filename>/etc/nvidia/gridd.conf.template</filename>.
-    </para>
-   </step>
-   <step>
-    <substeps>
-     <step>
-      <para>
-       For licenses that are served from the &nvidia; License System,
-       update the following options:
-      </para>
-      <variablelist>
-       <varlistentry>
-        <term>FeatureType</term>
-        <listitem>
-         <para>
-          For GPU passthrough, set <option>FeatureType</option> to
-          <literal>4</literal> for computing and <literal>2</literal> for graphic
-          purposes. In case of a virtual GPU, whatever vGPU type is created via
-          <command>mdev</command> determines the feature set that is enabled in
-          &vmguest;.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term>ClientConfigTokenPath</term>
-        <listitem>
-         <para>
-          Optional: If you want to store the client configuration token in a
-          custom location, add the <option>ClientConfigTokenPath</option>
-          configuration parameter on a new line as
-          <option>ClientConfigTokenPath="<replaceable>PATH_TO_TOKEN</replaceable>"</option>.
-          By default, the client searches for the client configuration token in
-          the <filename>/etc/nvidia/ClientConfigToken/</filename> directory.
-         </para>
-         <para>
-          Copy the client configuration token to the directory in which you
-          want to store it.
-         </para>
-        </listitem>
-       </varlistentry>
-      </variablelist>
-     </step>
-     <step>
-      <para>
-       For licenses that are served from the legacy &nvidia; vGPU software license server,
-       update the following options:
-      </para>
-      <variablelist>
-       <varlistentry>
-        <term>ServerAddress</term>
-        <listitem>
-         <para>
-          Add your license server IP address.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term>ServerPort</term>
-        <listitem>
-         <para>
-          Use the default "7070" or the port configured during the server setup.
-         </para>
-        </listitem>
-       </varlistentry>
-       <varlistentry>
-        <term>FeatureType</term>
-        <listitem>
-         <para>
-          For GPU passthrough, set <option>FeatureType</option> to
-          <literal>4</literal> for computing and <literal>2</literal> for graphic
-          purposes. In case of a virtual GPU, whatever vGPU type is created via
-          <command>mdev</command> determines the feature set that is enabled in
-          &vmguest;.
-         </para>
-        </listitem>
-       </varlistentry>
-      </variablelist>
-     </step>
-    </substeps>
-   </step>
-   <step>
-    <para>
-     Restart the <systemitem class="daemon">nvidia-gridd</systemitem> service:
-    </para>
+    <procedure>
+      <step>
+        <para>
+          Create the configuration file <filename>/etc/nvidia/gridd.conf</filename> based on
+          <filename>/etc/nvidia/gridd.conf.template</filename>.
+        </para>
+      </step>
+      <step>
+        <substeps>
+          <step>
+            <para>
+              For licenses that are served from the &nvidia; License System, update the following
+              options:
+            </para>
+            <variablelist>
+              <varlistentry>
+                <term>FeatureType</term>
+                <listitem>
+                  <para>
+                    For GPU passthrough, set <option>FeatureType</option> to <literal>4</literal>
+                    for computing and <literal>2</literal> for graphic purposes. In case of a
+                    virtual GPU, whatever vGPU type is created via <command>mdev</command>
+                    determines the feature set that is enabled in &vmguest;.
+                  </para>
+                </listitem>
+              </varlistentry>
+              <varlistentry>
+                <term>ClientConfigTokenPath</term>
+                <listitem>
+                  <para>
+                    Optional: To store the client configuration token in a custom location, add the
+                    <option>ClientConfigTokenPath</option> configuration parameter on a new line as
+                    <option>ClientConfigTokenPath="<replaceable>PATH_TO_TOKEN</replaceable>"</option>.
+                    By default, the client searches for the client configuration token in the
+                    <filename>/etc/nvidia/ClientConfigToken/</filename> directory.
+                  </para>
+                  <para>
+                    Copy the client configuration token to the directory in which you want to store
+                    it.
+                  </para>
+                </listitem>
+              </varlistentry>
+            </variablelist>
+          </step>
+          <step>
+            <para>
+              For licenses that are served from the legacy &nvidia; vGPU software license server,
+              update the following options:
+            </para>
+            <variablelist>
+              <varlistentry>
+                <term>ServerAddress</term>
+                <listitem>
+                  <para>
+                    Add your license server IP address.
+                  </para>
+                </listitem>
+              </varlistentry>
+              <varlistentry>
+                <term>ServerPort</term>
+                <listitem>
+                  <para>
+                    Use the default "7070" or the port configured during the server setup.
+                  </para>
+                </listitem>
+              </varlistentry>
+              <varlistentry>
+                <term>FeatureType</term>
+                <listitem>
+                  <para>
+                    For GPU passthrough, set <option>FeatureType</option> to <literal>4</literal>
+                    for computing and <literal>2</literal> for graphic purposes. In case of a
+                    virtual GPU, whatever vGPU type is created via <command>mdev</command>
+                    determines the feature set that is enabled in &vmguest;.
+                  </para>
+                </listitem>
+              </varlistentry>
+            </variablelist>
+          </step>
+        </substeps>
+      </step>
+      <step>
+        <para>
+          Restart the <systemitem class="daemon">nvidia-gridd</systemitem> service:
+        </para>
 <screen>&prompt.sudo;systemctl restart nvidia-gridd.service</screen>
-   </step>
-   <step>
-    <para>
-     Inspect the log file for possible errors:
-    </para>
+      </step>
+      <step>
+        <para>
+          Inspect the log file for possible errors:
+        </para>
 <screen>
 &prompt.sudo;grep gridd /var/log/messages
 [...]
 Aug 5 15:40:06 localhost nvidia-gridd: Started (4293)
 Aug 5 15:40:24 localhost nvidia-gridd: License acquired successfully.
 </screen>
-   </step>
-  </procedure>
- </sect1>
- <sect1 xml:id="configure-nvidia-vgpu-xorg">
-  <title>Configuring a graphics mode</title>
+      </step>
+    </procedure>
+  </sect1>
+  <sect1 xml:id="configure-nvidia-vgpu-xorg">
+    <title>Configuring a graphics mode</title>
 
-  <sect2 xml:id="configure-nvidia-vgpu-xorg-create">
-   <title>Create or update the <filename>/etc/X11/xorg.conf</filename> file</title>
-   <procedure>
-    <step>
-     <para>
-      If there is no <filename>/etc/X11/xorg.conf</filename> on the &vmguest;,
-      run the <command>nvidia-xconfig</command> utility.
-     </para>
-    </step>
-    <step>
-     <para>
-      Query the GPU device for detailed information:
-     </para>
+    <sect2 xml:id="configure-nvidia-vgpu-xorg-create">
+      <title>Create or update the <filename>/etc/X11/xorg.conf</filename> file</title>
+      <procedure>
+        <step>
+          <para>
+            If there is no <filename>/etc/X11/xorg.conf</filename> on the &vmguest;, run the
+            <command>nvidia-xconfig</command> utility.
+          </para>
+        </step>
+        <step>
+          <para>
+            Query the GPU device for detailed information:
+          </para>
 <screen>
 &prompt.user;nvidia-xconfig --query-gpu-info
 Number of GPUs: 1
@@ -959,11 +945,11 @@ PCI BusID : PCI:0:10:0
 
 Number of Display Devices: 0
 </screen>
-    </step>
-    <step>
-     <para>
-      Add GPU's BusID to <filename>/etc/X11/xorg.conf</filename>, for example:
-     </para>
+        </step>
+        <step>
+          <para>
+            Add GPU's BusID to <filename>/etc/X11/xorg.conf</filename>, for example:
+          </para>
 <screen>
 Section "Device"
 Identifier "Device0"
@@ -972,25 +958,25 @@ BusID "PCI:0:10:0"
 VendorName "NVIDIA Corporation"
 EndSection
 </screen>
-    </step>
-   </procedure>
-  </sect2>
+        </step>
+      </procedure>
+    </sect2>
 
-  <sect2 xml:id="configure-nvidia-vgpu-xorg-verify">
-   <title>Verify the graphics mode</title>
-   <para>
-    Verify the following:
-   </para>
-   <itemizedlist>
-    <listitem>
-     <para>
-      A graphic desktop is booted correctly.
-     </para>
-    </listitem>
-    <listitem>
-     <para>
-      The 'X' process of a running X-server is running in GPU:
-     </para>
+    <sect2 xml:id="configure-nvidia-vgpu-xorg-verify">
+      <title>Verify the graphics mode</title>
+      <para>
+        Verify the following:
+      </para>
+      <itemizedlist>
+        <listitem>
+          <para>
+            A graphic desktop is booted correctly.
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            The 'X' process of a running X-server is running in GPU:
+          </para>
 <screen>
 &prompt.user;nvidia-smi
 +-----------------------------------------------------------------------------+
@@ -1014,52 +1000,50 @@ EndSection
 |    0   N/A  N/A      1957      G   /usr/bin/gnome-shell               87MiB |
 +-----------------------------------------------------------------------------+
 </screen>
-    </listitem>
-   </itemizedlist>
-  </sect2>
+        </listitem>
+      </itemizedlist>
+    </sect2>
 
-  <sect2 xml:id="configure-nvidia-vgpu-vnc">
-   <title>Remote display</title>
-   <para>
-    You need to install and configure the VNC server package
-    <package>x11vnc</package> inside the &vmguest;, and start it with the
-    following command:
-   </para>
+    <sect2 xml:id="configure-nvidia-vgpu-vnc">
+      <title>Remote display</title>
+      <para>
+        You need to install and configure the VNC server package <package>x11vnc</package> inside
+        the &vmguest;, and start it with the following command:
+      </para>
 <screen>&prompt.sudo;x11vnc -display :0 -auth /run/user/1000/gdm/Xauthority -forever -shared -ncache -bg -usepw -geometry 1900x1080</screen>
-   <para>
-    You can use <command>virt-manager</command> or
-    <command>virt-viewer</command> to display the graphical output of a
-    &vmguest;.
-   </para>
-   <important>
-    <para>
-     For a &libvirt;-based &vmguest;, verify that its XML configuration
-     includes <literal>display=on</literal> as suggested in
-     <xref linkend="configure-nvidia-vgpu-passthrough-to-vm-libvirt"/>.
-    </para>
-   </important>
-  </sect2>
- </sect1>
- <sect1 xml:id="configure-nvidia-vgpu-compute">
-  <title>Configuring compute mode</title>
+      <para>
+        You can use <command>virt-manager</command> or <command>virt-viewer</command> to display
+        the graphical output of a &vmguest;.
+      </para>
+      <important>
+        <para>
+          For a &libvirt;-based &vmguest;, verify that its XML configuration includes
+          <literal>display=on</literal> as suggested in
+          <xref linkend="configure-nvidia-vgpu-passthrough-to-vm-libvirt"/>.
+        </para>
+      </important>
+    </sect2>
+  </sect1>
+  <sect1 xml:id="configure-nvidia-vgpu-compute">
+    <title>Configuring compute mode</title>
 
-  <procedure>
-   <step>
-    <para>
-     Download and install the CUDA toolkit. You can find it at
-     <link
+    <procedure>
+      <step>
+        <para>
+          Download and install the CUDA toolkit. You can find it at
+          <link
      xlink:href="https://developer.nvidia.com/cuda-downloads?target_os=Linux&amp;target_arch=x86_64&amp;Distribution=SLES&amp;target_version=15&amp;target_type=runfile_local"/>.
-    </para>
-   </step>
-   <step>
-    <para>
-     Download CUDA samples from <link xlink:href="https://github.com/nvidia/cuda-samples"/>.
-    </para>
-   </step>
-   <step>
-    <para>
-     Run CUDA sampling example:
-    </para>
+        </para>
+      </step>
+      <step>
+        <para>
+          Download CUDA samples from <link xlink:href="https://github.com/nvidia/cuda-samples"/>.
+        </para>
+      </step>
+      <step>
+        <para>
+          Run CUDA sampling example:
+        </para>
 <screen>
 &prompt.user;cd <replaceable>YOUR_GIT_CLONE_LOCATION</replaceable>/cuda-samples/Samples/0_Introduction/clock
 &prompt.user; make
@@ -1072,37 +1056,36 @@ CUDA Clock sample
 GPU Device 0: "Volta" with compute capability 7.0
 Average clocks/block = 2820.718750
 </screen>
-   </step>
-  </procedure>
- </sect1>
- <sect1 xml:id="configure-nvidia-vgpu-additional">
-  <title>Additional tasks</title>
+      </step>
+    </procedure>
+  </sect1>
+  <sect1 xml:id="configure-nvidia-vgpu-additional">
+    <title>Additional tasks</title>
 
-  <para>
-   This section introduces additional procedures that may be helpful after you
-   have configured your vGPU.
-  </para>
+    <para>
+      This section introduces additional procedures that may be helpful after you have configured
+      your vGPU.
+    </para>
 
-  <sect2 xml:id="configure-nvidia-vgpu-additional-ftl">
-   <title>Disabling Frame Rate Limiter</title>
-   <para>
-    Frame Rate Limiter (FRL) is enabled by default. It limits the vGPU to a
-    fixed frame rate, for example 60fps. If you experience a bad graphic
-    display, you may need to disable FRL, for example:
-   </para>
+    <sect2 xml:id="configure-nvidia-vgpu-additional-ftl">
+      <title>Disabling Frame Rate Limiter</title>
+      <para>
+        Frame Rate Limiter (FRL) is enabled by default. It limits the vGPU to a fixed frame rate,
+        for example, 60fps. If you experience a bad graphic display, you may need to disable FRL,
+        for example:
+      </para>
 <screen>&prompt.sudo;echo "frame_rate_limiter=0" > /sys/bus/mdev/devices/86380ffb-8f13-4685-9c48-0e0f4e65fb87/nvidia/vgpu_params</screen>
-  </sect2>
+    </sect2>
 
-  <sect2 xml:id="configure-nvidia-vgpu-additional-ecc">
-   <title>Enabling/Disabling Error Correcting Code (ECC)</title>
-   <para>
-    Since the &nvidia; Pascal architecture, &nvidia; GPU Cards support ECC
-    memory to improve data integrity. ECC is also supported by software since
-    &nvidia; vGPU 9.0.
-   </para>
-   <para>
-    To enable ECC:
-   </para>
+    <sect2 xml:id="configure-nvidia-vgpu-additional-ecc">
+      <title>Enabling/Disabling Error Correcting Code (ECC)</title>
+      <para>
+        Since the &nvidia; Pascal architecture, &nvidia; GPU Cards support ECC memory to improve
+        data integrity. ECC is also supported by software since &nvidia; vGPU 9.0.
+      </para>
+      <para>
+        To enable ECC:
+      </para>
 <screen>
 &prompt.sudo;nvidia-smi –e 1
 &prompt.user;nvidia-smi -q
@@ -1110,33 +1093,33 @@ Ecc Mode
    Current                           : Enabled
    Pending                           : Enabled
 </screen>
-   <para>
-    To disable ECC:
-   </para>
+      <para>
+        To disable ECC:
+      </para>
 <screen>&prompt.sudo;nvidia-smi –e 0</screen>
-  </sect2>
+    </sect2>
 
-  <sect2 xml:id="configure-nvidia-vgpu-additional-vmanager-blank">
-   <title>Black screen in Virt-manager</title>
-   <para>
-    If you see only a black screen in Virt-manager, press
-    <keycombo><keycap function="alt"/><keycap function="control"/><keycap>2</keycap></keycombo>
-    from Virt-manager viewer. You should be able to get in the display again.
-   </para>
-  </sect2>
+    <sect2 xml:id="configure-nvidia-vgpu-additional-vmanager-blank">
+      <title>Black screen in Virt-manager</title>
+      <para>
+        If you see only a black screen in Virt-manager, press
+        <keycombo><keycap function="alt"/><keycap function="control"/><keycap>2</keycap></keycombo>
+        from Virt-manager viewer. You should be able to get in the display again.
+      </para>
+    </sect2>
 
-  <sect2 xml:id="configure-nvidia-vgpu-additional-vmanager-vnc-blank">
-   <title>Black screen in VNC client when using a non-&qemu; VNC server</title>
-   <para>
-    Use the xvnc server.
-   </para>
-  </sect2>
+    <sect2 xml:id="configure-nvidia-vgpu-additional-vmanager-vnc-blank">
+      <title>Black screen in VNC client when using a non-&qemu; VNC server</title>
+      <para>
+        Use the xvnc server.
+      </para>
+    </sect2>
 
-  <sect2 xml:id="configure-nvidia-vgpu-additional-noveau-kernel-panic">
-   <title>Kernel panic occurs because the Nouveau and &nvidia; drivers compete on GPU resources</title>
-   <para>
-    The boot messages will look as follows:
-   </para>
+    <sect2 xml:id="configure-nvidia-vgpu-additional-noveau-kernel-panic">
+      <title>Kernel panic occurs because the Nouveau and &nvidia; drivers compete on GPU resources</title>
+      <para>
+        The boot messages looks as follows:
+      </para>
 <screen>
 [ 16.742439] Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS rel-1.14.0-0-g155821a1990b-prebuilt.qemu.org 04/01/2014
 [ 16.742441] RIP: 0010:__pci_enable_msi_range+0x3a9/0x3f0
@@ -1184,218 +1167,214 @@ c 25
 [ 16.743426] ---[ end trace 8bf4d15315659a3e ]---
 [ 16.743431] NVRM: GPU 0000:00:0a.0: Failed to enable MSI; falling back to PCIe virtual-wire interrupts.
 </screen>
-   <para>
-    Make sure to run <command>mkintrd</command> and reboot after disabling the
-    Nouveau driver. Refer to
-    <xref linkend="configure-nvidia-vgpu-passthrough-to-vm"/>.
-   </para>
-  </sect2>
-
-  <sect2 xml:id="configure-nvidia-vgpu-additional-nvidia-bug">
-   <title>Filing an &nvidia; vGPU bug</title>
-   <para>
-    While filing an &nvidia; vGPU-related bug report to us, please attach the
-    vGPU configuration data <filename>nvidia-bug-report.log.gz</filename>
-    collected by the <command>nvidia-bug-report.sh</command> utility. Make sure
-    you cover both &vmhost; and &vmguest;.
-   </para>
-  </sect2>
-
-  <sect2 xml:id="configure-nvidia-vgpu-additional-license-server">
-   <title>Configuring a License Server</title>
-   <para>
-    Refer to
-    <link xlink:href="https://docs.nvidia.com/grid/ls/latest/grid-license-server-user-guide/index.html"/>.
-   </para>
-  </sect2>
- </sect1>
- <sect1 xml:id="configure-nvidia-vgpu-more-info">
-  <title>For more information</title>
-
-  <para>
-   &nvidia; has an extensive documentation on vGPU. Refer to
-   <link xlink:href="https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html"/>
-   for details.
-  </para>
- </sect1>
- <sect1 xml:id="configure-nvidia-vgpu-background">
-  <title>&nvidia; virtual GPU background</title>
-
-  <sect2 xml:id="configure-nvidia-vgpu-architecture">
-   <title>&nvidia; GPU architectures</title>
-   <para>
-    There are two types of GPU architectures:
-   </para>
-   <variablelist>
-    <varlistentry>
-     <term>Time-sliced vGPU architecture</term>
-     <listitem>
       <para>
-       Introduced on GPUs that are based on the &nvidia; Ampere GPU
-       architecture. Only Ampere GPU cards can support MIG-backed vGPU.
+        Make sure to run <command>mkintrd</command> and reboot after disabling the Nouveau driver.
+        Refer to <xref linkend="configure-nvidia-vgpu-passthrough-to-vm"/>.
       </para>
-      <figure>
-       <title>Time-sliced architecture (source: <link xlink:href="https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html"/>)</title>
-       <mediaobject>
-        <imageobject role="fo">
-         <imagedata fileref="nvidia-vgpu-time-sliced.png" width="75%"/>
-        </imageobject>
-        <imageobject role="html">
-         <imagedata fileref="nvidia-vgpu-time-sliced.png" width="75%"/>
-        </imageobject>
-       </mediaobject>
-      </figure>
-     </listitem>
-    </varlistentry>
-    <varlistentry>
-     <term>Multi-Instance GPU (MIG) vGPU architecture</term>
-     <listitem>
+    </sect2>
+
+    <sect2 xml:id="configure-nvidia-vgpu-additional-nvidia-bug">
+      <title>Filing an &nvidia; vGPU bug</title>
       <para>
-       All GPU cards support time-sliced vGPU. To do so, Ampere GPU cards use
-       the Single Root I/O Virtualization (SR-IOV) mechanism, while Volta and
-       the earlier GPU cards use the mediated device mechanism. Volta and the
-       earlier architecture are based on mediated device mechanism. These two
-       mechanisms are transparent to a VM. However, they need different
-       configurations from the host side.
+        While filing an &nvidia; vGPU-related bug report to us, please attach the vGPU
+        configuration data <filename>nvidia-bug-report.log.gz</filename> collected by the
+        <command>nvidia-bug-report.sh</command> utility. Make sure you cover both &vmhost; and
+        &vmguest;.
       </para>
-      <figure>
-       <title>MIG-backed architecture (source: <link xlink:href="https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html"/>)</title>
-       <mediaobject>
-        <imageobject role="fo">
-         <imagedata fileref="nvidia-vgpu-mig-backed.png" width="75%"/>
-        </imageobject>
-        <imageobject role="html">
-         <imagedata fileref="nvidia-vgpu-mig-backed.png" width="75%"/>
-        </imageobject>
-       </mediaobject>
-      </figure>
-     </listitem>
-    </varlistentry>
-   </variablelist>
-  </sect2>
+    </sect2>
 
-  <sect2 xml:id="configure-nvidia-vgpu-vgpu-types">
-   <title>vGPU types</title>
-   <para>
-    Each physical GPU can support several different types of vGPUs. vGPU types
-    have a fixed amount of frame buffer, the number of supported display heads,
-    and maximum resolutions. NVIDIA has four types of vGPUs: A, B, C, and
-    Q-series. &suse; currently supports Q and C-series.
-   </para>
-   <table>
-    <title>vGPU types</title>
-    <tgroup cols="2" align="left">
-     <colspec colname="c1" colwidth="20*"/>
-     <colspec colname="c2" colwidth="80*"/>
-     <thead>
-      <row>
-       <entry>
-        <para>
-         vGPU series
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Optimal workload
-        </para>
-       </entry>
-      </row>
-     </thead>
-     <tbody>
-      <row>
-       <entry>
-        <para>
-         Q-series
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Virtual workstations for creative and technical professionals who
-         require the performance and features of the &nvidia; Quadro
-         technology.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         C-series
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Compute-intensive server workloads, for example, artificial
-         intelligence (AI), deep learning, or high-performance computing (HPC).
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         B-series
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Virtual desktops for business professionals and knowledge workers.
-        </para>
-       </entry>
-      </row>
-      <row>
-       <entry>
-        <para>
-         A-series
-        </para>
-       </entry>
-       <entry>
-        <para>
-         Application streaming or session-based solutions for virtual
-         applications users.
-        </para>
-       </entry>
-      </row>
-     </tbody>
-    </tgroup>
-   </table>
-  </sect2>
+    <sect2 xml:id="configure-nvidia-vgpu-additional-license-server">
+      <title>Configuring a License Server</title>
+      <para>
+        Refer to
+        <link xlink:href="https://docs.nvidia.com/grid/ls/latest/grid-license-server-user-guide/index.html"/>.
+      </para>
+    </sect2>
+  </sect1>
+  <sect1 xml:id="configure-nvidia-vgpu-more-info">
+    <title>For more information</title>
 
-  <sect2 xml:id="configure-nvidia-vgpu-valid-configurations">
-   <title>Valid vGPU configurations on a single GPU</title>
-   <sect3 xml:id="configure-nvidia-vgpu-valid-configurations-time-sliced">
-    <title>Time-sliced vGPU configurations</title>
     <para>
-     For time-sliced vGPUs, all vGPUs types must be the same:
+      &nvidia; has an extensive documentation on vGPU. Refer to
+      <link xlink:href="https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html"/> for
+      details.
     </para>
-    <figure>
-     <title>Example time-sliced vGPU configurations on &nvidia; Tesla M60 (source: <link xlink:href="https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html"/>)</title>
-     <mediaobject>
-      <imageobject role="fo">
-       <imagedata fileref="nvidia-vgpus-supported.png" width="75%"/>
-      </imageobject>
-      <imageobject role="html">
-       <imagedata fileref="nvidia-vgpus-supported.png" width="75%"/>
-      </imageobject>
-     </mediaobject>
-    </figure>
-   </sect3>
-   <sect3 xml:id="configure-nvidia-vgpu-valid-configurations-mig-backed">
-    <title>MIG-backed vGPU configurations</title>
-    <para>
-     For MIG-backed vGPUs, vGPUs can be both homogeneous and mixed-type:
-    </para>
-    <figure>
-     <title>Example MIG-backed vGPU configurations on &nvidia; A100 PCIe 40GB (source: <link xlink:href="https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html"/>)</title>
-     <mediaobject>
-      <imageobject role="fo">
-       <imagedata fileref="nvidia-vgpus-supported2.png" width="75%"/>
-      </imageobject>
-      <imageobject role="html">
-       <imagedata fileref="nvidia-vgpus-supported2.png" width="75%"/>
-      </imageobject>
-     </mediaobject>
-    </figure>
-   </sect3>
-  </sect2>
- </sect1>
- <xi:include href="common_license_gfdl1.2.xml"/>
+  </sect1>
+  <sect1 xml:id="configure-nvidia-vgpu-background">
+    <title>&nvidia; virtual GPU background</title>
+
+    <sect2 xml:id="configure-nvidia-vgpu-architecture">
+      <title>&nvidia; GPU architectures</title>
+      <para>
+        There are two types of GPU architectures:
+      </para>
+      <variablelist>
+        <varlistentry>
+          <term>Time-sliced vGPU architecture</term>
+          <listitem>
+            <para>
+              Introduced on GPUs that are based on the &nvidia; Ampere GPU architecture. Only
+              Ampere GPU cards can support MIG-backed vGPU.
+            </para>
+            <figure>
+              <title>Time-sliced architecture (source: <link xlink:href="https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html"/>)</title>
+              <mediaobject>
+                <imageobject role="fo">
+                  <imagedata fileref="nvidia-vgpu-time-sliced.png" width="75%"/>
+                </imageobject>
+                <imageobject role="html">
+                  <imagedata fileref="nvidia-vgpu-time-sliced.png" width="75%"/>
+                </imageobject>
+              </mediaobject>
+            </figure>
+          </listitem>
+        </varlistentry>
+        <varlistentry>
+          <term>Multi-Instance GPU (MIG) vGPU architecture</term>
+          <listitem>
+            <para>
+              All GPU cards support time-sliced vGPU. To do so, Ampere GPU cards use the Single
+              Root I/O Virtualization (SR-IOV) mechanism, while Volta and the earlier GPU cards use
+              the mediated device mechanism. Volta and the earlier architecture are based on
+              mediated device mechanism. These two mechanisms are transparent to a VM. However,
+              they need different configurations from the host side.
+            </para>
+            <figure>
+              <title>MIG-backed architecture (source: <link xlink:href="https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html"/>)</title>
+              <mediaobject>
+                <imageobject role="fo">
+                  <imagedata fileref="nvidia-vgpu-mig-backed.png" width="75%"/>
+                </imageobject>
+                <imageobject role="html">
+                  <imagedata fileref="nvidia-vgpu-mig-backed.png" width="75%"/>
+                </imageobject>
+              </mediaobject>
+            </figure>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </sect2>
+
+    <sect2 xml:id="configure-nvidia-vgpu-vgpu-types">
+      <title>vGPU types</title>
+      <para>
+        Each physical GPU can support several different types of vGPUs. vGPU types have a fixed
+        amount of framebuffer, the number of supported display heads, and maximum resolutions.
+        NVIDIA has four types of vGPUs: A, B, C and Q-series. &suse; currently supports Q and
+        C-series.
+      </para>
+      <table>
+        <title>vGPU types</title>
+        <tgroup cols="2" align="left">
+          <colspec colname="c1" colwidth="20*"/>
+          <colspec colname="c2" colwidth="80*"/>
+          <thead>
+            <row>
+              <entry>
+                <para>
+                  vGPU series
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  Optimal workload
+                </para>
+              </entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry>
+                <para>
+                  Q-series
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  Virtual workstations for creative and technical professionals who require the
+                  performance and features of the &nvidia; Quadro technology.
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  C-series
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  Compute-intensive server workloads, for example, artificial intelligence (AI),
+                  deep learning, or high-performance computing (HPC).
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  B-series
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  Virtual desktops for business professionals and knowledge workers.
+                </para>
+              </entry>
+            </row>
+            <row>
+              <entry>
+                <para>
+                  A-series
+                </para>
+              </entry>
+              <entry>
+                <para>
+                  Application streaming or session-based solutions for virtual applications users.
+                </para>
+              </entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </sect2>
+
+    <sect2 xml:id="configure-nvidia-vgpu-valid-configurations">
+      <title>Valid vGPU configurations on a single GPU</title>
+      <sect3 xml:id="configure-nvidia-vgpu-valid-configurations-time-sliced">
+        <title>Time-sliced vGPU configurations</title>
+        <para>
+          For time-sliced vGPUs, all vGPUs types must be the same:
+        </para>
+        <figure>
+          <title>Example time-sliced vGPU configurations on &nvidia; Tesla M60 (source: <link xlink:href="https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html"/>)</title>
+          <mediaobject>
+            <imageobject role="fo">
+              <imagedata fileref="nvidia-vgpus-supported.png" width="75%"/>
+            </imageobject>
+            <imageobject role="html">
+              <imagedata fileref="nvidia-vgpus-supported.png" width="75%"/>
+            </imageobject>
+          </mediaobject>
+        </figure>
+      </sect3>
+      <sect3 xml:id="configure-nvidia-vgpu-valid-configurations-mig-backed">
+        <title>MIG-backed vGPU configurations</title>
+        <para>
+          For MIG-backed vGPUs, vGPUs can be both homogeneous and mixed-type:
+        </para>
+        <figure>
+          <title>Example MIG-backed vGPU configurations on &nvidia; A100 PCIe 40&nbsp;GB (source: <link xlink:href="https://docs.nvidia.com/grid/latest/grid-vgpu-user-guide/index.html"/>)</title>
+          <mediaobject>
+            <imageobject role="fo">
+              <imagedata fileref="nvidia-vgpus-supported2.png" width="75%"/>
+            </imageobject>
+            <imageobject role="html">
+              <imagedata fileref="nvidia-vgpus-supported2.png" width="75%"/>
+            </imageobject>
+          </mediaobject>
+        </figure>
+      </sect3>
+    </sect2>
+  </sect1>
+  <xi:include href="common_license_gfdl1.2.xml"/>
 </article>

--- a/xml/art-nvidia-vgpu.xml
+++ b/xml/art-nvidia-vgpu.xml
@@ -263,13 +263,13 @@ BOOT_IMAGE=/boot/vmlinuz-default [...] intel_iommu=on [...]
           </para>
 <screen>&prompt.sudo;<command>modprobe nvidia-modprobe</command></screen>
         </step>
-        <step>
+        <!-- step>
           <para>
             Reboot the system to ensure that all changes take effect and no conflicting driver
             components remain loaded.
           </para>
 <screen>&prompt.sudo;<command>systemctl reboot</command></screen>
-        </step>
+        </step -->
       </procedure>
     </sect2>
 

--- a/xml/art-nvidia-vgpu.xml
+++ b/xml/art-nvidia-vgpu.xml
@@ -154,6 +154,125 @@ BOOT_IMAGE=/boot/vmlinuz-default [...] intel_iommu=on [...]
       </procedure>
     </sect2>
 
+    <sect2 xml:id="remove-conflicting-nvidia-drivers">
+      <title>Remove conflicting and pre-installed &nvidia; drivers</title>
+      <para>
+        On a fresh installation of &sles; &productnumber;, the open-source NVIDIA desktop driver
+        such as <filename>nvidia-open-driver-G06-signed-kmp-default</filename> is often
+        automatically installed if an &nvidia; GPU is detected. This pre-installed driver can
+        conflict with the installation of the proprietary &nvidia; vGPU driver. The conflict can
+        lead to errors during the build process of the vGPU kernel modules and/or issues with the
+        correct driver being loaded, preventing the vGPU functionality from working correctly. This
+        section describes how to identify and remove conflicting drivers before proceeding with the
+        &nvidia; vGPU driver installation.
+      </para>
+      <procedure>
+        <step>
+          <para>
+            Check for pre-installed &nvidia; drivers that can potentially conflict with the vGPU
+            driver that you want to install.
+          </para>
+          <substeps>
+            <step>
+              <para>
+                Check for the presence of automatically installed open source &nvidia; driver.
+              </para>
+<screen>&prompt.user;<command>zypper info nvidia-open-driver-G06-signed-kmp-default</command></screen>
+              <note>
+                <para>
+                  If the package is <emphasis> not installed</emphasis>, you can skip the rest of
+                  this section and proceed to
+                  <xref linkend="configure-nvidia-vgpu-kvm-driver"></xref>. However, if it is
+                  <emphasis>installed</emphasis>, perform the rest of the steps to uninstall
+                  conflicting drivers and clean up any residues.
+                </para>
+              </note>
+            </step>
+            <step>
+              <para>
+                List all installed &nvidia;-related packages to identify any other potential
+                conflicts:
+              </para>
+<screen>&prompt.user;<command>zypper search --installed-only nvidia*</command></screen>
+              <para>
+                Look for any packages that might conflict with the vGPU driver, such as other
+                desktop driver versions.
+              </para>
+            </step>
+          </substeps>
+        </step>
+        <step>
+          <para>
+            Remove the conflicting &nvidia; drivers.
+          </para>
+          <substeps>
+            <step>
+              <para>
+                Remove the open source &nvidia; driver that is automatically installed.
+              </para>
+<screen>&prompt.sudo; <command>zypper remove nvidia-open-driver-G06-signed-kmp-default</command></screen>
+            </step>
+            <step>
+              <para>
+                If you identified other conflicting packages in the previous step, remove them
+                similarly.
+              </para>
+<screen>&prompt.sudo;<command>zypper remove <replaceable>CONFLICTING-NVIDIA-PACKAGE</replaceable> <replaceable>CONFLICTING-NVIDIA-PACKAGE</replaceable></command></screen>
+            </step>
+          </substeps>
+        </step>
+        <step>
+          <para>
+            <emphasis>OPTIONAL:</emphasis> Uninstall any manually installed &nvidia; drivers that
+            you have installed using <filename>.run</filename> files downloaded from &nvidia;'s web
+            site.
+          </para>
+<screen>&prompt.sudo;<command><replaceable>/PATH/TO/NVIDIA-Linux-x86_64-XXX.XX.XX.run</replaceable> --uninstall</command></screen>
+        </step>
+        <step>
+          <para>
+            <emphasis>OPTIONAL but RECOMMENDED:</emphasis> Sometimes, driver installations can
+            leave behind configuration files. To ensure a clean state, remove any potentially
+            conflicting configuration files.
+          </para>
+          <warning>
+            <para>
+              Remove driver configuration files only when you are absolutely sure that it relates
+              to a potentially conflicting &nvidia; driver that you have already uninstalled.
+            </para>
+          </warning>
+          <substeps>
+            <step>
+              <para>
+                Search for &nvidia;-related configuration directories.
+              </para>
+<screen>&prompt.sudo;<command>find /etc/ -name "*nvidia*"</command></screen>
+            </step>
+            <step>
+              <para>
+                Remove the directories related to conflicting uninstalled &nvidia; drivers.
+              </para>
+<screen>&prompt.sudo;<command>rm -rf /etc/<replaceable>CONFLICTING/NVIDIA/DIRECTORY</replaceable></command></screen>
+            </step>
+          </substeps>
+        </step>
+        <step>
+          <para>
+            Manually load the <literal>nvidia-modprobe</literal> utility before attempting the vGPU
+            driver installation:
+          </para>
+<screen>&prompt.sudo;<command>modprobe nvidia-modprobe</command></screen>
+        </step>
+        <step>
+          <para>
+            Reboot the system to ensure that all changes take effect and no conflicting driver
+            components remain loaded.
+          </para>
+<screen>&prompt.sudo;<command>systemctl reboot</command></screen>
+        </step>
+      </procedure>
+    </sect2>
+
     <sect2 xml:id="configure-nvidia-vgpu-kvm-driver">
       <title>Install the &nvidia; &kvm; driver</title>
       <procedure>


### PR DESCRIPTION
### PR creator: Description

Document the fix for the following issue: NVIDIA vGPU driver v16.2 failed to be installed on SLE 15 SP7 KVM host


### PR creator: Are there any relevant issues/feature requests?

* https://bugzilla.suse.com/show_bug.cgi?id=1239449
* https://jira.suse.com/browse/DOCTEAM-1768


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP6/openSUSE Leap 15.6
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [x] all necessary backports are done
