### PR TITLE
Fixed Gnome broken links for SLES/SLED 15 SP5

### DIFF
--- a/l10n/sled/de-de/xml/x11.xml
+++ b/l10n/sled/de-de/xml/x11.xml
@@ -244,7 +244,7 @@ enabled=true</screen>
   <sect2 xml:id="sec-gui-desktop-gnome-more-info">
    <title>Weitere Informationen</title>
    <para>
-    Weitere Informationen finden Sie im <link xlink:href="http://help.gnome.org/admin/"/>.
+    Weitere Informationen finden Sie im <link xlink:href="http://help.gnome.org/system-admin-guide/"/>.
    </para>
   </sect2>
  </sect1>

--- a/l10n/sled/ja-jp/xml/x11.xml
+++ b/l10n/sled/ja-jp/xml/x11.xml
@@ -244,7 +244,7 @@ enabled=true</screen>
   <sect2 xml:id="sec-gui-desktop-gnome-more-info">
    <title>詳細情報</title>
    <para>
-    詳細については、<link xlink:href="http://help.gnome.org/admin/"/>を参照してください。
+    詳細については、<link xlink:href="http://help.gnome.org/system-admin-guide/"/>を参照してください。
    </para>
   </sect2>
  </sect1>

--- a/l10n/sled/pt-br/xml/x11.xml
+++ b/l10n/sled/pt-br/xml/x11.xml
@@ -244,7 +244,7 @@ enabled=true</screen>
   <sect2 xml:id="sec-gui-desktop-gnome-more-info">
    <title>Mais informações</title>
    <para>
-    Para obter mais informações, consulte <link xlink:href="http://help.gnome.org/admin/"/>. 
+    Para obter mais informações, consulte <link xlink:href="http://help.gnome.org/system-admin-guide/"/>. 
    </para>
   </sect2>
  </sect1>

--- a/l10n/sled/zh-cn/xml/user_management.xml
+++ b/l10n/sled/zh-cn/xml/user_management.xml
@@ -603,8 +603,8 @@ EOF</screen>
 fi</screen>
 
    <para>
-    需将文本 <replaceable>This system is classified...</replaceable> 替换为所需的标题文本。请注意，此对话框不会阻止登录继续进行。有关 GDM 脚本的详细信息，请参见 <link xlink:href="https://help.gnome.org/admin/gdm/stable/configuration.html.en#scripting">
-    GDM Admin Manual</link>。
+    需将文本 <replaceable>This system is classified...</replaceable> 替换为所需的标题文本。请注意，此对话框不会阻止登录继续进行。有关 GDM 脚本的详细信息，请参见 <link xlink:href="https://gitlab.gnome.org/GNOME/gdm">
+    GDM documentation</link>。
    </para>
   </sect1>
      <sect1 xml:id="sec-sec-prot-misc-account-utils">

--- a/l10n/sled/zh-cn/xml/x11.xml
+++ b/l10n/sled/zh-cn/xml/x11.xml
@@ -244,7 +244,7 @@ enabled=true</screen>
   <sect2 xml:id="sec-gui-desktop-gnome-more-info">
    <title>更多信息</title>
    <para>
-    有关详细信息，请参见 <link xlink:href="http://help.gnome.org/admin/"/>。
+    有关详细信息，请参见 <link xlink:href="http://help.gnome.org/system-admin-guide/"/>。
    </para>
   </sect2>
  </sect1>

--- a/l10n/sled/zh-tw/xml/x11.xml
+++ b/l10n/sled/zh-tw/xml/x11.xml
@@ -244,7 +244,7 @@ enabled=true</screen>
   <sect2 xml:id="sec-gui-desktop-gnome-more-info">
    <title>更多資訊</title>
    <para>
-    如需詳細資訊，請參閱 <link xlink:href="http://help.gnome.org/admin/"/>。
+    如需詳細資訊，請參閱 <link xlink:href="http://help.gnome.org/system-admin-guide/"/>。
    </para>
   </sect2>
  </sect1>

--- a/l10n/sles/de-de/xml/x11.xml
+++ b/l10n/sles/de-de/xml/x11.xml
@@ -117,7 +117,7 @@ enabled=true</screen>
   <sect2 xml:id="sec-gui-desktop-gnome-more-info">
    <title>Weitere Informationen</title>
    <para>
-    Weitere Informationen finden Sie im <link xlink:href="http://help.gnome.org/admin/"/>.
+    Weitere Informationen finden Sie im <link xlink:href="http://help.gnome.org/system-admin-guide/"/>.
    </para>
   </sect2>
  </sect1>

