### PR TITLE
DOCTEAM-2059 Modified values and explanation for sched_min_granularity_ns and sched_wakeup_granularity_ns

### DIFF
--- a/xml/book_tuning.xml
+++ b/xml/book_tuning.xml
@@ -144,6 +144,14 @@
   <info>
    <revhistory xml:id="rh-tuning-part-kerneltuning">
     <revision>
+     <date>2026-03-31</date>
+     <revdescription>
+      <para>
+       Modified values and explanation for sched_min_granularity_ns and sched_wakeup_granularity_ns.
+      </para>
+     </revdescription>
+    </revision>
+    <revision>
      <date>2024-03-12</date>
      <revdescription>
       <para/>

--- a/xml/tuning_taskscheduler.xml
+++ b/xml/tuning_taskscheduler.xml
@@ -615,9 +615,14 @@ kernel.sched_wakeup_granularity_ns = 10000000</screen>
           <term><systemitem>sched_min_granularity_ns</systemitem></term>
           <listitem>
             <para>
-              Minimal preemption granularity for CPU bound tasks. See
-              <systemitem>sched_latency_ns</systemitem> for details. The
-              default value is <literal>4000000</literal> (ns).
+             Minimal preemption granularity for CPU bound tasks. See
+             <systemitem>sched_latency_ns</systemitem> for details. The default value is calculated
+             as <literal>750000 * (1 + ilog(ncpus))</literal> nanoseconds, where
+             <literal>ilog(ncpus)</literal> is the integer <literal>base-2</literal> logarithm of
+             the number of online CPUs. For example, on a 2-CPU system the default is
+             <literal>1500000</literal> ns. The actual value reported by
+             <systemitem>sysctl</systemitem> is therefore machine-specific and varies with CPU count
+             and the value of <literal>sched_tunable_scaling</literal>.
             </para>
           </listitem>
         </varlistentry>
@@ -625,12 +630,7 @@ kernel.sched_wakeup_granularity_ns = 10000000</screen>
           <term><systemitem>sched_wakeup_granularity_ns</systemitem></term>
           <listitem>
             <para>
-              The wake-up preemption granularity. Increasing this variable
-              reduces wake-up preemption, reducing disturbance of compute bound
-              tasks. Lowering it improves wake-up latency and throughput for
-              latency critical tasks, particularly when a short duty cycle load
-              component must compete with CPU bound components. The default
-              value is <literal>2500000</literal> (ns).
+             The wake-up preemption granularity. Increasing this variable reduces wake-up preemption, reducing disturbance of compute bound tasks. Lowering it improves wake-up latency and throughput for latency critical tasks, particularly when a short duty cycle load component must compete with CPU bound components. The default value is calculated as <literal>1000000 * (1 + ilog(ncpus))</literal> nanoseconds, where <literal>ilog(ncpus)</literal> is the integer <literal>base-2</literal> logarithm of the number of online CPUs. For example, on a 2-CPU system the default is <literal>2000000</literal> ns. The actual value reported by <systemitem>sysctl</systemitem> is therefore machine-specific and varies with CPU count and the value of <literal>sched_tunable_scaling</literal>.
             </para>
             <warning>
               <title>Setting the right wake-up granularity value</title>


### PR DESCRIPTION
### PR creator: Description

Modified values and explanation for sched_min_granularity_ns and sched_wakeup_granularity_ns.


### PR creator: Are there any relevant issues/feature requests?

* bsc#...https://bugzilla.suse.com/show_bug.cgi?id=1253641, https://bugzilla.suse.com/show_bug.cgi?id=1249629
* jsc#...https://jira.suse.com/browse/DOCTEAM-2059


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP7/openSUSE Leap 15.7 *(current `main`, no backport necessary)* [merge commit](https://github.com/SUSE/doc-sle/commit/ad0e7bc1075651c257a760004c8f2ee7eda9cd54) 
  - [x] SLE 15 SP6/openSUSE Leap 15.6 [merge commit](https://github.com/SUSE/doc-sle/commit/f1992288923a207c71232707491ae0652ddc8f62)
  - [x] SLE 15 SP5/openSUSE Leap 15.5 [merge commit](https://github.com/SUSE/doc-sle/commit/765aee0992c37a87b410eadf57d42bfbc205aa99)
  - [x] SLE 15 SP4/openSUSE Leap 15.4 [merge commit](https://github.com/SUSE/doc-sle/commit/e55e3c8e162d34f16d8ea78a071183fe41c7c6c6)
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer: Checklist

The doc team member merging your PR will take care of the following tasks and will tick the boxes if done.

- [x] all necessary backports are done
- [x] check and update `<revision><date>YYYY-MM-DD</date>` of chapter, part and book (if the change warrants it - for criteria, see https://documentation.suse.com/style/current/html/style-guide-db/sec-structure.html#sec-revinfo) 
