### PR TITLE
Update sle_update_online.xml

### DIFF
--- a/xml/sle_update_online.xml
+++ b/xml/sle_update_online.xml
@@ -624,7 +624,7 @@ Continue? [y/n/? shows all options] (y):</screen>
      With the above command, zypper downloads all packages in advance&mdash;which is more reliable
      if your Internet connection may fail. To download and install packages in heaps, run:
     </para>
-<screen>&prompt.sudo;<command>zypper zypper --releasever=&product-dsc-url-substring; dup --no-allow-vendor-change --no-recommends --download-in-heaps</command></screen>
+<screen>&prompt.sudo;<command>zypper --releasever=&product-dsc-url-substring; dup --no-allow-vendor-change --no-recommends --download-in-heaps</command></screen>
     <para>
      When the distribution update is finished, &productname; sets the <varname>$releasever</varname>
      variable to the new version and you no longer need to specify it with the


### PR DESCRIPTION
fix duplicate command typo

### PR creator: Description

Deleted the repeated `zypper` command in [Update sle_update_online.xml/5.6 Upgrading with plain Zypper] to ensure accuracy.

### PR creator: Are there any relevant issues/feature requests?
Uncertainty

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.
- SLE 15
  - [x] SLE 15 SP7


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
