### PR TITLE
DOCTEAM-2217 SLE 15 SP7 Changes to supported hosts and guests

### DIFF
--- a/xml/book_virtualization.xml
+++ b/xml/book_virtualization.xml
@@ -34,6 +34,14 @@
   </meta>
   <revhistory xml:id="rh-book-virtualization">
     <revision>
+      <date>2026-04-01</date>
+      <revdescription>
+        <para>
+          Added &sls; 16.0 and SUSE Virtualization (Harvester) as supported KVM hosts; added Windows Server 2022, Windows Server 2025, and &sls; 16.0 as supported guests.
+        </para>
+      </revdescription>
+    </revision>
+    <revision>
       <date>2025-06-17</date>
       <revdescription>
         <para>

--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -376,6 +376,30 @@
               </para>
             </entry>
           </row>
+          <row>
+            <entry>
+              <para>
+                &sls; 16.0
+              </para>
+            </entry>
+            <entry>
+              <para>
+                KVM
+              </para>
+            </entry>
+          </row>
+          <row>
+            <entry>
+              <para>
+                SUSE Virtualization (Harvester)
+              </para>
+            </entry>
+            <entry>
+              <para>
+                KVM
+              </para>
+            </entry>
+          </row>
         </tbody>
       </tgroup>
     </table>
@@ -488,12 +512,17 @@
       </listitem>
       <listitem>
         <para>
+          &sls; 16.0
+        </para>
+      </listitem>
+      <listitem>
+        <para>
           &slem; 5.1, 5.2, 5.3, 5.4, 5.5, 6.0
         </para>
       </listitem>
       <listitem>
         <para>
-          Windows Server 2016, 2019
+          Windows Server 2016, 2019, 2022, 2025
         </para>
       </listitem>
 <!--


### PR DESCRIPTION
### PR creator: Description

- Added SLES 16.0 and SUSE Virtualization (Harvester) as supported KVM hosts.
- Added Windows Server 2022, Windows Server 2025, and SLES 16.0 as supported guests.


### PR creator: Are there any relevant issues/feature requests?

| BSC | JSC |
| --- | --- |
| https://bugzilla.suse.com/show_bug.cgi?id=1261262 | https://jira.suse.com/browse/DOCTEAM-2216 |
| https://bugzilla.suse.com/show_bug.cgi?id=1247955 | https://jira.suse.com/browse/DOCTEAM-1954 |
| https://bugzilla.suse.com/show_bug.cgi?id=1250437 | https://jira.suse.com/browse/DOCTEAM-1995 |

> **Note**: The JIRA issues are housed under an umbrella issue https://jira.suse.com/browse/DOCTEAM-2217 for tracking convenience.


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP7/openSUSE Leap 15.7 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP6/openSUSE Leap 15.6
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer: Checklist

The doc team member merging your PR will take care of the following tasks and will tick the boxes if done.

- [ ] all necessary backports are done
- [x] check and update `<revision><date>YYYY-MM-DD</date>` of chapter, part and book (if the change warrants it - for criteria, see https://documentation.suse.com/style/current/html/style-guide-db/sec-structure.html#sec-revinfo) 
