### PR TITLE
Added a note as a fix to DOCTEAM-1759

### DIFF
--- a/xml/tuning_multikernel.xml
+++ b/xml/tuning_multikernel.xml
@@ -30,6 +30,17 @@
   </dm:docmanager>
  <revhistory xml:id="rh-cha-tuning-multikernel">
    <revision>
+     <date>2026-09-03</date>
+     <revdescription>
+       <para>
+        Kernels selected for removal by <literal>multiversion.kernels</literal>
+        are purged at the next reboot by the <literal>purge-kernels.service</literal>
+        systemd service, which is enabled by default and can also be triggered
+        manually with <literal>zypper purge-kernels</literal>.
+       </para>
+     </revdescription>
+   </revision>
+   <revision>
      <date>2024-05-13</date>
      <revdescription>
        <para/>
@@ -227,6 +238,19 @@
      </tip>
     </step>
    </procedure>
+   <note>
+    <title>When the purge is applied</title>
+    <para>
+     Kernels selected for removal are not deleted immediately. They are
+     purged the next time the system boots, by the
+     <systemitem class="service">purge-kernels.service</systemitem> systemd
+     service, which is enabled by default. To apply the purge without
+     rebooting, run <command>zypper purge-kernels</command> as &rootuser;.
+     Add the <option>--dry-run</option> option to preview which kernels
+     would be removed without deleting anything, or
+     <option>--details</option> for a detailed installation summary.
+    </para>
+   </note>
   </sect2>
   <sect2 xml:id="sec-tuning-multikernel-deleteoldkernel">
    <title>Use case: deleting an old kernel after reboot only</title>


### PR DESCRIPTION
### PR creator: Description

Added a note as a fix to DOCTEAM-1759

### PR creator: Are there any relevant issues/feature requests?

* bsc#...https://bugzilla.suse.com/show_bug.cgi?id=1239166
* jsc#...https://jira.suse.com/browse/DOCTEAM-1759


### PR creator: Which product versions do the changes apply to?

When opening a PR, check all versions of the documentation that your PR applies to.

- SLE 15/openSUSE Leap 15.x
  - [x] SLE 15 SP7/openSUSE Leap 15.7 *(current `main`, no backport necessary)*
  - [x] SLE 15 SP6/openSUSE Leap 15.6 https://github.com/SUSE/doc-sle/commit/104c675c3df5a650c6f6c20c9c5f2408bb1ff399
  - [x] SLE 15 SP5/openSUSE Leap 15.5 https://github.com/SUSE/doc-sle/commit/57f8a5612de157e64edf3f7fc8b6729119d067aa
  - [x] SLE 15 SP4/openSUSE Leap 15.4 https://github.com/SUSE/doc-sle/commit/e1187c8617d3bc0c5cbd8bfb520acc3e8dcb649a
  - [ ] SLE 15 SP3/openSUSE Leap 15.3 https://github.com/SUSE/doc-sle/commit/46de6cd0a9744d0b2269b785bdd0aafbf9c31e98
  
- SLE 12
  - [x] SLE 12 SP5 https://github.com/SUSE/doc-sle/commit/1f8f3b6274afa025b229fa58db31a40f0529fd78


### PR reviewer: Checklist

The doc team member merging your PR will take care of the following tasks and will tick the boxes if done.

- [x] all necessary backports are done
- [x] check and update `<revision><date>YYYY-MM-DD</date>` of chapter, part and book (if the change warrants it - for criteria, see https://documentation.suse.com/style/current/html/style-guide-db/sec-structure.html#sec-revinfo) 
