### PR TITLE
Removed broken link from AY Guide

### DIFF
--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -2055,7 +2055,7 @@ size=40G features='0' hwhandler='0' wp=rw
    improve the performance of a large (but slow) drive by using a fast one as a
    cache.
   </para>
-  <para>For more information about bcache on SUSE Linux Enterprise Server, also see <link xlink:href="https://documentation.suse.com/sles/15-SP7/single-html/SLES-storage/#sec-multitiercache-bcache"></link>.</para>
+  <para>For more information about &bcache; on SUSE Linux Enterprise Server, see <link xlink:href="https://documentation.suse.com/sles/15-SP7/single-html/SLES-storage/#sec-multitiercache-bcache"></link>.</para>
   <para>
    To set up a &bcache; device, &ay; needs a profile that specifies the
    following:

--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -1051,7 +1051,7 @@
    </variablelist>
   </sect3>
   <sect3 xml:id="ay-btrfs-subvolumes">
-   <title>Btrfs subvolumes</title>
+   <title>btrfs subvolumes</title>
    <para>
     As mentioned in <xref linkend="ay-partition-configuration"/>, it is
     possible to define a set of subvolumes for each Btrfs file system. In its
@@ -2054,11 +2054,6 @@ size=40G features='0' hwhandler='0' wp=rw
    speed up the access to one or more slower drives. For example, you can
    improve the performance of a large (but slow) drive by using a fast one as a
    cache.
-  </para>
-  <para>
-   For more information about bcache on &productname;, also see the blog post
-   at
-   <link xlink:href="https://www.suse.com/c/combine-the-performance-of-solid-state-drive-with-the-capacity-of-a-hard-drive-with-bcache-and-yast/"/>.
   </para>
   <para>
    To set up a &bcache; device, &ay; needs a profile that specifies the

--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -2055,6 +2055,7 @@ size=40G features='0' hwhandler='0' wp=rw
    improve the performance of a large (but slow) drive by using a fast one as a
    cache.
   </para>
+  <para>For more information about bcache on SUSE Linux Enterprise Server, also see <link xlink:href="https://documentation.suse.com/sles/15-SP7/single-html/SLES-storage/#sec-multitiercache-bcache"></link>.</para>
   <para>
    To set up a &bcache; device, &ay; needs a profile that specifies the
    following:

--- a/xml/ay_partitioning.xml
+++ b/xml/ay_partitioning.xml
@@ -2055,7 +2055,7 @@ size=40G features='0' hwhandler='0' wp=rw
    improve the performance of a large (but slow) drive by using a fast one as a
    cache.
   </para>
-  <para>For more information about &bcache; on SUSE Linux Enterprise Server, see <link xlink:href="https://documentation.suse.com/sles/15-SP7/single-html/SLES-storage/#sec-multitiercache-bcache"></link>.</para>
+  <para>For more information about &bcache; on &productname;, see <link xlink:href="https://documentation.suse.com/sles/15/html/SLES-all/cha-multitiercache.html#sec-multitiercache-bcache"></link>.</para>
   <para>
    To set up a &bcache; device, &ay; needs a profile that specifies the
    following:


### PR DESCRIPTION
### PR creator: Description

Removed the following para since the link is not available anymore.

For more information about bcache on SUSE Linux Enterprise Server, also see the blog post at [https://www.suse.com/c/combine-the-performance-of-solid-state-drive-with-the-capacity-of-a-hard-drive-with-bcache-and-yast/](https://www.suse.com/c/combine-the-performance-of-solid-state-drive-with-the-capacity-of-a-hard-drive-with-bcache-and-yast/?_gl=1*6zggqs*_gcl_aw*R0NMLjE3NzMzMjkzNTguQ2p3S0NBand5TW5OQmhCTkVpd0EtS2NndThhSzlselVrY3VObzlZV1poV3NZVnl6SDgtZGpZZVB5MmJQRVVzQTAxUWQwV2E3eDV0Y2hSb0NPcjRRQXZEX0J3RQ..*_gcl_au*MTYwNTgxMjc2Mi4xNzc2ODc5MDA1*_ga*MjgwODMzNzI0LjE3NDUzODI4NDQ.*_ga_JEVBS2XFKK*czE3Nzk3NzgyNTUkbzEyMyRnMSR0MTc3OTc3ODgyMCRqNTgkbDAkaDc5Njc2Njc0MA..).

### PR creator: Are there any relevant issues/feature requests?

* bsc#...
* jsc#...


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP7/openSUSE Leap 15.7 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP6/openSUSE Leap 15.6
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer: Checklist

The doc team member merging your PR will take care of the following tasks and will tick the boxes if done.

- [ ] all necessary backports are done
- [ ] check and update `<revision><date>YYYY-MM-DD</date>` of chapter, part and book (if the change warrants it - for criteria, see https://documentation.suse.com/style/current/html/style-guide-db/sec-structure.html#sec-revinfo) 
