### PR TITLE
Add missing l10n links to security_himmelblau.xml

### DIFF
--- a/l10n/sled/ar-ar/xml/security_himmelblau.xml
+++ b/l10n/sled/ar-ar/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sled/cs-cz/xml/security_himmelblau.xml
+++ b/l10n/sled/cs-cz/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sled/de-de/xml/security_himmelblau.xml
+++ b/l10n/sled/de-de/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sled/es-es/xml/security_himmelblau.xml
+++ b/l10n/sled/es-es/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sled/fr-fr/xml/security_himmelblau.xml
+++ b/l10n/sled/fr-fr/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sled/hu-hu/xml/security_himmelblau.xml
+++ b/l10n/sled/hu-hu/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sled/it-it/xml/security_himmelblau.xml
+++ b/l10n/sled/it-it/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sled/ja-jp/xml/security_himmelblau.xml
+++ b/l10n/sled/ja-jp/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sled/ko-kr/xml/security_himmelblau.xml
+++ b/l10n/sled/ko-kr/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sled/pl-pl/xml/security_himmelblau.xml
+++ b/l10n/sled/pl-pl/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sled/pt-br/xml/security_himmelblau.xml
+++ b/l10n/sled/pt-br/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sled/ru-ru/xml/security_himmelblau.xml
+++ b/l10n/sled/ru-ru/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sled/zh-cn/xml/security_himmelblau.xml
+++ b/l10n/sled/zh-cn/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sled/zh-tw/xml/security_himmelblau.xml
+++ b/l10n/sled/zh-tw/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sles/ar-ar/xml/security_himmelblau.xml
+++ b/l10n/sles/ar-ar/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sles/cs-cz/xml/security_himmelblau.xml
+++ b/l10n/sles/cs-cz/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sles/de-de/xml/security_himmelblau.xml
+++ b/l10n/sles/de-de/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sles/es-es/xml/security_himmelblau.xml
+++ b/l10n/sles/es-es/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sles/fr-fr/xml/security_himmelblau.xml
+++ b/l10n/sles/fr-fr/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sles/hu-hu/security_himmelblau.xml
+++ b/l10n/sles/hu-hu/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sles/it-it/xml/security_himmelblau.xml
+++ b/l10n/sles/it-it/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sles/ja-jp/security_himmelblau.xml
+++ b/l10n/sles/ja-jp/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sles/ja-jp/xml/security_himmelblau.xml
+++ b/l10n/sles/ja-jp/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sles/ko-kr/xml/security_himmelblau.xml
+++ b/l10n/sles/ko-kr/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sles/pl-pl/xml/security_himmelblau.xml
+++ b/l10n/sles/pl-pl/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sles/pt-br/xml/security_himmelblau.xml
+++ b/l10n/sles/pt-br/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sles/ru-ru/xml/security_himmelblau.xml
+++ b/l10n/sles/ru-ru/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sles/zh-cn/xml/security_himmelblau.xml
+++ b/l10n/sles/zh-cn/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml

--- a/l10n/sles/zh-tw/xml/security_himmelblau.xml
+++ b/l10n/sles/zh-tw/xml/security_himmelblau.xml
@@ -1,0 +1,1 @@
+../../../../xml/security_himmelblau.xml


### PR DESCRIPTION
### PR creator: Description

On Docserv, translations couldn't be built as links to `security_himmelblau.xml` were missing.


### PR creator: Are there any relevant issues/feature requests?

not available


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP7/openSUSE Leap 15.7 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP6/openSUSE Leap 15.6
  - [ ] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer: Checklist

The doc team member merging your PR will take care of the following tasks and will tick the boxes if done.

- [ ] all necessary backports are done
- [ ] check and update `<revision><date>YYYY-MM-DD</date>` of chapter, part and book (if the change warrants it - for criteria, see https://documentation.suse.com/style/current/html/style-guide-db/sec-structure.html#sec-revinfo) 
