### PR TITLE
Updated for DOCTEAM-1882.

### DIFF
--- a/xml/ay_erb_templates.xml
+++ b/xml/ay_erb_templates.xml
@@ -697,7 +697,7 @@ fi;
   &lt;/drive&gt;
   &lt;% if home_in_sdb %&gt;
   &lt;drive&gt;
-    &lt;device&gt;/dev/sdb&lt;/device&gt;
+    &lt;device&gt;sdb&lt;/device&gt;
     &lt;disklabel&gt;none&lt;/disklabel&gt;
     &lt;partitions t="list"&gt;
       &lt;partition&gt;


### PR DESCRIPTION
### PR creator: Description
Updated the document to fix DOCTEAM-1882. Changed the line with:

    <device>/dev/sdb</device>

into

    <device>sdb</device>


### PR creator: Are there any relevant issues/feature requests?

DOCTEAM:1882


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP6/openSUSE Leap 15.6
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
