### PR TITLE
Tuning Guide: integrate proofing corrections

### DIFF
--- a/xml/tuning_tuned.xml
+++ b/xml/tuning_tuned.xml
@@ -17,7 +17,7 @@ xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-tuning-tune
         tuning profiles tailored for common use cases such as servers and virtual machines, as well
         as the ability to create custom profiles. &tunedapp; leverages several tuning plug-ins that
         interact with underlying Linux subsystems to tune the CPU, disk I/O, networking, virtual
-        memory, power management, and other components.
+        memory, power management and other components.
       </para>
     </abstract>
     <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
@@ -40,7 +40,7 @@ xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-tuning-tune
       System administrators can apply predefined or customized <emphasis>&tunedapp;
       profiles</emphasis> based on the current usage scenario or workload on the system. These
       profiles contain settings for certain system components such as the CPU, disk I/O schedulers,
-      virtual memory, and power management. The system components are managed by
+      virtual memory and power management. The system components are managed by
       <emphasis>plug-ins</emphasis>, which tune the system based on the activated profile settings.
     </para>
   </sect1>
@@ -63,7 +63,7 @@ xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-tuning-tune
           <itemizedlist>
             <listitem>
               <para>
-                The <command>tuned</command> command that you can use after enabling &tunedapp;
+                The <command>tuned</command> command, which you can use after enabling &tunedapp;
                 using <command>systemctl</command>. By default, when invoked from the terminal
                 manually, <command>tuned</command> runs as a normal process. However, you can use
                 the <option>--daemon</option> option to run it as a background process.
@@ -71,7 +71,7 @@ xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-tuning-tune
             </listitem>
             <listitem>
               <para>
-                A &tuned; systemd service that manages the daemon process, such as starting the
+                A &tuned; systemd service, which manages the daemon process, such as starting the
                 daemon at boot time, stopping or restarting it, and ensuring it runs with the
                 necessary permissions and environment.
               </para>
@@ -102,7 +102,7 @@ xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-tuning-tune
             the supported profiles that are installed at <filename>/usr/lib/tuned/</filename> as
             part of the <package>tuned</package> package, or apply customized profiles by creating
             them at <filename>/etc/tuned/</filename>. If the filenames for a custom and a supported
-            profile matches, the custom profile takes precedence when applied. For more
+            profile match, the custom profile takes precedence when applied. For more
             information, see <xref linkend="sec-tuning-tuned-profiles"></xref>.
           </para>
         </listitem>
@@ -207,7 +207,7 @@ xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-tuning-tune
         <step>
           <para>
             To enable a systemd service for future boots so that the &tuned; daemon starts
-            automatically at the boot time, run the following command:
+            automatically at boot time, run the following command:
           </para>
 <screen>&prompt.sudo;<command>systemctl enable tuned</command></screen>
           <para>
@@ -340,9 +340,9 @@ xmlns:xlink="http://www.w3.org/1999/xlink" version="5.0" xml:id="cha-tuning-tune
     <para>
       &tunedapp; optimizes &sles; systems using predefined profiles with settings tailored for
       different use cases. These profiles adjust several system settings, including CPU governor
-      policies, disk I/O scheduling, network parameters, and kernel parameters, to enhance
-      performance, energy efficiency, or other system characteristics. Each profile is designed for
-      specific scenarios, such as high throughput, low latency, power saving, or virtualized
+      policies, disk I/O scheduling, network parameters and kernel parameters, to enhance
+      performance, energy efficiency or other system characteristics. Each profile is designed for
+      specific scenarios, such as high throughput, low latency, power saving or virtualized
       environments. System administrators can switch between profiles using the
       <command>tuned-adm</command> command and customize or combine profiles to meet unique
       requirements. This section covers the basics of managing, creating and customizing &tunedapp;
@@ -767,7 +767,7 @@ log_file_max_size = 1MB <co xml:id="tuned-main-conf-log-file-max-size"></co>
           <para>
             Specifies whether to use the &tuned; daemon. When set to <literal>1</literal>, the
             daemon is used, enabling features such as D-Bus integration, settings rollback, hotplug
-            support, and dynamic tuning. Disabling the daemon by setting it to <literal>0</literal>
+            support and dynamic tuning. Disabling the daemon by setting it to <literal>0</literal>
             is <emphasis>not recommended</emphasis>, as it limits &tunedapp;'s functionality to
             static tuning only.
           </para>
