### PR TITLE
vt-doc: Mention use of snpguest to verify SEV-SNP

### DIFF
--- a/xml/vm_security.xml
+++ b/xml/vm_security.xml
@@ -86,7 +86,7 @@
     <title>Verifying setup</title>
 
     <para>
-      You can verify the installation and configuration of the &vmhost; using dmesg or 
+      You can verify the installation and configuration of the &vmhost; using dmesg or
       the optional <command>snphost</command> tool.
     </para>
     <procedure>
@@ -292,7 +292,7 @@
 
     <para>
       The kernel log will contain messages describing the state of AMD memory encryption features
-      within the virtual machine. To check the kernel log, run the command:
+      within the virtual machine. To check the kernel log, run the following command:
     </para>
 
 <screen>&prompt.sudo; <command>dmesg | grep -i sev-snp</command>
@@ -304,7 +304,7 @@
     </para>
 
     <para>
-      The optional <command>snpguest</command> tool can also be used to verify if the SEV-SNP
+      You can use the optional <command>snpguest</command> tool to verify if the SEV-SNP
       feature is active in the virtual machine. Similar to <command>snphost</command>, the
       <command>snpguest</command> tool requires the MSR kernel module. The following example
       demonstrates using <command>snpguest</command> to check the status of memory encryption


### PR DESCRIPTION
Along with inspecting the kernel log, mention the snpguest tool can be used to verify the status of SEV-SNP memory encryption feature.

As part of bsc#1246648, include a note that snpguest requires the MSR kernel module.

### PR creator: Are there any relevant issues/feature requests?

* bsc#1246648
* bsc#1237858


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 next/openSUSE Leap next *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP6/openSUSE Leap 15.6
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer only: Have all backports been applied?

The doc team member merging your PR will take care of backporting to older documents.
When opening a PR, do *not* set the following check box.

- [ ] all necessary backports are done
