### PR TITLE
Fix style issues in "Manual Kdump configuration" of Tuning guide

### DIFF
--- a/xml/tuning_kexec.xml
+++ b/xml/tuning_kexec.xml
@@ -657,14 +657,14 @@ cio_ignore=all,!da5d,!f500-f502</screen>
     </step>
     <step>
      <para>
-      Reboot the computer.
+      Reboot the system.
      </para>
     </step>
     <step>
      <para>
       Enable the &kdump; service:
      </para>
-<screen>&prompt.root;<command>systemctl</command> enable kdump</screen>
+<screen>&prompt.sudo;<command>systemctl</command> enable kdump</screen>
      <para>
 <!--taroth 2014-03-19: systemd - according to fcrozat, no more boot.* stuff:
        <command>chkconfig boot.kdump
@@ -679,10 +679,19 @@ cio_ignore=all,!da5d,!f500-f502</screen>
      </para>
     </step>
     <step>
-     <para>
-      Execute the init script once with <command>sudo systemctl start
-      kdump</command>, or reboot the system.
-     </para>
+     <stepalternatives>
+      <step>
+       <para>
+        Execute the init script once.
+       </para>
+<screen>&prompt.sudo;<command>systemctl</command> start kdump</screen>
+      </step>
+      <step>
+       <para>
+        Reboot the system.
+       </para>
+      </step>
+     </stepalternatives>
     </step>
    </procedure>
    <para>
@@ -693,34 +702,34 @@ cio_ignore=all,!da5d,!f500-f502</screen>
    <procedure>
     <step>
      <para>
-      Switch to the rescue target with <command>systemctl isolate
-      rescue.target</command>
+      Switch to the rescue target.
      </para>
+<screen>&prompt.sudo;<command>systemctl</command> isolate rescue.target</screen>
     </step>
     <step>
      <para>
       Restart the &kdump; service:
      </para>
-<screen>&prompt.root;<command>systemctl</command> start kdump</screen>
+<screen>&prompt.sudo;<command>systemctl</command> start kdump</screen>
     </step>
     <step>
      <para>
       Unmount all the disk file systems except the root file system with:
      </para>
-<screen>&prompt.root;<command>umount</command> -a</screen>
+<screen>&prompt.sudo;<command>umount</command> -a</screen>
     </step>
     <step>
      <para>
       Remount the root file system in read-only mode:
      </para>
-<screen>&prompt.root;<command>mount</command> -o remount,ro /</screen>
+<screen>&prompt.sudo;<command>mount</command> -o remount,ro /</screen>
     </step>
     <step>
      <para>
       Invoke a <quote>kernel panic</quote> with the <literal>procfs</literal>
       interface to Magic SysRq keys:
      </para>
-<screen>&prompt.root;<command>echo</command> c &gt; /proc/sysrq-trigger</screen>
+<screen>&prompt.sudo;<command>echo</command> c &gt; /proc/sysrq-trigger</screen>
     </step>
    </procedure>
    <important>


### PR DESCRIPTION
### PR creator: Description

Fix style issues in "Manual Kdump configuration" of Tuning guide. For more information, see the description of the JIRA issue.


### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#...https://jira.suse.com/browse/DOCTEAM-1933


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [x] SLE 15 SP6/openSUSE Leap 15.6: https://github.com/SUSE/doc-sle/commit/950233fb84cb7dca1527f80eed4006a85d01aa5e
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [x] all necessary backports are done
