### PR TITLE
Updates for Marvel FC-NVMe adaptors. From Bugilla 1243204.

### DIFF
--- a/xml/storage_nvmeof.xml
+++ b/xml/storage_nvmeof.xml
@@ -136,7 +136,7 @@
         IPv4 address. Replace <replaceable>SERVICE_ID</replaceable> with the
         transport service ID. If the service is IP based, like RDMA or TCP,
         this specifies the port number. Replace
-        <replaceable>SUBSYSTEM_NQN</replaceable> with the NVMe qualified name
+        <replaceable>SUBSYSTEM_NQN</replaceable> with the &nvme; qualified name
         of the desired subsystem as found by the discovery command.
         <emphasis>NQN</emphasis> is the abbreviation for <emphasis> &nvme;
         Qualified Name</emphasis>. The NQN must be unique.
@@ -171,7 +171,7 @@
       </para>
 <screen>&prompt.sudo;nvme connect --ctrl-loss-tmo=-1</screen>
       <para>
-        To make an NVMe over Fabrics subsystem available at boot, create a
+        To make an &nvme; over Fabrics subsystem available at boot, create a
         <filename>/etc/nvme/discovery.conf</filename> file on the host with the
         parameters passed to the <command>discover</command> command (as
         described in
@@ -195,7 +195,7 @@
       <para>
         &nvme; native multipathing is enabled by default. If the
         <option>CMIC</option> option in the controller identity settings is
-        set, the NVMe stack recognizes an NVME drive as a multipathed device by
+        set, the &nvme; stack recognizes an NVME drive as a multipathed device by
         default.
       </para>
       <para>
@@ -226,7 +226,7 @@
           <term><option>nvme-core.multipath=N</option></term>
           <listitem>
             <para>
-              When the option is added as a boot parameter, the NVMe native
+              When the option is added as a boot parameter, the &nvme; native
               multipathing will be disabled.
             </para>
           </listitem>
@@ -543,7 +543,7 @@ Parameter traddr is now '10.0.0.3'.</screen>
         <para>
 
           Once you have configured the UEFI driver using the BIOS setup menu
-          for FC-&nvme; boot, and configured the NVMe storage with the
+          for FC-&nvme; boot, and configured the &nvme; storage with the
           Initiator Host NQN, there are no more FC-&nvme; BFS steps. You can
           now detect the &nvme; storage during the install of SLES 15 SP4, or
           later.
@@ -603,7 +603,7 @@ Parameter traddr is now '10.0.0.3'.</screen>
     <para>
       The UEFI pre-boot environment can be configured to attempt &nvmeof; over
       TCP connections to remote storage servers and use these for booting. The
-      pre-boot environment creates an ACPI table&mdash;NVMe Boot Firmware Table
+      pre-boot environment creates an ACPI table&mdash;&nvme; Boot Firmware Table
       (NBFT) to store information about the &nvmeof; configuration used for
       booting. The operating system uses this table at a later boot stage to
       set up networking and &nvmeof; connections to access the root file
@@ -650,7 +650,7 @@ Parameter traddr is now '10.0.0.3'.</screen>
             Use the host system's UEFI setup menus to configure &nvmeof;
             connections to be established at boot time. Typically, you need to
             configure both networking (local IP addresses, gateways, etc.) and
-            NVMe-oF targets (remote IP address, subsystem NQN or discovery
+            &nvmeof; targets (remote IP address, subsystem NQN or discovery
             NQN). Refer to the hardware documentation for the configuration
             description. Your hardware vendor may provide means to manage the
             BIOS configuration centrally and remotely. Please contact your
@@ -674,7 +674,7 @@ Parameter traddr is now '10.0.0.3'.</screen>
           <para>
             If the BIOS has been configured correctly, the disk partitioning
             dialog in &yast; will show &nvme; namespaces exported by the
-            subsystems configured in the BIOS. They will be displayed as NVMe
+            subsystems configured in the BIOS. They will be displayed as &nvme;
             devices, where the <literal>tcp</literal> string indicates that the
             devices are connected via the TCP transport. Install the operating
             system (in particular the EFI boot partition and the root file


### PR DESCRIPTION
### PR creator: Description

Update section on Marvell FC-NVMe adpators.


### PR creator: Are there any relevant issues/feature requests?

* bsc#1243204



### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP6/openSUSE Leap 15.6
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
