### PR TITLE
Update fuse.xml … mention archivemount-ng

### DIFF
--- a/xml/fuse.xml
+++ b/xml/fuse.xml
@@ -239,6 +239,18 @@ ntfs-3g /dev/<replaceable>DEVICE</replaceable> <replaceable>MOUNT POINT</replace
      <row os="osuse">
       <entry>
        <para>
+        <systemitem class="resource">archivemount-ng</systemitem>
+       </para>
+      </entry>
+      <entry>
+       <para>
+        mount archives as a file system
+       </para>
+      </entry>
+     </row>
+     <row os="osuse">
+      <entry>
+       <para>
         <systemitem class="resource">curlftpfs</systemitem>
        </para>
       </entry>


### PR DESCRIPTION
There is a complete mess of various FUSE plugins dealing with archives (requirement for vifm, for example): most of them are in various stages of abandonment and support or not of fuse3. Also, not all of them (fuse-archive) are included in openSUSE. `archivemount-ng` seems to be working at least as RO file system.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

openSUSE/Tumbleweed (and perhaps Leap 15.6+).

### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
