### PR TITLE
Storage Guide: integrate proofing corrections

### DIFF
--- a/xml/storage_filesystems.xml
+++ b/xml/storage_filesystems.xml
@@ -182,7 +182,7 @@
     <listitem>
      <!--taroth 2015-08-07: fix for http://doccomments.provo.novell.com/comments/28887-->
      <para>
-      Multivolume Btrfs is supported in RAID0, RAID1, and RAID10 profiles in
+      Multi-volume Btrfs is supported in RAID0, RAID1, and RAID10 profiles in
       &productname; &productnumber;. Higher RAID levels are not supported yet,
       but might be enabled with a future service pack.
      </para>
@@ -228,7 +228,7 @@
     <title>Mounting compressed Btrfs file systems</title>
     <para>
      The Btrfs file system supports transparent compression. While enabled,
-     Btrfs compresses file data when written and uncompresses file data when
+     Btrfs compresses file data when written and decompresses file data when
      read.
     </para>
     <para>
@@ -2104,7 +2104,7 @@ The file system has the following characteristics:
       <entry>
        <para>
         Server Message Block is used by products such as Windows to enable file
-        access over a network. Includes support for  <literal>cifs</literal>&mdash; a network file system client for mounting SMB/CIFS shares.
+        access over a network. Includes support for  <literal>cifs</literal>&mdash;a network file system client for mounting SMB/CIFS shares.
        </para>
       </entry>
      </row>
@@ -2189,7 +2189,7 @@ unblacklist: cramfs un-blacklisted by creating /etc/modprobe.d/60-blacklist_fs-c
 </para>
 <variablelist>
   <varlistentry>
-    <term><keycap>y</keycap>es</term>
+    <term><keycap>y</keycap> for <literal>yes</literal></term>
     <listitem>
       <para>
         The module will be loaded and removed from the blacklist. Therefore, the module will be
@@ -2202,17 +2202,16 @@ unblacklist: cramfs un-blacklisted by creating /etc/modprobe.d/60-blacklist_fs-c
     </listitem>
   </varlistentry>
 <varlistentry>
-  <term><keycap>n</keycap>o</term>
+  <term><keycap>n</keycap> for <literal>no</literal></term>
   <listitem>
     <para>
-      The module will be loaded, but it is not removed from the blacklist. Therefore, on a next
-      module loading
-      you will see the prompt above again.
+      The module will be loaded, but it is not removed from the blacklist. Therefore, on a
+      subsequent module loading you will see the prompt above again.
     </para>
   </listitem>
 </varlistentry>
 <varlistentry>
-  <term><keycap>e</keycap>ver</term>
+  <term><keycap>e</keycap> for <literal>ever</literal></term>
   <listitem>
     <para>
       The module will be loaded, but autoloading is disabled even for future use, and the prompt 
@@ -2601,9 +2600,9 @@ unblacklist: cramfs un-blacklisted by creating /etc/modprobe.d/60-blacklist_fs-c
     required value.
    </para>
    <para>
-    The default behaviour of <command>fstrim</command> is to discard all blocks
+    The default behavior of <command>fstrim</command> is to discard all blocks
     in the file system. You can use options when invoking the command to modify
-    this behaviour. For example, you can pass the <literal>offset</literal>
+    this behavior. For example, you can pass the <literal>offset</literal>
     option to define the place where to start the trimming procedure. For
     details, see <command>man fstrim</command>.
    </para>

--- a/xml/storage_nfs.xml
+++ b/xml/storage_nfs.xml
@@ -328,7 +328,7 @@
             On Btrfs, we strongly recommend changing the default option <literal>no_subtree_check</literal> to
             <literal>subtree_check</literal> for security reasons. When several
             exports with different security settings are performed on the same Btrfs file system, one
-            client having access to one export may access all other exports, too. Using this option
+            client having access to one export can access all other exports, too. Using this option
             prevents such an attack. Alternatively, you can place each export on a separate file system. 
           </para>
         </step>
@@ -413,7 +413,7 @@
               <listitem>
                 <para>
                   <literal>&subnetI;.0/24</literal>: only exports
-                  to clients with IP adresses in the range of &subnetI;.0/24
+                  to clients with IP addresses in the range of &subnetI;.0/24
                 </para>
               </listitem>
               <listitem>

--- a/xml/storage_uuids.xml
+++ b/xml/storage_uuids.xml
@@ -128,7 +128,7 @@ lrwxrwxrwx 1 10 Dec  5 07:48 e014e482-1c2d-4d09-84ec-61b3aefde77a -&gt; ../../sd
 mars.example.org:/nfsexport  /shared   nfs  defaults,_netdev,x-systemd.requires=iscsi.service    0  0
   </screen>
   <para>
-Do not use the <literal>nofail</literal> option as booting of the machine continues without waiting
+Do not use the <literal>nofail</literal> option, as booting of the machine continues without waiting
 for the particular storage device to be successfully mounted.
   </para>
  </sect1>


### PR DESCRIPTION
### PR creator: Description

Integrate proofing corrections for the Storage Administration Guide from the proofing drop.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP6/openSUSE Leap 15.6
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