@@ -783,7 +783,7 @@ log_file_max_size = 1MB <co xml:id="tuned-main-conf-log-file-max-size"></co>
         </callout>
         <callout arearefs="tuned-main-conf-sleep-interval">
           <para>
-            Defines the interval in seconds that the &tuned; daemon sleeps before checking for
+            Defines the interval in seconds for which the &tuned; daemon sleeps before checking for
             events. A higher value reduces overhead but increases response time to changes.
           </para>
         </callout>
@@ -797,7 +797,7 @@ log_file_max_size = 1MB <co xml:id="tuned-main-conf-log-file-max-size"></co>
           <para>
             Controls the availability of the <command>tuned-adm recommend</command> command. When
             enabled by setting it to <literal>1</literal>, &tuned; parses the custom recommendation
-            figuration at <filename>/etc/tuned/recommend.conf</filename> or the default
+            configuration at <filename>/etc/tuned/recommend.conf</filename> or the default
             recommendation configuration
             <filename>/usr/lib/tuned/recommend.d/50-tuned.conf</filename> and provides profile
             recommendations. When disabled by setting it to <literal>0</literal>, the daemon
@@ -843,11 +843,11 @@ log_file_max_size = 1MB <co xml:id="tuned-main-conf-log-file-max-size"></co>
       <warning>
         <para>
           Modify the values of the global settings in <filename>/etc/tuned/</filename> only when
-          you are sure of its effects on the behavior of &tunedapp;.
+          you are sure of the effects on the behavior of &tunedapp;.
         </para>
       </warning>
       <para>
-        For a detailed overview of the main &tunedapp; configuration file, read its man page:
+        For a detailed overview of the main &tunedapp; configuration file, read the man page:
       </para>
 <screen>&prompt.user;<command>man 5 tuned-main.conf</command></screen>
     </sect2>
@@ -898,7 +898,7 @@ include=<replaceable>ANOTHER_PROFILE_NAME_AS_BASE</replaceable>
         directory. For example, the configuration file for a custom profile can be at the path
         <filename>/etc/tuned/<replaceable>PROFILE_NAME</replaceable>/tuned.conf</filename>.
         However, if there is a match between <replaceable>PROFILE_NAME</replaceable> in the default
-        path <filename>/usr/lib/tuned/<replaceable>PROFILE_NAME</replaceable></filename> path and
+        path <filename>/usr/lib/tuned/<replaceable>PROFILE_NAME</replaceable></filename> and
         the custom path <filename>/etc/tuned/<replaceable>PROFILE_NAME</replaceable></filename>,
         the custom profile configuration is prioritized and applied. As a best practice for
         customizing a supported profile, copy it from <filename>/usr/lib/tuned/</filename> to
@@ -908,7 +908,7 @@ include=<replaceable>ANOTHER_PROFILE_NAME_AS_BASE</replaceable>
       <note>
         <title>Path to &tunedapp; profile configuration files</title>
         <para>
-          Although <emphasis>not recommended</emphasis>, you can specify paths in the
+          Although <emphasis>not recommended</emphasis>, you can specify paths in
           <filename>/etc/tuned/</filename> other than the standard paths for supported and custom
           profiles:
         </para>
@@ -923,7 +923,7 @@ include=<replaceable>ANOTHER_PROFILE_NAME_AS_BASE</replaceable>
       <warning>
         <para>
           &suse; does not support any profile that is not part of the supported profiles supplied
-          with the <package>tuned</package> from official &sles; repositories. Create and apply a
+          with <package>tuned</package> from official &sles; repositories. Create and apply a
           custom profile on a production system only if you are sure of its effect.
         </para>
       </warning>
@@ -985,7 +985,7 @@ vm.swappiness=10 <co xml:id="reduce-vm-swappiness"></co>
                 </callout>
                 <callout arearefs="cpu-settings-override">
                   <para>
-                    Overrides CPU parameters such as <literal>governor</literal> and
+                    Override CPU parameters such as <literal>governor</literal> and
                     <literal>energy-perf-bias</literal> to <literal>powersave</literal>.
                   </para>
                 </callout>
@@ -1027,7 +1027,7 @@ vm.swappiness=10 <co xml:id="reduce-vm-swappiness"></co>
       system daemon. These plug-ins allow system administrators to create custom optimization
       profiles tailored to specific workloads or hardware configurations. By leveraging several
       system metrics and user-defined parameters, &tunedapp; plug-ins can dynamically adjust kernel
