### PR TITLE
Add note on old kernels in /boot/zipl (BSC#1204547)

### DIFF
--- a/xml/sle_update_preparation.xml
+++ b/xml/sle_update_preparation.xml
@@ -930,6 +930,39 @@ postgres &gt; <command>pg_upgrade</command> \
    <xref linkend="sec-tuning-multikernel-enable"/>.
   </para>
  </sect1>
+
+ <sect1 xml:id="sec-update-preparation-zipl">
+    <title>&zsystems;: Adjust <command>zipl</command> for &uefisecboot;</title>
+    <para>
+      When upgrading from &sles; 12, enabling &uefisecboot; during or after the
+      upgrade with <command>yast bootloader</command> will fail with an error:
+    </para>
+<screen>Error: Could not install Secure Boot IPL records: Missing
+signature in image file /boot/zipl/image.prev
+/sbin/zipl: Failed
+/usr/sbin/grub2-install: error: `grub2-zipl-setup' failed.</screen>
+    <para>
+      This happens because <filename>/boot/zipl</filename> still contains the previous, unsigned
+      kernel and initrd as fallback in case the new kernel does not boot. To avoid this error, edit
+      <filename>/etc/default/grub</filename> and change <literal>SUSE_SECURE_BOOT=1</literal> to
+      <literal>SUSE_SECURE_BOOT=auto</literal>. This setting makes <command>zipl</command> write a
+      signature for the new kernel but not yield an error for the old kernel. Then run
+      <command>grub2-install</command> to re-install the boot loader.
+    </para>
+    <para>
+      Alternatively you can remove the obsolete kernel and initrd files from
+      <filename>/boot/zipl</filename> manually. Only do so when you have already rebooted into the
+      new kernel after the upgrade.
+    </para>
+    <para>
+      After the next &sle; 15 kernel update, you can switch back to
+      <literal>SUSE_SECURE_BOOT=1</literal> to ensure all kernels are signed.
+    </para>
+    <para>
+      For more information, refer to <command>man 8 zipl</command> and the IBM documentation at
+      <link xlink:href="https://www.ibm.com/docs/en/linux-on-systems?topic=loader-parameters"/>.
+    </para>
+ </sect1>
  <sect1 xml:id="sec-upgrade-prepare-boot-config">
   <title>Adjust the <literal>resume</literal> boot parameter</title>
   <para>


### PR DESCRIPTION
### PR creator: Description

After upgrading from SLE 12 to SLE 15, zipl fails when enabling secure boot as there is no signature for the old kernel. This can be fixed with `SUSE_SECURE_BOOT=auto` in /etc/default/grub.

### PR creator: Are there any relevant issues/feature requests?

* [bsc#1204547](https://bugzilla.suse.com/show_bug.cgi?id=1204547)

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP6/openSUSE Leap 15.6
  - [x] SLE 15 SP5/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
