### PR TITLE
rm duplicate product entity

### DIFF
--- a/xml/suse_l10n.xml
+++ b/xml/suse_l10n.xml
@@ -107,7 +107,7 @@
    settings.
   </para>
   <note>
-   <title>Behavior of older configuration files under &productname; &productname;</title>
+   <title>Behavior of older configuration files under &productname;</title>
    <para>
     Earlier versions of &productname; read locale settings from
     <filename>/etc/sysconfig/language</filename>,


### PR DESCRIPTION
Description
Removing duplicated product entity

PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP6/openSUSE Leap 15.6
  - [x] SLE 15 SP5/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [x] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