-      settings, CPU frequencies, disk I/O schedulers, and other low-level system parameters to
+      settings, CPU frequencies, disk I/O schedulers and other low-level system parameters to
       achieve optimal performance and energy efficiency. While the core <package>tuned</package>
       package includes several preconfigured profiles, you can extend it through custom plug-ins
       for fine-grained control over the system.
@@ -1166,20 +1166,20 @@ cpufreq_conservative=+r,down_threshold=20,up_threshold=80,sampling_rate=20000 <c
                     <itemizedlist>
                       <listitem>
                         <para>
-                          <parameter>down_threshold=20</parameter> indicate that when the CPU usage
+                          <parameter>down_threshold=20</parameter> indicates that when the CPU usage
                           drops below 20%, the governor lowers the CPU frequency to conserve power.
                         </para>
                       </listitem>
                       <listitem>
                         <para>
-                          <parameter>up_threshold=80</parameter> indicate that when the CPU usage
+                          <parameter>up_threshold=80</parameter> indicates that when the CPU usage
                           exceeds 80%, the governor raises the CPU frequency to improve
                           performance.
                         </para>
                       </listitem>
                       <listitem>
                         <para>
-                          <parameter>sampling_rate=20000</parameter> indicate that the governor
+                          <parameter>sampling_rate=20000</parameter> indicates that the governor
                           samples the CPU usage every 20,000 microseconds (or 20 milliseconds).
                         </para>
                       </listitem>
@@ -1203,7 +1203,7 @@ cpufreq_conservative=+r,down_threshold=20,up_threshold=80,sampling_rate=20000 <c
               The <literal>cpu</literal> plug-in manages and optimizes CPU-related settings to
               enhance performance, power savings, or a balance between the two. This plug-in allows
               fine-grained control over how the CPU operates, including setting the frequency
-              governor, energy performance bias, and other parameters that directly influence the
+              governor, energy performance bias and other parameters that directly influence the
               CPU's behavior and performance characteristics.
             </para>
             <para>
@@ -1248,7 +1248,7 @@ cpufreq_conservative=+r,down_threshold=20,up_threshold=80,sampling_rate=20000 <c
               </listitem>
               <listitem>
                 <para>
-                  <parameter>energy_perf_bias</parameter>: Hints to the CPU how to balance between
+                  <parameter>energy_perf_bias</parameter>: Hints to the CPU how to balance
                   power consumption and performance. Common options for this parameter include the
                   following:
                 </para>
@@ -1478,7 +1478,7 @@ radeon_powersave=dpm-balanced
                 <para>
                   <parameter>apm</parameter>: An integer (1&ndash;254) that sets the Advanced Power
                   Management (APM) level of the disk. Higher values typically mean better
-                  performance, but higher power consumption.
+                  performance but higher power consumption.
                 </para>
               </listitem>
               <listitem>
@@ -1554,7 +1554,7 @@ scheduler_quantum=64
                 <para>
                   <parameter>alpm</parameter>: The Aggressive Link Power Management (ALPM) setting
                   controls the power management policy for Serial ATA (SATA) links. It can take
-                  different values to balance between power savings and performance. The possible
+                  different values to balance power savings and performance. The possible
                   options for this parameter include the following:
                 </para>
                 <itemizedlist>
@@ -1583,7 +1583,7 @@ scheduler_quantum=64
                   </listitem>
                 </itemizedlist>
                 <para>
-                  For example, consider the following configuration that is appropriate for
+                  For example, consider the following configuration, which is appropriate for
                   battery-powered devices, low-usage servers, and systems with long idle periods:
                 </para>
 <screen>
@@ -1691,12 +1691,12 @@ disable_offload=yes
             <para>
               The <literal>sysctl</literal> plug-in offers a powerful way to customize several
               kernel parameters at runtime. This allows system administrators to optimize system
-              performance, enhance security, and adjust network behavior without directly editing
+              performance, enhance security and adjust network behavior without directly editing
               system files or running manual sysctl commands.
             </para>
             <para>
-              The <literal>sysctl</literal> plug-in accepts a wide range of parameters. Certain
-              common categories include:
+              The <literal>sysctl</literal> plug-in accepts a wide range of parameters.
+              Common categories include:
             </para>
             <itemizedlist>
               <listitem>
