### PR TITLE
Add a short paragraph about 'unhandled trap' message

### DIFF
--- a/xml/ulp.xml
+++ b/xml/ulp.xml
@@ -276,18 +276,18 @@
     </sect2>
   </sect1>
   <sect1 xml:id="sec-ppc64le-patching-systemd">
-    <title>&ppc64le; specific information</title>
+    <title>&ppc64le; specific behavior of user space live patching</title>
 
     <para>
-      There are some specific behaviour of user space livepatching according to
-      the system architecture.  On &ppc64le;, livepatching systemd (process with
-      PID = 1) will result in the following message in dmesg:
+      The system architecture can influence the behavior of user space live patching.
+      On &ppc64le;, livepatching &systemd; (the process with PID = 1) results
+      in the following message in <literal>dmesg</literal>:
       </para>
 <screen>unhandled trap code 1 in libpulp.so.0.0.0</screen>
       <para>
-      This message is harmless and can be ignored, as the &ppc64le; kernel will
-      always display this if the process with PID = 1 executes a `trap`
-      instruction. See  <link xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=1244263"/> for more information.
+      This message is harmless and can be ignored, as the &ppc64le; kernel always display this
+      if the process with PID = 1 executes a <quote>trap</quote>instruction.
+      Refer <link xlink:href="https://bugzilla.suse.com/show_bug.cgi?id=1244263"/> for more information.
     </para>
   </sect1>
   <sect1 xml:id="sec-ulp-info">


### PR DESCRIPTION
### PR creator: Description


ULP on power makes the kernel display a message in dmesg:
```
unhandled trap from libpulp.so.0.0.0
```
Update the documentation to show that this message is harmless and is there because the process with pid=1 (systemd) is being livepatched.

### PR creator: Are there any relevant issues/feature requests?

* bsc#1244263

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP6/openSUSE Leap 15.6
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
