### PR TITLE
Removed officially (SUSE) unsupported profiles

### DIFF
--- a/xml/article_openscap.xml
+++ b/xml/article_openscap.xml
@@ -44,6 +44,14 @@
     <meta name="task" its:translate="no"><phrase>Auditing</phrase><phrase>Compliance</phrase>
     </meta>
     <revhistory xml:id="rh-openscap">
+     <revision>
+      <date>2026-06-25</date>
+      <revdescription>
+       <para>
+        Removed unsupported SSG profiles.
+       </para>
+      </revdescription>
+     </revision>
       <revision><date>2026-04-27</date>
         <revdescription>
           <para>

--- a/xml/article_openscap.xml
+++ b/xml/article_openscap.xml
@@ -730,16 +730,6 @@ xml:id="ssg-profiles-info-view"></co></screen>
               Public Cloud Hardening for &productname; &product-ga;
             </para>
           </listitem>
-          <listitem>
-            <para>
-              Standard System Security Profile for &productname; &product-ga;
-            </para>
-          </listitem>
-          <listitem>
-            <para>
-              General System Security Profile for &productname; (&slsa;) &product-ga;
-            </para>
-          </listitem>
         </itemizedlist>
         <note>
           <title>Text-based list as updated information on supported profiles</title>


### PR DESCRIPTION
### PR creator: Description

Remove officially (SUSE) **unsupported** profiles:
- Standard System Security Profile for SUSE Linux Enterprise Server 15
- General System Security Profile for SUSE Linux Enterprise Server (SLES) 15


### PR creator: Are there any relevant issues/feature requests?

* bsc#...https://bugzilla.suse.com/show_bug.cgi?id=1262576
* jsc#...https://jira.suse.com/browse/DOCTEAM-2275


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP7/openSUSE Leap 15.7 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP6/openSUSE Leap 15.6 https://github.com/SUSE/doc-sle/commit/25b90e6048f0e258ede163eb64d0142e6d1ebac2
  - [x] SLE 15 SP5/openSUSE Leap 15.5 https://github.com/SUSE/doc-sle/commit/239716bce8a673fc612de5938de9525b8fd99be5
  - [x] SLE 15 SP4/openSUSE Leap 15.4 https://github.com/SUSE/doc-sle/commit/dfa303c5a089f824b5a8c7855484a0bceda6116a
  - [] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [ ] SLE 12 SP5 See https://github.com/SUSE/doc-sle/pull/1944


### PR reviewer: Checklist

The doc team member merging your PR will take care of the following tasks and will tick the boxes if done.

- [x] all necessary backports are done
- [x] check and update `<revision><date>YYYY-MM-DD</date>` of chapter, part and book (if the change warrants it - for criteria, see https://documentation.suse.com/style/current/html/style-guide-db/sec-structure.html#sec-revinfo) 