@@ -1779,7 +1779,7 @@ disable_offload=yes
               <listitem>
                 <para>
                   <parameter>kernel.sched_migration_cost_ns</parameter>: The time (in nanoseconds)
-                  the scheduler considers a migrated process <quote>cache hot</quote>.
+                  for which the scheduler considers a migrated process <quote>cache hot</quote>.
                 </para>
               </listitem>
               <listitem>
@@ -2013,10 +2013,10 @@ cpu_affinity=0,1,2 <co xml:id="systemd-plugin-cpu-affinity"></co>
                   <para>
                     Binds the systemd services to multiple specified CPU cores. By default, it is
                     <literal>None</literal>. In this example, the services are configured to run on
-                    CPU cores <literal>0</literal>, <literal>1</literal>, and <literal>2</literal>.
+                    CPU cores <literal>0</literal>, <literal>1</literal> and <literal>2</literal>.
                     Alternate ways of passing the values include passing a range of CPU cores, such
-                    as <literal>0-2</literal>. However, you <emphasis>cannot</emphasis> pass on the
-                    CPU cores as values which you have declared as
+                    as <literal>0-2</literal>. However, you <emphasis>cannot</emphasis> pass on as 
+                    values the CPU cores that you have declared as
                     <parameter>isolated_cores</parameter> in the file
                     <filename>/etc/tuned/cpu-partitioning-variables.conf</filename>. Configuring
                     the <parameter>cpu_affinity</parameter> parameter in the plug-in is equivalent
@@ -2237,7 +2237,7 @@ grub2_cfg_file="/etc/grub2.cfg"
               </listitem>
               <listitem>
                 <para>
-                  <parameter>wake_on_lan</parameter>: Configure Wake-on-LAN (WoL) settings using
+                  <parameter>wake_on_lan</parameter>: Configures Wake-on-LAN (WoL) settings using
                   any combination of the following characters:
                 </para>
                 <itemizedlist>
@@ -2335,7 +2335,7 @@ grub2_cfg_file="/etc/grub2.cfg"
               <listitem>
                 <para>
                   <parameter>ring</parameter>: A dictionary of ring buffer sizes. Each of the
-                  following ring buffer size parameter has integer values: <literal>rx</literal>,
+                  following ring buffer size parameters has integer values: <literal>rx</literal>,
                   <literal>rx-mini</literal>, <literal>rx-jumbo</literal> and
                   <literal>tx</literal>.
                 </para>
@@ -2366,7 +2366,7 @@ ring=rx:2048, tx:1024
             <para>
               The <literal>vm</literal> plug-in optimizes memory management in virtualized
               environments. It provides mechanisms for tuning memory-related parameters,
-              specifically focusing on the management of Transparent Hugepages (THP). Commonly used
+              specifically focusing on the management of Transparent HugePages (THP). Commonly used
               parameters and their values for this plug-in include the following:
             </para>
             <itemizedlist>
@@ -2375,14 +2375,14 @@ ring=rx:2048, tx:1024
                   <parameter>transparent_hugepage</parameter> or
                   <parameter>transparent_hugepages</parameter>: Often used interchangeably, these
                   parameters are aliases for each other and perform the function of controlling the
-                  behavior of Transparent Hugepages. The common properties and values associated
+                  behavior of Transparent HugePages. The common properties and values associated
                   with this parameter are as follows:
                 </para>
                 <itemizedlist>
                   <listitem>
                     <para>
                       <literal>enabled</literal>: Controls the overall enabling of transparent
-                      hugepages. Possible values are <literal>always</literal>,
+                      huge pages. Possible values are <literal>always</literal>,
                       <literal>madvise</literal> and <literal>never</literal>.
                     </para>
                   </listitem>
@@ -2444,7 +2444,7 @@ transparent_hugepages.khugepaged.scan_sleep_millisecs=10000
               </listitem>
               <listitem>
                 <para>
-                  <parameter>she_powersave</parameter>: Value to set SHE to power saving mode.
+                  <parameter>she_powersave</parameter>: Value to set SHE to power-saving mode.
                   Default value is <literal>2</literal>.
                 </para>
               </listitem>

--- a/xml/utilities.xml
+++ b/xml/utilities.xml
@@ -493,7 +493,7 @@ Average:    92.08    211.70 1097.30     0.26 12010.28      0.00      0.00      0
        changes include separating background and direct reclaim metrics, tracking memory operations
        with greater granularity, introducing deferred reclamation, and adding support for NUMA-aware
        and cgroup-based memory management. Such updates can cause tools like <command>sar</command>
