### PR TITLE
Correct the location of the init-scripts section

### DIFF
--- a/xml/ay_custom_user_scripts.xml
+++ b/xml/ay_custom_user_scripts.xml
@@ -34,8 +34,7 @@
  </para>
 
  <para>
-  Except for <literal>init scripts</literal>, all scripts must be included in
-    the <literal>&lt;scripts&gt;</literal> section.
+  All scripts need to be in the &lt;scripts&gt; section.
  </para>
 
  <itemizedlist mark="bullet" spacing="normal">
@@ -192,13 +191,13 @@
   <para>
    The <literal>init-script</literal> elements must be placed as follows:
   </para>
-<screen>
+<screen>&lt;scripts&gt;
   &lt;init-scripts config:type="list"&gt;
     &lt;script&gt;
     ...
     &lt;/script&gt;
   &lt;/init-scripts&gt;
-</screen>
+&lt;/scripts&gt;</screen>
   <para>
    Init scripts are different from the other script types because they are not
    executed by &yast;, but after &yast; has finished. For this reason, their

--- a/xml/ay_custom_user_scripts.xml
+++ b/xml/ay_custom_user_scripts.xml
@@ -34,7 +34,7 @@
  </para>
 
  <para>
-  All scripts need to be in the &lt;scripts&gt; section.
+  All scripts must be in the &lt;scripts&gt; section.
  </para>
 
  <itemizedlist mark="bullet" spacing="normal">


### PR DESCRIPTION
### Description

Fix the location of the `init-scripts` in the AutoYaST documentation. It partially reverts #1819 which assumes that the `init-scripts` are out of the `scripts` section. If that's the case, it is a bug in AutoYaST, not in the documentation.

@eeagle please, do you have more info about the original problem? Thank you!

### Are there any relevant issues/feature requests?

* #1819
* [bsc#1243421](https://bugzilla.suse.com/show_bug.cgi?id=1243421)

### Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

NOTE: I marked the same versions than the original PR.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP6/openSUSE Leap 15.6
  - [x] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