--- a/l10n/sles/ja-jp/xml/x11.xml
+++ b/l10n/sles/ja-jp/xml/x11.xml
@@ -117,7 +117,7 @@ enabled=true</screen>
   <sect2 xml:id="sec-gui-desktop-gnome-more-info">
    <title>詳細情報</title>
    <para>
-    詳細については、<link xlink:href="http://help.gnome.org/admin/"/>を参照してください。
+    詳細については、<link xlink:href="http://help.gnome.org/system-admin-guide/"/>を参照してください。
    </para>
   </sect2>
  </sect1>

--- a/l10n/sles/zh-cn/xml/user_management.xml
+++ b/l10n/sles/zh-cn/xml/user_management.xml
@@ -603,8 +603,8 @@ EOF</screen>
 fi</screen>
 
    <para>
-    需将文本 <replaceable>This system is classified...</replaceable> 替换为所需的标题文本。请注意，此对话框不会阻止登录继续进行。有关 GDM 脚本的详细信息，请参见 <link xlink:href="https://help.gnome.org/admin/gdm/stable/configuration.html.en#scripting">
-    GDM Admin Manual</link>。
+    需将文本 <replaceable>This system is classified...</replaceable> 替换为所需的标题文本。请注意，此对话框不会阻止登录继续进行。有关 GDM 脚本的详细信息，请参见 <link xlink:href="https://gitlab.gnome.org/GNOME/gdm">
+    GDM documentation</link>。
    </para>
   </sect1>
      <sect1 xml:id="sec-sec-prot-misc-account-utils">

--- a/l10n/sles/zh-cn/xml/x11.xml
+++ b/l10n/sles/zh-cn/xml/x11.xml
@@ -117,7 +117,7 @@ enabled=true</screen>
   <sect2 xml:id="sec-gui-desktop-gnome-more-info">
    <title>更多信息</title>
    <para>
-    有关详细信息，请参见 <link xlink:href="http://help.gnome.org/admin/"/>。
+    有关详细信息，请参见 <link xlink:href="http://help.gnome.org/system-admin-guide/"/>。
    </para>
   </sect2>
  </sect1>

--- a/l10n/sles/zh-tw/xml/x11.xml
+++ b/l10n/sles/zh-tw/xml/x11.xml
@@ -117,7 +117,7 @@ enabled=true</screen>
   <sect2 xml:id="sec-gui-desktop-gnome-more-info">
    <title>更多資訊</title>
    <para>
-    如需詳細資訊，請參閱 <link xlink:href="http://help.gnome.org/admin/"/>。
+    如需詳細資訊，請參閱 <link xlink:href="http://help.gnome.org/system-admin-guide/"/>。
    </para>
   </sect2>
  </sect1>

--- a/xml/user_management.xml
+++ b/xml/user_management.xml
@@ -934,8 +934,8 @@ fi</screen>
     be replaced with the desired banner text. Note that
     this dialog does not prevent a login from progressing. For more
     information about GDM scripting, refer to the
-    <link xlink:href="https://help.gnome.org/admin/gdm/stable/configuration.html.en#scripting">
-    GDM Admin Manual</link>.
+    <link xlink:href="https://gitlab.gnome.org/GNOME/gdm">
+    GDM documentation</link>.
    </para>
   </sect1>
      <sect1 xml:id="sec-sec-prot-misc-account-utils">

--- a/xml/x11.xml
+++ b/xml/x11.xml
@@ -354,7 +354,7 @@ enabled=true</screen>
    <title>More information</title>
    <para>
     For more information, see
-    <link xlink:href="https://help.gnome.org/admin/"/>.
+    <link xlink:href="https://help.gnome.org/system-admin-guide/"/>.
    </para>
   </sect2>
  </sect1>


### PR DESCRIPTION
### PR creator: Description

Fixed broken links in the Gnome guide for SLES/SLED 15 SP5.

### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [ ] SLE 15 SP7/openSUSE Leap 15.7 *(current `main`, no backport necessary)*
  - [ ] SLE 15 SP6/openSUSE Leap 15.6
  - [x] SLE 15 SP5/openSUSE Leap 15.5
  - [ ] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [ ] SLE 12 SP5


### PR reviewer: Checklist

The doc team member merging your PR will take care of the following tasks and will tick the boxes if done.

- [ ] all necessary backports are done
- [ ] check and update `<revision><date>YYYY-MM-DD</date>` of chapter, part and book (if the change warrants it - for criteria, see https://documentation.suse.com/style/current/html/style-guide-db/sec-structure.html#sec-revinfo) 
