### PR TITLE
Modules QS: integrate proofing corrections

### DIFF
--- a/xml/art_modules.xml
+++ b/xml/art_modules.xml
@@ -395,10 +395,10 @@
         <title><package>docker-stable</package></title>
         <para>
           &suse; ships a package named <package>docker-stable</package>, based on selected versions
-          of the the Moby project, which is the upstream for <phrase
+          of the Moby project, which is the upstream for <phrase
           role="productname">&docker;</phrase>. When this version is no longer supported by the Moby
           project, &suse; will provide reactive support for an additional 3 years, which may require
-          a LTSS subscription depending on the lifecycle of the underlying product.
+          an LTSS subscription depending on the lifecycle of the underlying product.
         </para>
       </note>
       <warning>


### PR DESCRIPTION
### PR creator: Description

Integrated proofing corrections in the Modules and Extensions QS.

@cwickert: please check section "Python" for version numbers and support lifecycles. It seems strange that support for version 3.11 lasts for longer than 3.13. 
It currently states: 

_The Python 3.11 interpreter and modules are supported until the end of December 2029 and might be updated with the next service pack (if compatible and when needed).

Python 3.13 with all necessary modules for getting Python modules from PyPI. The Python 3.13 interpreter and modules are supported for 1.5 years until the end of December 2026._


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP6/openSUSE Leap 15.6
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [ ] SLE 12 SP5