-       to misinterpret metrics like <guimenu>pgsteal</guimenu> and <guimenu>pgscank</guimenu>, resulting in <guimenu>%vmeff</guimenu> value
+       to misinterpret metrics like <guimenu>pgsteal</guimenu> and <guimenu>pgscank</guimenu>, resulting in a <guimenu>%vmeff</guimenu> value
        exceeding 100% in certain situations.
       </para>
       <para>
@@ -1773,10 +1773,10 @@ DirectMap2M:     2017280 kB</screen>
      <term><guimenu>AnonHugePages</guimenu></term>
      <listitem>
       <para>
-       Anonymous hugepages that are mapped into user space page tables.
+       Anonymous huge pages that are mapped into user space page tables.
        These are allocated transparently for processes without being
        specifically requested, therefore they are also known as
-       <emphasis>transparent hugepages</emphasis> (THP).
+       <emphasis>Transparent HugePages</emphasis> (THP).
       </para>
      </listitem>
     </varlistentry>
@@ -1784,7 +1784,7 @@ DirectMap2M:     2017280 kB</screen>
      <term><guimenu>HugePages_Total</guimenu></term>
      <listitem>
       <para>
-       Number of preallocated hugepages for use by
+       Number of preallocated huge pages for use by
        <systemitem>SHM_HUGETLB</systemitem> and
        <systemitem>MAP_HUGETLB</systemitem> or through the
        <systemitem>hugetlbfs</systemitem> file system, as defined in
@@ -1796,7 +1796,7 @@ DirectMap2M:     2017280 kB</screen>
      <term><guimenu>HugePages_Free</guimenu></term>
      <listitem>
       <para>
-       Number of hugepages available.
+       Number of huge pages available.
       </para>
      </listitem>
     </varlistentry>
@@ -1804,7 +1804,7 @@ DirectMap2M:     2017280 kB</screen>
      <term><guimenu>HugePages_Rsvd</guimenu></term>
      <listitem>
       <para>
-       Number of hugepages that are committed.
+       Number of huge pages that are committed.
       </para>
      </listitem>
     </varlistentry>
@@ -1812,7 +1812,7 @@ DirectMap2M:     2017280 kB</screen>
      <term><guimenu>HugePages_Surp</guimenu></term>
      <listitem>
       <para>
-       Number of hugepages available beyond
+       Number of huge pages available beyond
        <guimenu>HugePages_Total</guimenu> (<quote>surplus</quote>), as defined
        in <filename>/proc/sys/vm/nr_overcommit_hugepages</filename>.
       </para>
@@ -1822,7 +1822,7 @@ DirectMap2M:     2017280 kB</screen>
      <term><guimenu>Hugepagesize</guimenu></term>
      <listitem>
       <para>
-       Size of a hugepage&mdash;on &x86-64; the default is 2048&nbsp;KB.
+       Size of a huge page&mdash;on &x86-64; the default is 2048&nbsp;KB.
       </para>
      </listitem>
     </varlistentry>
@@ -2424,7 +2424,7 @@ irq 40:   3216894 hpet2                 irq 50:   1088673 nvidia</screen>
      <term><command>sysctl fs</command> (<filename>/proc/sys/fs/</filename>)</term>
      <listitem>
       <para>
-       Used file handles, quotas, and other file system-oriented parameters.
+       Used file handles, quotas and other file system-oriented parameters.
        For details see
        <filename>/usr/src/linux/Documentation/sysctl/fs.txt</filename>.
       </para>
@@ -2434,8 +2434,8 @@ irq 40:   3216894 hpet2                 irq 50:   1088673 nvidia</screen>
      <term><command>sysctl kernel</command> (<filename>/proc/sys/kernel/</filename>)</term>
      <listitem>
       <para>
-       Information about the task scheduler, system shared memory, and other
-       kernel-related parameters. For details see
+       Information about the task scheduler, system shared memory and other
+       kernel-related parameters. For details, see
        <filename>/usr/src/linux/Documentation/sysctl/kernel.txt</filename>
       </para>
      </listitem>


### PR DESCRIPTION
### PR creator: Description

Integrated proofing corrections in the Tuning Guide.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP6/openSUSE Leap 15.6
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [ ] SLE 12 SP5
