### PR TITLE
Fix for DOCTEAM-1636

### DIFF
--- a/xml/libvirt_configuration_virsh.xml
+++ b/xml/libvirt_configuration_virsh.xml
@@ -730,11 +730,11 @@ Used memory:    8388608 KiB
         </para>
 <screen>&prompt.sudo;<command>lspci -nn</command>
 [...]
-<emphasis role="bold">03:07.0</emphasis> Ethernet controller [0200]: Digital Equipment Corporation DECchip \
+<emphasis role="bold">17:00.0</emphasis> Ethernet controller [0200]: Digital Equipment Corporation DECchip \
 21140 [FasterNet] [1011:0009] (rev 22)
 [...]</screen>
         <para>
-          Write down the device ID, <literal>03:07.0</literal> in this example.
+          Write down the device ID, <literal>17:00.0</literal> in this example.
         </para>
       </step>
       <step>
@@ -742,22 +742,22 @@ Used memory:    8388608 KiB
           Gather detailed information about the device using <command>virsh
           nodedev-dumpxml <replaceable>ID</replaceable></command>. To get the
           <replaceable>ID</replaceable>, replace the colon and the period in
-          the device ID (<literal>03:07.0</literal>) with underscores. Prefix
+          the device ID (<literal>17:00.0</literal>) with underscores. Prefix
           the result with <quote>pci_0000_</quote>:
-          <literal>pci_0000_03_07_0</literal>.
+          <literal>pci_0000_17_00_0</literal>.
         </para>
-<screen>&prompt.sudo;<command>virsh nodedev-dumpxml pci_0000_03_07_0</command>
+<screen>&prompt.sudo;<command>virsh nodedev-dumpxml pci_0000_17_00_0</command>
 &lt;device&gt;
-  &lt;name&gt;pci_0000_03_07_0&lt;/name&gt;
-  &lt;path&gt;/sys/devices/pci0000:00/0000:00:14.4/0000:03:07.0&lt;/path&gt;
+  &lt;name&gt;pci_0000_17_00_0&lt;/name&gt;
+  &lt;path&gt;/sys/devices/pci0000:00/0000:00:14.4/0000:17:00.0&lt;/path&gt;
   &lt;parent&gt;pci_0000_00_14_4&lt;/parent&gt;
   &lt;driver&gt;
     &lt;name&gt;tulip&lt;/name&gt;
   &lt;/driver&gt;
   &lt;capability type='pci'&gt;
     <emphasis role="bold">&lt;domain&gt;0&lt;/domain&gt;
-    &lt;bus&gt;3&lt;/bus&gt;
-    &lt;slot&gt;7&lt;/slot&gt;
+    &lt;bus&gt;23&lt;/bus&gt;
+    &lt;slot&gt;0&lt;/slot&gt;
     &lt;function&gt;0&lt;/function&gt;</emphasis>
     &lt;product id='0x0009'&gt;DECchip 21140 [FasterNet]&lt;/product&gt;
     &lt;vendor id='0x1011'&gt;Digital Equipment Corporation&lt;/vendor&gt;
@@ -765,8 +765,8 @@ Used memory:    8388608 KiB
   &lt;/capability&gt;
 &lt;/device&gt;</screen>
         <para>
-          Write down the values for domain, bus and function (see the previous
-          XML code printed in bold).
+          Write down the values for domain, bus, slot, and function (see the
+          previous XML code printed in bold).
         </para>
       </step>
       <step>
@@ -774,8 +774,8 @@ Used memory:    8388608 KiB
           Detach the device from the host system before attaching it to the
           &vmguest;:
         </para>
-<screen>&prompt.sudo;<command>virsh nodedev-detach pci_0000_03_07_0</command>
-  Device pci_0000_03_07_0 detached</screen>
+<screen>&prompt.sudo;<command>virsh nodedev-detach pci_0000_17_00_0</command>
+  Device pci_0000_17_00_0 detached</screen>
         <tip>
           <title>Multi-function PCI devices</title>
           <para>
@@ -791,14 +791,28 @@ Used memory:    8388608 KiB
       <step>
         <para>
           Convert the domain, bus, slot, and function value from decimal to
-          hexadecimal. In our example, domain = 0, bus = 3, slot = 7, and
+          hexadecimal. In our example, domain = 0, bus = 23, slot = 0, and
           function = 0. Ensure that the values are inserted in the right order:
         </para>
