### PR TITLE
RMT: Update documentation for Ansible-based configuration (SLE 16)

### DIFF
--- a/xml/rmt_certificates.xml
+++ b/xml/rmt_certificates.xml
@@ -46,9 +46,10 @@
       </step>
       <step>
         <para>
-          Run the <command>yast rmt</command> module as described in
-          <xref linkend="sec-rmt-installation-yast-configuration"/>.
+          Regenerate certificates using the &ansible; playbook:
         </para>
+<screen>&prompt.root;<command>cd /usr/share/ansible/rmt</command>
+&prompt.root;<command>ansible-playbook site.yml --tags certificates</command></screen>
       </step>
     </procedure>
   </sect1>
@@ -87,9 +88,10 @@
       </step>
       <step>
         <para>
-          Run the <command>yast rmt</command> module as described in
-          <xref linkend="sec-rmt-installation-yast-configuration"/>.
+          Regenerate certificates using the &ansible; playbook:
         </para>
+<screen>&prompt.root;<command>cd /usr/share/ansible/rmt</command>
+&prompt.root;<command>ansible-playbook site.yml --tags certificates</command></screen>
       </step>
     </procedure>
   </sect1>

--- a/xml/rmt_config_files.xml
+++ b/xml/rmt_config_files.xml
@@ -18,16 +18,15 @@
  </info>
  <para>
   The main &rmt; configuration file is <filename>/etc/rmt.conf</filename>.
-  You can set most of the options with the &yast; &rmt; Server module.
+  Configuration is performed using the &ansible; playbooks provided in the ansible-rmt-server package.
  </para>
 
  <sect2 xml:id="sec-rmt-config-rmtconf">
   <title>/etc/rmt.conf</title>
   <para>
-   The only supported way of doing the initial configuration is with
-   <command>yast2 rmt</command> as described in <xref
-   linkend="sec-rmt-installation-yast-configuration" />. Only the proxy
-   configuration needs to be entered manually. The other configuration
+   The initial configuration is performed using &ansible; as described in
+   <xref linkend="sec-rmt-installation-ansible-configuration" />. Only the
+   proxy configuration needs to be entered manually. The other configuration
    parameters are documented for reference.
   </para>
   <para>
@@ -235,7 +234,7 @@
    </listitem>
   </itemizedlist>
   <para>
-   The &yast; &rmt; module generates a custom certificate authority which
+   The &ansible; playbook generates a custom certificate authority which
    is used to sign HTTPS certificates. This means that to register,
    this certificate authority must be trusted by the client machines:
   </para>

--- a/xml/rmt_install.xml
+++ b/xml/rmt_install.xml
@@ -148,7 +148,7 @@
         &minvm;, run the following command from the &minvm; command line as
         &rootuser;:
       </para>
-<screen>&prompt.root;zypper install rmt-server yast2-rmt nginx mariadb</screen>
+<screen>&prompt.root;zypper install rmt-server ansible-rmt-server nginx mariadb</screen>
       <important>
         <title>Hardware requirements</title>
         <para>
@@ -454,123 +454,168 @@ EOF
       </sect3>
     </sect2>
   </sect1>
-  <sect1 xml:id="sec-rmt-installation-yast-configuration">
-    <title>&rmt; configuration with &yast;</title>
+  <sect1 xml:id="sec-rmt-installation-ansible-configuration">
+    <title>&rmt; configuration with &ansible;</title>
 
     <para>
-      Configure &rmt; with &yast; as described in the following procedure. It
-      is assumed that this procedure is executed on a newly installed system.
+      Configure &rmt; with &ansible; as described in the following procedure.
+      The ansible-rmt-server package provides pre-built playbooks and roles for
+      automated &rmt; configuration. It is assumed that this procedure is
+      executed on a newly installed system.
     </para>
 
     <procedure>
       <step>
         <para>
-          Start &yast; with the <literal>rmt</literal> module.
+          Navigate to the &ansible; configuration directory:
         </para>
-<screen>&prompt.sudo;<command>yast2 rmt</command></screen>
-        <para>
-          Alternatively, start &yast; and select <menuchoice> <guimenu>Network
-          Services</guimenu> <guimenu>&rmt; Configuration</guimenu>
-          </menuchoice>.
-        </para>
+<screen>&prompt.root;<command>cd /usr/share/ansible/rmt</command></screen>
       </step>
+
       <step>
         <para>
-          Enter your organization credentials. To retrieve your credentials,
-          refer to <xref linkend="sec-rmt-mirroring-credentials"/>.
+          Create the configuration file <filename>group_vars/all.yml</filename>
+          based on the provided example:
         </para>
+<screen>&prompt.root;<command>cp group_vars/all.yml.example group_vars/all.yml</command></screen>
       </step>
+
       <step>
         <para>
-          Enter credentials for a new &mariadb; user and database name, and
-          confirm with <guimenu>Next</guimenu>.
+          Edit <filename>group_vars/all.yml</filename> and configure the
+          following variables:
         </para>
