### PR TITLE
Fix for DOCTEAM-2337 in virtualization docs

### DIFF
--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -519,8 +519,10 @@
       <para>
         &mswin; guests can be rebooted by &libvirt;/&virsh; only if
         paravirtualized drivers are installed in the guest. Refer to
-        <link xlink:href="https://www.suse.com/products/vmdriverpack/"/> for
-        more details on downloading and installing PV drivers.
+        <link xlink:href="https://documentation.suse.com/sle-vmdp/"/> for
+        more details on downloading and installing PV drivers. See
+        <xref linkend="virt-support-guests"/> for the current list of
+        supported Windows Server versions.
       </para>
     </important>
 
@@ -616,7 +618,8 @@
           All guest operating systems are supported both fully virtualized and
           paravirtualized. The exception is Windows systems, which are only
           supported fully virtualized (but they can use PV drivers:
-          <link xlink:href="https://www.suse.com/products/vmdriverpack/"/>), and
+          <link xlink:href="https://documentation.suse.com/sle-vmdp/"/>; see
+          <xref linkend="virt-support-guests"/> for supported versions), and
           OES operating systems, which are supported only paravirtualized.
         </para>
       </listitem>
@@ -715,7 +718,9 @@
               &suse; has developed virtio-based drivers for Windows, which are
               available in the Virtual Machine Driver Pack (VMDP). For more
               information, see
-              <link xlink:href="https://www.suse.com/products/vmdriverpack/"/>.
+              <link xlink:href="https://documentation.suse.com/sle-vmdp/"/>. See
+              <xref linkend="virt-support-guests"/> for the current list of
+              supported Windows Server versions.
             </para>
           </listitem>
         </varlistentry>
@@ -1611,7 +1616,9 @@
           Hotplugging of virtual network and virtual block devices, and
           resizing, shrinking and restoring dynamic virtual memory are supported
           in &xen; and &kvm; only if PV drivers are being used
-          (<link xlink:href="https://www.suse.com/products/vmdriverpack/">VMDP</link>).
+          (<link xlink:href="https://documentation.suse.com/sle-vmdp/">VMDP</link>).
+          See <xref linkend="virt-support-guests"/> for the current list of
+          supported Windows Server versions.
         </para>
       </note>
       <note>

--- a/xml/virt_support.xml
+++ b/xml/virt_support.xml
@@ -26,6 +26,12 @@
          is provided in the Introduction section of the guide for your &sliberty; version,
          not on the &sliberty; documentation landing page itself.
        </para>
+       <para>
+         The Virtual Machine Driver Pack (VMDP) documentation link points to
+         <link xlink:href="https://documentation.suse.com/sle-vmdp/"/>. See
+         <xref linkend="virt-support-guests"/> for the current list of supported
+         Windows Server versions.
+       </para>
      </revdescription>
    </revision>
    <revision>


### PR DESCRIPTION

### PR creator: Description

Fix for DOCTEAM-2337 in virtualization docs; VDMP docs to be updated by its maintainer.


### PR creator: Are there any relevant issues/feature requests?

* bsc#...https://bugzilla.suse.com/show_bug.cgi?id=1267898
* jsc#...https://jira.suse.com/browse/DOCTEAM-2337


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP7/openSUSE Leap 15.7 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP6/openSUSE Leap 15.6
  - [x] SLE 15 SP5/openSUSE Leap 15.5
  - [x] SLE 15 SP4/openSUSE Leap 15.4
  - [ ] SLE 15 SP3/openSUSE Leap 15.3
  
- SLE 12
  - [x] SLE 12 SP5


### PR reviewer: Checklist

The doc team member merging your PR will take care of the following tasks and will tick the boxes if done.

- [x] all necessary backports are done
- [x] check and update `<revision><date>YYYY-MM-DD</date>` of chapter, part and book (if the change warrants it - for criteria, see https://documentation.suse.com/style/current/html/style-guide-db/sec-structure.html#sec-revinfo) 