-<screen>&prompt.user;<command>printf "&lt;address domain='0x%x' bus='0x%x' slot='0x%x' function='0x%x'/&gt;\n" 0 3 7 0</command></screen>
+        <note>
+          <title>Use the decimal values from the <command>nodedev-dumpxml</command> output</title>
+          <para>
+            The <literal>domain</literal>, <literal>bus</literal>, <literal>slot</literal>, and
+            <literal>function</literal> values in the <literal>&lt;capability&gt;</literal> section of
+            <command>virsh nodedev-dumpxml</command> are decimal numbers, even though the device name
+            (for example, <literal>pci_0000_17_00_0</literal>) and the output of
+            <command>lspci</command> already use hexadecimal notation. Convert only the decimal values
+            from <command>nodedev-dumpxml</command>. Using the hexadecimal segments from the device
+            name or from <command>lspci</command> as input to <command>printf</command> produces an
+            incorrect address, for example <literal>0x11</literal> instead of the correct
+            <literal>0x17</literal> for bus <literal>23</literal>.
+          </para>
+        </note>
+<screen>&prompt.user;<command>printf "&lt;address domain='0x%x' bus='0x%x' slot='0x%x' function='0x%x'/&gt;\n" 0 23 0 0</command></screen>
         <para>
           This results in:
         </para>
-<screen>&lt;address domain='0x0' bus='0x3' slot='0x7' function='0x0'/&gt;</screen>
+<screen>&lt;address domain='0x0' bus='0x17' slot='0x0' function='0x0'/&gt;</screen>
       </step>
       <step>
         <para>
@@ -808,7 +822,7 @@ Used memory:    8388608 KiB
         </para>
 <screen>&lt;hostdev mode='subsystem' type='pci' managed='yes'&gt;
   &lt;source&gt;
-    &lt;address domain='0x0' bus='0x03' slot='0x07' function='0x0'/&gt;
+    &lt;address domain='0x0' bus='0x17' slot='0x00' function='0x0'/&gt;
   &lt;/source&gt;
 &lt;/hostdev&gt;</screen>
         <tip xml:id="tip-libvirt-config-pci-virsh-managed">
@@ -837,9 +851,9 @@ Used memory:    8388608 KiB
           <command>virsh nodedev-detach</command> and <command>virsh
           nodedev-reattach</command> commands. Before starting the &vmguest;,
           you need to detach the device from the host by running <command>virsh
-          nodedev-detach pci_0000_03_07_0</command>. In case the &vmguest; is
+          nodedev-detach pci_0000_17_00_0</command>. In case the &vmguest; is
           not running, you can make the device available for the host by
-          running <command>virsh nodedev-reattach pci_0000_03_07_0</command>.
+          running <command>virsh nodedev-reattach pci_0000_17_00_0</command>.
         </para>
       </step>
       <step>


### PR DESCRIPTION
### PR creator: Description

Fix for DOCTEAM-1636


### PR creator: Are there any relevant issues/feature requests?

* bsc#...https://bugzilla.suse.com/show_bug.cgi?id=1233425
* jsc#...https://jira.suse.com/browse/DOCTEAM-1636


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP7/openSUSE Leap 15.7 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP6/openSUSE Leap 15.6 https://github.com/SUSE/doc-sle/commit/a7595a6c03971a700be4aa831d29b665dd50a7b1
  - [x] SLE 15 SP5/openSUSE Leap 15.5 https://github.com/SUSE/doc-sle/commit/56de61673381b4f9a083145f0900907a42f41785
  - [x] SLE 15 SP4/openSUSE Leap 15.4 https://github.com/SUSE/doc-sle/commit/c27d6314527bb4d819236f82e5eca71bf8075f4a
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [x] SLE 12 SP5 https://github.com/SUSE/doc-sle/commit/a6e2ddaa0d5cd1188c3c8d09e8603988a6c84d47


### PR reviewer: Checklist

The doc team member merging your PR will take care of the following tasks and will tick the boxes if done.

- [x] all necessary backports are done
- [ ] check and update `<revision><date>YYYY-MM-DD</date>` of chapter, part and book (if the change warrants it - for criteria, see https://documentation.suse.com/style/current/html/style-guide-db/sec-structure.html#sec-revinfo) 