-        <para>
-          If a password for the &mariadb; <literal>root</literal> user is
-          already set, you are required to enter it. If no password is set for
-          <literal>root</literal>, you are asked to enter a new one.
-        </para>
-      </step>
-      <step>
-        <para>
-          Enter a common name for the SSL certificates. The common name should
-          be the <emphasis>fully qualified domain name</emphasis>
-          (<emphasis>FQDN</emphasis>) of the server. Enter all domain names and
-          IP addresses with which you want to reach the &rmt; server as
-          alternative common names.
-        </para>
-        <para>
-          When all common names are entered, select <guimenu>Next</guimenu>.
-        </para>
-        <tip>
-          <title>Certificate locations for RMT</title>
-          <itemizedlist>
+        <variablelist>
+          <varlistentry>
+            <term><literal>rmt_db_username</literal></term>
             <listitem>
               <para>
-                <filename>/etc/rmt/ssl/rmt-ca.crt</filename>
-              </para>
-              <para>
-                This is the CA certificate bundle that <command>yast2
-                rmt</command> uses to certify the &rmt; server certificate.
-                <command>yast2 rmt</command> only creates this file if it does
-                not already exist.
+                Database username for &rmt; (default: <literal>rmt</literal>)
               </para>
             </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term><literal>rmt_db_password</literal></term>
             <listitem>
               <para>
-                <filename>/etc/rmt/ssl/rmt-server.crt</filename> and
-                <filename>/etc/rmt/ssl/rmt-server.key</filename>
-              </para>
-              <para>
-                <command>yast2 rmt</command> only generates a new server
-                certificate and private key if one does not already exist. To
-                regenerate this certificate, refer to
-                <xref linkend="cha-manage-certificates-https"/>.
+                Secure password for the &rmt; database user
               </para>
             </listitem>
-          </itemizedlist>
-        </tip>
+          </varlistentry>
+          <varlistentry>
+            <term><literal>RMT_ORGANIZATION_USERNAME</literal></term>
+            <listitem>
+              <para>
+                Your &scc; organization credentials. To retrieve your
+                credentials, refer to <xref linkend="sec-rmt-mirroring-credentials"/>.
+              </para>
+            </listitem>
+          </varlistentry>
+          <varlistentry>
+            <term><literal>RMT_ORGANIZATION_PASSWORD</literal></term>
+            <listitem>
+              <para>
+                Your &scc; organization password
+              </para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+
+        <para>
+          Example configuration:
+        </para>
+<screen>---
+rmt_db_username: rmt
+rmt_db_password: "your_secure_password"
+
+rmt:
+  RMT_ORGANIZATION_USERNAME: "your_scc_username"
+  RMT_ORGANIZATION_PASSWORD: "your_scc_password"</screen>
       </step>
+
       <step>
         <para>
-          If &firewalld; is enabled on this system, enable the check box to
-          open the required ports.
+          Run the &ansible; playbook to configure &rmt;:
         </para>
-        <figure>
-          <title>Enabling ports in &firewalld;</title>
-          <mediaobject>
-            <imageobject role="fo">
-              <imagedata fileref="rmt_firewalld.png" width="60%"/>
-            </imageobject>
-            <imageobject role="html">
-              <imagedata fileref="rmt_firewalld.png" width="65%"/>
-            </imageobject>
-          </mediaobject>
-        </figure>
+<screen>&prompt.root;<command>ansible-playbook site.yml</command></screen>
+
         <para>
-          If &firewalld; is not enabled now and you plan to enable it later,
-          you can always open relevant ports by running the <command>yast2
-          rmt</command> module.
+          The playbook will automatically perform the following tasks:
         </para>
-        <tip>
-          <title>Fine-tuning &firewalld; settings</title>
-          <para>
-            By clicking <guimenu>Firewall Details</guimenu>, you can open the
-            relevant ports for specific network interfaces only.
-          </para>
-        </tip>
-        <para>
-          Continue with <guimenu>Next</guimenu>.
-        </para>
+        <itemizedlist>
+          <listitem>
+            <para>Install required dependencies (MariaDB, nginx, Python modules)</para>
+          </listitem>
+          <listitem>
+            <para>Configure and start the MariaDB database service</para>
+          </listitem>
+          <listitem>
+            <para>Create the &rmt; database and database user</para>
+          </listitem>
+          <listitem>
+            <para>Generate SSL certificates for HTTPS</para>
+          </listitem>
+          <listitem>
+            <para>Configure nginx virtual hosts</para>
+          </listitem>
+          <listitem>
+            <para>Create <filename>/etc/rmt.conf</filename> configuration file</para>
+          </listitem>
+          <listitem>
+            <para>Run database migrations</para>
+          </listitem>
+          <listitem>
+            <para>Start and enable the &rmt; server service</para>
+          </listitem>
+        </itemizedlist>
       </step>
+
       <step>
         <para>
-          To view the summary, click <guimenu>Next</guimenu>. Close &yast; by
-          clicking <guimenu>Finish</guimenu>. &yast; then enables and starts
-          all &systemd; services and timers.
+          On systems with SELinux in enforcing mode, allow nginx to connect to
+          the &rmt; backend service:
         </para>
+<screen>&prompt.root;<command>setsebool -P httpd_can_network_connect 1</command></screen>
+      </step>
+
+      <step>
+        <para>
+          Verify the installation by checking the API health status:
+        </para>
+<screen>&prompt.root;<command>curl -s http://localhost/api/health/status</command>
+{"state":"online"}</screen>
       </step>
     </procedure>
+
+    <tip>
+      <title>SSL Certificate Locations</title>
+      <para>
+        The &ansible; playbook generates SSL certificates at the following
+        locations:
+      </para>
+      <itemizedlist>
+        <listitem>
+          <para>
+            <filename>/etc/rmt/ssl/rmt-ca.crt</filename> - CA certificate
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            <filename>/etc/rmt/ssl/rmt-ca.key</filename> - CA private key
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            <filename>/etc/rmt/ssl/rmt-server.crt</filename> - Server certificate
+          </para>
+        </listitem>
+        <listitem>
+          <para>
+            <filename>/etc/rmt/ssl/rmt-server.key</filename> - Server private key
+          </para>
+        </listitem>
+      </itemizedlist>
+    </tip>
   </sect1>
   <sect1>
     <title>Enabling SLP announcements</title>

--- a/xml/rmt_migrate_from_smt.xml
+++ b/xml/rmt_migrate_from_smt.xml
@@ -849,10 +849,10 @@
       </step>
       <step>
         <para>
-          Run the &yast; &rmt; configuration module as described in
-          <xref linkend="sec-rmt-installation-yast-configuration"/>. If
-          you imported the &smt; CA certificate, add the domain of the &smt;
-          server to the common names of the new SSL certificate.
+          Configure &rmt; using &ansible; as described in
+          <xref linkend="sec-rmt-installation-ansible-configuration"/>. If
+          you imported the &smt; CA certificate, ensure the domain of the &smt;
+          server is included in the SSL certificate configuration.
         </para>
       </step>
       <step>

--- a/xml/rmt_mirroring.xml
+++ b/xml/rmt_mirroring.xml
@@ -115,9 +115,11 @@
     </procedure>
 
     <para>
-      The obtained credentials should be set with the &yast; &rmt; Server
-      Configuration module or added directly to the
-      <filename>/etc/rmt.conf</filename> file. For more information about the
+      The obtained credentials should be configured in
+      <filename>/usr/share/ansible/rmt/group_vars/all.yml</filename> before running
+      the &ansible; playbook, or added directly to the
+      <filename>/etc/rmt.conf</filename> file after installation.
+      For more information about the
       <filename>/etc/rmt.conf</filename> file, see
       <xref linkend="sec-rmt-config-rmtconf"/>.
     </para>
@@ -526,10 +528,11 @@ Clean finished. An estimated 157 MB were removed.
       </step>
       <step>
         <para>
-          If not yet done, set up &rmt; on <literal>sirius</literal> by running
-          the <command>yast2 rmt</command>. In case of an offline &rmt; setup,
-          select <guimenu>Skip</guimenu> on the <guimenu>Organization
-          Credentials</guimenu> screen.
+          If not yet done, set up &rmt; on <literal>sirius</literal> by configuring
+          the &ansible; variables. In case of an offline &rmt; setup, leave the
+          organization credentials empty in
+          <filename>/usr/share/ansible/rmt/group_vars/all.yml</filename> and run
+          the playbook.
         </para>
       </step>
       <step>


### PR DESCRIPTION
## Summary
Replace YaST-based RMT configuration with Ansible playbook approach for SLE 16. This update removes conditional rendering and standardizes on the new Ansible workflow.

## Changes
- **Installation**: Use `ansible-rmt-server` package instead of `yast2-rmt`
- **Configuration**: New Ansible configuration section with playbook usage
- **Certificate management**: Use Ansible playbook for certificate regeneration
- **Credentials**: Configure via `group_vars/all.yml` or `/etc/rmt.conf`
- **Removed**: Entire YaST configuration section (`sec-rmt-installation-yast-configuration`)

## Files Modified
- `xml/rmt_install.xml` - Added Ansible configuration section, removed YaST section
- `xml/rmt_certificates.xml` - Updated certificate regeneration procedures
- `xml/rmt_config_files.xml` - Updated configuration references
- `xml/rmt_migrate_from_smt.xml` - Updated migration steps
- `xml/rmt_mirroring.xml` - Updated credential configuration instructions

## Test Plan
- [x] Built documentation with DAPS
- [x] Verified HTML output renders correctly
- [x] Confirmed all conditional attributes removed
- [x] Checked cross-references are valid